### PR TITLE
Migrate to AGP built-in Kotlin and update AGP to 9.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.DS_Store
 .idea/
+android/gradle/gradle-daemon-jvm.properties

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,12 +3,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.application")
+    alias(libs.plugins.compose.compiler)
     id("com.google.dagger.hilt.android")
-    kotlin("android")
     id("kotlinx-serialization")
     id("com.google.devtools.ksp")
     id("androidx.room")
-    alias(libs.plugins.compose.compiler)
     id("com.google.gms.google-services")
 }
 

--- a/android/blockchain/build.gradle.kts
+++ b/android/blockchain/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
     id("kotlinx-serialization")
 }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,6 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath(libs.kotlin.gradle.plugin)
         classpath(libs.gradle)
         classpath(libs.hilt.android.gradle.plugin)
         classpath(libs.kotlin.serialization)
@@ -16,7 +15,6 @@ buildscript {
 plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.room) apply false
     alias(libs.plugins.compose.compiler) apply false

--- a/android/data/coordinators/build.gradle.kts
+++ b/android/data/coordinators/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/data/repositories/build.gradle.kts
+++ b/android/data/repositories/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/data/services/remote-gem/build.gradle.kts
+++ b/android/data/services/remote-gem/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
     id("kotlinx-serialization")
 }

--- a/android/data/services/store/build.gradle.kts
+++ b/android/data/services/store/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/activities/presents/build.gradle.kts
+++ b/android/features/activities/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/activities/viewmodels/build.gradle.kts
+++ b/android/features/activities/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/add_asset/presents/build.gradle.kts
+++ b/android/features/add_asset/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/add_asset/viewmodels/build.gradle.kts
+++ b/android/features/add_asset/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/asset/presents/build.gradle.kts
+++ b/android/features/asset/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/asset/viewmodels/build.gradle.kts
+++ b/android/features/asset/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/asset_select/presents/build.gradle.kts
+++ b/android/features/asset_select/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/asset_select/viewmodels/build.gradle.kts
+++ b/android/features/asset_select/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/assets/presents/build.gradle.kts
+++ b/android/features/assets/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/assets/viewmodels/build.gradle.kts
+++ b/android/features/assets/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/banner/presents/build.gradle.kts
+++ b/android/features/banner/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/banner/viewmodels/build.gradle.kts
+++ b/android/features/banner/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/bridge/presents/build.gradle.kts
+++ b/android/features/bridge/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/bridge/viewmodels/build.gradle.kts
+++ b/android/features/bridge/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/buy/presents/build.gradle.kts
+++ b/android/features/buy/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/buy/viewmodels/build.gradle.kts
+++ b/android/features/buy/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/confirm/presents/build.gradle.kts
+++ b/android/features/confirm/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/confirm/viewmodels/build.gradle.kts
+++ b/android/features/confirm/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/earn/delegation/presents/build.gradle.kts
+++ b/android/features/earn/delegation/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/earn/delegation/viewmodels/build.gradle.kts
+++ b/android/features/earn/delegation/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/earn/stake/presents/build.gradle.kts
+++ b/android/features/earn/stake/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/earn/stake/viewmodels/build.gradle.kts
+++ b/android/features/earn/stake/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/nft/presents/build.gradle.kts
+++ b/android/features/nft/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/nft/viewmodels/build.gradle.kts
+++ b/android/features/nft/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/perpetual/presents/build.gradle.kts
+++ b/android/features/perpetual/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/perpetual/viewmodels/build.gradle.kts
+++ b/android/features/perpetual/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/receive/presents/build.gradle.kts
+++ b/android/features/receive/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/receive/viewmodels/build.gradle.kts
+++ b/android/features/receive/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/recipient/presents/build.gradle.kts
+++ b/android/features/recipient/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/recipient/viewmodels/build.gradle.kts
+++ b/android/features/recipient/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/referral/presents/build.gradle.kts
+++ b/android/features/referral/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/referral/viewmodels/build.gradle.kts
+++ b/android/features/referral/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 android {

--- a/android/features/settings/aboutus/presents/build.gradle.kts
+++ b/android/features/settings/aboutus/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/settings/aboutus/viewmodels/build.gradle.kts
+++ b/android/features/settings/aboutus/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/settings/build.gradle.kts
+++ b/android/features/settings/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    kotlin("android")
 }
 
 android {

--- a/android/features/settings/currency/presents/build.gradle.kts
+++ b/android/features/settings/currency/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/settings/currency/viewmodels/build.gradle.kts
+++ b/android/features/settings/currency/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/settings/develop/presents/build.gradle.kts
+++ b/android/features/settings/develop/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/settings/develop/viewmodels/build.gradle.kts
+++ b/android/features/settings/develop/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/settings/networks/presents/build.gradle.kts
+++ b/android/features/settings/networks/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/settings/networks/viewmodels/build.gradle.kts
+++ b/android/features/settings/networks/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/settings/price_alerts/presents/build.gradle.kts
+++ b/android/features/settings/price_alerts/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/settings/price_alerts/viewmodels/build.gradle.kts
+++ b/android/features/settings/price_alerts/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/settings/security/presents/build.gradle.kts
+++ b/android/features/settings/security/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/settings/security/viewmodels/build.gradle.kts
+++ b/android/features/settings/security/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/settings/settings/presents/build.gradle.kts
+++ b/android/features/settings/settings/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/settings/settings/viewmodels/build.gradle.kts
+++ b/android/features/settings/settings/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/swap/presents/build.gradle.kts
+++ b/android/features/swap/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/swap/viewmodels/build.gradle.kts
+++ b/android/features/swap/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/transfer_amount/presents/build.gradle.kts
+++ b/android/features/transfer_amount/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/transfer_amount/viewmodels/build.gradle.kts
+++ b/android/features/transfer_amount/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/update_app/presents/build.gradle.kts
+++ b/android/features/update_app/presents/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }

--- a/android/features/update_app/viewmodels/build.gradle.kts
+++ b/android/features/update_app/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/wallet-details/presents/build.gradle.kts
+++ b/android/features/wallet-details/presents/build.gradle.kts
@@ -3,8 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/wallet-details/presents/build.gradle.kts
+++ b/android/features/wallet-details/presents/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
+    alias(libs.plugins.compose.compiler)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/wallet-details/viewmodels/build.gradle.kts
+++ b/android/features/wallet-details/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/features/wallets/presents/build.gradle.kts
+++ b/android/features/wallets/presents/build.gradle.kts
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
-    id("com.google.devtools.ksp")
     alias(libs.plugins.compose.compiler)
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/android/features/wallets/viewmodels/build.gradle.kts
+++ b/android/features/wallets/viewmodels/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.devtools.ksp")
 }
 

--- a/android/flavors/fcm/build.gradle.kts
+++ b/android/flavors/fcm/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     id("com.google.dagger.hilt.android")
     id("com.google.gms.google-services")
     id("com.google.devtools.ksp")

--- a/android/flavors/google-review/build.gradle.kts
+++ b/android/flavors/google-review/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
 }
 
 android {

--- a/android/flavors/pushes-stub/build.gradle.kts
+++ b/android/flavors/pushes-stub/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
 }
 
 android {

--- a/android/flavors/review-stub/build.gradle.kts
+++ b/android/flavors/review-stub/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
 }
 
 android {

--- a/android/gemcore/build.gradle.kts
+++ b/android/gemcore/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
     id("kotlinx-serialization")
 }
 

--- a/android/gemstone/build.gradle.kts
+++ b/android/gemstone/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 val gemstoneRoot = rootProject.projectDir.resolve("../core/gemstone")

--- a/android/gemstone/build.gradle.kts
+++ b/android/gemstone/build.gradle.kts
@@ -37,12 +37,12 @@ android {
 
     sourceSets {
         getByName("main") {
-            java.srcDirs(generatedKotlinDir)
+            kotlin.srcDirs(generatedKotlinDir)
             jniLibs.srcDirs(jniLibsDir)
             manifest.srcFile(gemstoneSrc.resolve("main/AndroidManifest.xml"))
         }
         getByName("androidTest") {
-            java.srcDirs(gemstoneSrc.resolve("androidTest/java"))
+            kotlin.srcDirs(gemstoneSrc.resolve("androidTest/java"))
         }
     }
 }

--- a/android/google/build.gradle.kts
+++ b/android/google/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
 }
 
 android {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -24,7 +24,4 @@ android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 firebasePerformanceInstrumentationEnabled=false
 
-# Re-enable when finish migration to AGP 9.0
-android.newDsl=false
-android.enableDesugaring=true
-android.builtInKotlin=false
+android.builtInKotlin=true

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -30,13 +30,12 @@ room = "2.8.4"
 gson = "2.13.2"
 securityCrypto = "1.1.0"
 google-services = "4.4.4"
-gradle = "9.0.1"
+gradle = "9.1.0"
 ksp = "2.3.4"
-android-lib = "9.0.1"
+android-lib = "9.1.0"
 kotlin = "2.3.20"
 hiltAndroid = "2.59.2"
 hiltNavigationCompose = "1.3.0"
-kotlinGradlePlugin = "2.2.10"
 kotlinSerialization = "2.3.20"
 kotlinxSerializationJson = "1.10.0"
 kotlinxCollectionsImmutable = "0.4.0"
@@ -60,7 +59,6 @@ tink = "1.20.0"
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 ktx-core = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
-kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlinSerialization" }
@@ -174,7 +172,6 @@ mockk-agent =  { module = "io.mockk:mockk-agent", version.ref = "mockkVersion" }
 [plugins]
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}
 android-library = { id = "com.android.library", version.ref = "android-lib" }
-kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
 room = { id = "androidx.room", version.ref = "room" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 28 21:24:58 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/localize/build.gradle.kts
+++ b/android/localize/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
 }
 
 android {

--- a/android/ui-models/build.gradle.kts
+++ b/android/ui-models/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
 }
 
 android {

--- a/android/ui/build.gradle.kts
+++ b/android/ui/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin)
     alias(libs.plugins.compose.compiler)
 }
 


### PR DESCRIPTION
AGP 9.0+ bundles the Kotlin compiler, making the separate org.jetbrains.kotlin.android plugin unnecessary. This removes the plugin from all 70+ modules, drops kotlin-gradle-plugin from the buildscript classpath and version catalog, and enables android.builtInKotlin=true. The Compose compiler plugin is retained as AGP still requires it for Compose-enabled modules.