### PR TITLE
Update Android toolbar buttons to circular filled style

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/PhraseAlert.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/PhraseAlert.kt
@@ -15,8 +15,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,6 +29,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.components.buttons.ToolbarIconButton
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.actions.CancelAction
 import com.gemwallet.android.ui.open
@@ -61,8 +60,9 @@ fun PhraseAlertDialog(
             )
         },
         actions = {
-            IconButton(
-                {
+            ToolbarIconButton(
+                imageVector = Icons.Outlined.Info,
+                onClick = {
                     uriHandler.open(
                         context,
                         Config().getPublicUrl(PublicUrl.TERMS_OF_SERVICE).toUri()
@@ -71,10 +71,8 @@ fun PhraseAlertDialog(
                             .build()
                             .toString()
                     )
-                }
-            ) {
-                Icon(Icons.Outlined.Info, "")
-            }
+                },
+            )
         },
         onClose = { onCancel() }
     ) {

--- a/android/app/src/main/kotlin/com/gemwallet/android/features/onboarding/AcceptTermsScreen.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/onboarding/AcceptTermsScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,6 +37,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.net.toUri
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.components.buttons.ToolbarIconButton
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.actions.CancelAction
 import com.gemwallet.android.ui.open
@@ -70,8 +70,9 @@ fun AcceptTermsScreen(
             )
         },
         actions = {
-            IconButton(
-                {
+            ToolbarIconButton(
+                imageVector = Icons.Outlined.Info,
+                onClick = {
                     uriHandler.open(
                         context,
                         Config().getPublicUrl(PublicUrl.TERMS_OF_SERVICE).toUri()
@@ -80,10 +81,8 @@ fun AcceptTermsScreen(
                             .build()
                             .toString()
                     )
-                }
-            ) {
-                Icon(Icons.Outlined.Info, "")
-            }
+                },
+            )
         },
     ) {
         LazyColumn (

--- a/android/app/src/main/kotlin/com/gemwallet/android/features/setup_wallet/views/SetupWalletScreen.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/setup_wallet/views/SetupWalletScreen.kt
@@ -9,10 +9,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,6 +23,7 @@ import com.gemwallet.android.features.setup_wallet.viewmodels.SetupWalletViewMod
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.GemTextField
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.components.buttons.ToolbarCheckmarkButton
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.theme.extraLargeIconSize
 import com.gemwallet.android.ui.theme.paddingDefault
@@ -51,9 +48,7 @@ fun SetupWalletScreen(
         title = title,
         backHandle = true,
         actions = {
-            IconButton(onClick = handleDone) {
-                Icon(imageVector = Icons.Default.Check, contentDescription = "")
-            }
+            ToolbarCheckmarkButton(onClick = handleDone)
         },
         mainAction = {
             MainActionButton(

--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsScene.kt
@@ -4,12 +4,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Share
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.transaction.aggregates.TransactionDetailsAggregate
+import com.gemwallet.android.ui.components.buttons.ToolbarIconButton
 import com.gemwallet.android.domains.transaction.values.TransactionDetailsValue
 import com.gemwallet.android.features.activities.presents.details.components.DestinationPropertyItem
 import com.gemwallet.android.features.activities.presents.details.components.TransactionExplorer
@@ -35,9 +34,7 @@ fun TransactionDetailsScene(
     Scene(
         title = data.getTitle(),
         actions = {
-            IconButton(onShare) {
-                Icon(Icons.Default.Share, "")
-            }
+            ToolbarIconButton(imageVector = Icons.Default.Share, onClick = onShare)
         },
         onClose = onCancel,
     ) {

--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
@@ -12,9 +12,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FilterAlt
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -32,6 +29,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.gemwallet.android.domains.transaction.aggregates.TransactionDataAggregate
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.buttons.ToolbarIconButton
 import com.gemwallet.android.ui.components.filters.TransactionsFilter
 import com.gemwallet.android.ui.components.list_item.transaction.transactionsList
 import com.gemwallet.android.ui.components.screen.Scene
@@ -60,16 +58,13 @@ internal fun TransactionsScene(
         title = stringResource(id = R.string.activity_title),
         mainActionPadding = PaddingValues(0.dp),
         actions = {
-            IconButton(onClick = { showFilters = !showFilters }) {
-                Icon(
-                    imageVector = Icons.Default.FilterAlt,
-                    tint = if (chainsFilter.isEmpty() && typeFilter.isEmpty())
-                        LocalContentColor.current
-                    else
-                        MaterialTheme.colorScheme.primary,
-                    contentDescription = "Filter by networks",
-                )
-            }
+            ToolbarIconButton(
+                imageVector = Icons.Default.FilterAlt,
+                contentDescription = "Filter by networks",
+                tint = if (chainsFilter.isEmpty() && typeFilter.isEmpty()) null
+                    else MaterialTheme.colorScheme.primary,
+                onClick = { showFilters = !showFilters },
+            )
         },
         navigationBarPadding = false,
     ) {

--- a/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/AssetSelectScene.kt
+++ b/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/AssetSelectScene.kt
@@ -20,9 +20,6 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FilterAlt
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -43,6 +40,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.ui.R
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import com.gemwallet.android.ui.components.SearchBar
 import com.gemwallet.android.ui.components.TabsBar
 import com.gemwallet.android.ui.components.filters.AssetsFilter

--- a/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsTopBar.kt
+++ b/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsTopBar.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -18,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
+import com.gemwallet.android.ui.components.buttons.ToolbarIconButton
 import com.gemwallet.android.domains.wallet.aggregates.WalletSummaryAggregate
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.image.AsyncImage
@@ -65,16 +65,12 @@ internal fun AssetsTopBar(
             }
         },
         actions = {
-            IconButton(
+            ToolbarIconButton(
+                imageVector = Icons.Default.Search,
+                modifier = Modifier.testTag("assetsManageAction"),
+                contentDescription = "asset_select",
                 onClick = onSearch,
-                Modifier.testTag("assetsManageAction")
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    tint = MaterialTheme.colorScheme.onSurface,
-                    contentDescription = "asset_select",
-                )
-            }
+            )
         }
     )
 }

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/ConnectionsScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/ConnectionsScene.kt
@@ -83,7 +83,7 @@ fun ConnectionsScene(
             ) {
                 Icon(imageVector = Icons.Default.ContentPaste, contentDescription = "paste_uri")
             }
-            IconButton(onClick = { scannerShowed  = true }) {
+            IconButton(onClick = { scannerShowed = true }) {
                 Icon(imageVector = Icons.Default.QrCodeScanner, contentDescription = "scan_qr")
             }
             IconButton(onClick = { uriHandler.open(context, Config().getDocsUrl(DocsUrl.WalletConnect)) }) {

--- a/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftDetailsScene.kt
+++ b/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftDetailsScene.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowUpward
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -19,6 +17,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.buttons.ToolbarIconButton
 import com.gemwallet.android.ui.components.image.AsyncImage
 import com.gemwallet.android.ui.components.list_item.SubheaderItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
@@ -53,9 +52,11 @@ fun NFTDetailsScene(
         title = model.assetName,
         actions = {
             if (assetData?.asset?.chain == Chain.Ethereum) {
-                IconButton( { onRecipient(AssetId(model.asset.chain), model.asset.id) } ) {
-                    Icon(Icons.Default.ArrowUpward, contentDescription = "Send nft")
-                }
+                ToolbarIconButton(
+                    imageVector = Icons.Default.ArrowUpward,
+                    contentDescription = "Send nft",
+                    onClick = { onRecipient(AssetId(model.asset.chain), model.asset.id) },
+                )
             }
         },
         onClose = { cancelAction() },

--- a/android/features/receive/presents/src/main/kotlin/com/gemwallet/android/features/receive/presents/ReceiveScreen.kt
+++ b/android/features/receive/presents/src/main/kotlin/com/gemwallet/android/features/receive/presents/ReceiveScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -44,6 +43,7 @@ import com.gemwallet.android.ext.type
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.components.buttons.ToolbarIconButton
 import com.gemwallet.android.ui.components.clickable
 import com.gemwallet.android.ui.components.clipboard.setPlainText
 import com.gemwallet.android.ui.components.list_head.CenteredListHead
@@ -105,9 +105,7 @@ private fun ReceiveScene(
         title = stringResource(id = R.string.receive_title, ""),
         onClose = onCancel,
         actions = {
-            IconButton(onShare) {
-                Icon(Icons.Default.Share, "")
-            }
+            ToolbarIconButton(imageVector = Icons.Default.Share, onClick = onShare)
         },
         mainAction = {
             MainActionButton(onClick = onCopyClick) {

--- a/android/features/settings/networks/presents/src/main/kotlin/com/gemwallet/android/features/settings/networks/presents/NetworkScene.kt
+++ b/android/features/settings/networks/presents/src/main/kotlin/com/gemwallet/android/features/settings/networks/presents/NetworkScene.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
@@ -29,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import com.gemwallet.android.ext.asset
 import com.gemwallet.android.model.NodeStatus
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.buttons.ToolbarIconButton
 import com.gemwallet.android.ui.components.list_item.ListItem
 import com.gemwallet.android.ui.components.list_item.ListItemTitleText
 import com.gemwallet.android.ui.components.list_item.SelectionCheckmark
@@ -58,9 +57,7 @@ fun NetworkScene(
         title = chain.asset().name,
         actions = {
             if (state.availableAddNode) {
-                IconButton(onClick = { isShowAddSource = true }) {
-                    Icon(imageVector = Icons.Default.Add, contentDescription = "")
-                }
+                ToolbarIconButton(imageVector = Icons.Default.Add, onClick = { isShowAddSource = true })
             }
         },
         onClose = onCancel,

--- a/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertScene.kt
+++ b/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertScene.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -42,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import com.gemwallet.android.domains.pricealerts.aggregates.PriceAlertDataAggregate
 import com.gemwallet.android.domains.pricealerts.aggregates.PriceAlertType
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.buttons.ToolbarIconButton
 import com.gemwallet.android.ui.components.image.AssetIcon
 import com.gemwallet.android.ui.components.list_item.ActionIcon
 import com.gemwallet.android.ui.components.list_item.Badge
@@ -80,11 +80,12 @@ fun PriceAlertScene(
     Scene(
         title = stringResource(R.string.settings_price_alerts_title),
         actions = @Composable {
-            IconButton(onClick = if (assetId == null) onAdd else {
-                { onAddTarget(assetId) }
-            }) {
-                Icon(imageVector = Icons.Default.Add, contentDescription = "")
-            }
+            ToolbarIconButton(
+                imageVector = Icons.Default.Add,
+                onClick = if (assetId == null) onAdd else {
+                    { onAddTarget(assetId) }
+                },
+            )
         },
         onClose = onCancel
     ) {

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/QRScanner.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/QRScanner.kt
@@ -21,8 +21,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -54,6 +52,8 @@ import coil3.compose.AsyncImage
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import com.gemwallet.android.ui.R
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.theme.alpha70
 import com.gemwallet.android.ui.theme.defaultPadding

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/buttons/ToolbarIconButton.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/buttons/ToolbarIconButton.kt
@@ -1,0 +1,106 @@
+package com.gemwallet.android.ui.components.buttons
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.gemwallet.android.ui.theme.compactIconSize
+import com.gemwallet.android.ui.theme.paddingDefault
+import com.gemwallet.android.ui.theme.space12
+import com.gemwallet.android.ui.theme.toolbarButtonSize
+import com.gemwallet.android.ui.theme.WalletTheme
+
+@Composable
+fun ToolbarIconButton(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    enabled: Boolean = true,
+    tint: Color? = null,
+    onClick: () -> Unit,
+) {
+    FilledIconButton(
+        modifier = modifier.size(toolbarButtonSize),
+        onClick = onClick,
+        enabled = enabled,
+        colors = IconButtonDefaults.filledIconButtonColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            contentColor = tint ?: MaterialTheme.colorScheme.onSurface,
+            disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.5f),
+            disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+        ),
+    ) {
+        Icon(
+            modifier = Modifier.size(compactIconSize),
+            imageVector = imageVector,
+            contentDescription = contentDescription,
+        )
+    }
+}
+
+@Composable
+fun ToolbarCloseButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    ToolbarIconButton(
+        modifier = modifier,
+        imageVector = Icons.Default.Close,
+        onClick = onClick,
+    )
+}
+
+@Composable
+fun ToolbarCheckmarkButton(
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    ToolbarIconButton(
+        modifier = modifier,
+        imageVector = Icons.Default.Check,
+        enabled = enabled,
+        onClick = onClick,
+    )
+}
+
+@Preview(showBackground = true, name = "Toolbar Buttons - Light")
+@Composable
+private fun ToolbarButtonsLightPreview() {
+    WalletTheme(darkTheme = false) {
+        Row(
+            modifier = Modifier.padding(paddingDefault),
+            horizontalArrangement = Arrangement.spacedBy(space12),
+        ) {
+            ToolbarCheckmarkButton(onClick = {})
+            ToolbarCloseButton(onClick = {})
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF1A191A, name = "Toolbar Buttons - Dark")
+@Composable
+private fun ToolbarButtonsDarkPreview() {
+    WalletTheme(darkTheme = true) {
+        Row(
+            modifier = Modifier.padding(paddingDefault),
+            horizontalArrangement = Arrangement.spacedBy(space12),
+        ) {
+            ToolbarCheckmarkButton(onClick = {})
+            ToolbarCloseButton(onClick = {})
+        }
+    }
+}

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/Scene.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/Scene.kt
@@ -15,11 +15,8 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -32,6 +29,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.gemwallet.android.ui.components.buttons.ToolbarCloseButton
+import com.gemwallet.android.ui.components.buttons.ToolbarIconButton
 import com.gemwallet.android.ui.theme.SceneSizing
 import com.gemwallet.android.ui.theme.Spacer16
 import com.gemwallet.android.ui.theme.isSmallScreen
@@ -107,10 +106,12 @@ fun Scene(
                     title = titleContent,
                     navigationIcon = {
                         if (onClose != null) {
-                            IconButton(onClick = onClose) {
-                                Icon(
-                                    imageVector = if (closeIcon) Icons.Default.Close else Icons.AutoMirrored.Filled.ArrowBack,
-                                    contentDescription = null,
+                            if (closeIcon) {
+                                ToolbarCloseButton(onClick = onClose)
+                            } else {
+                                ToolbarIconButton(
+                                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                    onClick = onClose,
                                 )
                             }
                         }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/theme/paddings.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/theme/paddings.kt
@@ -18,6 +18,7 @@ val tinyIconSize = 16.dp
 val listItemIconSize = 44.dp
 val headerLargeImageSize = 128.dp
 val iconSize = 32.dp
+val toolbarButtonSize = 36.dp
 
 val space0 = 0.dp
 val space2 = 2.dp


### PR DESCRIPTION
Replace plain IconButton with ToolbarIconButton/ToolbarCloseButton across all toolbar actions and navigation for consistent circular filled button style. Add tint parameter for conditional coloring. ConnectionsScene keeps standard IconButton due to multiple actions.



<img width="320" alt="Screenshot_20260401_190322" src="https://github.com/user-attachments/assets/3f2cd38c-d543-4a9e-a2ba-93c8d4290a55" />
