### PR TITLE
Fix onboarding warning title to match iOS

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/PhraseAlert.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/PhraseAlert.kt
@@ -100,7 +100,7 @@ fun PhraseAlertDialog(
             )
             InfoBlock(
                 Emoji.warning,
-                R.string.secret_phrase_do_not_share_title,
+                R.string.onboarding_security_create_wallet_do_not_share_title,
                 R.string.onboarding_security_create_wallet_do_not_share_subtitle,
             )
             InfoBlock(


### PR DESCRIPTION
<img width="320" alt="Screenshot_20260402_105949" src="https://github.com/user-attachments/assets/6d84251e-4085-4d07-b0c0-79697cd0e35f" />
