### PR TITLE
Fix empty assets on portfolio

### DIFF
--- a/ios/Features/WalletTab/Sources/Scenes/WalletPortfolioScene.swift
+++ b/ios/Features/WalletTab/Sources/Scenes/WalletPortfolioScene.swift
@@ -27,7 +27,9 @@ public struct WalletPortfolioScene: View {
             .navigationTitle(model.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbarDismissItem(type: .close, placement: .cancellationAction)
-            .bindQuery(model.assetsQuery)
+            .onChangeBindQuery(model.assetsQuery) { _, _ in
+                Task { await model.fetch() }
+            }
         }
     }
 }

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletPortfolioSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletPortfolioSceneViewModel.swift
@@ -70,6 +70,7 @@ public final class WalletPortfolioSceneViewModel: ChartListViewable {
 
 public extension WalletPortfolioSceneViewModel {
     func fetch() async {
+        guard assets.isNotEmpty else { return }
         state = .loading
         do {
             let rate = try priceService.getRate(currency: currencyCode)


### PR DESCRIPTION
Use .onChangeBindQuery in WalletPortfolioScene to call model.fetch() only when the assets query changes. Add an early return in WalletPortfolioSceneViewModel.fetch() (guard assets.isNotEmpty) to avoid triggering loading/network calls for empty portfolios. This reduces unnecessary fetches and avoids showing loading state when there are no assets.