### PR TITLE
Fetch portfolio via AssetStore and walletId

### DIFF
--- a/ios/Features/WalletTab/Sources/Scenes/WalletPortfolioScene.swift
+++ b/ios/Features/WalletTab/Sources/Scenes/WalletPortfolioScene.swift
@@ -3,7 +3,6 @@
 import Components
 import Localization
 import PrimitivesComponents
-import Store
 import SwiftUI
 
 public struct WalletPortfolioScene: View {
@@ -27,9 +26,6 @@ public struct WalletPortfolioScene: View {
             .navigationTitle(model.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbarDismissItem(type: .close, placement: .cancellationAction)
-            .onChangeBindQuery(model.assetsQuery) { _, _ in
-                Task { await model.fetch() }
-            }
         }
     }
 }

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletPortfolioSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletPortfolioSceneViewModel.swift
@@ -7,7 +7,6 @@ import Localization
 import PriceService
 import Primitives
 import PrimitivesComponents
-import Store
 
 @Observable
 @MainActor
@@ -22,8 +21,6 @@ public final class WalletPortfolioSceneViewModel: ChartListViewable {
     private let priceFormatter: CurrencyFormatter
     private let percentFormatter: CurrencyFormatter
 
-    public let assetsQuery: ObservableQuery<AssetsRequest>
-
     var state: StateViewType<WalletPortfolioData> = .loading
     public var selectedPeriod: ChartPeriod = .day
 
@@ -37,10 +34,6 @@ public final class WalletPortfolioSceneViewModel: ChartListViewable {
         self.priceService = priceService
         self.wallet = wallet
 
-        assetsQuery = ObservableQuery(
-            AssetsRequest(walletId: wallet.walletId, filters: [.enabledBalance, .hasBalance]),
-            initialValue: [],
-        )
         self.currencyCode = currencyCode
         currencyFormatter = CurrencyFormatter(type: .currency, currencyCode: currencyCode)
         priceFormatter = CurrencyFormatter(currencyCode: currencyCode)
@@ -48,11 +41,9 @@ public final class WalletPortfolioSceneViewModel: ChartListViewable {
     }
 
     var navigationTitle: String { Localized.Wallet.Portfolio.title }
-    private var assets: [AssetData] { assetsQuery.value }
 
     public var periods: [ChartPeriod] { [.day, .week, .month, .year, .all] }
     public var chartState: StateViewType<ChartValuesViewModel> {
-        guard assets.isNotEmpty else { return .noData }
         return state.map(\.chart)
     }
 
@@ -70,11 +61,10 @@ public final class WalletPortfolioSceneViewModel: ChartListViewable {
 
 public extension WalletPortfolioSceneViewModel {
     func fetch() async {
-        guard assets.isNotEmpty else { return }
         state = .loading
         do {
             let rate = try priceService.getRate(currency: currencyCode)
-            let portfolio = try await service.getPortfolioAssets(assets: assets, period: selectedPeriod)
+            let portfolio = try await service.getPortfolioAssets(walletId: wallet.walletId, period: selectedPeriod)
             let charts = portfolio.values.map {
                 ChartDateValue(date: Date(timeIntervalSince1970: TimeInterval($0.timestamp)), value: Double($0.value) * rate)
             }

--- a/ios/Gem/Services/ServicesFactory.swift
+++ b/ios/Gem/Services/ServicesFactory.swift
@@ -161,7 +161,7 @@ struct ServicesFactory {
             priceStore: storeManager.priceStore,
             fiatRateStore: storeManager.fiatRateStore,
         )
-        let portfolioService = PortfolioService(apiService: apiService)
+        let portfolioService = PortfolioService(apiService: apiService, assetStore: storeManager.assetStore)
         let perpetualService = Self.makePerpetualService(
             perpetualStore: storeManager.perpetualStore,
             assetStore: storeManager.assetStore,

--- a/ios/Packages/FeatureServices/PriceService/PortfolioService.swift
+++ b/ios/Packages/FeatureServices/PriceService/PortfolioService.swift
@@ -3,15 +3,19 @@
 import Foundation
 import GemAPI
 import Primitives
+import Store
 
 public struct PortfolioService: Sendable {
     private let apiService: any GemAPIPortfolioService
+    private let assetStore: AssetStore
 
-    public init(apiService: any GemAPIPortfolioService) {
+    public init(apiService: any GemAPIPortfolioService, assetStore: AssetStore) {
         self.apiService = apiService
+        self.assetStore = assetStore
     }
 
-    public func getPortfolioAssets(assets: [AssetData], period: ChartPeriod) async throws -> PortfolioAssets {
+    public func getPortfolioAssets(walletId: WalletId, period: ChartPeriod) async throws -> PortfolioAssets {
+        let assets = try assetStore.getAssetsData(walletId: walletId, filters: [.enabledBalance, .hasBalance])
         let portfolioAssets = assets.map { PortfolioAsset(assetId: $0.asset.id, value: String($0.balance.total)) }
         let request = PortfolioAssetsRequest(assets: portfolioAssets)
         return try await apiService.getPortfolioAssets(period: period, request: request)

--- a/ios/Packages/Store/Sources/Stores/AssetStore.swift
+++ b/ios/Packages/Store/Sources/Stores/AssetStore.swift
@@ -45,6 +45,12 @@ public struct AssetStore: Sendable {
         }
     }
 
+    public func getAssetsData(walletId: WalletId, filters: [AssetsRequestFilter]) throws -> [AssetData] {
+        try db.read { db in
+            try AssetsRequest(walletId: walletId, filters: filters).fetch(db)
+        }
+    }
+
     public func getAssets() throws -> [Asset] {
         try db.read { db in
             try AssetRecord


### PR DESCRIPTION
 - Move asset fetching into `PortfolioService` by injecting `AssetStore` — the service now handles DB query + API    
  call internally                              
  - Simplify `getPortfolioAssets` API to take only`(walletId, period)` instead of `([AssetData], period)`   
  - Remove `ObservableQuery` binding and  `.onChangeBindQuery` from `WalletPortfolioScene` —        
  `ChartListView` already triggers `fetch()` via `.task(id:selectedPeriod)`                                          