### PR TITLE
Extract coordinators for assets feature

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetHideBalancesStateImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetHideBalancesStateImpl.kt
@@ -1,0 +1,14 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
+import com.gemwallet.android.data.repositories.config.UserConfig
+import kotlinx.coroutines.flow.Flow
+
+class GetHideBalancesStateImpl(
+    private val userConfig: UserConfig,
+) : GetHideBalancesState {
+
+    override fun invoke(): Flow<Boolean> {
+        return userConfig.isHideBalances()
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetImportInProgressImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetImportInProgressImpl.kt
@@ -1,0 +1,28 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.GetImportInProgress
+import com.gemwallet.android.application.wallet_import.coordinators.GetImportWalletState
+import com.gemwallet.android.application.wallet_import.values.ImportWalletState
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.mapLatest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetImportInProgressImpl(
+    private val sessionRepository: SessionRepository,
+    private val getImportWalletState: GetImportWalletState,
+) : GetImportInProgress {
+
+    override fun invoke(): Flow<Boolean> {
+        return sessionRepository.session()
+            .filterNotNull()
+            .flatMapLatest { session ->
+                getImportWalletState
+                    .getImportState(session.wallet.id)
+                    .mapLatest { it == ImportWalletState.Importing }
+            }
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetShowWelcomeBannerImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetShowWelcomeBannerImpl.kt
@@ -1,0 +1,29 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.GetShowWelcomeBanner
+import com.gemwallet.android.data.repositories.config.UserConfig
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.wallet.core.primitives.WalletSource
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetShowWelcomeBannerImpl(
+    private val sessionRepository: SessionRepository,
+    private val userConfig: UserConfig,
+) : GetShowWelcomeBanner {
+
+    override fun invoke(isWalletEmpty: Flow<Boolean>): Flow<Boolean> {
+        return sessionRepository.session()
+            .filterNotNull()
+            .flatMapLatest { session ->
+                combine(isWalletEmpty, userConfig.isWelcomeBannerHidden(session.wallet.id)) { isEmpty, isHidden ->
+                    val created = session.wallet.source == WalletSource.Create
+                    isEmpty && created && !isHidden
+                }
+            }
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/HideAssetImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/HideAssetImpl.kt
@@ -1,0 +1,19 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.HideAsset
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.ext.getAccount
+import com.wallet.core.primitives.AssetId
+
+class HideAssetImpl(
+    private val sessionRepository: SessionRepository,
+    private val assetsRepository: AssetsRepository,
+) : HideAsset {
+
+    override suspend fun invoke(assetId: AssetId) {
+        val session = sessionRepository.session().value ?: return
+        val account = session.wallet.getAccount(assetId.chain) ?: return
+        assetsRepository.switchVisibility(session.wallet.id, account, assetId, false)
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/HideWelcomeBannerImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/HideWelcomeBannerImpl.kt
@@ -1,0 +1,16 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.HideWelcomeBanner
+import com.gemwallet.android.data.repositories.config.UserConfig
+import com.gemwallet.android.data.repositories.session.SessionRepository
+
+class HideWelcomeBannerImpl(
+    private val sessionRepository: SessionRepository,
+    private val userConfig: UserConfig,
+) : HideWelcomeBanner {
+
+    override suspend fun invoke() {
+        val walletId = sessionRepository.session().value?.wallet?.id ?: return
+        userConfig.hideWelcomeBanner(walletId)
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/SyncAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/SyncAssetsImpl.kt
@@ -1,0 +1,13 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.SyncAssets
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+
+class SyncAssetsImpl(
+    private val assetsRepository: AssetsRepository,
+) : SyncAssets {
+
+    override suspend fun invoke() {
+        assetsRepository.sync()
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/ToggleAssetPinImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/ToggleAssetPinImpl.kt
@@ -1,0 +1,17 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.wallet.core.primitives.AssetId
+
+class ToggleAssetPinImpl(
+    private val sessionRepository: SessionRepository,
+    private val assetsRepository: AssetsRepository,
+) : ToggleAssetPin {
+
+    override suspend fun invoke(assetId: AssetId) {
+        val session = sessionRepository.session().value ?: return
+        assetsRepository.togglePin(session.wallet.id, assetId)
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/ToggleHideBalancesImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/ToggleHideBalancesImpl.kt
@@ -1,0 +1,13 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.ToggleHideBalances
+import com.gemwallet.android.data.repositories.config.UserConfig
+
+class ToggleHideBalancesImpl(
+    private val userConfig: UserConfig,
+) : ToggleHideBalances {
+
+    override suspend fun invoke() {
+        userConfig.hideBalances()
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetModule.kt
@@ -1,18 +1,35 @@
 package com.gemwallet.android.data.coordinators.di
 
-import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
-import com.gemwallet.android.application.assets.coordinators.GetAssetChartData
 import com.gemwallet.android.application.assets.coordinators.GetActiveAssetsInfo
+import com.gemwallet.android.application.assets.coordinators.GetAssetChartData
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
+import com.gemwallet.android.application.assets.coordinators.GetImportInProgress
+import com.gemwallet.android.application.assets.coordinators.GetShowWelcomeBanner
+import com.gemwallet.android.application.assets.coordinators.GetWalletSummary
+import com.gemwallet.android.application.assets.coordinators.HideAsset
+import com.gemwallet.android.application.assets.coordinators.HideWelcomeBanner
+import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
 import com.gemwallet.android.application.assets.coordinators.SearchAssets
 import com.gemwallet.android.application.assets.coordinators.SyncAssetInfo
-import com.gemwallet.android.application.assets.coordinators.GetWalletSummary
+import com.gemwallet.android.application.assets.coordinators.SyncAssets
+import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
+import com.gemwallet.android.application.assets.coordinators.ToggleHideBalances
+import com.gemwallet.android.application.wallet_import.coordinators.GetImportWalletState
 import com.gemwallet.android.cases.banners.HasMultiSign
-import com.gemwallet.android.data.coordinators.asset.GetAssetChartDataImpl
-import com.gemwallet.android.data.coordinators.asset.PrefetchAssetsImpl
 import com.gemwallet.android.data.coordinators.asset.GetActiveAssetsInfoImpl
+import com.gemwallet.android.data.coordinators.asset.GetAssetChartDataImpl
+import com.gemwallet.android.data.coordinators.asset.GetHideBalancesStateImpl
+import com.gemwallet.android.data.coordinators.asset.GetImportInProgressImpl
+import com.gemwallet.android.data.coordinators.asset.GetShowWelcomeBannerImpl
 import com.gemwallet.android.data.coordinators.asset.GetWalletSummaryImpl
+import com.gemwallet.android.data.coordinators.asset.HideAssetImpl
+import com.gemwallet.android.data.coordinators.asset.HideWelcomeBannerImpl
+import com.gemwallet.android.data.coordinators.asset.PrefetchAssetsImpl
 import com.gemwallet.android.data.coordinators.asset.SearchAssetsImpl
 import com.gemwallet.android.data.coordinators.asset.SyncAssetInfoImpl
+import com.gemwallet.android.data.coordinators.asset.SyncAssetsImpl
+import com.gemwallet.android.data.coordinators.asset.ToggleAssetPinImpl
+import com.gemwallet.android.data.coordinators.asset.ToggleHideBalancesImpl
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.config.UserConfig
 import com.gemwallet.android.data.repositories.session.SessionRepository
@@ -85,4 +102,57 @@ object AssetModule {
         assetsRepository = assetsRepository,
         streamSubscriptionService = streamSubscriptionService,
     )
+
+    @Provides
+    @Singleton
+    fun provideSyncAssets(
+        assetsRepository: AssetsRepository,
+    ): SyncAssets = SyncAssetsImpl(assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideHideAsset(
+        sessionRepository: SessionRepository,
+        assetsRepository: AssetsRepository,
+    ): HideAsset = HideAssetImpl(sessionRepository, assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideToggleAssetPin(
+        sessionRepository: SessionRepository,
+        assetsRepository: AssetsRepository,
+    ): ToggleAssetPin = ToggleAssetPinImpl(sessionRepository, assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideGetShowWelcomeBanner(
+        sessionRepository: SessionRepository,
+        userConfig: UserConfig,
+    ): GetShowWelcomeBanner = GetShowWelcomeBannerImpl(sessionRepository, userConfig)
+
+    @Provides
+    @Singleton
+    fun provideHideWelcomeBanner(
+        sessionRepository: SessionRepository,
+        userConfig: UserConfig,
+    ): HideWelcomeBanner = HideWelcomeBannerImpl(sessionRepository, userConfig)
+
+    @Provides
+    @Singleton
+    fun provideGetHideBalancesState(
+        userConfig: UserConfig,
+    ): GetHideBalancesState = GetHideBalancesStateImpl(userConfig)
+
+    @Provides
+    @Singleton
+    fun provideToggleHideBalances(
+        userConfig: UserConfig,
+    ): ToggleHideBalances = ToggleHideBalancesImpl(userConfig)
+
+    @Provides
+    @Singleton
+    fun provideGetImportInProgress(
+        sessionRepository: SessionRepository,
+        getImportWalletState: GetImportWalletState,
+    ): GetImportInProgress = GetImportInProgressImpl(sessionRepository, getImportWalletState)
 }

--- a/android/features/assets/viewmodels/build.gradle.kts
+++ b/android/features/assets/viewmodels/build.gradle.kts
@@ -50,7 +50,6 @@ android {
 dependencies {
     api(project(":ui-models"))
     implementation(project(":ui"))
-    implementation(project(":data:repositories"))
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsViewModel.kt
+++ b/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsViewModel.kt
@@ -3,30 +3,28 @@ package com.gemwallet.android.features.assets.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.assets.coordinators.GetActiveAssetsInfo
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
+import com.gemwallet.android.application.assets.coordinators.GetImportInProgress
+import com.gemwallet.android.application.assets.coordinators.GetShowWelcomeBanner
 import com.gemwallet.android.application.assets.coordinators.GetWalletSummary
-import com.gemwallet.android.application.wallet_import.coordinators.GetImportWalletState
-import com.gemwallet.android.application.wallet_import.values.ImportWalletState
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.config.UserConfig
-import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.application.assets.coordinators.HideAsset
+import com.gemwallet.android.application.assets.coordinators.HideWelcomeBanner
+import com.gemwallet.android.application.assets.coordinators.SyncAssets
+import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
+import com.gemwallet.android.application.assets.coordinators.ToggleHideBalances
 import com.gemwallet.android.domains.asset.aggregates.AssetInfoDataAggregate
-import com.gemwallet.android.ext.getAccount
 import com.gemwallet.android.model.SyncState
 import com.wallet.core.primitives.AssetId
-import com.wallet.core.primitives.WalletSource
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -35,28 +33,24 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class AssetsViewModel @Inject constructor(
-    sessionRepository: SessionRepository,
-    private val assetsRepository: AssetsRepository,
-    private val userConfig: UserConfig,
-    private val getImportWalletState: GetImportWalletState,
+    private val syncAssets: SyncAssets,
+    private val hideAsset: HideAsset,
+    private val toggleAssetPin: ToggleAssetPin,
+    private val toggleHideBalances: ToggleHideBalances,
+    private val hideWelcomeBanner: HideWelcomeBanner,
+    getImportInProgress: GetImportInProgress,
     getActiveAssetsInfo: GetActiveAssetsInfo,
     getWalletSummary: GetWalletSummary,
+    getHideBalancesState: GetHideBalancesState,
+    getShowWelcomeBanner: GetShowWelcomeBanner,
 ) : ViewModel() {
-
-    private val session = sessionRepository.session()
 
     private data class AssetGroups(
         val pinned: List<AssetInfoDataAggregate> = emptyList(),
         val unpinned: List<AssetInfoDataAggregate> = emptyList(),
     )
 
-    val importInProgress = session
-        .filterNotNull()
-        .flatMapLatest { session ->
-            getImportWalletState
-                .getImportState(session.wallet.id)
-                .mapLatest { it == ImportWalletState.Importing }
-        }
+    val importInProgress = getImportInProgress()
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     val refreshingState = MutableStateFlow<RefreshingState>(RefreshingState.OnOpen)
@@ -76,7 +70,7 @@ class AssetsViewModel @Inject constructor(
         .map { it == SyncState.InSync }
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
-    private val isHideBalances = userConfig.isHideBalances()
+    private val isHideBalances = getHideBalancesState()
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     private val assetGroups = getActiveAssetsInfo.getAssetsInfo(isHideBalances)
@@ -108,44 +102,32 @@ class AssetsViewModel @Inject constructor(
     val walletSummary = getWalletSummary.getWalletSummary()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    val showWelcomeBanner = session
-        .filterNotNull()
-        .flatMapLatest { session ->
-            combine(isWalletEmpty, userConfig.isWelcomeBannerHidden(session.wallet.id)) { isWalletEmpty, isWelcomeBannerHidden ->
-                val created = session.wallet.source == WalletSource.Create
-                isWalletEmpty && created && !isWelcomeBannerHidden
-            }
-        }
+    val showWelcomeBanner = getShowWelcomeBanner(isWalletEmpty)
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     fun onRefresh() {
-        session.value?.let { session ->
-            refreshingState.update { RefreshingState.OnForce }
-            updateAssetData()
-        }
+        refreshingState.update { RefreshingState.OnForce }
+        updateAssetData()
     }
 
     private fun updateAssetData() = viewModelScope.launch(Dispatchers.IO) {
-        assetsRepository.sync()
+        syncAssets()
     }
 
     fun hideAsset(assetId: AssetId) = viewModelScope.launch {
-        val session = session.value ?: return@launch
-        val account = session.wallet.getAccount(assetId.chain) ?: return@launch
-        assetsRepository.switchVisibility(session.wallet.id, account, assetId, false)
+        hideAsset.invoke(assetId)
     }
 
     fun togglePin(assetId: AssetId) = viewModelScope.launch {
-        val session = session.value ?: return@launch
-        assetsRepository.togglePin(session.wallet.id, assetId)
+        toggleAssetPin(assetId)
     }
 
     fun hideBalances() = viewModelScope.launch {
-        userConfig.hideBalances()
+        toggleHideBalances()
     }
 
     fun onHideWelcomeBanner() = viewModelScope.launch {
-        userConfig.hideWelcomeBanner(session.value?.wallet?.id ?: return@launch)
+        hideWelcomeBanner()
     }
 
     enum class RefreshingState {

--- a/android/features/assets/viewmodels/src/test/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsViewModelTest.kt
+++ b/android/features/assets/viewmodels/src/test/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsViewModelTest.kt
@@ -1,26 +1,25 @@
 package com.gemwallet.android.features.assets.viewmodels
 
 import com.gemwallet.android.application.assets.coordinators.GetActiveAssetsInfo
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
+import com.gemwallet.android.application.assets.coordinators.GetImportInProgress
+import com.gemwallet.android.application.assets.coordinators.GetShowWelcomeBanner
 import com.gemwallet.android.application.assets.coordinators.GetWalletSummary
-import com.gemwallet.android.application.wallet_import.coordinators.GetImportWalletState
-import com.gemwallet.android.application.wallet_import.values.ImportWalletState
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.config.UserConfig
-import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.application.assets.coordinators.HideAsset
+import com.gemwallet.android.application.assets.coordinators.HideWelcomeBanner
+import com.gemwallet.android.application.assets.coordinators.SyncAssets
+import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
+import com.gemwallet.android.application.assets.coordinators.ToggleHideBalances
 import com.gemwallet.android.domains.asset.aggregates.AssetInfoDataAggregate
-import com.gemwallet.android.model.Session
-import com.gemwallet.android.testkit.mockAccount
 import com.gemwallet.android.testkit.mockAsset
-import com.gemwallet.android.testkit.mockWallet
 import com.wallet.core.primitives.Chain
-import com.wallet.core.primitives.Currency
-import com.wallet.core.primitives.WalletSource
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -37,15 +36,6 @@ import org.junit.Test
 class AssetsViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
-    private val wallet = mockWallet(
-        id = "wallet-id",
-        accounts = listOf(mockAccount(Chain.Solana)),
-        source = WalletSource.Create,
-    )
-    private val sessionFlow = MutableStateFlow<Session?>(Session(wallet, Currency.USD))
-    private val hideBalancesFlow = MutableStateFlow(false)
-    private val welcomeBannerHiddenFlow = MutableStateFlow(false)
-    private val importStateFlow = MutableStateFlow(ImportWalletState.Complete)
     private val activeAssetsFlow = MutableStateFlow(
         listOf(
             assetAggregate(chain = Chain.Solana, symbol = "SOL", pinned = true),
@@ -53,22 +43,27 @@ class AssetsViewModelTest {
         )
     )
 
-    private val sessionRepository = mockk<SessionRepository>(relaxed = true) {
-        every { session() } returns sessionFlow
-    }
-    private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
-    private val userConfig = mockk<UserConfig>(relaxed = true) {
-        every { isHideBalances() } returns hideBalancesFlow
-        every { isWelcomeBannerHidden(wallet.id) } returns welcomeBannerHiddenFlow
-    }
-    private val getImportWalletState = mockk<GetImportWalletState>(relaxed = true) {
-        every { getImportState(wallet.id) } returns importStateFlow
+    private val syncAssets = mockk<SyncAssets>(relaxed = true)
+    private val hideAsset = mockk<HideAsset>(relaxed = true)
+    private val toggleAssetPin = mockk<ToggleAssetPin>(relaxed = true)
+    private val toggleHideBalances = mockk<ToggleHideBalances>(relaxed = true)
+    private val hideWelcomeBanner = mockk<HideWelcomeBanner>(relaxed = true)
+    private val getImportInProgress = object : GetImportInProgress {
+        override fun invoke(): Flow<Boolean> = flowOf(false)
     }
     private val getActiveAssetsInfo = object : GetActiveAssetsInfo {
         override fun getAssetsInfo(hideBalance: Boolean): Flow<List<AssetInfoDataAggregate>> = activeAssetsFlow
     }
     private val getWalletSummary = mockk<GetWalletSummary>(relaxed = true) {
         every { getWalletSummary() } returns flowOf(null)
+    }
+    private val getHideBalancesState = object : GetHideBalancesState {
+        override fun invoke(): Flow<Boolean> = flowOf(false)
+    }
+    private val getShowWelcomeBanner = object : GetShowWelcomeBanner {
+        override fun invoke(isWalletEmpty: Flow<Boolean>): Flow<Boolean> {
+            return isWalletEmpty.combine(flowOf(true)) { isEmpty, _ -> isEmpty }
+        }
     }
 
     @Before
@@ -102,12 +97,16 @@ class AssetsViewModelTest {
     }
 
     private fun createViewModel() = AssetsViewModel(
-        sessionRepository = sessionRepository,
-        assetsRepository = assetsRepository,
-        userConfig = userConfig,
-        getImportWalletState = getImportWalletState,
+        syncAssets = syncAssets,
+        hideAsset = hideAsset,
+        toggleAssetPin = toggleAssetPin,
+        toggleHideBalances = toggleHideBalances,
+        hideWelcomeBanner = hideWelcomeBanner,
+        getImportInProgress = getImportInProgress,
         getActiveAssetsInfo = getActiveAssetsInfo,
         getWalletSummary = getWalletSummary,
+        getHideBalancesState = getHideBalancesState,
+        getShowWelcomeBanner = getShowWelcomeBanner,
     )
 
     private fun assetAggregate(

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetHideBalancesState.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetHideBalancesState.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.assets.coordinators
+
+import kotlinx.coroutines.flow.Flow
+
+interface GetHideBalancesState {
+    operator fun invoke(): Flow<Boolean>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetImportInProgress.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetImportInProgress.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.assets.coordinators
+
+import kotlinx.coroutines.flow.Flow
+
+interface GetImportInProgress {
+    operator fun invoke(): Flow<Boolean>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetShowWelcomeBanner.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetShowWelcomeBanner.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.assets.coordinators
+
+import kotlinx.coroutines.flow.Flow
+
+interface GetShowWelcomeBanner {
+    operator fun invoke(isWalletEmpty: Flow<Boolean>): Flow<Boolean>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/HideAsset.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/HideAsset.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.assets.coordinators
+
+import com.wallet.core.primitives.AssetId
+
+interface HideAsset {
+    suspend operator fun invoke(assetId: AssetId)
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/HideWelcomeBanner.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/HideWelcomeBanner.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.application.assets.coordinators
+
+interface HideWelcomeBanner {
+    suspend operator fun invoke()
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/SyncAssets.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/SyncAssets.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.application.assets.coordinators
+
+interface SyncAssets {
+    suspend operator fun invoke()
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/ToggleAssetPin.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/ToggleAssetPin.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.assets.coordinators
+
+import com.wallet.core.primitives.AssetId
+
+interface ToggleAssetPin {
+    suspend operator fun invoke(assetId: AssetId)
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/ToggleHideBalances.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/ToggleHideBalances.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.application.assets.coordinators
+
+interface ToggleHideBalances {
+    suspend operator fun invoke()
+}


### PR DESCRIPTION
Extract remaining coordinator interfaces and implementations for AssetsViewModel. Remove `:data:repositories` dependency from assets viewmodel module.

Closes gemwalletcom/gem-android-issues#12

- [x] Test