### PR TITLE
Organize feature/asset_select

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/GetRecentAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/GetRecentAssetsImpl.kt
@@ -9,6 +9,6 @@ import kotlinx.coroutines.flow.Flow
 class GetRecentAssetsImpl(
     private val assetsRepository: AssetsRepository,
 ) : GetRecentAssets {
-    override fun getRecentActivities(types: List<RecentType>): Flow<List<AssetInfo>> =
+    override fun invoke(types: List<RecentType>): Flow<List<AssetInfo>> =
         assetsRepository.getRecentActivities(types)
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/GetRecentAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/GetRecentAssetsImpl.kt
@@ -1,0 +1,14 @@
+package com.gemwallet.android.data.coordinators.asset_select
+
+import com.gemwallet.android.application.asset_select.coordinators.GetRecentAssets
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.model.AssetInfo
+import com.gemwallet.android.model.RecentType
+import kotlinx.coroutines.flow.Flow
+
+class GetRecentAssetsImpl(
+    private val assetsRepository: AssetsRepository,
+) : GetRecentAssets {
+    override fun getRecentActivities(types: List<RecentType>): Flow<List<AssetInfo>> =
+        assetsRepository.getRecentActivities(types)
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/GetSelectAssetsInfoImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/GetSelectAssetsInfoImpl.kt
@@ -8,5 +8,5 @@ import kotlinx.coroutines.flow.Flow
 class GetSelectAssetsInfoImpl(
     private val assetsRepository: AssetsRepository,
 ) : GetSelectAssetsInfo {
-    override fun getAssetsInfo(): Flow<List<AssetInfo>> = assetsRepository.getAssetsInfo()
+    override fun invoke(): Flow<List<AssetInfo>> = assetsRepository.getAssetsInfo()
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/GetSelectAssetsInfoImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/GetSelectAssetsInfoImpl.kt
@@ -1,0 +1,12 @@
+package com.gemwallet.android.data.coordinators.asset_select
+
+import com.gemwallet.android.application.asset_select.coordinators.GetSelectAssetsInfo
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.model.AssetInfo
+import kotlinx.coroutines.flow.Flow
+
+class GetSelectAssetsInfoImpl(
+    private val assetsRepository: AssetsRepository,
+) : GetSelectAssetsInfo {
+    override fun getAssetsInfo(): Flow<List<AssetInfo>> = assetsRepository.getAssetsInfo()
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SearchSelectAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SearchSelectAssetsImpl.kt
@@ -9,6 +9,6 @@ import kotlinx.coroutines.flow.Flow
 class SearchSelectAssetsImpl(
     private val assetsRepository: AssetsRepository,
 ) : SearchSelectAssets {
-    override fun search(query: String, tags: List<AssetTag>): Flow<List<AssetInfo>> =
+    override fun invoke(query: String, tags: List<AssetTag>): Flow<List<AssetInfo>> =
         assetsRepository.search(query, tags, false)
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SearchSelectAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SearchSelectAssetsImpl.kt
@@ -1,0 +1,14 @@
+package com.gemwallet.android.data.coordinators.asset_select
+
+import com.gemwallet.android.application.asset_select.coordinators.SearchSelectAssets
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.model.AssetInfo
+import com.wallet.core.primitives.AssetTag
+import kotlinx.coroutines.flow.Flow
+
+class SearchSelectAssetsImpl(
+    private val assetsRepository: AssetsRepository,
+) : SearchSelectAssets {
+    override fun search(query: String, tags: List<AssetTag>): Flow<List<AssetInfo>> =
+        assetsRepository.search(query, tags, false)
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SwitchAssetVisibilityImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SwitchAssetVisibilityImpl.kt
@@ -1,0 +1,13 @@
+package com.gemwallet.android.data.coordinators.asset_select
+
+import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.wallet.core.primitives.Account
+import com.wallet.core.primitives.AssetId
+
+class SwitchAssetVisibilityImpl(
+    private val assetsRepository: AssetsRepository,
+) : SwitchAssetVisibility {
+    override suspend fun switchVisibility(walletId: String, account: Account, assetId: AssetId, visible: Boolean) =
+        assetsRepository.switchVisibility(walletId, account, assetId, visible)
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SwitchAssetVisibilityImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SwitchAssetVisibilityImpl.kt
@@ -8,6 +8,6 @@ import com.wallet.core.primitives.AssetId
 class SwitchAssetVisibilityImpl(
     private val assetsRepository: AssetsRepository,
 ) : SwitchAssetVisibility {
-    override suspend fun switchVisibility(walletId: String, account: Account, assetId: AssetId, visible: Boolean) =
+    override suspend fun invoke(walletId: String, account: Account, assetId: AssetId, visible: Boolean) =
         assetsRepository.switchVisibility(walletId, account, assetId, visible)
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/ToggleAssetPinImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/ToggleAssetPinImpl.kt
@@ -7,7 +7,7 @@ import com.wallet.core.primitives.AssetId
 class ToggleAssetPinImpl(
     private val assetsRepository: AssetsRepository,
 ) : ToggleAssetPin {
-    override suspend fun togglePin(walletId: String, assetId: AssetId) {
+    override suspend fun invoke(walletId: String, assetId: AssetId) {
         assetsRepository.togglePin(walletId, assetId)
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/ToggleAssetPinImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/ToggleAssetPinImpl.kt
@@ -1,0 +1,13 @@
+package com.gemwallet.android.data.coordinators.asset_select
+
+import com.gemwallet.android.application.asset_select.coordinators.ToggleAssetPin
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.wallet.core.primitives.AssetId
+
+class ToggleAssetPinImpl(
+    private val assetsRepository: AssetsRepository,
+) : ToggleAssetPin {
+    override suspend fun togglePin(walletId: String, assetId: AssetId) {
+        assetsRepository.togglePin(walletId, assetId)
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetSelectModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetSelectModule.kt
@@ -1,0 +1,53 @@
+package com.gemwallet.android.data.coordinators.di
+
+import com.gemwallet.android.application.asset_select.coordinators.GetRecentAssets
+import com.gemwallet.android.application.asset_select.coordinators.GetSelectAssetsInfo
+import com.gemwallet.android.application.asset_select.coordinators.SearchSelectAssets
+import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.application.asset_select.coordinators.ToggleAssetPin
+import com.gemwallet.android.data.coordinators.asset_select.GetRecentAssetsImpl
+import com.gemwallet.android.data.coordinators.asset_select.GetSelectAssetsInfoImpl
+import com.gemwallet.android.data.coordinators.asset_select.SearchSelectAssetsImpl
+import com.gemwallet.android.data.coordinators.asset_select.SwitchAssetVisibilityImpl
+import com.gemwallet.android.data.coordinators.asset_select.ToggleAssetPinImpl
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object AssetSelectModule {
+
+    @Provides
+    @Singleton
+    fun provideSearchSelectAssets(
+        assetsRepository: AssetsRepository,
+    ): SearchSelectAssets = SearchSelectAssetsImpl(assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideGetSelectAssetsInfo(
+        assetsRepository: AssetsRepository,
+    ): GetSelectAssetsInfo = GetSelectAssetsInfoImpl(assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideGetRecentAssets(
+        assetsRepository: AssetsRepository,
+    ): GetRecentAssets = GetRecentAssetsImpl(assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideSwitchAssetVisibility(
+        assetsRepository: AssetsRepository,
+    ): SwitchAssetVisibility = SwitchAssetVisibilityImpl(assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideToggleAssetPin(
+        assetsRepository: AssetsRepository,
+    ): ToggleAssetPin = ToggleAssetPinImpl(assetsRepository)
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/SessionModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/SessionModule.kt
@@ -1,7 +1,9 @@
 package com.gemwallet.android.data.coordinators.di
 
+import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.application.session.coordinators.SetCurrentCurrency
 import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.data.coordinators.session.GetSessionImpl
 import com.gemwallet.android.data.coordinators.session.SetCurrentCurrencyImpl
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import dagger.Module
@@ -13,6 +15,12 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 @Module
 object SessionModule {
+
+    @Provides
+    @Singleton
+    fun provideGetSession(
+        sessionRepository: SessionRepository,
+    ): GetSession = GetSessionImpl(sessionRepository)
 
     @Provides
     @Singleton

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/session/GetSessionImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/session/GetSessionImpl.kt
@@ -8,5 +8,5 @@ import kotlinx.coroutines.flow.StateFlow
 class GetSessionImpl(
     private val sessionRepository: SessionRepository,
 ) : GetSession {
-    override fun getSession(): StateFlow<Session?> = sessionRepository.session()
+    override fun invoke(): StateFlow<Session?> = sessionRepository.session()
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/session/GetSessionImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/session/GetSessionImpl.kt
@@ -1,0 +1,12 @@
+package com.gemwallet.android.data.coordinators.session
+
+import com.gemwallet.android.application.session.coordinators.GetSession
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.model.Session
+import kotlinx.coroutines.flow.StateFlow
+
+class GetSessionImpl(
+    private val sessionRepository: SessionRepository,
+) : GetSession {
+    override fun getSession(): StateFlow<Session?> = sessionRepository.session()
+}

--- a/android/features/asset_select/viewmodels/build.gradle.kts
+++ b/android/features/asset_select/viewmodels/build.gradle.kts
@@ -50,7 +50,6 @@ android {
 dependencies {
     api(project(":ui-models"))
     implementation(project(":ui"))
-    implementation(project(":data:repositories"))
 
     implementation(libs.ktx.core)
     implementation(libs.lifecycle.runtime.ktx)

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/AssetSelectViewModel.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/AssetSelectViewModel.kt
@@ -1,8 +1,11 @@
 package com.gemwallet.android.features.asset_select.viewmodels
 
+import com.gemwallet.android.application.asset_select.coordinators.GetRecentAssets
+import com.gemwallet.android.application.asset_select.coordinators.SearchSelectAssets
+import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.application.asset_select.coordinators.ToggleAssetPin
+import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.cases.tokens.SearchTokensCase
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.features.asset_select.viewmodels.models.BaseSelectSearch
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -11,12 +14,17 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class AssetSelectViewModel @Inject constructor(
-    sessionRepository: SessionRepository,
-    assetsRepository: AssetsRepository,
+    getSession: GetSession,
+    searchSelectAssets: SearchSelectAssets,
+    getRecentAssets: GetRecentAssets,
+    switchAssetVisibility: SwitchAssetVisibility,
+    toggleAssetPin: ToggleAssetPin,
     searchTokensCase: SearchTokensCase,
 ) : BaseAssetSelectViewModel(
-    sessionRepository,
-    assetsRepository,
+    getSession,
+    getRecentAssets,
+    switchAssetVisibility,
+    toggleAssetPin,
     searchTokensCase,
-    BaseSelectSearch(assetsRepository)
+    BaseSelectSearch(searchSelectAssets),
 )

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/BaseAssetSelectViewModel.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/BaseAssetSelectViewModel.kt
@@ -56,7 +56,7 @@ open class BaseAssetSelectViewModel(
     val chainFilter = MutableStateFlow<List<Chain>>(emptyList())
     val balanceFilter = MutableStateFlow(false)
 
-    private val session = getSession.getSession()
+    private val session = getSession()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     private val searchState = MutableStateFlow(SearchState.Init)
@@ -145,7 +145,7 @@ open class BaseAssetSelectViewModel(
         val balanceFilter = filters.hasBalance
         val hasChainFilter = chainFilter.isNotEmpty()
 
-        getRecentAssets.getRecentActivities(RecentType.entries).map { items ->
+        getRecentAssets(RecentType.entries).map { items ->
             items.filter {
                 (!hasChainFilter || chainFilter.contains(it.id().chain))
                         && (!balanceFilter || it.balance.totalAmount > 0.0)
@@ -166,21 +166,21 @@ open class BaseAssetSelectViewModel(
     }
     .stateIn(viewModelScope, SharingStarted.Eagerly, UIState.Idle)
 
-    val isAddAssetAvailable = getSession.getSession().map { session ->
+    val isAddAssetAvailable = getSession().map { session ->
         session?.wallet?.accounts?.any { it.chain.assetType() != null } == true
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     fun onChangeVisibility(assetId: AssetId, visible: Boolean) = viewModelScope.launch {
         val session = session.value ?: return@launch
         val account = session.wallet.getAccount(assetId.chain) ?: return@launch
-        switchAssetVisibility.switchVisibility(session.wallet.id, account, assetId, visible)
+        switchAssetVisibility(session.wallet.id, account, assetId, visible)
     }
 
     fun onTogglePin(assetId: AssetId) = viewModelScope.launch {
         val session = session.value ?: return@launch
         val account = session.wallet.getAccount(assetId.chain) ?: return@launch
-        switchAssetVisibility.switchVisibility(session.wallet.id, account, assetId, true)
-        toggleAssetPin.togglePin(session.wallet.id, assetId)
+        switchAssetVisibility(session.wallet.id, account, assetId, true)
+        toggleAssetPin(session.wallet.id, assetId)
     }
 
     fun onChainFilter(chain: Chain) {

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/BaseAssetSelectViewModel.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/BaseAssetSelectViewModel.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.asset_select.coordinators.GetRecentAssets
+import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.application.asset_select.coordinators.ToggleAssetPin
+import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.cases.tokens.SearchTokensCase
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.ext.assetType
 import com.gemwallet.android.ext.getAccount
 import com.gemwallet.android.model.RecentType
@@ -41,8 +43,10 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class)
 open class BaseAssetSelectViewModel(
-    sessionRepository: SessionRepository,
-    private val assetsRepository: AssetsRepository,
+    getSession: GetSession,
+    private val getRecentAssets: GetRecentAssets,
+    private val switchAssetVisibility: SwitchAssetVisibility,
+    private val toggleAssetPin: ToggleAssetPin,
     private val searchTokensCase: SearchTokensCase,
     val search: SelectSearch,
 ) : ViewModel() {
@@ -52,7 +56,7 @@ open class BaseAssetSelectViewModel(
     val chainFilter = MutableStateFlow<List<Chain>>(emptyList())
     val balanceFilter = MutableStateFlow(false)
 
-    private val session = sessionRepository.session()
+    private val session = getSession.getSession()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     private val searchState = MutableStateFlow(SearchState.Init)
@@ -141,7 +145,7 @@ open class BaseAssetSelectViewModel(
         val balanceFilter = filters.hasBalance
         val hasChainFilter = chainFilter.isNotEmpty()
 
-        assetsRepository.getRecentActivities(RecentType.entries).map { items ->
+        getRecentAssets.getRecentActivities(RecentType.entries).map { items ->
             items.filter {
                 (!hasChainFilter || chainFilter.contains(it.id().chain))
                         && (!balanceFilter || it.balance.totalAmount > 0.0)
@@ -162,21 +166,21 @@ open class BaseAssetSelectViewModel(
     }
     .stateIn(viewModelScope, SharingStarted.Eagerly, UIState.Idle)
 
-    val isAddAssetAvailable = sessionRepository.session().map { session ->
+    val isAddAssetAvailable = getSession.getSession().map { session ->
         session?.wallet?.accounts?.any { it.chain.assetType() != null } == true
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     fun onChangeVisibility(assetId: AssetId, visible: Boolean) = viewModelScope.launch {
         val session = session.value ?: return@launch
         val account = session.wallet.getAccount(assetId.chain) ?: return@launch
-        assetsRepository.switchVisibility(session.wallet.id, account, assetId, visible)
+        switchAssetVisibility.switchVisibility(session.wallet.id, account, assetId, visible)
     }
 
     fun onTogglePin(assetId: AssetId) = viewModelScope.launch {
         val session = session.value ?: return@launch
         val account = session.wallet.getAccount(assetId.chain) ?: return@launch
-        assetsRepository.switchVisibility(session.wallet.id, account, assetId, true)
-        assetsRepository.togglePin(session.wallet.id, assetId)
+        switchAssetVisibility.switchVisibility(session.wallet.id, account, assetId, true)
+        toggleAssetPin.togglePin(session.wallet.id, assetId)
     }
 
     fun onChainFilter(chain: Chain) {

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/BuySelectViewModel.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/BuySelectViewModel.kt
@@ -1,8 +1,11 @@
 package com.gemwallet.android.features.asset_select.viewmodels
 
+import com.gemwallet.android.application.asset_select.coordinators.GetRecentAssets
+import com.gemwallet.android.application.asset_select.coordinators.SearchSelectAssets
+import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.application.asset_select.coordinators.ToggleAssetPin
+import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.cases.tokens.SearchTokensCase
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.RecentType
 import com.gemwallet.android.features.asset_select.viewmodels.models.BaseSelectSearch
@@ -14,21 +17,26 @@ import javax.inject.Inject
 
 @HiltViewModel
 class BuySelectViewModel @Inject constructor(
-    sessionRepository: SessionRepository,
-    assetsRepository: AssetsRepository,
+    getSession: GetSession,
+    searchSelectAssets: SearchSelectAssets,
+    getRecentAssets: GetRecentAssets,
+    switchAssetVisibility: SwitchAssetVisibility,
+    toggleAssetPin: ToggleAssetPin,
     searchTokensCase: SearchTokensCase,
 ) : BaseAssetSelectViewModel(
-    sessionRepository,
-    assetsRepository,
+    getSession,
+    getRecentAssets,
+    switchAssetVisibility,
+    toggleAssetPin,
     searchTokensCase,
-    BuySelectSearch(assetsRepository)
+    BuySelectSearch(searchSelectAssets),
 ) {
     override fun getRecentType(): RecentType = RecentType.Buy
 }
 
 class BuySelectSearch(
-    assetsRepository: AssetsRepository,
-) : BaseSelectSearch(assetsRepository) {
+    searchSelectAssets: SearchSelectAssets,
+) : BaseSelectSearch(searchSelectAssets) {
 
     override fun items(filters: Flow<SelectAssetFilters?>): Flow<List<AssetInfo>> {
         return super.items(filters).map { items -> filter(items) }

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/SendAssetsViewModel.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/SendAssetsViewModel.kt
@@ -56,9 +56,9 @@ class SendSelectSearch(
             .map { filters -> filters?.query.orEmpty() to filters?.tag }
             .flatMapLatest { (query, tag) ->
                 val source = if (query.isEmpty() && tag == null) {
-                    getSelectAssetsInfo.getAssetsInfo()
+                    getSelectAssetsInfo()
                 } else {
-                    searchSelectAssets.search(query, tag?.let(::listOf) ?: emptyList())
+                    searchSelectAssets(query, tag?.let(::listOf) ?: emptyList())
                 }
 
                 source.map { items ->

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/SendAssetsViewModel.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/SendAssetsViewModel.kt
@@ -1,8 +1,12 @@
 package com.gemwallet.android.features.asset_select.viewmodels
 
+import com.gemwallet.android.application.asset_select.coordinators.GetRecentAssets
+import com.gemwallet.android.application.asset_select.coordinators.GetSelectAssetsInfo
+import com.gemwallet.android.application.asset_select.coordinators.SearchSelectAssets
+import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.application.asset_select.coordinators.ToggleAssetPin
+import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.cases.tokens.SearchTokensCase
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.RecentType
@@ -18,15 +22,21 @@ import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
-open class SendSelectViewModel@Inject constructor(
-    sessionRepository: SessionRepository,
-    assetsRepository: AssetsRepository,
+open class SendSelectViewModel @Inject constructor(
+    getSession: GetSession,
+    searchSelectAssets: SearchSelectAssets,
+    getSelectAssetsInfo: GetSelectAssetsInfo,
+    getRecentAssets: GetRecentAssets,
+    switchAssetVisibility: SwitchAssetVisibility,
+    toggleAssetPin: ToggleAssetPin,
     searchTokensCase: SearchTokensCase,
 ) : BaseAssetSelectViewModel(
-    sessionRepository,
-    assetsRepository,
+    getSession,
+    getRecentAssets,
+    switchAssetVisibility,
+    toggleAssetPin,
     searchTokensCase,
-    SendSelectSearch(assetsRepository)
+    SendSelectSearch(searchSelectAssets, getSelectAssetsInfo),
 ) {
     override fun getRecentType(): RecentType? = RecentType.Send
 
@@ -38,16 +48,17 @@ open class SendSelectViewModel@Inject constructor(
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SendSelectSearch(
-    private val assetsRepository: AssetsRepository,
-) : BaseSelectSearch(assetsRepository) {
+    private val searchSelectAssets: SearchSelectAssets,
+    private val getSelectAssetsInfo: GetSelectAssetsInfo,
+) : BaseSelectSearch(searchSelectAssets) {
     override fun items(filters: Flow<SelectAssetFilters?>): Flow<List<AssetInfo>> {
         return filters
             .map { filters -> filters?.query.orEmpty() to filters?.tag }
             .flatMapLatest { (query, tag) ->
                 val source = if (query.isEmpty() && tag == null) {
-                    assetsRepository.getAssetsInfo()
+                    getSelectAssetsInfo.getAssetsInfo()
                 } else {
-                    assetsRepository.search(query, tag?.let(::listOf) ?: emptyList(), false)
+                    searchSelectAssets.search(query, tag?.let(::listOf) ?: emptyList())
                 }
 
                 source.map { items ->

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/models/BaseSelectSearch.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/models/BaseSelectSearch.kt
@@ -1,6 +1,6 @@
 package com.gemwallet.android.features.asset_select.viewmodels.models
 
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.application.asset_select.coordinators.SearchSelectAssets
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.model.AssetInfo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -10,12 +10,12 @@ import kotlinx.coroutines.flow.map
 
 @OptIn(ExperimentalCoroutinesApi::class)
 open class BaseSelectSearch(
-    private val assetsRepository: AssetsRepository,
+    private val searchSelectAssets: SearchSelectAssets,
 ) : SelectSearch {
 
     override fun items(filters: Flow<SelectAssetFilters?>): Flow<List<AssetInfo>> {
         return filters.flatMapLatest { filters ->
-            assetsRepository.search(filters?.query ?: "", filters?.tag?.let { listOf(it) } ?: emptyList(), false)
+            searchSelectAssets.search(filters?.query ?: "", filters?.tag?.let { listOf(it) } ?: emptyList())
         }.map { items -> items.distinctBy { it.asset.id.toIdentifier() } }
     }
 }

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/models/BaseSelectSearch.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/models/BaseSelectSearch.kt
@@ -15,7 +15,7 @@ open class BaseSelectSearch(
 
     override fun items(filters: Flow<SelectAssetFilters?>): Flow<List<AssetInfo>> {
         return filters.flatMapLatest { filters ->
-            searchSelectAssets.search(filters?.query ?: "", filters?.tag?.let { listOf(it) } ?: emptyList())
+            searchSelectAssets(filters?.query ?: "", filters?.tag?.let { listOf(it) } ?: emptyList())
         }.map { items -> items.distinctBy { it.asset.id.toIdentifier() } }
     }
 }

--- a/android/features/asset_select/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset_select/viewmodels/SendSelectSearchTest.kt
+++ b/android/features/asset_select/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset_select/viewmodels/SendSelectSearchTest.kt
@@ -55,8 +55,8 @@ class SendSelectSearchTest {
         val result = search.items(filters).first()
 
         assertEquals(walletAssetResults, result)
-        verify(exactly = 1) { getSelectAssetsInfo.getAssetsInfo() }
-        verify(exactly = 0) { searchSelectAssets.search(any(), any()) }
+        verify(exactly = 1) { getSelectAssetsInfo.invoke() }
+        verify(exactly = 0) { searchSelectAssets.invoke(any(), any()) }
     }
 
     @Test
@@ -77,14 +77,14 @@ class SendSelectSearchTest {
         val result = search.items(filters).first()
 
         assertEquals(searchResults, result)
-        verify(exactly = 1) { searchSelectAssets.search("", listOf(AssetTag.Stablecoins)) }
+        verify(exactly = 1) { searchSelectAssets.invoke("", listOf(AssetTag.Stablecoins)) }
     }
 
-    private fun searchCoordinator() = mockk<SearchSelectAssets>(relaxed = true) {
-        every { search(any(), any()) } returns flowOf(searchResults)
+    private fun searchCoordinator() = mockk<SearchSelectAssets> {
+        every { this@mockk(any(), any()) } returns flowOf(searchResults)
     }
 
-    private fun assetsInfoCoordinator() = mockk<GetSelectAssetsInfo>(relaxed = true) {
-        every { getAssetsInfo() } returns flowOf(walletAssetResults)
+    private fun assetsInfoCoordinator() = mockk<GetSelectAssetsInfo> {
+        every { this@mockk() } returns flowOf(walletAssetResults)
     }
 }

--- a/android/features/asset_select/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset_select/viewmodels/SendSelectSearchTest.kt
+++ b/android/features/asset_select/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset_select/viewmodels/SendSelectSearchTest.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.features.asset_select.viewmodels
 
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.application.asset_select.coordinators.GetSelectAssetsInfo
+import com.gemwallet.android.application.asset_select.coordinators.SearchSelectAssets
 import com.gemwallet.android.features.asset_select.viewmodels.models.SelectAssetFilters
 import com.gemwallet.android.model.AssetBalance
 import com.gemwallet.android.testkit.mockAsset
@@ -38,8 +39,9 @@ class SendSelectSearchTest {
 
     @Test
     fun `empty query uses current wallet assets`() = runTest {
-        val assetsRepository = repository()
-        val search = SendSelectSearch(assetsRepository)
+        val searchSelectAssets = searchCoordinator()
+        val getSelectAssetsInfo = assetsInfoCoordinator()
+        val search = SendSelectSearch(searchSelectAssets, getSelectAssetsInfo)
         val filters = MutableStateFlow(
             SelectAssetFilters(
                 session = null,
@@ -53,14 +55,15 @@ class SendSelectSearchTest {
         val result = search.items(filters).first()
 
         assertEquals(walletAssetResults, result)
-        verify(exactly = 1) { assetsRepository.getAssetsInfo() }
-        verify(exactly = 0) { assetsRepository.search(any(), any(), false) }
+        verify(exactly = 1) { getSelectAssetsInfo.getAssetsInfo() }
+        verify(exactly = 0) { searchSelectAssets.search(any(), any()) }
     }
 
     @Test
     fun `selected tag keeps using repository search`() = runTest {
-        val assetsRepository = repository()
-        val search = SendSelectSearch(assetsRepository)
+        val searchSelectAssets = searchCoordinator()
+        val getSelectAssetsInfo = assetsInfoCoordinator()
+        val search = SendSelectSearch(searchSelectAssets, getSelectAssetsInfo)
         val filters = MutableStateFlow(
             SelectAssetFilters(
                 session = null,
@@ -74,11 +77,14 @@ class SendSelectSearchTest {
         val result = search.items(filters).first()
 
         assertEquals(searchResults, result)
-        verify(exactly = 1) { assetsRepository.search("", listOf(AssetTag.Stablecoins), false) }
+        verify(exactly = 1) { searchSelectAssets.search("", listOf(AssetTag.Stablecoins)) }
     }
 
-    private fun repository() = mockk<AssetsRepository>(relaxed = true) {
+    private fun searchCoordinator() = mockk<SearchSelectAssets>(relaxed = true) {
+        every { search(any(), any()) } returns flowOf(searchResults)
+    }
+
+    private fun assetsInfoCoordinator() = mockk<GetSelectAssetsInfo>(relaxed = true) {
         every { getAssetsInfo() } returns flowOf(walletAssetResults)
-        every { search(any(), any(), false) } returns flowOf(searchResults)
     }
 }

--- a/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/PriceAlertsSelectViewModel.kt
+++ b/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/PriceAlertsSelectViewModel.kt
@@ -1,9 +1,12 @@
 package com.gemwallet.android.features.settings.price_alerts.viewmodels
 
+import com.gemwallet.android.application.asset_select.coordinators.GetRecentAssets
+import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.application.asset_select.coordinators.ToggleAssetPin
 import com.gemwallet.android.application.pricealerts.coordinators.GetPriceAlerts
+import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.RecentType
@@ -23,12 +26,17 @@ import javax.inject.Inject
 @HiltViewModel
 class PriceAlertsSelectViewModel @Inject constructor(
     getPriceAlerts: GetPriceAlerts,
-    sessionRepository: SessionRepository,
+    getSession: GetSession,
+    getRecentAssets: GetRecentAssets,
+    switchAssetVisibility: SwitchAssetVisibility,
+    toggleAssetPin: ToggleAssetPin,
     assetsRepository: AssetsRepository,
     searchTokensCase: SearchTokensCase,
 ) : BaseAssetSelectViewModel(
-    sessionRepository,
-    assetsRepository,
+    getSession,
+    getRecentAssets,
+    switchAssetVisibility,
+    toggleAssetPin,
     searchTokensCase,
     PriceAlertSelectSearch(assetsRepository, getPriceAlerts),
 ) {

--- a/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapSelectViewModel.kt
+++ b/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapSelectViewModel.kt
@@ -3,10 +3,13 @@ package com.gemwallet.android.features.swap.viewmodels
 import androidx.compose.foundation.text.input.clearText
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.asset_select.coordinators.GetRecentAssets
+import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.application.asset_select.coordinators.ToggleAssetPin
+import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.cases.swap.GetSwapSupported
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.ext.isSwapSupport
 import com.gemwallet.android.ext.toAssetId
 import com.gemwallet.android.ext.toChain
@@ -41,16 +44,21 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class SwapSelectViewModel @Inject constructor(
-    sessionRepository: SessionRepository,
+    getSession: GetSession,
+    getRecentAssets: GetRecentAssets,
+    switchAssetVisibility: SwitchAssetVisibility,
+    toggleAssetPin: ToggleAssetPin,
     assetsRepository: AssetsRepository,
     searchTokensCase: SearchTokensCase,
     getSwapSupported: GetSwapSupported,
     val savedStateHandle: SavedStateHandle,
 ) : BaseAssetSelectViewModel(
-    sessionRepository = sessionRepository,
-    assetsRepository = assetsRepository,
+    getSession = getSession,
+    getRecentAssets = getRecentAssets,
+    switchAssetVisibility = switchAssetVisibility,
+    toggleAssetPin = toggleAssetPin,
     searchTokensCase = searchTokensCase,
-    search = SwapSelectSearch(assetsRepository, getSwapSupported)
+    search = SwapSelectSearch(assetsRepository, getSwapSupported),
 ) {
 
     val payAssetId = savedStateHandle.getStateFlow<String?>("payAssetId", null)

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/GetRecentAssets.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/GetRecentAssets.kt
@@ -1,0 +1,9 @@
+package com.gemwallet.android.application.asset_select.coordinators
+
+import com.gemwallet.android.model.AssetInfo
+import com.gemwallet.android.model.RecentType
+import kotlinx.coroutines.flow.Flow
+
+interface GetRecentAssets {
+    fun getRecentActivities(types: List<RecentType>): Flow<List<AssetInfo>>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/GetRecentAssets.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/GetRecentAssets.kt
@@ -5,5 +5,5 @@ import com.gemwallet.android.model.RecentType
 import kotlinx.coroutines.flow.Flow
 
 interface GetRecentAssets {
-    fun getRecentActivities(types: List<RecentType>): Flow<List<AssetInfo>>
+    operator fun invoke(types: List<RecentType>): Flow<List<AssetInfo>>
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/GetSelectAssetsInfo.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/GetSelectAssetsInfo.kt
@@ -1,0 +1,8 @@
+package com.gemwallet.android.application.asset_select.coordinators
+
+import com.gemwallet.android.model.AssetInfo
+import kotlinx.coroutines.flow.Flow
+
+interface GetSelectAssetsInfo {
+    fun getAssetsInfo(): Flow<List<AssetInfo>>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/GetSelectAssetsInfo.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/GetSelectAssetsInfo.kt
@@ -4,5 +4,5 @@ import com.gemwallet.android.model.AssetInfo
 import kotlinx.coroutines.flow.Flow
 
 interface GetSelectAssetsInfo {
-    fun getAssetsInfo(): Flow<List<AssetInfo>>
+    operator fun invoke(): Flow<List<AssetInfo>>
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/SearchSelectAssets.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/SearchSelectAssets.kt
@@ -5,5 +5,5 @@ import com.wallet.core.primitives.AssetTag
 import kotlinx.coroutines.flow.Flow
 
 interface SearchSelectAssets {
-    fun search(query: String, tags: List<AssetTag>): Flow<List<AssetInfo>>
+    operator fun invoke(query: String, tags: List<AssetTag>): Flow<List<AssetInfo>>
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/SearchSelectAssets.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/SearchSelectAssets.kt
@@ -1,0 +1,9 @@
+package com.gemwallet.android.application.asset_select.coordinators
+
+import com.gemwallet.android.model.AssetInfo
+import com.wallet.core.primitives.AssetTag
+import kotlinx.coroutines.flow.Flow
+
+interface SearchSelectAssets {
+    fun search(query: String, tags: List<AssetTag>): Flow<List<AssetInfo>>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/SwitchAssetVisibility.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/SwitchAssetVisibility.kt
@@ -1,0 +1,8 @@
+package com.gemwallet.android.application.asset_select.coordinators
+
+import com.wallet.core.primitives.Account
+import com.wallet.core.primitives.AssetId
+
+interface SwitchAssetVisibility {
+    suspend fun switchVisibility(walletId: String, account: Account, assetId: AssetId, visible: Boolean)
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/SwitchAssetVisibility.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/SwitchAssetVisibility.kt
@@ -4,5 +4,5 @@ import com.wallet.core.primitives.Account
 import com.wallet.core.primitives.AssetId
 
 interface SwitchAssetVisibility {
-    suspend fun switchVisibility(walletId: String, account: Account, assetId: AssetId, visible: Boolean)
+    suspend operator fun invoke(walletId: String, account: Account, assetId: AssetId, visible: Boolean)
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/ToggleAssetPin.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/ToggleAssetPin.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.asset_select.coordinators
+
+import com.wallet.core.primitives.AssetId
+
+interface ToggleAssetPin {
+    suspend fun togglePin(walletId: String, assetId: AssetId)
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/ToggleAssetPin.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/asset_select/coordinators/ToggleAssetPin.kt
@@ -3,5 +3,5 @@ package com.gemwallet.android.application.asset_select.coordinators
 import com.wallet.core.primitives.AssetId
 
 interface ToggleAssetPin {
-    suspend fun togglePin(walletId: String, assetId: AssetId)
+    suspend operator fun invoke(walletId: String, assetId: AssetId)
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/session/coordinators/GetSession.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/session/coordinators/GetSession.kt
@@ -4,5 +4,5 @@ import com.gemwallet.android.model.Session
 import kotlinx.coroutines.flow.StateFlow
 
 interface GetSession {
-    fun getSession(): StateFlow<Session?>
+    operator fun invoke(): StateFlow<Session?>
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/session/coordinators/GetSession.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/session/coordinators/GetSession.kt
@@ -1,0 +1,8 @@
+package com.gemwallet.android.application.session.coordinators
+
+import com.gemwallet.android.model.Session
+import kotlinx.coroutines.flow.StateFlow
+
+interface GetSession {
+    fun getSession(): StateFlow<Session?>
+}


### PR DESCRIPTION
Extract coordinator interfaces and implementations for asset_select viewmodels. Remove `:data:repositories` dependency from the module.

Closes gemwalletcom/gem-android-issues#14

- [x] Test