### PR TITLE
Use Chain for DustThreshold and add UI info

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         android:name="com.gemwallet.android.App"
         android:exported="true"
         tools:node="merge"
+        tools:replace="android:dataExtractionRules"
         >
         <activity
             android:name="com.gemwallet.android.MainActivity"

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -341,7 +341,7 @@ fun ConfirmError.toLabel() = when (this) {
     is ConfirmError.BroadcastError -> "${stringResource(R.string.errors_transfer_error)}: ${this.details}"
     is ConfirmError.SignFail -> stringResource(R.string.errors_transfer_error)
     is ConfirmError.RecipientEmpty -> "${stringResource(R.string.errors_transfer_error)}: recipient can't be empty"
-    is ConfirmError.DustThreshold -> stringResource(id = R.string.errors_dust_threshold, chainTitle)
+    is ConfirmError.DustThreshold -> stringResource(id = R.string.errors_dust_threshold_short)
     is ConfirmError.None -> stringResource(id = R.string.transfer_confirm)
     is ConfirmError.MinimumAccountBalanceTooLow -> stringResource(R.string.transfer_minimum_account_balance, asset.symbol)
 }

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/ConfirmErrorInfo.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/ConfirmErrorInfo.kt
@@ -84,5 +84,6 @@ private fun ConfirmError.toInfoSheetEntity(feeValue: String, onBuy: AssetIdActio
         asset = asset,
         value = asset.format(required.toBigInteger(), dynamicPlace = true),
     )
+    is ConfirmError.DustThreshold -> InfoSheetEntity.DustThresholdInfo(chain = chain)
     else -> null
 }

--- a/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
+++ b/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
@@ -13,7 +13,6 @@ import com.gemwallet.android.data.repositories.stake.StakeRepository
 import com.gemwallet.android.data.repositories.transactions.TransactionBalanceService
 import com.gemwallet.android.domains.stake.sumRewardsBalance
 import com.gemwallet.android.domains.asset.chain
-import com.gemwallet.android.ext.asset
 import com.gemwallet.android.ext.getAccount
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.model.AssetInfo
@@ -140,7 +139,7 @@ class ConfirmViewModel @Inject constructor(
             state.update {
                 ConfirmState.Error(
                     when (err.message?.contains(GemPlatformErrors.Dust.message)) {
-                        true -> ConfirmError.DustThreshold("${owner.chain.asset().name} (${owner.chain.asset().symbol})")
+                        true -> ConfirmError.DustThreshold(owner.chain)
                         else -> ConfirmError.PreloadError
                     }
                 )

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/ConfirmError.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/ConfirmError.kt
@@ -14,5 +14,5 @@ sealed class ConfirmError : Exception() {
     class InsufficientFee(val chain: Chain) : ConfirmError()
     class MinimumAccountBalanceTooLow(val asset: Asset, val required: Long) : ConfirmError()
     class BroadcastError(val details: String) : ConfirmError()
-    class DustThreshold(val chainTitle: String) : ConfirmError()
+    class DustThreshold(val chain: Chain) : ConfirmError()
 }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/InfoBottomSheet.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/InfoBottomSheet.kt
@@ -83,6 +83,14 @@ sealed class InfoSheetEntity(
         descriptionArgs = listOf("**$value**"),
     )
 
+    class DustThresholdInfo(chain: Chain) : InfoSheetEntity(
+        icon = chain.asset().getIconUrl(),
+        title = R.string.errors_transfer_error,
+        description = R.string.errors_dust_threshold,
+        infoUrl = { AppUrl.docs(DocsUrl.Dust) },
+        descriptionArgs = listOf("**${chain.asset().name}**"),
+    )
+
     class ReserveForFee(icon: Any) : InfoSheetEntity(
         icon = icon,
         title = R.string.info_stake_reserved_title,


### PR DESCRIPTION
Change ConfirmError.DustThreshold to carry a Chain instead of a string title so callers can access chain/asset data. Update ConfirmViewModel to construct DustThreshold with owner.chain. Adapt ConfirmScreen to use a short dust-threshold string resource. Add a DustThresholdInfo InfoSheetEntity (with icon, description and docs link) and map the error to that sheet in ConfirmErrorInfo. Also add tools:replace="android:dataExtractionRules" to the AndroidManifest entry.

Fix: https://github.com/gemwalletcom/wallet/issues/146

<img width="320" alt="Screenshot_20260415_163554" src="https://github.com/user-attachments/assets/98bdeed1-71de-478a-b4ff-aa19f979ecfc" />
<img width="320" alt="Screenshot_20260415_163615" src="https://github.com/user-attachments/assets/a87d789b-9eb5-4772-ba20-8f3d560a9adf" />
