### PR TITLE
Add Receive to NFT collections scene on Android

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/features/main/views/MainScreen.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/main/views/MainScreen.kt
@@ -58,6 +58,7 @@ import com.gemwallet.android.ui.navigation.routes.navigateToPerpetualsScreen
 import com.gemwallet.android.ui.navigation.routes.navigateToPreferences
 import com.gemwallet.android.ui.navigation.routes.navigateToNotifications
 import com.gemwallet.android.ui.navigation.routes.navigateToPriceAlertsScreen
+import com.gemwallet.android.ui.navigation.routes.navigateToReceiveNftChains
 import com.gemwallet.android.ui.navigation.routes.navigateToReceiveScreen
 import com.gemwallet.android.ui.navigation.routes.navigateToRecipientInput
 import com.gemwallet.android.ui.navigation.routes.navigateToReferralScreen
@@ -225,6 +226,7 @@ fun MainScreen(
                     cancelAction = null,
                     collectionAction = navController::navigateToNftCollection,
                     assetAction = navController::navigateToNftAsset,
+                    onReceive = { navController.navigateToReceiveNftChains() },
                 )
                 else -> SettingsScene(
                     scrollState = settingsScrollState,

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/WalletNavGraph.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/WalletNavGraph.kt
@@ -77,6 +77,7 @@ import com.gemwallet.android.ui.navigation.routes.navigateToSecurityReminderScre
 import com.gemwallet.android.ui.navigation.routes.navigateToNotifications
 import com.gemwallet.android.ui.navigation.routes.navigateToPreferences
 import com.gemwallet.android.ui.navigation.routes.navigateToPriceAlertsScreen
+import com.gemwallet.android.ui.navigation.routes.navigateToReceiveNftChains
 import com.gemwallet.android.ui.navigation.routes.navigateToReceiveScreen
 import com.gemwallet.android.ui.navigation.routes.navigateToRecipientInput
 import com.gemwallet.android.ui.navigation.routes.navigateToReferralScreen
@@ -221,7 +222,8 @@ fun WalletNavGraph(
             cancelAction = onCancel,
             collectionIdAction = navController::navigateToNftCollection,
             assetIdAction = navController::navigateToNftAsset,
-            onRecipient = navController::navigateToRecipientInput
+            onRecipient = navController::navigateToRecipientInput,
+            onReceive = { navController.navigateToReceiveNftChains() },
         )
 
         fiatScreen(

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/routes/Nft.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/routes/Nft.kt
@@ -31,11 +31,12 @@ fun NavController.navigateToNftAsset(assetId: String) {
 fun NavGraphBuilder.nftCollection(
     cancelAction: CancelAction,
     onRecipient: (AssetId, String) -> Unit,
+    onReceive: () -> Unit,
     collectionIdAction: NftCollectionIdAction,
     assetIdAction: NftAssetIdAction,
 ) {
     composable<NftCollectionRoute> {
-        NftListScene(cancelAction, collectionIdAction, assetIdAction)
+        NftListScene(cancelAction, collectionIdAction, assetIdAction, onReceive = onReceive)
     }
 
     composable<NftAssetRoute> {

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/routes/Receive.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/routes/Receive.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navOptions
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.features.asset_select.presents.views.SelectReceiveScreen
+import com.gemwallet.android.features.receive.presents.ReceiveNftChainsScreen
 import com.gemwallet.android.features.receive.presents.ReceiveScreen
 import com.wallet.core.primitives.AssetId
 import kotlinx.serialization.Serializable
@@ -17,6 +18,9 @@ class ReceiveRoute(val assetId: String)
 @Serializable
 class ReceiveSelectRoute
 
+@Serializable
+class ReceiveNftChainsRoute
+
 fun NavController.navigateToReceiveScreen(assetId: AssetId? = null, navOptions: NavOptions? = null) {
     if (assetId == null) {
         navigate(ReceiveSelectRoute(), navOptions ?: navOptions { launchSingleTop = true })
@@ -24,6 +28,10 @@ fun NavController.navigateToReceiveScreen(assetId: AssetId? = null, navOptions: 
         navigate(ReceiveRoute(assetId.toIdentifier()), navOptions ?: navOptions { launchSingleTop = true })
     }
 
+}
+
+fun NavController.navigateToReceiveNftChains(navOptions: NavOptions? = null) {
+    navigate(ReceiveNftChainsRoute(), navOptions ?: navOptions { launchSingleTop = true })
 }
 
 fun NavGraphBuilder.receiveScreen(
@@ -38,6 +46,13 @@ fun NavGraphBuilder.receiveScreen(
         SelectReceiveScreen(
             onCancel = onCancel,
             onSelect = { onReceive(it) }
+        )
+    }
+
+    composable<ReceiveNftChainsRoute> {
+        ReceiveNftChainsScreen(
+            onCancel = onCancel,
+            onSelect = { onReceive(AssetId(it)) },
         )
     }
 }

--- a/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
+++ b/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
@@ -10,7 +10,11 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -46,6 +50,7 @@ fun NftListScene(
     cancelAction: CancelAction?,
     collectionAction: NftCollectionIdAction,
     assetAction: NftAssetIdAction,
+    onReceive: (() -> Unit)? = null,
     listState: LazyGridState = rememberLazyGridState(),
 ) {
     val viewModel: NftListViewModels = hiltViewModel()
@@ -59,6 +64,16 @@ fun NftListScene(
     Scene(
         title = stringResource(R.string.nft_collections),
         navigationBarPadding = false,
+        actions = {
+            if (onReceive != null) {
+                IconButton(onClick = onReceive) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = stringResource(R.string.wallet_receive),
+                    )
+                }
+            }
+        },
         onClose = if (cancelAction == null) null else { { cancelAction() } } // TODO: Replace to action in scene
     ) {
         val isRefreshing = isLoading && !items.isEmpty()
@@ -104,7 +119,7 @@ fun NftListScene(
             }
 
             if (!isLoading && items.isEmpty()) {
-                EmptyContentView(type = EmptyContentType.Nft(), modifier = Modifier.fillMaxSize())
+                EmptyContentView(type = EmptyContentType.Nft(onReceive = onReceive), modifier = Modifier.fillMaxSize())
                 return@PullToRefreshBox
             }
 

--- a/android/features/receive/presents/src/main/kotlin/com/gemwallet/android/features/receive/presents/ReceiveNftChainsScreen.kt
+++ b/android/features/receive/presents/src/main/kotlin/com/gemwallet/android/features/receive/presents/ReceiveNftChainsScreen.kt
@@ -1,0 +1,49 @@
+package com.gemwallet.android.features.receive.presents
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gemwallet.android.features.receive.viewmodels.ReceiveNftChainsViewModel
+import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.clipboard.setPlainText
+import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
+import com.gemwallet.android.ui.components.screen.SelectChain
+import com.wallet.core.primitives.Chain
+
+@Composable
+fun ReceiveNftChainsScreen(
+    onCancel: () -> Unit,
+    onSelect: (Chain) -> Unit,
+    viewModel: ReceiveNftChainsViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val clipboardManager = LocalClipboard.current.nativeClipboard
+    val chains by viewModel.chains.collectAsStateWithLifecycle()
+    SelectChain(
+        chains = chains,
+        chainFilter = viewModel.chainFilter,
+        title = stringResource(id = R.string.wallet_receive_collection),
+        trailing = { chain ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(
+                    onClick = { clipboardManager.setPlainText(context, viewModel.addressFor(chain)) },
+                ) {
+                    Icon(imageVector = Icons.Default.ContentCopy, contentDescription = null)
+                }
+                DataBadgeChevron()
+            }
+        },
+        onSelect = onSelect,
+        onCancel = onCancel,
+    )
+}

--- a/android/features/receive/viewmodels/build.gradle.kts
+++ b/android/features/receive/viewmodels/build.gradle.kts
@@ -50,6 +50,7 @@ android {
 dependencies {
     api(project(":ui-models"))
     implementation(project(":ui"))
+    implementation(project(":data:repositories"))
 
     implementation(libs.ktx.core)
     implementation(libs.lifecycle.runtime.ktx)

--- a/android/features/receive/viewmodels/src/main/kotlin/com/gemwallet/android/features/receive/viewmodels/ReceiveNftChainsViewModel.kt
+++ b/android/features/receive/viewmodels/src/main/kotlin/com/gemwallet/android/features/receive/viewmodels/ReceiveNftChainsViewModel.kt
@@ -1,0 +1,42 @@
+package com.gemwallet.android.features.receive.viewmodels
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.snapshotFlow
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.ext.asset
+import com.gemwallet.android.ext.getAccount
+import com.gemwallet.android.ext.isNftSupported
+import com.wallet.core.primitives.Chain
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class ReceiveNftChainsViewModel @Inject constructor(
+    sessionRepository: SessionRepository,
+) : ViewModel() {
+
+    private val wallet = sessionRepository.session().value?.wallet
+
+    private val allChains: List<Chain> = Chain.entries
+        .filter { it.isNftSupported() }
+        .filter { chain -> wallet?.getAccount(chain) != null }
+
+    val chainFilter = TextFieldState()
+
+    val chains = snapshotFlow { chainFilter.text.toString() }
+        .map { query ->
+            if (query.isBlank()) allChains
+            else allChains.filter { it.asset().name.contains(query, ignoreCase = true) }
+        }
+        .flowOn(Dispatchers.IO)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, allChains)
+
+    fun addressFor(chain: Chain): String = wallet?.getAccount(chain)?.address.orEmpty()
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/Chain.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/Chain.kt
@@ -98,6 +98,8 @@ fun Chain.getMinimumAccountBalance(): Long = Config().getChainConfig(this.string
 
 fun Chain.isStakeSupported(): Boolean = Config().getChainConfig(this.string).isStakeSupported
 
+fun Chain.isNftSupported(): Boolean = Config().getChainConfig(this.string).isNftSupported
+
 fun Chain.asset(): Asset {
     val wrapper = uniffi.gemstone.assetWrapper(string)
     return Asset(

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/empty/EmptyContentView.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/empty/EmptyContentView.kt
@@ -85,7 +85,7 @@ private fun EmptyContentType.iconVector(): ImageVector? = when (this) {
 @Composable
 private fun EmptyContentType.buttons(): List<EmptyAction> = when (this) {
     is EmptyContentType.Nft -> listOfNotNull(
-        onReceive?.let { EmptyAction(stringResource(R.string.wallet_receive), it) },
+        onReceive?.let { EmptyAction(stringResource(R.string.wallet_receive), it, EmptyActionStyle.Secondary) },
     )
     is EmptyContentType.Asset -> if (isViewOnly) emptyList() else listOfNotNull(
         onBuy?.let { EmptyAction(stringResource(R.string.wallet_buy), it) },

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/SelectChain.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/SelectChain.kt
@@ -22,11 +22,13 @@ fun SelectChain(
     chains: List<Chain>,
     chainFilter: TextFieldState,
     listState: LazyListState = rememberLazyListState(),
+    title: String = stringResource(id = R.string.settings_networks_title),
+    trailing: (@Composable (Chain) -> Unit)? = null,
     onSelect: (Chain) -> Unit,
     onCancel: () -> Unit,
 ) {
     Scene(
-        title = stringResource(id = R.string.settings_networks_title),
+        title = title,
         onClose = onCancel,
     ) {
         LazyColumn(modifier = Modifier, state = listState) {
@@ -46,10 +48,10 @@ fun SelectChain(
                     ChainItem(
                         title = item.asset().name,
                         icon = item,
-                        listPosition = ListPosition.getPosition(index, size)
-                    ) {
-                        onSelect(item)
-                    }
+                        listPosition = ListPosition.getPosition(index, size),
+                        trailing = trailing?.let { t -> @Composable { t(item) } },
+                        onClick = { onSelect(item) },
+                    )
                 }
             }
         }


### PR DESCRIPTION
Mirrors iOS Collections flow: `+` toolbar button and empty-state "Receive" action both open a new "Receive Collection" sheet — a chain picker filtered to chains with `is_nft_supported = true` (Ethereum, BNB Chain, Solana, Polygon). Each row has a copy-address button and a navigation chevron; tapping a row opens the existing receive screen for that chain.

Closes: https://github.com/gemwalletcom/wallet/issues/158

<img width="320" alt="Screenshot_20260421_221433" src="https://github.com/user-attachments/assets/a9b229e1-2bf5-4069-aa16-47bc4e088ca7" />
<img width="320" alt="Screenshot_20260421_221525" src="https://github.com/user-attachments/assets/3e79b47f-6135-46f9-aa2b-42c7b2a57eb4" />

