### PR TITLE
Match iOS amount switch button styling on Android

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/fields/AmountField.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/fields/AmountField.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.ui.components.fields
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,8 +11,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -21,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextRange
@@ -33,9 +33,10 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
+import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.models.AmountInputType
-import com.gemwallet.android.ui.theme.smallIconSize
+import com.gemwallet.android.ui.theme.compactIconSize
+import com.gemwallet.android.ui.theme.paddingSmall
 import com.wallet.core.primitives.Currency
 
 @Composable
@@ -84,18 +85,27 @@ fun ColumnScope.AmountField(
         cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
         readOnly = readOnly,
     )
-    Spacer(modifier = Modifier.height(4.dp))
+    Spacer(modifier = Modifier.height(paddingSmall))
     if (equivalent.isNotEmpty()) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            modifier = if (onInputTypeClick == null) Modifier else Modifier.clickable(
+                interactionSource = null,
+                indication = null,
+                onClick = onInputTypeClick,
+            ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(paddingSmall),
+        ) {
             Text(
                 text = equivalent,
                 color = MaterialTheme.colorScheme.secondary,
             )
-            if (onInputTypeClick != null) {
+            onInputTypeClick?.let {
                 Icon(
-                    modifier = Modifier.size(smallIconSize).clickable { onInputTypeClick() },
-                    imageVector = Icons.Default.SwapVert,
-                    contentDescription = ""
+                    modifier = Modifier.size(compactIconSize),
+                    painter = painterResource(R.drawable.amount_switch),
+                    tint = MaterialTheme.colorScheme.secondary,
+                    contentDescription = null,
                 )
             }
         }

--- a/android/ui/src/main/res/drawable/amount_switch.xml
+++ b/android/ui/src/main/res/drawable/amount_switch.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="23dp"
+    android:height="28dp"
+    android:viewportWidth="23"
+    android:viewportHeight="28">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M5.5,3V5H12.09L0.5,16.59L1.91,18L13.5,6.41V13H15.5V3H5.5Z"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M17.5,25V23H10.91L22.5,11.41L21.09,10L9.5,21.59V15H7.5V25H17.5Z"/>
+</vector>


### PR DESCRIPTION
Port the custom swap icon from iOS, tint it with the secondary color, expand the tappable area to include the fiat label, and align row spacing with iOS.

<img width="320" alt="Screenshot_20260418_214432" src="https://github.com/user-attachments/assets/077d9cf7-2605-46a5-87de-b17e860fd469" />
