### PR TITLE
Fix/android swap screen UI glitches 108

### DIFF
--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -173,8 +172,13 @@ fun ConfirmScreen(
                     )
                 }
             }
+            val groupSize = displayTxProperties.size + detailElements.size
             itemsIndexed(displayTxProperties) { index, item ->
-                val listPosition = ListPosition.getPosition(index, displayTxProperties.size)
+                val listPosition = if (detailElements.isNotEmpty()) {
+                    ListPosition.getPosition(index, groupSize)
+                } else {
+                    ListPosition.getPosition(index, displayTxProperties.size)
+                }
                 when (item) {
                     is ConfirmProperty.Destination -> PropertyDestination(item, listPosition)
                     is ConfirmProperty.Memo -> PropertyItem(R.string.transfer_memo, item.data, listPosition = listPosition)
@@ -182,11 +186,15 @@ fun ConfirmScreen(
                     is ConfirmProperty.Source -> PropertyItem(R.string.common_wallet, item.data, listPosition = listPosition)
                 }
             }
-            items(
-                items = detailElements,
-            ) { item ->
+            itemsIndexed(detailElements) { index, item ->
+                val listPosition = if (displayTxProperties.isNotEmpty()) {
+                    ListPosition.getPosition(displayTxProperties.size + index, groupSize)
+                } else {
+                    ListPosition.getPosition(index, detailElements.size)
+                }
                 ConfirmDetailElementRow(
                     item = item,
+                    listPosition = listPosition,
                     onClick = { selectedDetailElement = item },
                 )
             }
@@ -290,11 +298,13 @@ fun ConfirmScreen(
 @Composable
 private fun ConfirmDetailElementRow(
     item: ConfirmDetailElement,
+    listPosition: ListPosition,
     onClick: () -> Unit,
 ) {
     when (item) {
         is ConfirmDetailElement.SwapDetails -> SwapDetailsSummaryItem(
             model = item.model,
+            listPosition = listPosition,
             onClick = onClick,
         )
     }

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -129,7 +129,7 @@ fun ConfirmScreen(
                 enabled = state !is ConfirmState.Prepare
                     && state !is ConfirmState.Sending
                     && !walletConnectReview.warnings.hasCriticalWarning(),
-                loading = state is ConfirmState.Sending || state is ConfirmState.Prepare || state is ConfirmState.Result,
+                loading = state is ConfirmState.Sending || state is ConfirmState.Result,
                 onClick = {
                     context.requestAuth(AuthRequest.Phrase) {
                         viewModel.send(finishAction)

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
@@ -27,7 +27,7 @@ import com.gemwallet.android.ui.components.list_item.ListItemDefaults
 import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.ui.components.list_item.ListItemTitleText
 import com.gemwallet.android.ui.components.list_item.SelectionCheckmark
-import com.gemwallet.android.ui.components.list_item.SubheaderItem
+import com.gemwallet.android.ui.components.dialog.SheetHeader
 import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkFee
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet
@@ -58,13 +58,16 @@ fun FeeDetails(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onCancel,
+        dragHandle = {
+            SheetHeader(
+                title = stringResource(R.string.transfer_network_fee),
+                onDismissRequest = onCancel,
+            )
+        },
     ) {
         LazyColumn {
 
             if (feeRates.size > 1) {
-                item {
-                    SubheaderItem(R.string.transfer_network_fee)
-                }
                 itemsPositioned(feeRates) { position, item ->
                     val feeRate = FeeRateUIModel(
                         feeRate = item,

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
@@ -2,7 +2,9 @@ package com.gemwallet.android.features.swap.views
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.input.TextFieldState
@@ -12,9 +14,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
@@ -49,6 +57,15 @@ internal fun SwapScene(
     onPrimaryAction: () -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+    var pendingDetails by remember { mutableStateOf(false) }
+
+    LaunchedEffect(imeVisible) {
+        if (!imeVisible && pendingDetails) {
+            pendingDetails = false
+            onDetails()
+        }
+    }
 
     Scene(
         title = stringResource(id = R.string.wallet_swap),
@@ -111,7 +128,12 @@ internal fun SwapScene(
             }
             item {
                 swapDetails?.let {
-                    SwapDetailsSummaryItem(model = it, onClick = onDetails)
+                    SwapDetailsSummaryItem(model = it, onClick = {
+                        if (imeVisible) {
+                            keyboardController?.hide()
+                            pendingDetails = true
+                        } else onDetails()
+                    })
                 }
             }
 

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
@@ -69,8 +69,10 @@ internal fun SwapScene(
 
     Scene(
         title = stringResource(id = R.string.wallet_swap),
-        mainAction = {
-            SwapAction(swapState, onPrimaryAction)
+        mainAction = if (swapState.isSwapButtonVisible) {
+            { SwapAction(swapState, onPrimaryAction) }
+        } else {
+            null
         },
         onClose = onCancel,
     ) {

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
@@ -1,10 +1,14 @@
 package com.gemwallet.android.features.swap.views
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.input.TextFieldState
@@ -12,7 +16,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -26,6 +34,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.sectionHeaderItem
@@ -38,7 +47,12 @@ import com.gemwallet.android.features.swap.views.components.SwapError
 import com.gemwallet.android.features.swap.views.components.SwapItem
 import com.gemwallet.android.ui.models.swap.SwapDetailsUIModel
 import com.gemwallet.android.ui.theme.iconSize
+import com.gemwallet.android.ui.theme.paddingDefault
+import com.gemwallet.android.ui.theme.paddingSmall
+import com.gemwallet.android.ui.theme.sceneContentPadding
 import com.gemwallet.android.ui.theme.space0
+
+private val payPercentOptions = listOf(25, 50, 100)
 
 @Composable
 internal fun SwapScene(
@@ -55,6 +69,7 @@ internal fun SwapScene(
     onDetails: () -> Unit,
     onCancel: () -> Unit,
     onPrimaryAction: () -> Unit,
+    onSelectPayPercent: (Int) -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
@@ -67,13 +82,29 @@ internal fun SwapScene(
         }
     }
 
+    val showPercentBar = imeVisible && swapState.payItemInteraction.isAmountEditable && pay != null
+
     Scene(
         title = stringResource(id = R.string.wallet_swap),
-        mainAction = if (swapState.isSwapButtonVisible) {
-            { SwapAction(swapState, onPrimaryAction) }
-        } else {
-            null
+        mainAction = when {
+            showPercentBar -> {
+                {
+                    PayPercentBar(
+                        options = payPercentOptions,
+                        onSelect = onSelectPayPercent,
+                        onDone = { keyboardController?.hide() },
+                    )
+                }
+            }
+            swapState.isSwapButtonVisible -> {
+                { SwapAction(swapState, onPrimaryAction) }
+            }
+            else -> null
         },
+        mainActionPadding = if (showPercentBar) PaddingValues(0.dp) else PaddingValues(
+            horizontal = sceneContentPadding(),
+            vertical = paddingDefault,
+        ),
         onClose = onCancel,
     ) {
         LazyColumn {
@@ -155,4 +186,49 @@ private fun SwapSectionHeader(resId: Int, topPadding: Dp? = null) {
         style = MaterialTheme.typography.labelMedium,
         color = MaterialTheme.colorScheme.secondary,
     )
+}
+
+@Composable
+private fun PayPercentBar(
+    options: List<Int>,
+    onSelect: (Int) -> Unit,
+    onDone: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = paddingDefault, vertical = paddingSmall),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(paddingSmall),
+        ) {
+            options.forEach { percent ->
+                TextButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = { onSelect(percent) },
+                    shape = MaterialTheme.shapes.extraLarge,
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+                ) {
+                    Text(text = "$percent%", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+            TextButton(
+                modifier = Modifier.weight(1f),
+                onClick = onDone,
+                colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
+            ) {
+                Text(
+                    text = stringResource(R.string.common_done),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+    }
 }

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScreen.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScreen.kt
@@ -76,6 +76,7 @@ fun SwapScreen(
         onCancel = onCancel,
         onDetails = { isShowDetails = true },
         onPrimaryAction = onPrimaryAction,
+        onSelectPayPercent = viewModel::onSelectPayPercent,
     )
 
     PriceImpactWarningDialog(

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/components/SwapAction.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/components/SwapAction.kt
@@ -44,7 +44,10 @@ internal fun SwapAction(
                 text = stringResource(R.string.wallet_swap),
                 style = MaterialTheme.typography.bodyLarge,
             )
-            SwapActionState.QuoteLoading,
+            SwapActionState.QuoteLoading -> Text(
+                text = stringResource(R.string.wallet_swap),
+                style = MaterialTheme.typography.bodyLarge,
+            )
             SwapActionState.TransferLoading -> CircularProgressIndicator20(color = Color.White)
             is SwapActionState.QuoteError,
             is SwapActionState.TransferError -> Text(

--- a/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModel.kt
+++ b/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModel.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uniffi.gemstone.SwapperProvider
 import java.math.BigDecimal
+import com.gemwallet.android.model.Crypto
 import java.math.BigInteger
 import javax.inject.Inject
 
@@ -248,6 +249,19 @@ class SwapViewModel @Inject constructor(
                 savedStateHandle["to"] = assetId.toIdentifier()
             }
         }
+    }
+
+    fun onSelectPayPercent(percent: Int) {
+        val asset = payAsset.value ?: return
+        val available = asset.balance.balance.available.toBigIntegerOrNull() ?: return
+        val scaled = available.multiply(percent.toBigInteger()).divide(100.toBigInteger())
+        val formatted = Crypto(scaled)
+            .value(asset.asset.decimals)
+            .stripTrailingZeros()
+            .toPlainString()
+        clearTransferQuoteState()
+        payValue.clearText()
+        payValue.setTextAndPlaceCursorAtEnd(formatted)
     }
 
     fun switchSwap() = viewModelScope.launch {

--- a/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/models/SwapUiState.kt
+++ b/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/models/SwapUiState.kt
@@ -35,6 +35,7 @@ data class SwapUiState(
     val action: SwapActionState = SwapActionState.None,
     val isQuoteLoading: Boolean = false,
     val isTransferLoading: Boolean = false,
+    val isSwapButtonVisible: Boolean = false,
 ) {
     val error: SwapError?
         get() = when (val currentAction = action) {
@@ -47,7 +48,7 @@ data class SwapUiState(
         }
 
     val isReceiveLoading: Boolean
-        get() = isQuoteLoading && !isTransferLoading
+        get() = isQuoteLoading
 
     val isQuoteInteractionEnabled: Boolean
         get() = !isTransferLoading
@@ -104,5 +105,6 @@ internal fun createSwapUiState(
         action = action,
         isQuoteLoading = quoteState is QuoteUiState.Loading,
         isTransferLoading = transferState is TransferDataUiState.Loading,
+        isSwapButtonVisible = quoteState !is QuoteUiState.NoInput,
     )
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeRateUIModel.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeRateUIModel.kt
@@ -33,9 +33,9 @@ data class FeeRateUIModel(
 
     val emoji: String
         get() = when (priority) {
-            FeePriority.Slow -> "\uD83D\uDC22"
+            FeePriority.Slow -> "\u23F1\uFE0F"
             FeePriority.Normal -> "\uD83D\uDC8E"
-            FeePriority.Fast -> "\uD83D\uDE80"
+            FeePriority.Fast -> "\u26A1\uFE0F"
         }
 
     private val feeAmount: BigInteger?

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/dialog/DialogBar.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/dialog/DialogBar.kt
@@ -8,8 +8,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,6 +28,49 @@ import com.gemwallet.android.ui.theme.iconSize
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.paddingSmall
 import com.gemwallet.android.ui.theme.space4
+
+@Composable
+fun SheetHeader(
+    title: String,
+    onDismissRequest: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(top = paddingDefault, bottom = paddingSmall)
+                .width(iconSize)
+                .height(space4)
+                .background(
+                    color = MaterialTheme.colorScheme.secondary.copy(alpha = alpha50),
+                    shape = RoundedCornerShape(percent = 50),
+                ),
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = paddingSmall, vertical = space4),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(modifier = Modifier.align(Alignment.CenterStart)) {
+                IconButton(
+                    onClick = onDismissRequest,
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.secondary.copy(alpha = alpha10),
+                    ),
+                ) {
+                    Icon(imageVector = Icons.Default.Close, contentDescription = null)
+                }
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+    }
+}
 
 @Composable
 fun DialogBar(

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapDetailsComponents.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapDetailsComponents.kt
@@ -75,6 +75,7 @@ import uniffi.gemstone.SwapperProvider
 fun SwapDetailsSummaryItem(
     model: SwapDetailsUIModel,
     onClick: () -> Unit,
+    listPosition: ListPosition = ListPosition.Single,
 ) {
     val badgeText = model.summaryPriceImpactBadgeText
 
@@ -101,7 +102,7 @@ fun SwapDetailsSummaryItem(
                 },
             )
         },
-        listPosition = ListPosition.Single,
+        listPosition = listPosition,
     )
 }
 

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapDetailsComponents.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapDetailsComponents.kt
@@ -1,17 +1,30 @@
 package com.gemwallet.android.ui.components.swap
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,11 +35,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import com.gemwallet.android.ui.theme.alpha10
+import com.gemwallet.android.ui.theme.alpha50
+import com.gemwallet.android.ui.theme.iconSize
+import com.gemwallet.android.ui.theme.paddingDefault
+import com.gemwallet.android.ui.theme.paddingSmall
+import com.gemwallet.android.ui.theme.space4
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.InfoSheetEntity
-import com.gemwallet.android.ui.components.dialog.DialogBar
 import com.gemwallet.android.ui.components.image.AsyncImage
 import com.gemwallet.android.ui.components.image.IconWithBadge
 import com.gemwallet.android.ui.components.list_item.ListItem
@@ -48,8 +67,8 @@ import com.gemwallet.android.ui.models.swap.SwapRateUIModel
 import com.wallet.core.primitives.swap.SwapPriceImpactType
 import com.gemwallet.android.ui.theme.Spacer4
 import com.gemwallet.android.ui.theme.Spacer8
-import com.gemwallet.android.ui.theme.pendingColor
 import com.gemwallet.android.ui.theme.listItemIconSize
+import com.gemwallet.android.ui.theme.pendingColor
 import uniffi.gemstone.SwapperProvider
 
 @Composable
@@ -100,12 +119,24 @@ fun SwapDetailsBottomSheet(
 ) {
     if (model == null) return
 
+    var showProviderPicker by remember { mutableStateOf(false) }
+    val canSelectProvider = onProviderSelect != null && model.isProviderSelectable && model.providers.size > 1
+
     ModalBottomSheet(
         isVisible = isVisible,
-        onDismissRequest = onDismiss,
+        onDismissRequest = {
+            showProviderPicker = false
+            onDismiss()
+        },
         modifier = modifier,
         skipPartiallyExpanded = skipPartiallyExpanded,
-        dragHandle = { DialogBar(onDismissRequest = onDismiss, showDismissAction = false) },
+        dragHandle = {
+            SwapDetailsSheetHeader(
+                title = if (showProviderPicker) R.string.buy_providers_title else R.string.common_details,
+                onDismiss = if (showProviderPicker) { { showProviderPicker = false } } else onDismiss,
+                showCheckmark = !showProviderPicker,
+            )
+        },
     ) {
         if (isLoading) {
             Box(modifier = Modifier.fillMaxWidth()) {
@@ -114,69 +145,131 @@ fun SwapDetailsBottomSheet(
             return@ModalBottomSheet
         }
 
-        LazyColumn {
-            val providers = model.inlineProviders(onProviderSelect != null)
-            val providerSectionTitle = when {
-                onProviderSelect != null -> R.string.buy_providers_title
-                showProviderSectionHeader -> R.string.common_provider
-                else -> null
-            }
-
-            if (providerSectionTitle != null && providers.isNotEmpty()) {
-                item {
-                    SubheaderItem(providerSectionTitle)
+        AnimatedContent(
+            targetState = showProviderPicker && canSelectProvider && onProviderSelect != null,
+            transitionSpec = {
+                if (targetState) {
+                    slideInVertically { it } togetherWith slideOutVertically { -it }
+                } else {
+                    slideInVertically { -it } togetherWith slideOutVertically { it }
                 }
-            }
-            if (providers.size > 1 && onProviderSelect != null) {
-                itemsIndexed(providers) { index, provider ->
-                    SwapProviderListItemView(
-                        provider = provider,
-                        listPosition = ListPosition.getPosition(index, providers.size),
-                        isSelected = provider.id == model.provider.id,
-                        onProviderSelect = { selected ->
-                            onDismiss()
-                            onProviderSelect(selected)
-                        },
-                    )
+            },
+            label = "swap_details_content",
+        ) { showingPicker ->
+            if (showingPicker && onProviderSelect != null) {
+                LazyColumn {
+                    item { SubheaderItem(R.string.buy_providers_title) }
+                    itemsIndexed(model.providers) { index, provider ->
+                        SwapProviderListItemView(
+                            provider = provider,
+                            listPosition = ListPosition.getPosition(index, model.providers.size),
+                            isSelected = provider.id == model.provider.id,
+                            onProviderSelect = { selected ->
+                                showProviderPicker = false
+                                onProviderSelect(selected)
+                            },
+                        )
+                    }
                 }
             } else {
-                item {
-                    SwapCurrentProviderRow(
-                        provider = providers.firstOrNull() ?: model.provider,
-                    )
+                LazyColumn {
+                    if (onProviderSelect != null || showProviderSectionHeader) {
+                        item { SubheaderItem(R.string.common_provider) }
+                    }
+                    item {
+                        SwapCurrentProviderRow(
+                            provider = model.provider,
+                            showChevron = canSelectProvider,
+                            onClick = if (canSelectProvider) { { showProviderPicker = true } } else null,
+                        )
+                    }
+                    item { SwapRatePropertyItem(model.rate, ListPosition.First) }
+                    model.estimatedTime?.let {
+                        item {
+                            PropertyItem(
+                                title = R.string.swap_estimated_time_title,
+                                data = it,
+                                listPosition = ListPosition.Middle,
+                            )
+                        }
+                    }
+                    model.priceImpact?.let {
+                        item { PriceImpactPropertyItem(it, ListPosition.Middle) }
+                    }
+                    item {
+                        PropertyItem(
+                            title = R.string.swap_min_receive,
+                            data = model.minimumReceive,
+                            listPosition = ListPosition.Middle,
+                        )
+                    }
+                    item {
+                        PropertyItem(
+                            title = R.string.swap_slippage,
+                            data = model.slippageText,
+                            info = InfoSheetEntity.Slippage,
+                            listPosition = ListPosition.Last,
+                        )
+                    }
                 }
             }
-            item {
-                SwapRatePropertyItem(model.rate, ListPosition.First)
-            }
-            model.estimatedTime?.let {
-                item {
-                    PropertyItem(
-                        title = R.string.swap_estimated_time_title,
-                        data = it,
-                        listPosition = ListPosition.Middle,
-                    )
+        }
+    }
+}
+
+@Composable
+private fun SwapDetailsSheetHeader(
+    title: Int,
+    onDismiss: () -> Unit,
+    showCheckmark: Boolean,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(top = paddingDefault, bottom = paddingSmall)
+                .width(iconSize)
+                .height(space4)
+                .background(
+                    color = MaterialTheme.colorScheme.secondary.copy(alpha = alpha50),
+                    shape = RoundedCornerShape(percent = 50),
+                ),
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = paddingSmall, vertical = space4),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (!showCheckmark) {
+                Box(modifier = Modifier.align(Alignment.CenterStart)) {
+                    IconButton(
+                        onClick = onDismiss,
+                        colors = IconButtonDefaults.iconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.secondary.copy(alpha = alpha10),
+                        ),
+                    ) {
+                        Icon(imageVector = Icons.Default.Close, contentDescription = null)
+                    }
                 }
             }
-            model.priceImpact?.let {
-                item {
-                    PriceImpactPropertyItem(it, ListPosition.Middle)
+            Text(
+                text = stringResource(title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            if (showCheckmark) {
+                Box(modifier = Modifier.align(Alignment.CenterEnd)) {
+                    IconButton(
+                        onClick = onDismiss,
+                        colors = IconButtonDefaults.iconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.secondary.copy(alpha = alpha10),
+                        ),
+                    ) {
+                        Icon(imageVector = Icons.Default.Check, contentDescription = null)
+                    }
                 }
-            }
-            item {
-                PropertyItem(
-                    title = R.string.swap_min_receive,
-                    data = model.minimumReceive,
-                    listPosition = ListPosition.Middle,
-                )
-            }
-            item {
-                PropertyItem(
-                    title = R.string.swap_slippage,
-                    data = model.slippageText,
-                    info = InfoSheetEntity.Slippage,
-                    listPosition = ListPosition.Last,
-                )
             }
         }
     }
@@ -211,14 +304,20 @@ private fun SwapProviderListItemView(
 @Composable
 private fun SwapCurrentProviderRow(
     provider: SwapProviderUIModel,
+    showChevron: Boolean = false,
+    onClick: (() -> Unit)? = null,
 ) {
     ListItem(
+        modifier = if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier,
         leading = { SwapProviderIcon(provider.icon, listItemIconSize) },
-        title = {
-            ListItemTitleText(provider.title)
-        },
+        title = { ListItemTitleText(provider.title) },
         trailing = {
-            SwapProviderAmounts(provider)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                SwapProviderAmounts(provider)
+                if (showChevron) {
+                    DataBadgeChevron()
+                }
+            }
         },
         listPosition = ListPosition.Single,
     )
@@ -266,23 +365,6 @@ private fun SwapProviderAmounts(provider: SwapProviderUIModel) {
 private fun SwapProviderIcon(icon: Any, size: Dp) {
     AsyncImage(model = icon, size = size)
 }
-
-private fun SwapDetailsUIModel.inlineProviders(isSelectionEnabled: Boolean): List<SwapProviderUIModel> {
-    if (!isSelectionEnabled || !isProviderSelectable) {
-        return listOf(provider)
-    }
-
-    val topProviders = providers.take(MAX_INLINE_PROVIDERS).toMutableList()
-    if (topProviders.none { it.id == provider.id }) {
-        topProviders.add(0, provider)
-    }
-
-    return topProviders
-        .distinctBy { it.id }
-        .take(MAX_INLINE_PROVIDERS)
-}
-
-private const val MAX_INLINE_PROVIDERS = 3
 
 @Composable
 private fun PriceImpactPropertyItem(


### PR DESCRIPTION
Android Swap — UI polish & iOS parity

A set of focused improvements to the Android swap and confirm screens, closing visual and interaction gaps with iOS.

## What's changed

- **Confirm screen grouping** — Wallet, Network, and Details now render as a single grouped card, matching iOS where all three share one section.
- **Network fee sheet header** — added centered title and leading X close button, matching iOS `NetworkFeeScene`.
- **Fee rate emojis** — aligned with iOS `Emoji.FeeRate`: ⏱️ slow · 💎 normal · ⚡️ fast (was 🐢 / 🚀).
- **Provider picker** — consolidated into the swap details sheet with an animated slide transition and a themed header.
- **Swap CTA visibility** — hidden until quote input is present; buttons disabled during loading instead of showing double indicators.
- **Swap details sheet** — deferred until IME is dismissed to prevent layout jumps.
- **25 / 50 / 100% pay shortcuts** — pill bar appears above the keyboard when the pay field is focused, replacing the Swap button. Tapping a pill fills the pay amount and triggers a new quote. Matches iOS `InputAccessoryView`.


close #108 

## Files changed

`SwapScene.kt` · `SwapScreen.kt` · `SwapViewModel.kt` · `SwapDetailsComponents.kt` · `SwapAction.kt` · `SwapUiState.kt` · `ConfirmScreen.kt` · `FeeDetails.kt` · `DialogBar.kt` · `FeeRateUIModel.kt`

