### PR TITLE
fix(android): disable buttons instead of double loading indicators.

### DIFF
--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -129,7 +129,7 @@ fun ConfirmScreen(
                 enabled = state !is ConfirmState.Prepare
                     && state !is ConfirmState.Sending
                     && !walletConnectReview.warnings.hasCriticalWarning(),
-                loading = state is ConfirmState.Sending || state is ConfirmState.Prepare || state is ConfirmState.Result,
+                loading = state is ConfirmState.Sending || state is ConfirmState.Result,
                 onClick = {
                     context.requestAuth(AuthRequest.Phrase) {
                         viewModel.send(finishAction)

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
@@ -2,7 +2,9 @@ package com.gemwallet.android.features.swap.views
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.input.TextFieldState
@@ -12,9 +14,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
@@ -49,6 +57,15 @@ internal fun SwapScene(
     onPrimaryAction: () -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+    var pendingDetails by remember { mutableStateOf(false) }
+
+    LaunchedEffect(imeVisible) {
+        if (!imeVisible && pendingDetails) {
+            pendingDetails = false
+            onDetails()
+        }
+    }
 
     Scene(
         title = stringResource(id = R.string.wallet_swap),
@@ -111,7 +128,12 @@ internal fun SwapScene(
             }
             item {
                 swapDetails?.let {
-                    SwapDetailsSummaryItem(model = it, onClick = onDetails)
+                    SwapDetailsSummaryItem(model = it, onClick = {
+                        if (imeVisible) {
+                            keyboardController?.hide()
+                            pendingDetails = true
+                        } else onDetails()
+                    })
                 }
             }
 

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
@@ -69,8 +69,10 @@ internal fun SwapScene(
 
     Scene(
         title = stringResource(id = R.string.wallet_swap),
-        mainAction = {
-            SwapAction(swapState, onPrimaryAction)
+        mainAction = if (swapState.isSwapButtonVisible) {
+            { SwapAction(swapState, onPrimaryAction) }
+        } else {
+            null
         },
         onClose = onCancel,
     ) {

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/components/SwapAction.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/components/SwapAction.kt
@@ -44,7 +44,10 @@ internal fun SwapAction(
                 text = stringResource(R.string.wallet_swap),
                 style = MaterialTheme.typography.bodyLarge,
             )
-            SwapActionState.QuoteLoading,
+            SwapActionState.QuoteLoading -> Text(
+                text = stringResource(R.string.wallet_swap),
+                style = MaterialTheme.typography.bodyLarge,
+            )
             SwapActionState.TransferLoading -> CircularProgressIndicator20(color = Color.White)
             is SwapActionState.QuoteError,
             is SwapActionState.TransferError -> Text(

--- a/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/models/SwapUiState.kt
+++ b/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/models/SwapUiState.kt
@@ -35,6 +35,7 @@ data class SwapUiState(
     val action: SwapActionState = SwapActionState.None,
     val isQuoteLoading: Boolean = false,
     val isTransferLoading: Boolean = false,
+    val isSwapButtonVisible: Boolean = false,
 ) {
     val error: SwapError?
         get() = when (val currentAction = action) {
@@ -47,7 +48,7 @@ data class SwapUiState(
         }
 
     val isReceiveLoading: Boolean
-        get() = isQuoteLoading && !isTransferLoading
+        get() = isQuoteLoading
 
     val isQuoteInteractionEnabled: Boolean
         get() = !isTransferLoading
@@ -104,5 +105,6 @@ internal fun createSwapUiState(
         action = action,
         isQuoteLoading = quoteState is QuoteUiState.Loading,
         isTransferLoading = transferState is TransferDataUiState.Loading,
+        isSwapButtonVisible = quoteState !is QuoteUiState.NoInput,
     )
 }

--- a/android/features/swap/viewmodels/src/test/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModelTest.kt
+++ b/android/features/swap/viewmodels/src/test/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModelTest.kt
@@ -10,10 +10,13 @@ import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.features.swap.viewmodels.cases.QuoteRequester
 import com.gemwallet.android.features.swap.viewmodels.models.QuoteRequestKey
 import com.gemwallet.android.features.swap.viewmodels.models.QuoteRequestParams
+import com.gemwallet.android.features.swap.viewmodels.models.QuoteUiState
 import com.gemwallet.android.features.swap.viewmodels.models.QuotesState
 import com.gemwallet.android.features.swap.viewmodels.models.SwapActionState
 import com.gemwallet.android.features.swap.viewmodels.models.SwapError
 import com.gemwallet.android.features.swap.viewmodels.models.SwapItemType
+import com.gemwallet.android.features.swap.viewmodels.models.TransferDataUiState
+import com.gemwallet.android.features.swap.viewmodels.models.createSwapUiState
 import com.gemwallet.android.model.AssetBalance
 import com.gemwallet.android.model.ConfirmParams
 import com.gemwallet.android.model.Session
@@ -124,6 +127,15 @@ class SwapViewModelTest {
         quoteRequester = quoteRequester,
         savedStateHandle = savedStateHandle,
     )
+
+    @Test
+    fun `isSwapButtonVisible is false with no input and true once quote is loading`() {
+        val noInput = createSwapUiState(QuoteUiState.NoInput, TransferDataUiState.Idle, null)
+        assertEquals(false, noInput.isSwapButtonVisible)
+
+        val loading = createSwapUiState(QuoteUiState.Loading(mockk()), TransferDataUiState.Idle, null)
+        assertEquals(true, loading.isSwapButtonVisible)
+    }
 
     @Test
     fun `onSelect updates pay asset from empty state`() = runTest(testDispatcher) {


### PR DESCRIPTION
Android swap/confirm UX polish

- no double spinners on the main buttons.
- swap CTA hidden until there is input amount.
- receive loading follows quote loading.
- opening swap details waits until the keyboard is dismissed so the sheet does not jump.

related #108 

https://github.com/user-attachments/assets/8622834c-7068-47ec-a9a8-12b9485e39c6

