### PR TITLE
fix(android): improve network fee sheet header UI and fee rate emojis

### DIFF
--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/FeeDetailsDialog.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/FeeDetailsDialog.kt
@@ -2,9 +2,11 @@ package com.gemwallet.android.features.activities.presents.details
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.transaction.values.TransactionDetailsValue
 import com.gemwallet.android.ext.asset
+import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkFee
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet
 
@@ -19,6 +21,7 @@ internal fun FeeDetailsDialog(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onCancel,
+        title = stringResource(R.string.transfer_network_fee),
     ) {
         model.asset.chain.asset().let {
             PropertyNetworkFee(

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
@@ -34,7 +34,6 @@ import com.gemwallet.android.features.confirm.presents.ConfirmScreen
 import com.gemwallet.android.model.AuthRequest
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
-import com.gemwallet.android.ui.components.dialog.DialogBar
 import com.gemwallet.android.ui.components.list_head.CenteredListHead
 import com.gemwallet.android.ui.components.list_head.CenteredListHeadSubtitleLayout
 import com.gemwallet.android.ui.components.list_item.SubheaderItem
@@ -176,16 +175,9 @@ private fun SignMessageScene(
                 ModalBottomSheet(
                     onDismissRequest = { sheetType = null },
                     sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-                    dragHandle = {
-                        DialogBar(
-                            onDismissRequest = { sheetType = null },
-                        )
-                    },
+                    title = stringResource(R.string.common_details),
                 ) {
                     LazyColumn {
-                        item {
-                            SubheaderItem(R.string.common_details)
-                        }
                         simulationPayloadDetailsContent(
                             primaryFields = request.primaryPayloadFields,
                             secondaryFields = request.secondaryPayloadFields,
@@ -193,11 +185,7 @@ private fun SignMessageScene(
                         item {
                             PropertyItem(
                                 action = R.string.sign_message_view_full_message,
-                                listPosition = if (request.primaryPayloadFields.isEmpty() && request.secondaryPayloadFields.isEmpty()) {
-                                    ListPosition.Single
-                                } else {
-                                    ListPosition.Last
-                                },
+                                listPosition = ListPosition.Single,
                                 onClick = { sheetType = SignMessageSheetType.FullMessage },
                             )
                         }
@@ -209,11 +197,7 @@ private fun SignMessageScene(
                 ModalBottomSheet(
                     onDismissRequest = { sheetType = null },
                     sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-                    dragHandle = {
-                        DialogBar(
-                            onDismissRequest = { sheetType = null },
-                        )
-                    },
+                    title = stringResource(R.string.sign_message_view_full_message),
                 ) {
                     Box(
                         modifier = Modifier

--- a/android/features/buy/presents/src/main/kotlin/com/gemwallet/android/features/buy/views/ProviderList.kt
+++ b/android/features/buy/presents/src/main/kotlin/com/gemwallet/android/features/buy/views/ProviderList.kt
@@ -9,11 +9,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import com.gemwallet.android.domains.asset.getFiatProviderIcon
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.image.AsyncImage
 import com.gemwallet.android.ui.components.image.IconWithBadge
-import com.gemwallet.android.ui.components.list_item.SubheaderItem
 import com.gemwallet.android.ui.components.list_item.ListItem
 import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.ui.components.list_item.ListItemTitleText
@@ -35,11 +35,9 @@ fun ProviderList(
     ModalBottomSheet(
         isVisible = isShow.value,
         onDismissRequest = { isShow.value = false },
+        title = stringResource(R.string.buy_providers_title),
     ) {
         LazyColumn {
-            item {
-                SubheaderItem(R.string.buy_providers_title)
-            }
             itemsIndexed(providers) { index, item ->
                 FiatProviderListItemView(
                     provider = item,

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -41,11 +41,9 @@ import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.format
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
-import com.gemwallet.android.ui.components.dialog.DialogBar
 import com.gemwallet.android.ui.components.list_head.AmountListHead
 import com.gemwallet.android.ui.components.list_head.NftHead
 import com.gemwallet.android.ui.components.list_head.SwapListHead
-import com.gemwallet.android.ui.components.list_item.SubheaderItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyDataText
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkFee
@@ -248,16 +246,9 @@ fun ConfirmScreen(
             isVisible = showWalletConnectDetails,
             onDismissRequest = { showWalletConnectDetails = false },
             skipPartiallyExpanded = true,
-            dragHandle = {
-                DialogBar(
-                    onDismissRequest = { showWalletConnectDetails = false },
-                )
-            },
+            title = stringResource(R.string.common_details),
         ) {
             LazyColumn {
-                item {
-                    SubheaderItem(R.string.common_details)
-                }
                 simulationPayloadDetailsContent(
                     primaryFields = walletConnectReview.primaryPayloadFields,
                     secondaryFields = walletConnectReview.secondaryPayloadFields,

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
@@ -21,13 +21,13 @@ import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.ext.feeUnitType
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.dialog.SheetHeader
 import com.gemwallet.android.ui.components.image.IconWithBadge
 import com.gemwallet.android.ui.components.list_item.ListItem
 import com.gemwallet.android.ui.components.list_item.ListItemDefaults
 import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.ui.components.list_item.ListItemTitleText
 import com.gemwallet.android.ui.components.list_item.SelectionCheckmark
-import com.gemwallet.android.ui.components.dialog.SheetHeader
 import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkFee
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
@@ -27,7 +27,7 @@ import com.gemwallet.android.ui.components.list_item.ListItemDefaults
 import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.ui.components.list_item.ListItemTitleText
 import com.gemwallet.android.ui.components.list_item.SelectionCheckmark
-import com.gemwallet.android.ui.components.list_item.SubheaderItem
+import com.gemwallet.android.ui.components.dialog.SheetHeader
 import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkFee
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet
@@ -58,13 +58,16 @@ fun FeeDetails(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onCancel,
+        dragHandle = {
+            SheetHeader(
+                title = stringResource(R.string.transfer_network_fee),
+                onDismissRequest = onCancel,
+            )
+        },
     ) {
         LazyColumn {
 
             if (feeRates.size > 1) {
-                item {
-                    SubheaderItem(R.string.transfer_network_fee)
-                }
                 itemsPositioned(feeRates) { position, item ->
                     val feeRate = FeeRateUIModel(
                         feeRate = item,

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
@@ -21,7 +21,6 @@ import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.ext.feeUnitType
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.R
-import com.gemwallet.android.ui.components.dialog.SheetHeader
 import com.gemwallet.android.ui.components.image.IconWithBadge
 import com.gemwallet.android.ui.components.list_item.ListItem
 import com.gemwallet.android.ui.components.list_item.ListItemDefaults
@@ -58,12 +57,7 @@ fun FeeDetails(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onCancel,
-        dragHandle = {
-            SheetHeader(
-                title = stringResource(R.string.transfer_network_fee),
-                onDismissRequest = onCancel,
-            )
-        },
+        title = stringResource(R.string.transfer_network_fee),
     ) {
         LazyColumn {
 

--- a/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/ReferralNavScreen.kt
+++ b/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/ReferralNavScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -26,7 +25,6 @@ import com.gemwallet.android.domains.referral.values.ReferralError
 import com.gemwallet.android.features.referral.viewmodels.ReferralViewModel
 import com.gemwallet.android.features.referral.viewmodels.RewardsUIState
 import com.gemwallet.android.ui.R
-import com.gemwallet.android.ui.components.list_item.SubheaderItem
 import com.gemwallet.android.ui.components.list_item.WalletItem
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet
 import com.gemwallet.android.ui.models.ListPosition
@@ -77,13 +75,10 @@ fun ReferralNavScreen(
 
     ModalBottomSheet(
         isVisible = isShowSelectWallets,
-        dragHandle = { BottomSheetDefaults.DragHandle() },
         onDismissRequest = { isShowSelectWallets = false },
+        title = stringResource(R.string.wallets_title),
     ) {
         LazyColumn {
-            item {
-                SubheaderItem(R.string.wallets_title)
-            }
             itemsIndexed(availableWallets) { index, item ->
                 WalletItem(
                     wallet = item,

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeRateUIModel.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeRateUIModel.kt
@@ -33,9 +33,9 @@ data class FeeRateUIModel(
 
     val emoji: String
         get() = when (priority) {
-            FeePriority.Slow -> "\uD83D\uDC22"
+            FeePriority.Slow -> "\u23F1\uFE0F"
             FeePriority.Normal -> "\uD83D\uDC8E"
-            FeePriority.Fast -> "\uD83D\uDE80"
+            FeePriority.Fast -> "\u26A1\uFE0F"
         }
 
     private val feeAmount: BigInteger?

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/dialog/DialogBar.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/dialog/DialogBar.kt
@@ -1,17 +1,11 @@
 package com.gemwallet.android.ui.components.dialog
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -20,19 +14,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.theme.alpha10
-import com.gemwallet.android.ui.theme.alpha50
-import com.gemwallet.android.ui.theme.iconSize
-import com.gemwallet.android.ui.theme.paddingDefault
+import com.gemwallet.android.ui.theme.paddingHalfSmall
 import com.gemwallet.android.ui.theme.paddingSmall
-import com.gemwallet.android.ui.theme.space4
 
 @Composable
-fun SheetHeader(
-    title: String,
+fun DialogBar(
     onDismissRequest: () -> Unit,
+    title: String? = null,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -40,21 +29,15 @@ fun SheetHeader(
     ) {
         Box(
             modifier = Modifier
-                .padding(top = paddingDefault, bottom = paddingSmall)
-                .width(iconSize)
-                .height(space4)
-                .background(
-                    color = MaterialTheme.colorScheme.secondary.copy(alpha = alpha50),
-                    shape = RoundedCornerShape(percent = 50),
-                ),
-        )
-        Box(
-            modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = paddingSmall, vertical = space4),
+                .padding(horizontal = paddingSmall, vertical = paddingSmall),
             contentAlignment = Alignment.Center,
         ) {
-            Box(modifier = Modifier.align(Alignment.CenterStart)) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(horizontal = paddingHalfSmall, vertical = paddingHalfSmall),
+            ) {
                 IconButton(
                     onClick = onDismissRequest,
                     colors = IconButtonDefaults.iconButtonColors(
@@ -64,70 +47,12 @@ fun SheetHeader(
                     Icon(imageVector = Icons.Default.Close, contentDescription = null)
                 }
             }
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-            )
-        }
-    }
-}
-
-@Composable
-fun DialogBar(
-    onDismissRequest: () -> Unit,
-    showDismissAction: Boolean = true,
-) {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Box(
-            modifier = Modifier
-                .padding(top = paddingDefault, bottom = paddingSmall)
-                .width(iconSize)
-                .height(space4)
-                .background(
-                    color = MaterialTheme.colorScheme.secondary.copy(alpha = alpha50),
-                    shape = RoundedCornerShape(percent = 50),
-                ),
-        )
-        if (showDismissAction) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = paddingDefault),
-            ) {
-                DialogBarActionButton(
-                    modifier = Modifier.align(Alignment.CenterStart),
-                    onClick = onDismissRequest,
+            if (title != null) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
                 )
             }
         }
     }
 }
-
-@Composable
-private fun DialogBarActionButton(
-    modifier: Modifier,
-    onClick: () -> Unit,
-) {
-    ElevatedButton(
-        modifier = modifier,
-        shape = MaterialTheme.shapes.extraLarge,
-        contentPadding = ButtonDefaults.ContentPadding,
-        colors = dialogBarActionButtonColors(),
-        onClick = onClick,
-    ) {
-        Text(
-            text = stringResource(R.string.common_done),
-            style = MaterialTheme.typography.labelLarge,
-        )
-    }
-}
-
-@Composable
-private fun dialogBarActionButtonColors() = ButtonDefaults.elevatedButtonColors(
-    containerColor = MaterialTheme.colorScheme.background,
-    contentColor = MaterialTheme.colorScheme.primary,
-    disabledContainerColor = MaterialTheme.colorScheme.background.copy(alpha = alpha10),
-)

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/dialog/DialogBar.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/dialog/DialogBar.kt
@@ -8,8 +8,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,6 +28,49 @@ import com.gemwallet.android.ui.theme.iconSize
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.paddingSmall
 import com.gemwallet.android.ui.theme.space4
+
+@Composable
+fun SheetHeader(
+    title: String,
+    onDismissRequest: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(top = paddingDefault, bottom = paddingSmall)
+                .width(iconSize)
+                .height(space4)
+                .background(
+                    color = MaterialTheme.colorScheme.secondary.copy(alpha = alpha50),
+                    shape = RoundedCornerShape(percent = 50),
+                ),
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = paddingSmall, vertical = space4),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(modifier = Modifier.align(Alignment.CenterStart)) {
+                IconButton(
+                    onClick = onDismissRequest,
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.secondary.copy(alpha = alpha10),
+                    ),
+                ) {
+                    Icon(imageVector = Icons.Default.Close, contentDescription = null)
+                }
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+    }
+}
 
 @Composable
 fun DialogBar(

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/PropertyItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/PropertyItem.kt
@@ -62,7 +62,12 @@ fun PropertyItem(
 ) {
     PropertyItem(
         modifier = Modifier.clickable(onClick = onClick),
-        title = { PropertyTitleText(text = action, trailing = { AsyncImage(model = actionIconModel, size = smallIconSize) }) },
+        title = {
+            PropertyTitleText(
+                text = action,
+                trailing = actionIconModel?.let { { AsyncImage(model = it, size = smallIconSize) } },
+            )
+        },
         data = {
             PropertyDataText(
                 text = data ?: "",

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/ModalBottomSheet.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/ModalBottomSheet.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import com.gemwallet.android.ui.components.dialog.DialogBar
 import com.gemwallet.android.ui.theme.Spacer16
 import com.gemwallet.android.ui.theme.alpha20
 import com.gemwallet.android.ui.theme.sheetCornerSize
@@ -30,7 +31,8 @@ fun ModalBottomSheet(
     sheetState: SheetState = rememberModalBottomSheetState(),
     containerColor: Color = MaterialTheme.colorScheme.surface,
     shape: Shape = RoundedCornerShape(topStart = sheetCornerSize, topEnd = sheetCornerSize),
-    dragHandle: @Composable () -> Unit = { Box { Spacer16() } },
+    title: String? = null,
+    dragHandle: (@Composable () -> Unit)? = { Box { Spacer16() } },
     content: @Composable ColumnScope.() -> Unit,
 ) {
     androidx.compose.material3.ModalBottomSheet(
@@ -40,8 +42,8 @@ fun ModalBottomSheet(
         scrimColor = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha20),
         shape = shape,
         containerColor = containerColor,
-        dragHandle = dragHandle,
-        content = content
+        dragHandle = if (title != null) null else dragHandle,
+        content = { SheetContent(onDismissRequest, title, content) },
     )
 }
 
@@ -54,7 +56,8 @@ fun ModalBottomSheet(
     skipPartiallyExpanded: Boolean = false,
     containerColor: Color = MaterialTheme.colorScheme.surface,
     shape: Shape = RoundedCornerShape(topStart = sheetCornerSize, topEnd = sheetCornerSize),
-    dragHandle: @Composable () -> Unit = { Box { Spacer16() } },
+    title: String? = null,
+    dragHandle: (@Composable () -> Unit)? = { Box { Spacer16() } },
     content: @Composable ColumnScope.() -> Unit,
 ) {
     var showSheet by remember { mutableStateOf(false) }
@@ -93,8 +96,20 @@ fun ModalBottomSheet(
             scrimColor = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha20),
             shape = shape,
             containerColor = containerColor,
-            dragHandle = dragHandle,
-            content = content,
+            dragHandle = if (title != null) null else dragHandle,
+            content = { SheetContent(onDismissRequest, title, content) },
         )
     }
+}
+
+@Composable
+private fun ColumnScope.SheetContent(
+    onDismissRequest: () -> Unit,
+    title: String?,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    if (title != null) {
+        DialogBar(onDismissRequest = onDismissRequest, title = title)
+    }
+    content()
 }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapDetailsComponents.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapDetailsComponents.kt
@@ -22,11 +22,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.InfoSheetEntity
-import com.gemwallet.android.ui.components.dialog.DialogBar
 import com.gemwallet.android.ui.components.image.AsyncImage
 import com.gemwallet.android.ui.components.image.IconWithBadge
 import com.gemwallet.android.ui.components.list_item.ListItem
@@ -105,7 +105,7 @@ fun SwapDetailsBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,
         skipPartiallyExpanded = skipPartiallyExpanded,
-        dragHandle = { DialogBar(onDismissRequest = onDismiss, showDismissAction = false) },
+        title = stringResource(R.string.common_details),
     ) {
         if (isLoading) {
             Box(modifier = Modifier.fillMaxWidth()) {


### PR DESCRIPTION
Match iOS sheet header layout style:
- Add `SheetHeader` composable (title + close button) to the network fee bottom sheet, replacing the plain `SubheaderItem`
- Align fee rate emojis with iOS: Slow ⏱️, Fast ⚡️

related #108 

## Before 
<img width="1080" height="1156" alt="5127607918663502909" src="https://github.com/user-attachments/assets/7ef54caa-9c72-4d1b-af8f-dd20e93f5551" />

## After
<img width="1080" height="1163" alt="5127607918663502910" src="https://github.com/user-attachments/assets/6b3a3673-9f7c-4bff-9c9e-26efe8087db1" />