### PR TITLE
feat(android): add percent shortcuts to swap pay input

### DIFF
--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
@@ -66,6 +67,7 @@ internal fun SwapScene(
     onSelectPayPercent: (Int) -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
 
     val showPercentBar = imeVisible && swapState.payItemInteraction.isAmountEditable && pay != null
 
@@ -81,10 +83,9 @@ internal fun SwapScene(
                     )
                 }
             }
-            swapState.isSwapButtonVisible -> {
+            else -> {
                 { SwapAction(swapState, onPrimaryAction) }
             }
-            else -> null
         },
         mainActionPadding = if (showPercentBar) PaddingValues(0.dp) else PaddingValues(
             horizontal = sceneContentPadding(),

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
@@ -1,8 +1,14 @@
 package com.gemwallet.android.features.swap.views
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.input.TextFieldState
@@ -10,7 +16,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,6 +28,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.sectionHeaderItem
@@ -30,7 +41,12 @@ import com.gemwallet.android.features.swap.views.components.SwapError
 import com.gemwallet.android.features.swap.views.components.SwapItem
 import com.gemwallet.android.ui.models.swap.SwapDetailsUIModel
 import com.gemwallet.android.ui.theme.iconSize
+import com.gemwallet.android.ui.theme.paddingDefault
+import com.gemwallet.android.ui.theme.paddingSmall
+import com.gemwallet.android.ui.theme.sceneContentPadding
 import com.gemwallet.android.ui.theme.space0
+
+private val payPercentOptions = listOf(25, 50, 100)
 
 @Composable
 internal fun SwapScene(
@@ -47,14 +63,33 @@ internal fun SwapScene(
     onDetails: () -> Unit,
     onCancel: () -> Unit,
     onPrimaryAction: () -> Unit,
+    onSelectPayPercent: (Int) -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
+    val showPercentBar = imeVisible && swapState.payItemInteraction.isAmountEditable && pay != null
+
     Scene(
         title = stringResource(id = R.string.wallet_swap),
-        mainAction = {
-            SwapAction(swapState, onPrimaryAction)
+        mainAction = when {
+            showPercentBar -> {
+                {
+                    PayPercentBar(
+                        options = payPercentOptions,
+                        onSelect = onSelectPayPercent,
+                        onDone = { keyboardController?.hide() },
+                    )
+                }
+            }
+            swapState.isSwapButtonVisible -> {
+                { SwapAction(swapState, onPrimaryAction) }
+            }
+            else -> null
         },
+        mainActionPadding = if (showPercentBar) PaddingValues(0.dp) else PaddingValues(
+            horizontal = sceneContentPadding(),
+            vertical = paddingDefault,
+        ),
         onClose = onCancel,
     ) {
         LazyColumn {
@@ -131,4 +166,49 @@ private fun SwapSectionHeader(resId: Int, topPadding: Dp? = null) {
         style = MaterialTheme.typography.labelMedium,
         color = MaterialTheme.colorScheme.secondary,
     )
+}
+
+@Composable
+private fun PayPercentBar(
+    options: List<Int>,
+    onSelect: (Int) -> Unit,
+    onDone: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = paddingDefault, vertical = paddingSmall),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(paddingSmall),
+        ) {
+            options.forEach { percent ->
+                TextButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = { onSelect(percent) },
+                    shape = MaterialTheme.shapes.extraLarge,
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+                ) {
+                    Text(text = "$percent%", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+            TextButton(
+                modifier = Modifier.weight(1f),
+                onClick = onDone,
+                colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
+            ) {
+                Text(
+                    text = stringResource(R.string.common_done),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+    }
 }

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScreen.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScreen.kt
@@ -76,6 +76,7 @@ fun SwapScreen(
         onCancel = onCancel,
         onDetails = { isShowDetails = true },
         onPrimaryAction = onPrimaryAction,
+        onSelectPayPercent = viewModel::onSelectPayPercent,
     )
 
     PriceImpactWarningDialog(

--- a/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModel.kt
+++ b/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModel.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uniffi.gemstone.SwapperProvider
 import java.math.BigDecimal
+import com.gemwallet.android.model.Crypto
 import java.math.BigInteger
 import javax.inject.Inject
 
@@ -248,6 +249,19 @@ class SwapViewModel @Inject constructor(
                 savedStateHandle["to"] = assetId.toIdentifier()
             }
         }
+    }
+
+    fun onSelectPayPercent(percent: Int) {
+        val asset = payAsset.value ?: return
+        val available = asset.balance.balance.available.toBigIntegerOrNull() ?: return
+        val scaled = available.multiply(percent.toBigInteger()).divide(100.toBigInteger())
+        val formatted = Crypto(scaled)
+            .value(asset.asset.decimals)
+            .stripTrailingZeros()
+            .toPlainString()
+        clearTransferQuoteState()
+        payValue.clearText()
+        payValue.setTextAndPlaceCursorAtEnd(formatted)
     }
 
     fun switchSwap() = viewModelScope.launch {


### PR DESCRIPTION
Adds 25% / 50% / 100% quick-fill buttons to the swap pay input field.

When the pay amount field is focused, the bottom action bar is replaced by a `PayPercentBar` showing percent options and a "Done" button to dismiss the keyboard.

- `SwapScene` — renders `PayPercentBar` in place of the swap button when keyboard is open and pay field is editable
- `SwapViewModel` — `onSelectPayPercent(percent)` scales the available balance and sets the pay field value
- `SwapScreen` — wires `onSelectPayPercent` to the ViewModel


https://github.com/user-attachments/assets/abf07b57-44c6-4aa6-a620-80e23e6e6f23

