### PR TITLE
Show chain icon and resolved name in Android Setup wallet scene

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/features/setup_wallet/viewmodels/SetupWalletViewModel.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/setup_wallet/viewmodels/SetupWalletViewModel.kt
@@ -7,7 +7,9 @@ import androidx.navigation.toRoute
 import com.gemwallet.android.application.wallet.coordinators.SetWalletName
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.features.setup_wallet.navigation.SetupWalletRoute
+import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.WalletSource
+import com.wallet.core.primitives.WalletType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -39,6 +41,8 @@ class SetupWalletViewModel @Inject constructor(
                         it.copy(
                             walletName = wallet.name,
                             walletSource = wallet.source,
+                            walletType = wallet.type,
+                            walletChain = wallet.accounts.firstOrNull()?.chain,
                         )
                     }
                 }
@@ -57,4 +61,6 @@ class SetupWalletViewModel @Inject constructor(
 data class SetupWalletViewModelState(
     val walletName: String = "",
     val walletSource: WalletSource = WalletSource.Create,
+    val walletType: WalletType? = null,
+    val walletChain: Chain? = null,
 )

--- a/android/app/src/main/kotlin/com/gemwallet/android/features/setup_wallet/views/SetupWalletScreen.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/setup_wallet/views/SetupWalletScreen.kt
@@ -1,25 +1,19 @@
 package com.gemwallet.android.features.setup_wallet.views
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -27,6 +21,9 @@ import com.gemwallet.android.features.setup_wallet.viewmodels.SetupWalletViewMod
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.GemTextField
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.components.image.IconWithBadge
+import com.gemwallet.android.ui.components.list_item.supportIcon
+import com.gemwallet.android.ui.components.list_item.walletItemIconModel
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.theme.extraLargeIconSize
 import com.gemwallet.android.ui.theme.paddingDefault
@@ -69,13 +66,13 @@ fun SetupWalletScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(modifier = Modifier.size(paddingDefault))
-            Image(
-                painterResource(id = R.drawable.brandmark),
-                contentDescription = "",
-                modifier = Modifier
-                    .size(extraLargeIconSize)
-                    .clip(CircleShape),
-            )
+            uiState.walletType?.let { type ->
+                IconWithBadge(
+                    icon = walletItemIconModel(type = type, walletChain = uiState.walletChain),
+                    supportIcon = type.supportIcon(),
+                    size = extraLargeIconSize,
+                )
+            }
             Spacer(modifier = Modifier.size(paddingLarge))
             GemTextField(
                 value = uiState.walletName,

--- a/android/features/import_wallet/viewmodels/src/main/kotlin/com/gemwallet/android/features/import_wallet/viewmodels/ImportViewModel.kt
+++ b/android/features/import_wallet/viewmodels/src/main/kotlin/com/gemwallet/android/features/import_wallet/viewmodels/ImportViewModel.kt
@@ -65,7 +65,7 @@ class ImportViewModel @Inject constructor(
         try {
             val result = importWalletService.importWallet(
                 importType = state.value.importType,
-                walletName = generatedName,
+                walletName = nameRecord?.name?.takeIf { it.isNotBlank() } ?: generatedName,
                 data = if (nameRecord?.address.isNullOrEmpty()) data.trim() else nameRecord.address,
             )
             state.update { it.copy(dataError = null, loading = false) }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/WalletItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/WalletItem.kt
@@ -111,7 +111,7 @@ private fun WalletEditButton(
     }
 }
 
-private fun walletItemIconModel(type: WalletType, walletChain: Chain?): Any? = when (type) {
+fun walletItemIconModel(type: WalletType, walletChain: Chain?): Any? = when (type) {
     WalletType.Multicoin -> R.drawable.multicoin_wallet
     WalletType.Single,
     WalletType.PrivateKey,

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/WalletTypeExt.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/WalletTypeExt.kt
@@ -11,7 +11,7 @@ val WalletType.descriptionRes: Int get() = when (this) {
     WalletType.View -> R.string.common_address
 }
 
-internal fun WalletType.supportIcon(): String? = when (this) {
+fun WalletType.supportIcon(): String? = when (this) {
     WalletType.View -> "android.resource://com.gemwallet.android/drawable/${R.drawable.watch_badge}"
     else -> null
 }


### PR DESCRIPTION
Mirror iOS behavior on the Android import flow: the Setup wallet scene now displays the chain icon (with a watch badge for view wallets) and prefers a resolved NameRecord (e.g., ENS) as the wallet name.