### PR TITLE
Fix wallet scene balance layout for long token symbols

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/AssetItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/AssetItem.kt
@@ -3,12 +3,10 @@ package com.gemwallet.android.ui.components.list_item
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,8 +33,6 @@ import com.gemwallet.android.ui.theme.paddingHalfSmall
 import com.gemwallet.android.ui.theme.space0
 import com.gemwallet.android.ui.theme.space6
 import com.wallet.core.primitives.Asset
-
-private val balanceInfoMaxWidth = 136.dp
 
 @Composable
 private fun assetListItemContentPadding(): Dp {
@@ -238,7 +234,6 @@ private fun BalanceInfo(
     color: Color,
 ) {
     Column(
-        modifier = Modifier.widthIn(max = balanceInfoMaxWidth),
         horizontalAlignment = Alignment.End
     ) {
         Text(

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/ListItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/ListItem.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -64,16 +64,12 @@ fun ListItem(
                     .padding(start = contentSpacing)
             ),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(contentSpacing)
+        horizontalArrangement = Arrangement.spacedBy(contentSpacing),
     ) {
         leading?.invoke(this)
         Row(
             modifier = Modifier
-                .padding(
-                    top = contentPadding,
-                    end = trailingEndPadding,
-                    bottom = contentPadding,
-                )
+                .padding(top = contentPadding, end = trailingEndPadding, bottom = contentPadding)
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {


### PR DESCRIPTION
Remove 136.dp max-width cap on BalanceInfo so trailing balance takes its intrinsic width and title-Column (weight(1f)) absorbs the remainder. Previously long symbols like JELLY-MY-JELLY were truncated mid-string inside the 136.dp column; now they render fully when there's room.

Closes: https://github.com/gemwalletcom/wallet/issues/167

<img width="320" alt="Screenshot_20260420_135539" src="https://github.com/user-attachments/assets/45cbda49-16dd-409e-8b60-76a6977f94d8" />
