### PR TITLE
Fix Android empty state contrast and pull-to-refresh

### DIFF
--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
@@ -90,7 +90,11 @@ internal fun TransactionsScene(
                 } else {
                     EmptyContentType.Activity(onReceive = onReceive, onBuy = onBuy)
                 }
-                EmptyContentView(type = type, modifier = Modifier.fillMaxSize())
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    item {
+                        EmptyContentView(type = type, modifier = Modifier.fillParentMaxSize())
+                    }
+                }
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),

--- a/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
+++ b/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -104,7 +105,14 @@ fun NftListScene(
             }
 
             if (!isLoading && items.isEmpty()) {
-                EmptyContentView(type = EmptyContentType.Nft(), modifier = Modifier.fillMaxSize())
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    item {
+                        EmptyContentView(
+                            type = EmptyContentType.Nft(),
+                            modifier = Modifier.fillParentMaxSize(),
+                        )
+                    }
+                }
                 return@PullToRefreshBox
             }
 

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/empty/EmptyContentView.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/empty/EmptyContentView.kt
@@ -89,11 +89,11 @@ private fun EmptyContentType.buttons(): List<EmptyAction> = when (this) {
     )
     is EmptyContentType.Asset -> if (isViewOnly) emptyList() else listOfNotNull(
         onBuy?.let { EmptyAction(stringResource(R.string.wallet_buy), it) },
-        onSwap?.let { EmptyAction(stringResource(R.string.wallet_swap), it) },
+        onSwap?.let { EmptyAction(stringResource(R.string.wallet_swap), it, EmptyActionStyle.Secondary) },
     )
     is EmptyContentType.Activity -> if (isViewOnly) emptyList() else listOfNotNull(
         onBuy?.let { EmptyAction(stringResource(R.string.wallet_buy), it) },
-        onReceive?.let { EmptyAction(stringResource(R.string.wallet_receive), it) },
+        onReceive?.let { EmptyAction(stringResource(R.string.wallet_receive), it, EmptyActionStyle.Secondary) },
     )
     is EmptyContentType.SearchAssets -> listOfNotNull(
         onAddCustomToken?.let { EmptyAction(stringResource(R.string.assets_add_custom_token), it) },

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/empty/EmptyStateView.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/empty/EmptyStateView.kt
@@ -12,9 +12,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -23,16 +24,18 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
-import com.gemwallet.android.ui.theme.emptyImageColor
 import com.gemwallet.android.ui.theme.largeIconSize
 import com.gemwallet.android.ui.theme.listItemIconSize
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.paddingSmall
 import com.gemwallet.android.ui.theme.space8
 
+enum class EmptyActionStyle { Primary, Secondary }
+
 data class EmptyAction(
     val title: String,
     val onClick: () -> Unit,
+    val style: EmptyActionStyle = EmptyActionStyle.Primary,
 )
 
 @Composable
@@ -56,7 +59,7 @@ fun EmptyStateView(
                     modifier = Modifier
                         .size(largeIconSize)
                         .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.scrim),
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest),
                     contentAlignment = Alignment.Center,
                 ) {
                     if (iconVector != null) {
@@ -64,14 +67,14 @@ fun EmptyStateView(
                             imageVector = iconVector,
                             contentDescription = null,
                             modifier = Modifier.size(listItemIconSize),
-                            tint = emptyImageColor,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     } else if (icon != null) {
                         Icon(
                             painter = icon,
                             contentDescription = null,
                             modifier = Modifier.size(listItemIconSize),
-                            tint = emptyImageColor,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }
                 }
@@ -103,8 +106,19 @@ fun EmptyStateView(
                 Spacer(modifier = Modifier.height(paddingDefault))
                 Row(horizontalArrangement = Arrangement.spacedBy(paddingSmall)) {
                     buttons.forEach { action ->
-                        OutlinedButton(onClick = action.onClick) {
-                            Text(action.title)
+                        when (action.style) {
+                            EmptyActionStyle.Primary -> Button(onClick = action.onClick) {
+                                Text(action.title)
+                            }
+                            EmptyActionStyle.Secondary -> Button(
+                                onClick = action.onClick,
+                                colors = ButtonDefaults.buttonColors().copy(
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                    contentColor = MaterialTheme.colorScheme.onSurface,
+                                ),
+                            ) {
+                                Text(action.title)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
- Wrap Activity and NFT empty states in LazyColumn so PullToRefreshBox receives the gesture
- Switch empty state icon circle to surfaceContainerHighest and tint to onSurface for visibility on surface-colored scenes
- Add EmptyActionStyle to EmptyAction and let EmptyContentView declare primary/secondary per state

<img width="320" alt="Screenshot_20260421_124529" src="https://github.com/user-attachments/assets/03f0189b-a87f-40b4-9881-116b0d9e4241" />
