### PR TITLE
Show empty state immediately on Android NFT and Activity

### DIFF
--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
@@ -83,7 +83,7 @@ internal fun TransactionsScene(
                 )
             }
         ) {
-            if (transactions.isEmpty() && !loading) {
+            if (transactions.isEmpty()) {
                 val hasFilters = chainsFilter.isNotEmpty() || typeFilter.isNotEmpty()
                 val type = if (hasFilters) {
                     EmptyContentType.SearchActivity { onClearChainsFilter(); onClearTypesFilter() }

--- a/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
+++ b/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
@@ -35,7 +35,6 @@ import com.gemwallet.android.cases.nft.NftError
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.empty.EmptyContentType
 import com.gemwallet.android.ui.components.empty.EmptyContentView
-import com.gemwallet.android.ui.components.progress.CircularProgressIndicator20
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.actions.CancelAction
 import com.gemwallet.android.ui.models.actions.NftAssetIdAction
@@ -77,16 +76,15 @@ fun NftListScene(
         },
         onClose = if (cancelAction == null) null else { { cancelAction() } } // TODO: Replace to action in scene
     ) {
-        val isRefreshing = isLoading && !items.isEmpty()
         PullToRefreshBox(
             modifier = Modifier.fillMaxSize(),
-            isRefreshing = isRefreshing,
+            isRefreshing = isLoading,
             onRefresh = viewModel::refresh,
             state = pullToRefreshState,
             indicator = {
                 Indicator( // TODO: Out to view library
                     modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = isRefreshing,
+                    isRefreshing = isLoading,
                     state = pullToRefreshState,
                     containerColor = MaterialTheme.colorScheme.background
                 )
@@ -112,14 +110,7 @@ fun NftListScene(
                 return@PullToRefreshBox
             }
 
-            if (isLoading && items.isEmpty()) {
-                Box(modifier = Modifier.fillMaxSize()) {
-                    CircularProgressIndicator20(modifier = Modifier.align(Alignment.Center))
-                }
-                return@PullToRefreshBox
-            }
-
-            if (!isLoading && items.isEmpty()) {
+            if (items.isEmpty()) {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     item {
                         EmptyContentView(

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/empty/EmptyStateView.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/empty/EmptyStateView.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.gemwallet.android.ui.theme.largeIconSize
 import com.gemwallet.android.ui.theme.listItemIconSize
@@ -88,6 +89,7 @@ fun EmptyStateView(
                 } else {
                     MaterialTheme.typography.bodyMedium
                 },
+                fontWeight = FontWeight.Medium,
                 textAlign = TextAlign.Center,
             )
 


### PR DESCRIPTION
Replace centered loader on NFT collections with the empty state and let pull-to-refresh render on initial load too. Same change on the Activity screen so the empty state shows while loading instead of leaving a blank screen. Bumps empty-state title weight to Medium.

[Screen_recording_20260421_231302.webm](https://github.com/user-attachments/assets/f8dbb7ad-b409-4f14-9ab8-84c684667df9)
