### PR TITLE
Remove excess bottom padding on recipient list

### DIFF
--- a/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/RecipientScreen.kt
+++ b/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/RecipientScreen.kt
@@ -1,6 +1,6 @@
 package com.gemwallet.android.features.recipient.presents
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -37,6 +37,7 @@ import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.actions.AmountTransactionAction
 import com.gemwallet.android.ui.models.actions.CancelAction
 import com.gemwallet.android.ui.models.actions.ConfirmTransactionAction
+import com.gemwallet.android.ui.theme.paddingDefault
 import com.wallet.core.primitives.NameRecord
 import com.wallet.core.primitives.Wallet
 
@@ -122,7 +123,7 @@ fun RecipientScreen(
         }
     ) {
         LazyColumn(
-            modifier = Modifier.padding(bottom = 72.dp),
+            contentPadding = PaddingValues(bottom = paddingDefault),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             item { RecipientHead(type) }


### PR DESCRIPTION
Replace 72dp hard padding with idiomatic LazyColumn contentPadding so the recipient list no longer leaves a large gap above the Continue button.

Closes: https://github.com/gemwalletcom/wallet/issues/187

<img width="320" alt="photo_2026-04-22 12 42 14 PM" src="https://github.com/user-attachments/assets/4c4a7f7a-1ecd-4987-b555-fa7c08bfc64b" />
<img width="320" alt="photo_2026-04-22 12 42 17 PM" src="https://github.com/user-attachments/assets/84bd9ec1-061b-4ccb-a019-249bd32b49ea" />
