### PR TITLE
Show QR scanner as a modal bottom sheet on Android

### DIFF
--- a/android/features/add_asset/presents/src/main/kotlin/com/gemwallet/android/features/add_asset/views/AddAssetScreen.kt
+++ b/android/features/add_asset/presents/src/main/kotlin/com/gemwallet/android/features/add_asset/views/AddAssetScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.ext.asset
-import com.gemwallet.android.ui.components.QrCodeRequest
+import com.gemwallet.android.ui.components.QrCodeScannerModal
 import com.gemwallet.android.ui.components.screen.SelectChain
 import com.gemwallet.android.features.add_asset.viewmodels.AddAssetViewModel
 import com.gemwallet.android.features.add_asset.viewmodels.models.AddAssetUIState
@@ -35,9 +35,9 @@ fun AddAssetScree(
     }
 
     AnimatedContent(
-        targetState = uiState.scene,
+        targetState = uiState.scene == AddAssetUIState.Scene.SelectChain,
         transitionSpec = {
-            if (uiState.scene != AddAssetUIState.Scene.Form) {
+            if (targetState) {
                 slideIntoContainer(
                     towards = AnimatedContentTransitionScope.SlideDirection.Left,
                     animationSpec = tween(350)
@@ -56,33 +56,32 @@ fun AddAssetScree(
             }
         },
         label = "phrase"
-    ) {
-        when (it) {
-            AddAssetUIState.Scene.Form -> {
-                AddAssetScene(
-                    searchState = searchState,
-                    addressState = viewModel.addressState,
-                    network = network.asset(),
-                    token = token,
-                    explorerLink = explorerLink,
-                    onCancel = onCancel,
-                    onScan = viewModel::onQrScan,
-                    onAddAsset = { viewModel.addAsset(onFinish) },
-                    onChainSelect = if ((availableChains?.size ?: 0) > 1) viewModel::selectChain else null,
-                )
-            }
-            AddAssetUIState.Scene.QrScanner -> {
-                QrCodeRequest(
-                    onResult = viewModel::setQrData,
-                    onCancel = viewModel::cancelScan
-                )
-            }
-            AddAssetUIState.Scene.SelectChain -> SelectChain(
+    ) { isSelectChain ->
+        if (isSelectChain) {
+            SelectChain(
                 chains = chains,
                 chainFilter = viewModel.chainFilter,
                 onSelect = viewModel::setChain,
                 onCancel = viewModel::cancelSelectChain,
             )
+        } else {
+            AddAssetScene(
+                searchState = searchState,
+                addressState = viewModel.addressState,
+                network = network.asset(),
+                token = token,
+                explorerLink = explorerLink,
+                onCancel = onCancel,
+                onScan = viewModel::onQrScan,
+                onAddAsset = { viewModel.addAsset(onFinish) },
+                onChainSelect = if ((availableChains?.size ?: 0) > 1) viewModel::selectChain else null,
+            )
         }
     }
+
+    QrCodeScannerModal(
+        isVisible = uiState.scene == AddAssetUIState.Scene.QrScanner,
+        onDismissRequest = viewModel::cancelScan,
+        onResult = viewModel::setQrData,
+    )
 }

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/ConnectionsScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/ConnectionsScene.kt
@@ -30,7 +30,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.ext.getShortUrl
 import com.gemwallet.android.ext.shortName
 import com.gemwallet.android.ui.R
-import com.gemwallet.android.ui.components.QrCodeRequest
+import com.gemwallet.android.ui.components.QrCodeScannerModal
 import com.gemwallet.android.ui.components.clipboard.getPlainText
 import com.gemwallet.android.ui.components.empty.EmptyContentType
 import com.gemwallet.android.ui.components.empty.EmptyContentView
@@ -124,12 +124,14 @@ fun ConnectionsScene(
         }
     }
 
-    if (scannerShowed) {
-        QrCodeRequest(onCancel = { scannerShowed = false }) {
+    QrCodeScannerModal(
+        isVisible = scannerShowed,
+        onDismissRequest = { scannerShowed = false },
+        onResult = {
             viewModel.addPairing(it, onSuccess = {}, onError = {})
             scannerShowed = false
-        }
-    }
+        },
+    )
 
     if (pairError.isNotEmpty()) {
         AlertDialog(

--- a/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/RecipientScreen.kt
+++ b/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/RecipientScreen.kt
@@ -30,7 +30,7 @@ import com.gemwallet.android.features.recipient.viewmodel.models.RecipientError
 import com.gemwallet.android.features.recipient.viewmodel.models.RecipientType
 import com.gemwallet.android.model.DestinationAddress
 import com.gemwallet.android.ui.R
-import com.gemwallet.android.ui.components.QrCodeRequest
+import com.gemwallet.android.ui.components.QrCodeScannerModal
 import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.keyboardAsState
 import com.gemwallet.android.ui.components.screen.Scene
@@ -54,17 +54,6 @@ fun RecipientScreen(
 
     var scan by remember { mutableStateOf(QrScanField.None) }
 
-    if (scan != QrScanField.None) {
-        QrCodeRequest(
-            { scan = QrScanField.None },
-            {
-                viewModel.setQrData(scan, it, confirmAction)
-                scan = QrScanField.None
-            }
-        )
-        return
-    }
-
     val currentType = type ?: return
     RecipientScreen(
         type = currentType,
@@ -78,6 +67,15 @@ fun RecipientScreen(
         onQrScan = { scan = it },
         onNext = { viewModel.onNext(it, amountAction, confirmAction) },
         onCancel = cancelAction,
+    )
+
+    QrCodeScannerModal(
+        isVisible = scan != QrScanField.None,
+        onDismissRequest = { scan = QrScanField.None },
+        onResult = {
+            viewModel.setQrData(scan, it, confirmAction)
+            scan = QrScanField.None
+        },
     )
 }
 

--- a/android/features/settings/networks/presents/src/main/kotlin/com/gemwallet/android/features/settings/networks/presents/AddNodeScene.kt
+++ b/android/features/settings/networks/presents/src/main/kotlin/com/gemwallet/android/features/settings/networks/presents/AddNodeScene.kt
@@ -28,7 +28,7 @@ import com.gemwallet.android.ext.asset
 import com.gemwallet.android.features.settings.networks.viewmodels.AddNodeViewModel
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.GemTextField
-import com.gemwallet.android.ui.components.QrCodeRequest
+import com.gemwallet.android.ui.components.QrCodeScannerModal
 import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.clipboard.getPlainText
 import com.gemwallet.android.ui.components.fields.TransferTextFieldActions
@@ -127,13 +127,15 @@ fun AddNodeScene(chain: Chain, onCancel: () -> Unit) {
         }
     }
 
-    if (isShowQRScan) {
-        QrCodeRequest(onCancel = { isShowQRScan = false }) {
+    QrCodeScannerModal(
+        isVisible = isShowQRScan,
+        onDismissRequest = { isShowQRScan = false },
+        onResult = {
             isShowQRScan = false
             viewModel.url.value = it.trim()
             viewModel.onUrlChange()
-        }
-    }
+        },
+    )
 }
 
 @Composable

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/QrCodeScannerModal.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/QrCodeScannerModal.kt
@@ -1,0 +1,27 @@
+package com.gemwallet.android.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import com.gemwallet.android.ui.components.screen.ModalBottomSheet
+
+@Composable
+fun QrCodeScannerModal(
+    isVisible: Boolean,
+    onDismissRequest: () -> Unit,
+    onResult: (String) -> Unit,
+) {
+    ModalBottomSheet(
+        isVisible = isVisible,
+        onDismissRequest = onDismissRequest,
+        skipPartiallyExpanded = true,
+        shape = RectangleShape,
+        dragHandle = null,
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            QrCodeRequest(onCancel = onDismissRequest, onResult = onResult)
+        }
+    }
+}


### PR DESCRIPTION
Replace inline full-screen overlay with a fullscreen ModalBottomSheet across all four QR entry points (WalletConnect, recipient, custom node, add asset). Extract the wrapper into a reusable QrCodeScannerModal so each call site only passes visibility and the result callback.

Fix: https://github.com/gemwalletcom/wallet/issues/186