### PR TITLE
Show asset symbol in insufficient balance error on Android

### DIFF
--- a/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/components/AmountErrorString.kt
+++ b/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/components/AmountErrorString.kt
@@ -16,7 +16,7 @@ fun amountErrorString(error: AmountError): String = when (error) {
     AmountError.Unavailable -> "Unavailable"
     is AmountError.InsufficientBalance -> stringResource(
         id = R.string.transfer_insufficient_balance,
-        error.assetName
+        error.assetSymbol
     )
     is AmountError.InsufficientFeeBalance -> stringResource(
         id = R.string.transfer_insufficient_network_fee_balance,

--- a/android/features/transfer_amount/viewmodels/build.gradle.kts
+++ b/android/features/transfer_amount/viewmodels/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.lifecycle.runtime.ktx)
     implementation(libs.lifecycle.viewmodel.savedstate)
 
+    testImplementation(testFixtures(project(":gemcore")))
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/models/AmountError.kt
+++ b/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/models/AmountError.kt
@@ -11,7 +11,7 @@ sealed class AmountError : Exception() {
 
     object ZeroAmount : AmountError()
 
-    class InsufficientBalance(val assetName: String) : AmountError()
+    class InsufficientBalance(val assetSymbol: String) : AmountError()
 
     class InsufficientFeeBalance(val assetName: String) : AmountError()
 

--- a/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountBaseViewModel.kt
+++ b/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountBaseViewModel.kt
@@ -117,33 +117,6 @@ abstract class AmountBaseViewModel(
         onConfirm: (ConfirmParams) -> Unit
     )
 
-    internal fun validateAmount(asset: Asset, amount: String, minValue: BigInteger) {
-        if (amount.isEmpty()) {
-            throw AmountError.Required
-        }
-        try {
-            amount.parseNumber()
-        } catch (_: Throwable) {
-            throw AmountError.IncorrectAmount
-        }
-        val crypto = Crypto(amount.parseNumber(), asset.decimals)
-        if (BigInteger.ZERO != minValue && crypto.atomicValue < minValue) {
-            throw AmountError.MinimumValue(asset.format(Crypto(minValue), decimalPlace = 2))
-        }
-    }
-
-    internal fun validateBalance(
-        assetInfo: AssetInfo,
-        amount: Crypto
-    ) {
-        if (amount.atomicValue == BigInteger.ZERO) {
-            throw AmountError.ZeroAmount
-        }
-        if (amount.value(assetInfo.asset.decimals) > availableBalance.value) {
-            throw  AmountError.InsufficientBalance(assetInfo.asset.name)
-        }
-    }
-
     internal fun calcEquivalent(
         inputAmount: String,
         inputDirection: AmountInputType,
@@ -154,7 +127,7 @@ abstract class AmountBaseViewModel(
         return try {
             when (inputDirection) {
                 AmountInputType.Crypto -> {
-                    validateAmount(asset, inputAmount, BigInteger.ZERO)
+                    AmountValidation.validateAmount(asset, inputAmount, BigInteger.ZERO)
                     val amount = inputAmount.parseNumber()
                     val decimals = asset.decimals
                     val unit = Crypto(amount, decimals).convert(decimals, price)
@@ -163,7 +136,7 @@ abstract class AmountBaseViewModel(
                 AmountInputType.Fiat -> {
                     val value = inputAmount.parseNumber()
                     val crypto = value.divide(price.toBigDecimal(), MathContext.DECIMAL128)
-                    validateAmount(asset, crypto.toString(), BigInteger.ZERO)
+                    AmountValidation.validateAmount(asset, crypto.toString(), BigInteger.ZERO)
                     asset.format(crypto, dynamicPlace = true)
                 }
             }

--- a/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountValidation.kt
+++ b/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountValidation.kt
@@ -1,0 +1,41 @@
+package com.gemwallet.android.features.transfer_amount.viewmodels
+
+import com.gemwallet.android.features.transfer_amount.models.AmountError
+import com.gemwallet.android.math.parseNumber
+import com.gemwallet.android.model.AssetInfo
+import com.gemwallet.android.model.Crypto
+import com.gemwallet.android.model.format
+import com.wallet.core.primitives.Asset
+import java.math.BigDecimal
+import java.math.BigInteger
+
+object AmountValidation {
+
+    fun validateAmount(asset: Asset, amount: String, minValue: BigInteger) {
+        if (amount.isEmpty()) {
+            throw AmountError.Required
+        }
+        try {
+            amount.parseNumber()
+        } catch (_: Throwable) {
+            throw AmountError.IncorrectAmount
+        }
+        val crypto = Crypto(amount.parseNumber(), asset.decimals)
+        if (minValue != BigInteger.ZERO && crypto.atomicValue < minValue) {
+            throw AmountError.MinimumValue(asset.format(Crypto(minValue), decimalPlace = 2))
+        }
+    }
+
+    fun validateBalance(
+        assetInfo: AssetInfo,
+        amount: Crypto,
+        availableBalance: BigDecimal,
+    ) {
+        if (amount.atomicValue == BigInteger.ZERO) {
+            throw AmountError.ZeroAmount
+        }
+        if (amount.value(assetInfo.asset.decimals) > availableBalance) {
+            throw AmountError.InsufficientBalance(assetInfo.asset.symbol)
+        }
+    }
+}

--- a/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountViewModel.kt
+++ b/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountViewModel.kt
@@ -18,6 +18,7 @@ import com.gemwallet.android.domains.transaction.TransactionBalanceContext
 import com.gemwallet.android.domains.transaction.balance
 import com.gemwallet.android.ext.freezed
 import com.gemwallet.android.math.parseNumber
+import com.gemwallet.android.math.parseNumberOrNull
 import com.gemwallet.android.model.AmountParams
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.ConfirmParams
@@ -44,9 +45,11 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -233,6 +236,38 @@ class AmountViewModel @Inject constructor(
     }
     .stateIn(viewModelScope, SharingStarted.Eagerly, "")
 
+    init {
+        combine(
+            snapshotFlow { amount },
+            amountInputType,
+            assetInfo,
+            params,
+            combine(delegation, resource) { d, r -> d to r },
+        ) { input, inputType, asset, amountParams, (delegation, resource) ->
+            ValidationInputs(input, inputType, asset, amountParams, delegation, resource)
+        }
+        .mapLatest { validate(it) }
+        .onEach { errorUIState.value = it }
+        .launchIn(viewModelScope)
+    }
+
+    private suspend fun validate(inputs: ValidationInputs): AmountError {
+        if (inputs.amount.isEmpty()) return AmountError.None
+        if (inputs.amount.parseNumberOrNull()?.signum() == 0) return AmountError.None
+        val assetInfo = inputs.assetInfo ?: return AmountError.None
+        val params = inputs.params ?: return AmountError.None
+        return try {
+            val asset = assetInfo.asset
+            val price = assetInfo.price?.price?.price ?: 0.0
+            AmountValidation.validateAmount(asset, inputs.amount, getMinAmount(params.txType, asset.id.chain))
+            val cryptoAmount = inputs.inputType.getAmount(inputs.amount, asset.decimals, price)
+            checkBalance(assetInfo, params, inputs.delegation, inputs.resource, cryptoAmount)
+            AmountError.None
+        } catch (err: Throwable) {
+            err as? AmountError ?: AmountError.None
+        }
+    }
+
     fun setDelegatorValidator(validatorId: String?) {
         selectedValidatorId.update { validatorId }
     }
@@ -313,14 +348,15 @@ class AmountViewModel @Inject constructor(
         val inputType = amountInputType.value
 
         val minimumValue = getMinAmount(params.txType, asset.id.chain)
-        validateAmount(asset, rawAmount, minimumValue)
+        AmountValidation.validateAmount(asset, rawAmount, minimumValue)
 
         val amount = inputType.getAmount(rawAmount, decimals, price)
-        validateBalance(assetInfo, params, delegation, resource.value, amount)
+        val balance = checkBalance(assetInfo, params, delegation, resource.value, amount)
 
         errorUIState.update { AmountError.None }
 
-        val builder = ConfirmParams.Builder(asset, owner, amount.atomicValue, maxAmount.value)
+        val isMax = maxAmount.value || amount.atomicValue == balance
+        val builder = ConfirmParams.Builder(asset, owner, amount.atomicValue, isMax)
         val nextParams = when (params.txType) {
             TransactionType.Transfer -> builder.transfer(destination!!, memo)
             TransactionType.EarnDeposit,
@@ -354,7 +390,7 @@ class AmountViewModel @Inject constructor(
         return try {
             when (inputDirection) {
                 AmountInputType.Crypto -> {
-                    validateAmount(asset, inputAmount, BigInteger.ZERO)
+                    AmountValidation.validateAmount(asset, inputAmount, BigInteger.ZERO)
                     val amount = inputAmount.parseNumber()
                     val decimals = asset.decimals
                     val unit = Crypto(amount, decimals).convert(decimals, price)
@@ -363,7 +399,7 @@ class AmountViewModel @Inject constructor(
                 AmountInputType.Fiat -> {
                     val value = inputAmount.parseNumber()
                     val crypto = value.divide(price.toBigDecimal(), MathContext.DECIMAL128)
-                    validateAmount(asset, crypto.toString(), BigInteger.ZERO)
+                    AmountValidation.validateAmount(asset, crypto.toString(), BigInteger.ZERO)
                     asset.format(crypto, dynamicPlace = true)
                 }
             }
@@ -379,42 +415,22 @@ class AmountViewModel @Inject constructor(
         }
     }
 
-    private fun validateAmount(asset: Asset, amount: String, minValue: BigInteger) {
-        if (amount.isEmpty()) {
-            throw AmountError.Required
-        }
-        try {
-            amount.parseNumber()
-        } catch (_: Throwable) {
-            throw AmountError.IncorrectAmount
-        }
-        val crypto = Crypto(amount.parseNumber(), asset.decimals)
-        if (BigInteger.ZERO != minValue && crypto.atomicValue < minValue) {
-            throw AmountError.MinimumValue(asset.format(Crypto(minValue), decimalPlace = 2))
-        }
-    }
-
-    private suspend fun validateBalance(
+    private suspend fun checkBalance(
         assetInfo: AssetInfo,
         params: AmountParams,
         delegation: Delegation?,
         resource: Resource?,
-        amount: Crypto
-    ) {
-        if (amount.atomicValue == BigInteger.ZERO) {
-            throw AmountError.ZeroAmount
-        }
-        val availableAmount = Crypto(
-            transactionBalanceService.getBalance(
-                assetInfo = assetInfo,
-                params = params,
-                delegation = delegation,
-                resource = resource,
-            )
+        amount: Crypto,
+    ): BigInteger {
+        val balance = transactionBalanceService.getBalance(
+            assetInfo = assetInfo,
+            params = params,
+            delegation = delegation,
+            resource = resource,
         )
-        if (amount.atomicValue > availableAmount.atomicValue) {
-            throw  AmountError.InsufficientBalance(assetInfo.asset.name)
-        }
+        val availableBalance = balance.toBigDecimal().movePointLeft(assetInfo.asset.decimals)
+        AmountValidation.validateBalance(assetInfo, amount, availableBalance)
+        return balance
     }
 
     private fun getMinAmount(txType: TransactionType, chain: Chain): BigInteger {
@@ -446,6 +462,15 @@ class AmountViewModel @Inject constructor(
 private data class BalanceRequest(
     val params: AmountParams?,
     val assetInfo: AssetInfo?,
+    val delegation: Delegation?,
+    val resource: Resource,
+)
+
+private data class ValidationInputs(
+    val amount: String,
+    val inputType: AmountInputType,
+    val assetInfo: AssetInfo?,
+    val params: AmountParams?,
     val delegation: Delegation?,
     val resource: Resource,
 )

--- a/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/PerpetualAmountViewModel.kt
+++ b/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/PerpetualAmountViewModel.kt
@@ -116,10 +116,10 @@ class PerpetualAmountViewModel @Inject constructor(
         val decimals = asset.decimals
         val price = assetInfo.price?.price?.price ?: 0.0
         val inputType = amountInputType.value
-        validateAmount(asset, rawAmount, BigInteger.ZERO)
+        AmountValidation.validateAmount(asset, rawAmount, BigInteger.ZERO)
 
         val amount = inputType.getAmount(rawAmount, decimals, price)
-        validateBalance(assetInfo, amount)
+        AmountValidation.validateBalance(assetInfo, amount, availableBalance.value)
 
         amountError.update { AmountError.None }
 

--- a/android/features/transfer_amount/viewmodels/src/test/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountValidationTest.kt
+++ b/android/features/transfer_amount/viewmodels/src/test/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountValidationTest.kt
@@ -1,0 +1,71 @@
+package com.gemwallet.android.features.transfer_amount.viewmodels
+
+import com.gemwallet.android.features.transfer_amount.models.AmountError
+import com.gemwallet.android.model.Crypto
+import com.gemwallet.android.testkit.mockAssetCosmos
+import com.gemwallet.android.testkit.mockAssetInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+
+class AmountValidationTest {
+
+    @Test
+    fun `insufficient balance error uses asset symbol`() {
+        val error = assertThrows(AmountError.InsufficientBalance::class.java) {
+            AmountValidation.validateBalance(
+                assetInfo = mockAssetInfo(mockAssetCosmos()),
+                amount = Crypto(BigInteger("200000000")),
+                availableBalance = BigDecimal("100"),
+            )
+        }
+        assertEquals("ATOM", error.assetSymbol)
+    }
+
+    @Test
+    fun `validateBalance passes when amount equals balance`() {
+        AmountValidation.validateBalance(
+            assetInfo = mockAssetInfo(mockAssetCosmos()),
+            amount = Crypto(BigInteger("100000000")),
+            availableBalance = BigDecimal("100"),
+        )
+    }
+
+    @Test
+    fun `validateBalance throws ZeroAmount for zero`() {
+        assertThrows(AmountError.ZeroAmount::class.java) {
+            AmountValidation.validateBalance(
+                assetInfo = mockAssetInfo(mockAssetCosmos()),
+                amount = Crypto(BigInteger.ZERO),
+                availableBalance = BigDecimal("100"),
+            )
+        }
+    }
+
+    @Test
+    fun `validateAmount throws Required for empty input`() {
+        assertThrows(AmountError.Required::class.java) {
+            AmountValidation.validateAmount(mockAssetCosmos(), "", BigInteger.ZERO)
+        }
+    }
+
+    @Test
+    fun `validateAmount throws IncorrectAmount for unparseable input`() {
+        assertThrows(AmountError.IncorrectAmount::class.java) {
+            AmountValidation.validateAmount(mockAssetCosmos(), "abc", BigInteger.ZERO)
+        }
+    }
+
+    @Test
+    fun `validateAmount throws MinimumValue when below minimum`() {
+        assertThrows(AmountError.MinimumValue::class.java) {
+            AmountValidation.validateAmount(
+                asset = mockAssetCosmos(),
+                amount = "0.5",
+                minValue = BigInteger("1000000"),
+            )
+        }
+    }
+}


### PR DESCRIPTION
Use asset.symbol instead of asset.name for consistency with amount display. Add reactive validation so errors update live as the user types and when pressing Max. Extract validation into a pure AmountValidation object and remove duplicates across AmountViewModel / AmountBaseViewModel.

Closes: https://github.com/gemwalletcom/wallet/issues/188

<img width="320" alt="Screenshot_20260422_145401" src="https://github.com/user-attachments/assets/384ad302-50c3-436c-a614-d69e2f8f5e38" />
