### PR TITLE
Add padding and rounded corners to SubheaderItem

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/SubheaderItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/SubheaderItem.kt
@@ -2,9 +2,11 @@ package com.gemwallet.android.ui.components.list_item
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
@@ -13,12 +15,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.gemwallet.android.ui.theme.Spacer4
 import com.gemwallet.android.ui.theme.compactIconSize
+import com.gemwallet.android.ui.theme.paddingHalfSmall
 
 @Composable
 fun SubheaderItem(@StringRes title: Int, vararg formatArgs: Any) {
@@ -43,19 +47,22 @@ fun SubheaderItem(@StringRes title: Int, onClick: () -> Unit) {
 
 @Composable
 fun SubheaderItem(title: String, onClick: () -> Unit) {
-    Row(
-        modifier = Modifier
-            .sectionHeaderItem()
-            .clickable(onClick = onClick),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.secondary,
-        )
-        Spacer4()
-        ChevronIcon()
+    Row(modifier = Modifier.sectionHeaderItem()) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(paddingHalfSmall))
+                .clickable(onClick = onClick)
+                .padding(paddingHalfSmall),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.secondary,
+            )
+            Spacer4()
+            ChevronIcon()
+        }
     }
 }
 


### PR DESCRIPTION
Wrap the clickable row with a clipped rounded corner and small padding so the subheader has a padded, rounded clickable area; preserve icon and text styling. 

<img width="452" height="413" alt="image" src="https://github.com/user-attachments/assets/9ededd84-a490-43cf-9888-a1f83c2a9e27" />

close #182 