### PR TITLE
Add chevron to clickable WarningItem on Android

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/WarningItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/WarningItem.kt
@@ -20,6 +20,7 @@ import com.gemwallet.android.ui.theme.Spacer4
 import com.gemwallet.android.ui.theme.Spacer8
 import com.gemwallet.android.ui.theme.defaultPadding
 import com.gemwallet.android.ui.theme.smallIconSize
+import com.gemwallet.android.ui.theme.alpha50
 
 @Composable
 fun WarningItem(
@@ -30,39 +31,45 @@ fun WarningItem(
     onClick: (() -> Unit)? = null,
     trailing: (@Composable () -> Unit)? = null,
 ) {
-    Column(
+    Row(
         modifier = Modifier
             .listItem(position)
             .fillMaxWidth()
             .defaultPadding()
             .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                modifier = Modifier.size(smallIconSize),
-                imageVector = Icons.Outlined.Warning,
-                contentDescription = null,
-                tint = color,
-            )
-            Spacer8()
-            Text(
-                text = title,
-                color = color,
-                style = MaterialTheme.typography.titleMedium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-        message?.takeIf { it.isNotBlank() }?.let {
-            Spacer4()
+        Column(modifier = Modifier.weight(1f)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                trailing?.invoke()
+                Icon(
+                    modifier = Modifier.size(smallIconSize),
+                    imageVector = Icons.Outlined.Warning,
+                    contentDescription = null,
+                    tint = color,
+                )
+                Spacer8()
                 Text(
-                    text = it,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.secondary,
+                    text = title,
+                    color = color,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
+            message?.takeIf { it.isNotBlank() }?.let {
+                Spacer4()
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    trailing?.invoke()
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.secondary,
+                    )
+                }
+            }
+        }
+        if (onClick != null) {
+            ChevronIcon(tint = MaterialTheme.colorScheme.secondary.copy(alpha = alpha50))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Show a trailing chevron on `WarningItem` when it has an `onClick`, making the tap affordance explicit on confirm-screen errors (e.g. Bitcoin dust error).
- Chevron is vertically centered relative to the title + message column so it stays aligned whether the warning is one or two lines.
- Non-clickable callers (`SimulationWarningsContent`) are unaffected — the chevron only renders when `onClick != null`.

## Test plan
- [x] `./gradlew :ui:compileDebugKotlin`
- [x] `./gradlew :features:confirm:presents:compileDebugKotlin`
- [x] Visual check on confirm screen dust error

<img width="320" alt="Screenshot_20260424_143516" src="https://github.com/user-attachments/assets/5344fc88-0090-447f-8e80-a597becc8787" />
