### PR TITLE
Use onChange to bind queries on change

### DIFF
--- a/ios/Packages/Store/Sources/Query/QueryBindingModifier.swift
+++ b/ios/Packages/Store/Sources/Query/QueryBindingModifier.swift
@@ -10,7 +10,7 @@ struct QueryBindingModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onAppear {
+            .onChange(of: queries.map { ObjectIdentifier($0) }, initial: true) {
                 for query in queries {
                     query.bind(dbQueue: database.dbQueue)
                 }

--- a/ios/Packages/Store/Sources/ViewModifiers/OnChangeQueryObserverModifier.swift
+++ b/ios/Packages/Store/Sources/ViewModifiers/OnChangeQueryObserverModifier.swift
@@ -22,7 +22,7 @@ struct OnChangeBindQueryModifier<Q: DatabaseQueryable>: ViewModifier where Q.Val
 
     func body(content: Content) -> some View {
         content
-            .onAppear {
+            .onChange(of: ObjectIdentifier(query), initial: true) {
                 query.bind(dbQueue: database.dbQueue)
             }
             .onChange(


### PR DESCRIPTION
Problem:
The query-binding modifier used .onAppear, which runs once when the screen opens. On wallet switch, a fresh ObservableQuery was created but never bound to the database, so it stayed empty forever.

Fix:
 Replaced .onAppear with .onChange keyed on query identity. Now any new query instance gets bound automatically. 
 
closes #183 