### PR TITLE
Polish confirm error layout and NFT verified badge

### DIFF
--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/ConfirmErrorInfo.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/ConfirmErrorInfo.kt
@@ -1,21 +1,11 @@
 package com.gemwallet.android.features.confirm.presents.components
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import com.gemwallet.android.ext.asset
 import com.gemwallet.android.model.format
@@ -26,9 +16,6 @@ import com.gemwallet.android.ui.components.InfoSheetEntity.NetworkBalanceRequire
 import com.gemwallet.android.ui.components.list_item.WarningItem
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.models.actions.AssetIdAction
-import com.gemwallet.android.ui.theme.Spacer8
-import com.gemwallet.android.ui.theme.alpha50
-import com.gemwallet.android.ui.theme.smallIconSize
 import com.gemwallet.android.domains.confirm.ConfirmError
 import com.gemwallet.android.domains.confirm.ConfirmState
 import com.gemwallet.android.features.confirm.presents.toLabel
@@ -49,22 +36,6 @@ internal fun ConfirmErrorInfo(state: ConfirmState, feeValue: String, isShowBotto
         color = MaterialTheme.colorScheme.error,
         position = ListPosition.Single,
         onClick = infoSheetEntity?.let { { isShowInfoSheet = true } },
-        trailing = infoSheetEntity?.let {
-            {
-                Row {
-                    Icon(
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(percent = 50))
-                            .size(smallIconSize)
-                            .clickable(onClick = { isShowInfoSheet = true }),
-                        imageVector = Icons.Outlined.Info,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.secondary.copy(alpha = alpha50),
-                    )
-                    Spacer8()
-                }
-            }
-        },
     )
 
     if (isShowInfoSheet) {

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/WarningItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/WarningItem.kt
@@ -29,14 +29,13 @@ fun WarningItem(
     color: Color,
     position: ListPosition,
     onClick: (() -> Unit)? = null,
-    trailing: (@Composable () -> Unit)? = null,
 ) {
     Row(
         modifier = Modifier
             .listItem(position)
             .fillMaxWidth()
-            .defaultPadding()
-            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .defaultPadding(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
@@ -58,14 +57,11 @@ fun WarningItem(
             }
             message?.takeIf { it.isNotBlank() }?.let {
                 Spacer4()
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    trailing?.invoke()
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.secondary,
-                    )
-                }
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary,
+                )
             }
         }
         if (onClick != null) {

--- a/ios/Features/NFT/Sources/Scenes/CollectibleScene.swift
+++ b/ios/Features/NFT/Sources/Scenes/CollectibleScene.swift
@@ -39,7 +39,7 @@ public struct CollectibleScene: View {
                     Text(model.title)
                         .font(.headline)
                     if model.isVerified {
-                        VerifiedBadgeView()
+                        VerifiedBadgeView(font: .subheadline)
                     }
                 }
             }

--- a/ios/Packages/Components/Sources/VerifiedBadgeView.swift
+++ b/ios/Packages/Components/Sources/VerifiedBadgeView.swift
@@ -4,11 +4,15 @@ import Style
 import SwiftUI
 
 public struct VerifiedBadgeView: View {
-    public init() {}
+    private let font: Font
+
+    public init(font: Font = .callout) {
+        self.font = font
+    }
 
     public var body: some View {
         Images.System.checkmarkSealFill
-            .font(.callout)
+            .font(font)
             .foregroundStyle(Colors.whiteSolid, Colors.blue)
     }
 }


### PR DESCRIPTION
- Android: drop info icon from confirm error WarningItem, align message text with the warning icon, and extend the tap ripple to the full card width.
- iOS: make CollectibleScene toolbar verified badge use .subheadline so it sits proportional to the .headline title.
- Swap "—" for "-" in dust threshold error in remote Localize

<img width="320" alt="Screenshot_20260426_221712" src="https://github.com/user-attachments/assets/0ba540da-4b99-4e8a-bf75-26b8e3028c7e" />
<img width="320" alt="Screenshot_20260426_223150" src="https://github.com/user-attachments/assets/49a0e008-1bc4-4484-8cf8-ee69350c8a58" />
