### PR TITLE
Improve toast background color

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/Scene.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/Scene.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -154,7 +155,14 @@ fun Scene(
         },
         snackbarHost = {
             if (snackbar != null) {
-                SnackbarHost(hostState = snackbar)
+                SnackbarHost(hostState = snackbar) { data ->
+                    Snackbar(
+                        snackbarData = data,
+                        containerColor = MaterialTheme.colorScheme.scrim,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                        actionContentColor = MaterialTheme.colorScheme.primary,
+                    )
+                }
             }
         }
     ) { paddingValues ->


### PR DESCRIPTION
Closes #206

## Summary
- Override Material3 default `Snackbar` colors at the single render site in `Scene.kt`
- Snackbars now use the wallet's `scrim` token for the background and `onSurface` for text, instead of M3's untouched `inverseSurface` / `inverseOnSurface` baseline (which fell through to the purple-ish default palette since the theme never defined the inverse tokens)
<img width="320" alt="Screenshot_20260427_135659" src="https://github.com/user-attachments/assets/5ed5616f-a888-49e4-ac63-530be0769c36" />
<img width="320" alt="Screenshot_20260427_135710" src="https://github.com/user-attachments/assets/de1d1b90-7efb-4b93-8136-1a3c07f9c018" />

