### PR TITLE
Use unit price for Solana priority fee on Android

### DIFF
--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/clients/solana/SolanaSignClient.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/clients/solana/SolanaSignClient.kt
@@ -238,16 +238,7 @@ class SolanaSignClient(
     }
 
     private fun sign(input: Solana.SigningInput.Builder, fee: Fee.Solana): List<ByteArray> {
-        input.apply {
-            this.priorityFeeLimit = Solana.PriorityFeeLimit.newBuilder().apply {
-                this.limit = fee.limit.toInt()
-            }.build()
-            if (fee.minerFee > BigInteger.ZERO) {
-                this.priorityFeePrice = Solana.PriorityFeePrice.newBuilder().apply {
-                    this.price = fee.minerFee.toLong()
-                }.build()
-            }
-        }
+        applyPriorityFee(input, fee)
         val output = AnySigner.sign(input.build(), CoinType.SOLANA, Solana.SigningOutput.parser())
         val data = Base58.decodeNoCheck(output.encoded) ?: throw IllegalStateException("string is not Base58 encoding!")
         val base64 = Base64.encode(data)
@@ -275,6 +266,19 @@ class SolanaSignClient(
     }
 
     override fun supported(chain: Chain): Boolean = this.chain == chain
+
+    companion object {
+        internal fun applyPriorityFee(input: Solana.SigningInput.Builder, fee: Fee.Solana) {
+            input.priorityFeeLimit = Solana.PriorityFeeLimit.newBuilder().apply {
+                limit = fee.limit.toInt()
+            }.build()
+            if (fee.unitFee > BigInteger.ZERO) {
+                input.priorityFeePrice = Solana.PriorityFeePrice.newBuilder().apply {
+                    price = fee.unitFee.toLong()
+                }.build()
+            }
+        }
+    }
 }
 
 //public struct SolanaRawTxDecoder {

--- a/android/blockchain/src/test/kotlin/com/gemwallet/android/blockchain/clients/solana/SolanaSignClientTest.kt
+++ b/android/blockchain/src/test/kotlin/com/gemwallet/android/blockchain/clients/solana/SolanaSignClientTest.kt
@@ -1,9 +1,6 @@
 package com.gemwallet.android.blockchain.clients.solana
 
-import com.gemwallet.android.model.Fee
-import com.wallet.core.primitives.AssetId
-import com.wallet.core.primitives.Chain
-import com.wallet.core.primitives.FeePriority
+import com.gemwallet.android.testkit.mockFeeSolana
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
@@ -14,7 +11,11 @@ class SolanaSignClientTest {
 
     @Test
     fun applyPriorityFee_setsComputeUnitPriceFromUnitFee() {
-        val fee = solanaFee(unitFee = 25_000, minerFee = 2_500, limit = 100_000)
+        val fee = mockFeeSolana(
+            unitFee = BigInteger.valueOf(25_000),
+            minerFee = BigInteger.valueOf(2_500),
+            limit = BigInteger.valueOf(100_000),
+        )
         val builder = Solana.SigningInput.newBuilder()
 
         SolanaSignClient.applyPriorityFee(builder, fee)
@@ -25,7 +26,7 @@ class SolanaSignClientTest {
 
     @Test
     fun applyPriorityFee_skipsPriceWhenUnitFeeZero() {
-        val fee = solanaFee(unitFee = 0, minerFee = 2_500, limit = 100_000)
+        val fee = mockFeeSolana(unitFee = BigInteger.ZERO)
         val builder = Solana.SigningInput.newBuilder()
 
         SolanaSignClient.applyPriorityFee(builder, fee)
@@ -33,15 +34,4 @@ class SolanaSignClientTest {
         assertEquals(100_000, builder.priorityFeeLimit.limit)
         assertFalse(builder.hasPriorityFeePrice())
     }
-
-    private fun solanaFee(unitFee: Long, minerFee: Long, limit: Long) = Fee.Solana(
-        feeAssetId = AssetId(Chain.Solana),
-        priority = FeePriority.Normal,
-        amount = BigInteger.valueOf(5_000 + minerFee),
-        minerFee = BigInteger.valueOf(minerFee),
-        maxGasPrice = BigInteger.valueOf(5_000),
-        unitFee = BigInteger.valueOf(unitFee),
-        limit = BigInteger.valueOf(limit),
-        options = emptyMap(),
-    )
 }

--- a/android/blockchain/src/test/kotlin/com/gemwallet/android/blockchain/clients/solana/SolanaSignClientTest.kt
+++ b/android/blockchain/src/test/kotlin/com/gemwallet/android/blockchain/clients/solana/SolanaSignClientTest.kt
@@ -1,0 +1,47 @@
+package com.gemwallet.android.blockchain.clients.solana
+
+import com.gemwallet.android.model.Fee
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.FeePriority
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import wallet.core.jni.proto.Solana
+import java.math.BigInteger
+
+class SolanaSignClientTest {
+
+    @Test
+    fun applyPriorityFee_setsComputeUnitPriceFromUnitFee() {
+        val fee = solanaFee(unitFee = 25_000, minerFee = 2_500, limit = 100_000)
+        val builder = Solana.SigningInput.newBuilder()
+
+        SolanaSignClient.applyPriorityFee(builder, fee)
+
+        assertEquals(100_000, builder.priorityFeeLimit.limit)
+        assertEquals(25_000L, builder.priorityFeePrice.price)
+    }
+
+    @Test
+    fun applyPriorityFee_skipsPriceWhenUnitFeeZero() {
+        val fee = solanaFee(unitFee = 0, minerFee = 2_500, limit = 100_000)
+        val builder = Solana.SigningInput.newBuilder()
+
+        SolanaSignClient.applyPriorityFee(builder, fee)
+
+        assertEquals(100_000, builder.priorityFeeLimit.limit)
+        assertFalse(builder.hasPriorityFeePrice())
+    }
+
+    private fun solanaFee(unitFee: Long, minerFee: Long, limit: Long) = Fee.Solana(
+        feeAssetId = AssetId(Chain.Solana),
+        priority = FeePriority.Normal,
+        amount = BigInteger.valueOf(5_000 + minerFee),
+        minerFee = BigInteger.valueOf(minerFee),
+        maxGasPrice = BigInteger.valueOf(5_000),
+        unitFee = BigInteger.valueOf(unitFee),
+        limit = BigInteger.valueOf(limit),
+        options = emptyMap(),
+    )
+}

--- a/android/gemcore/src/testFixtures/kotlin/com/gemwallet/android/testkit/FeeMock.kt
+++ b/android/gemcore/src/testFixtures/kotlin/com/gemwallet/android/testkit/FeeMock.kt
@@ -1,0 +1,27 @@
+package com.gemwallet.android.testkit
+
+import com.gemwallet.android.model.Fee
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.FeePriority
+import java.math.BigInteger
+
+fun mockFeeSolana(
+    feeAssetId: AssetId = AssetId(Chain.Solana),
+    priority: FeePriority = FeePriority.Normal,
+    amount: BigInteger = BigInteger.valueOf(7_500),
+    minerFee: BigInteger = BigInteger.valueOf(2_500),
+    maxGasPrice: BigInteger = BigInteger.valueOf(5_000),
+    unitFee: BigInteger = BigInteger.valueOf(25_000),
+    limit: BigInteger = BigInteger.valueOf(100_000),
+    options: Map<String, BigInteger> = emptyMap(),
+) = Fee.Solana(
+    feeAssetId = feeAssetId,
+    priority = priority,
+    amount = amount,
+    minerFee = minerFee,
+    maxGasPrice = maxGasPrice,
+    unitFee = unitFee,
+    limit = limit,
+    options = options,
+)


### PR DESCRIPTION
`priorityFeePrice.price` in WalletCore's Solana proto is the `setComputeUnitPrice` argument — microlamports per CU — not the total priority fee. Sending `Fee.Solana.minerFee` (priority fee total in lamports) put the wrong number into the signed transaction, so the chain charged a different fee than the UI displayed. With max-amount SOL transfers this left the sender between 0 and the rent-exempt minimum and simulation failed with `insufficient funds for rent`.

Switch to `unitFee`, matching iOS, and extract `applyPriorityFee` so the field mapping is unit-testable without WalletCore JNI.

Closes #203