### PR TITLE
Fix splash screen icon shape on Xiaomi/Poco

### DIFF
--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -3,10 +3,9 @@
 
     <style name="Theme.Wallet" parent="Theme.Material3.DayNight.NoActionBar" />
 
-    <style name="Theme.Wallet.Starting" parent="Theme.SplashScreen.IconBackground">
+    <style name="Theme.Wallet.Starting" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/splash_background</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_gem_foreground</item>
-        <item name="windowSplashScreenIconBackgroundColor">@color/splash_icon_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_screen</item>
         <item name="postSplashScreenTheme">@style/Theme.Wallet</item>
     </style>
 </resources>

--- a/android/ui/src/main/res/drawable/ic_splash_screen.xml
+++ b/android/ui/src/main/res/drawable/ic_splash_screen.xml
@@ -1,0 +1,32 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="288dp"
+    android:height="288dp"
+    android:viewportWidth="288"
+    android:viewportHeight="288">
+    <group
+        android:translateX="48"
+        android:translateY="48"
+        android:scaleX="0.1875"
+        android:scaleY="0.1875">
+        <path
+            android:pathData="M512,512m-512,0a512,512 0,1 1,1024 0a512,512 0,1 1,-1024 0"
+            android:fillColor="#2D5BE6" />
+        <path
+            android:pathData="M512.3,772.4L872.6,494.9H152L512.3,772.4Z"
+            android:fillColor="#ffffff"
+            android:fillAlpha="0.7" />
+        <path
+            android:pathData="M512.1,772.4L692.3,252H332L512.1,772.4Z"
+            android:fillColor="#ffffff"
+            android:fillAlpha="0.5" />
+        <path
+            android:pathData="M332.1,252H692.4L872.6,494.9H152L332.1,252Z"
+            android:fillColor="#ffffff"
+            android:fillAlpha="0.8" />
+        <path
+            android:pathData="M416,494.9H608.3L692.3,252.1H332L416,494.9Z"
+            android:fillColor="#ffffff"
+            android:fillAlpha="0.9"
+            android:fillType="evenOdd" />
+    </group>
+</vector>


### PR DESCRIPTION
Replace system-rendered icon background with a self-contained vector that bakes the circular background into the drawable. MIUI/HyperOS applies its own rounded-square mask instead of the AOSP circle for windowSplashScreenIconBackgroundColor; rendering the circle inside the drawable makes the splash render consistently across OEMs.

Closes #227