### PR TITLE
Show block explorer context menu for WalletConnect payload addresses

### DIFF
--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.PasswordStore
 import com.gemwallet.android.blockchain.operators.LoadPrivateKeyOperator
+import com.gemwallet.android.cases.nodes.GetCurrentBlockExplorer
 import com.gemwallet.android.data.repositories.bridge.BridgesRepository
 import com.gemwallet.android.data.repositories.bridge.getNamespace
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
@@ -43,6 +44,7 @@ class WCRequestViewModel @Inject constructor(
     private val passwordStore: PasswordStore,
     private val loadPrivateKeyOperator: LoadPrivateKeyOperator,
     private val simulationService: com.gemwallet.android.blockchain.services.WalletConnectSimulationService,
+    private val getCurrentBlockExplorer: GetCurrentBlockExplorer,
 ) : ViewModel() {
 
     private val walletConnect = WalletConnect()
@@ -115,6 +117,7 @@ class WCRequestViewModel @Inject constructor(
                         appMetadata = appMetadata,
                         action = action,
                         simulation = simulationService.simulateSignMessage(action.chain, action.signType, action.data, sessionDomain),
+                        explorerName = getCurrentBlockExplorer.getCurrentBlockExplorer(chain),
                     )
 
                     is WalletConnectAction.SendTransaction -> WCRequest.Transaction.SendTransaction(

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WCRequest.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WCRequest.kt
@@ -7,6 +7,8 @@ import com.gemwallet.android.math.hexToBigInteger
 import com.gemwallet.android.model.ConfirmParams
 import com.gemwallet.android.model.ConfirmParams.TransferParams.Generic
 import com.gemwallet.android.model.DestinationAddress
+import com.gemwallet.android.ui.models.PayloadField
+import com.gemwallet.android.ui.models.withExplorerLinks
 import com.reown.walletkit.client.Wallet
 import com.wallet.core.primitives.Account
 import com.wallet.core.primitives.Chain
@@ -14,7 +16,6 @@ import com.wallet.core.primitives.WalletConnectionSessionAppMetadata
 import uniffi.gemstone.MessageSigner
 import com.gemwallet.android.blockchain.gemstone.toGem
 import com.gemwallet.android.blockchain.gemstone.toPrimitives
-import com.wallet.core.primitives.SimulationPayloadField
 import com.wallet.core.primitives.SimulationResult
 import uniffi.gemstone.TransferDataOutputType
 import uniffi.gemstone.WalletConnect
@@ -49,6 +50,7 @@ sealed class WCRequest(
         appMetadata: WalletConnectionSessionAppMetadata,
         val action: WalletConnectAction.SignMessage,
         val simulation: SimulationResult,
+        private val explorerName: String?,
     ) : WCRequest(sessionRequest, account, appMetadata) {
 
         private val signer by lazy {
@@ -66,11 +68,19 @@ sealed class WCRequest(
         val plainMessage: String
             get() = signer.getOrNull()?.plainPreview() ?: action.data
 
-        val primaryPayloadFields: List<SimulationPayloadField>
-            get() = payloadPreview?.primary?.map { it.toPrimitives() }.orEmpty()
+        val primaryPayloadFields: List<PayloadField> by lazy {
+            payloadPreview?.primary
+                ?.map { it.toPrimitives() }
+                .orEmpty()
+                .withExplorerLinks(chain, explorerName)
+        }
 
-        val secondaryPayloadFields: List<SimulationPayloadField>
-            get() = payloadPreview?.secondary?.map { it.toPrimitives() }.orEmpty()
+        val secondaryPayloadFields: List<PayloadField> by lazy {
+            payloadPreview?.secondary
+                ?.map { it.toPrimitives() }
+                .orEmpty()
+                .withExplorerLinks(chain, explorerName)
+        }
 
         val hasPayload: Boolean
             get() = primaryPayloadFields.isNotEmpty() || secondaryPayloadFields.isNotEmpty()

--- a/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
+++ b/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
@@ -7,6 +7,7 @@ import com.gemwallet.android.application.confirm.coordinators.BuildConfirmProper
 import com.gemwallet.android.application.confirm.coordinators.ConfirmTransaction
 import com.gemwallet.android.application.confirm.coordinators.ValidateBalance
 import com.gemwallet.android.blockchain.services.SignerPreloaderProxy
+import com.gemwallet.android.cases.nodes.GetCurrentBlockExplorer
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.transactions.TransactionBalanceService
@@ -64,6 +65,7 @@ class ConfirmViewModel @Inject constructor(
     private val validateBalance: ValidateBalance,
     private val confirmTransaction: ConfirmTransaction,
     private val buildConfirmProperties: BuildConfirmProperties,
+    private val getCurrentBlockExplorer: GetCurrentBlockExplorer,
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -98,7 +100,9 @@ class ConfirmViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     val walletConnectReview = combine(walletConnectSimulationState, walletConnectHeaderAssetInfo, request) { simulation, headerAssetInfo, params ->
-        val review = simulation?.toWalletConnectReview() ?: WalletConnectReview()
+        val chain = params?.assetId?.chain
+        val explorerName = chain?.let { getCurrentBlockExplorer.getCurrentBlockExplorer(it) }
+        val review = simulation?.toWalletConnectReview(chain, explorerName) ?: WalletConnectReview()
         val headerAssetId = simulation?.header?.assetId
         val asset = when {
             headerAssetId == null || params == null -> null

--- a/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/WalletConnectReviewState.kt
+++ b/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/WalletConnectReviewState.kt
@@ -1,10 +1,10 @@
 package com.gemwallet.android.features.confirm.viewmodels
 
 import com.gemwallet.android.domains.confirm.ConfirmProperty
+import com.gemwallet.android.ui.models.PayloadField
+import com.gemwallet.android.ui.models.withExplorerLinks
 import com.wallet.core.primitives.Asset
-import com.wallet.core.primitives.AssetId
-import com.wallet.core.primitives.SimulationHeader
-import com.wallet.core.primitives.SimulationPayloadField
+import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.SimulationPayloadFieldDisplay
 import com.wallet.core.primitives.SimulationPayloadFieldKind
 import com.wallet.core.primitives.SimulationResult
@@ -12,21 +12,26 @@ import com.wallet.core.primitives.SimulationWarning
 
 data class WalletConnectReview(
     val warnings: List<SimulationWarning> = emptyList(),
-    val primaryPayloadFields: List<SimulationPayloadField> = emptyList(),
-    val secondaryPayloadFields: List<SimulationPayloadField> = emptyList(),
+    val primaryPayloadFields: List<PayloadField> = emptyList(),
+    val secondaryPayloadFields: List<PayloadField> = emptyList(),
     val headerAsset: Asset? = null,
     val headerValue: String? = null,
     val headerIsUnlimited: Boolean = false,
 )
 
-fun SimulationResult.toWalletConnectReview(): WalletConnectReview {
+fun SimulationResult.toWalletConnectReview(
+    chain: Chain? = null,
+    explorerName: String? = null,
+): WalletConnectReview {
     val hideValueField = header != null
     val filtered = payload.filterNot { hideValueField && it.kind == SimulationPayloadFieldKind.Value }
 
     return WalletConnectReview(
         warnings = warnings,
-        primaryPayloadFields = filtered.filter { it.display == SimulationPayloadFieldDisplay.Primary },
-        secondaryPayloadFields = filtered.filter { it.display == SimulationPayloadFieldDisplay.Secondary },
+        primaryPayloadFields = filtered.filter { it.display == SimulationPayloadFieldDisplay.Primary }
+            .withExplorerLinks(chain, explorerName),
+        secondaryPayloadFields = filtered.filter { it.display == SimulationPayloadFieldDisplay.Secondary }
+            .withExplorerLinks(chain, explorerName),
         headerValue = header?.value,
         headerIsUnlimited = header?.isUnlimited == true,
     )

--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/WalletConnectSimulationExt.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/WalletConnectSimulationExt.kt
@@ -1,7 +1,31 @@
 package com.gemwallet.android.ui.models
 
+import com.wallet.core.primitives.BlockExplorerLink
+import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.SimulationPayloadField
+import com.wallet.core.primitives.SimulationPayloadFieldType
 import com.wallet.core.primitives.SimulationSeverity
 import com.wallet.core.primitives.SimulationWarning
+import uniffi.gemstone.Explorer
+
+data class PayloadField(
+    val field: SimulationPayloadField,
+    val explorerLink: BlockExplorerLink? = null,
+)
 
 fun List<SimulationWarning>.hasCriticalWarning(): Boolean =
     any { it.severity == SimulationSeverity.Critical }
+
+fun List<SimulationPayloadField>.withExplorerLinks(
+    chain: Chain?,
+    explorerName: String?,
+): List<PayloadField> {
+    if (chain == null || explorerName == null) return map { PayloadField(it) }
+    val explorer = Explorer(chain.string)
+    return map { field ->
+        val link = if (field.fieldType == SimulationPayloadFieldType.Address) {
+            BlockExplorerLink(explorerName, explorer.getAddressUrl(explorerName, field.value))
+        } else null
+        PayloadField(field, link)
+    }
+}

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/simulation/SimulationPayloadFieldsContent.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/simulation/SimulationPayloadFieldsContent.kt
@@ -6,34 +6,46 @@ import com.gemwallet.android.ext.AddressFormatter
 import com.gemwallet.android.math.getRelativeDate
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.SubheaderItem
+import com.gemwallet.android.ui.components.list_item.property.AddressPropertyItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.models.ListPosition
+import com.gemwallet.android.ui.models.PayloadField
 import com.wallet.core.primitives.SimulationPayloadField
 import com.wallet.core.primitives.SimulationPayloadFieldKind
 import com.wallet.core.primitives.SimulationPayloadFieldType
 import java.time.Instant
 
 fun LazyListScope.simulationPayloadFieldsContent(
-    fields: List<SimulationPayloadField>,
+    fields: List<PayloadField>,
     onDetailsClick: (() -> Unit)? = null,
 ) {
     if (fields.isEmpty() && onDetailsClick == null) {
         return
     }
     val totalItems = fields.size + if (onDetailsClick != null) 1 else 0
-    itemsIndexed(fields) { index, field ->
+    itemsIndexed(fields) { index, payload ->
         val listPosition = ListPosition.getPosition(index, totalItems)
-        fieldTitleRes(field)?.let { titleRes ->
-            PropertyItem(
+        val field = payload.field
+        val titleRes = fieldTitleRes(field)
+        when {
+            titleRes != null && field.fieldType == SimulationPayloadFieldType.Address -> AddressPropertyItem(
+                title = titleRes,
+                displayText = AddressFormatter(field.value).value(),
+                copyValue = field.value,
+                explorerLink = payload.explorerLink,
+                listPosition = listPosition,
+            )
+            titleRes != null -> PropertyItem(
                 title = titleRes,
                 data = fieldValue(field),
                 listPosition = listPosition,
             )
-        } ?: PropertyItem(
-            title = field.label.orEmpty(),
-            data = fieldValue(field),
-            listPosition = listPosition,
-        )
+            else -> PropertyItem(
+                title = field.label.orEmpty(),
+                data = fieldValue(field),
+                listPosition = listPosition,
+            )
+        }
     }
     onDetailsClick?.let {
         item {
@@ -47,8 +59,8 @@ fun LazyListScope.simulationPayloadFieldsContent(
 }
 
 fun LazyListScope.simulationPayloadDetailsContent(
-    primaryFields: List<SimulationPayloadField>,
-    secondaryFields: List<SimulationPayloadField>,
+    primaryFields: List<PayloadField>,
+    secondaryFields: List<PayloadField>,
 ) {
     simulationPayloadFieldsContent(primaryFields)
     if (secondaryFields.isNotEmpty()) {


### PR DESCRIPTION
Wrap Address-typed simulation payload fields in PayloadField with a BlockExplorerLink so AddressPropertyItem can offer copy / view-on-explorer on long-press, matching the pattern already used in confirm and asset detail screens. Enrichment happens in WCRequest.SignMessage and WalletConnectReview, so the UI receives ready-to-render data.

Closes #143