### PR TITLE
Build Gemstone as scheme pre-action so xcframework is fresh

### DIFF
--- a/ios/Gem.xcodeproj/project.pbxproj
+++ b/ios/Gem.xcodeproj/project.pbxproj
@@ -795,7 +795,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C30952D5299C39D80004C0F9 /* Build configuration list for PBXNativeTarget "Gem" */;
 			buildPhases = (
-				D8GEMST0NE2025040800001 /* Build Gemstone */,
 				C30952AC299C39D70004C0F9 /* Sources */,
 				C30952AD299C39D70004C0F9 /* Frameworks */,
 				C30952AE299C39D70004C0F9 /* Resources */,
@@ -1128,24 +1127,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		D8GEMST0NE2025040800001 /* Build Gemstone */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Build Gemstone";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/bash;
-			shellScript = "\"$SRCROOT/scripts/generate-stone.sh\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C30952AC299C39D70004C0F9 /* Sources */ = {

--- a/ios/Gem.xcodeproj/xcshareddata/xcschemes/Gem.xcscheme
+++ b/ios/Gem.xcodeproj/xcshareddata/xcschemes/Gem.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Build Gemstone"
+               scriptText = "mkdir -p &quot;${PROJECT_DIR}/build&quot;&#10;set -o pipefail&#10;&quot;${SRCROOT}/scripts/generate-stone.sh&quot; 2&gt;&amp;1 | tee &quot;${PROJECT_DIR}/build/generate-stone.log&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "C30952AF299C39D70004C0F9"
+                     BuildableName = "Gem.app"
+                     BlueprintName = "Gem"
+                     ReferencedContainer = "container:Gem.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/ios/justfile
+++ b/ios/justfile
@@ -166,7 +166,7 @@ generate-swiftgen:
     @swiftgen config run --quiet
 
 generate-stone BUILD_MODE="":
-    @./scripts/generate-stone.sh {{BUILD_MODE}}
+    @./scripts/generate-stone.sh --force {{BUILD_MODE}}
 
 bump TARGET="patch":
     @cd .. && just bump {{TARGET}}

--- a/ios/scripts/generate-stone.sh
+++ b/ios/scripts/generate-stone.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Build the Gemstone XCFramework, skipping when Rust sources are unchanged.
-# Usage: generate-stone.sh [release]
+# Usage: generate-stone.sh [--force] [release]
 
 set -euo pipefail
 
@@ -15,7 +15,16 @@ STONE_DIR="$CORE_DIR/gemstone"
 PACKAGES_DIR="$IOS_DIR/Packages/Gemstone"
 XCFRAMEWORK="$PACKAGES_DIR/Sources/GemstoneFFI.xcframework"
 
-BUILD_MODE="${1:-${BUILD_MODE:-}}"
+FORCE=0
+POSITIONAL=()
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+        *) POSITIONAL+=("$arg") ;;
+    esac
+done
+
+BUILD_MODE="${POSITIONAL[0]:-${BUILD_MODE:-}}"
 if [ -z "$BUILD_MODE" ] && [ "${CONFIGURATION:-Debug}" = "Release" ]; then
     BUILD_MODE="release"
 fi
@@ -35,7 +44,7 @@ HASH_FILE="$CACHE_DIR/sources-${BUILD_MODE:-debug}.hash"
 
 current_hash=$(compute_hash)
 
-if [ -f "$HASH_FILE" ] && [ -d "$XCFRAMEWORK" ]; then
+if [ "$FORCE" -eq 0 ] && [ -f "$HASH_FILE" ] && [ -d "$XCFRAMEWORK" ]; then
     cached_hash=$(cat "$HASH_FILE")
     if [ "$current_hash" = "$cached_hash" ]; then
         echo "note: Gemstone sources unchanged (${BUILD_MODE:-debug}) — skipping rebuild"
@@ -47,7 +56,11 @@ read_deployment_target() {
     echo -n $(/usr/libexec/PlistBuddy -c "Print" "$PROJ_PATH" | grep IPHONEOS_DEPLOYMENT_TARGET | awk -F ' = ' '{print $2}' | uniq)
 }
 
-echo "note: Gemstone sources changed — rebuilding XCFramework (${BUILD_MODE:-debug})..."
+if [ "$FORCE" -eq 1 ]; then
+    echo "note: Forcing Gemstone rebuild (${BUILD_MODE:-debug})..."
+else
+    echo "note: Gemstone sources changed — rebuilding XCFramework (${BUILD_MODE:-debug})..."
+fi
 
 pushd "$STONE_DIR" > /dev/null
 BUILD_MODE=$BUILD_MODE IPHONEOS_DEPLOYMENT_TARGET=$(read_deployment_target) just build-ios


### PR DESCRIPTION
Pre-actions run before SPM resolves binary targets, so the rebuilt GemstoneFFI.xcframework is what Xcode actually links. Previously the script ran as a build phase, after SPM had already consumed the prior xcframework, causing the linker to use stale bits until the next build.

<img width="451" height="119" alt="image" src="https://github.com/user-attachments/assets/6301d282-6380-4c26-835b-26bb090b1bd7" />
