### PR TITLE
Reconnect price stream immediately when network returns

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:required="false" />
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.VIBRATE" />
 

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
@@ -13,6 +13,7 @@ import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.assets.UpdateBalances
+import com.gemwallet.android.data.repositories.network.NetworkMonitor
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.stream.StreamEventHandler
 import com.gemwallet.android.data.repositories.stream.StreamObserverService
@@ -24,9 +25,11 @@ import com.gemwallet.android.data.service.store.database.BalancesDao
 import com.gemwallet.android.data.service.store.database.PriceAlertsDao
 import com.gemwallet.android.data.service.store.database.PricesDao
 import com.gemwallet.android.data.services.gemapi.http.DeviceRequestSigner
+import android.content.Context
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import uniffi.gemstone.GemGateway
 import javax.inject.Singleton
@@ -128,13 +131,21 @@ object AssetsModule {
 
     @Provides
     @Singleton
+    fun provideNetworkMonitor(
+        @ApplicationContext context: Context,
+    ): NetworkMonitor = NetworkMonitor(context = context)
+
+    @Provides
+    @Singleton
     fun provideStreamObserverService(
+        networkMonitor: NetworkMonitor,
         sessionRepository: SessionRepository,
         syncAssets: SyncAssets,
         deviceRequestSigner: DeviceRequestSigner,
         streamSubscriptionService: StreamSubscriptionService,
         eventHandler: StreamEventHandler,
     ): StreamObserverService = StreamObserverService(
+        networkMonitor = networkMonitor,
         sessionRepository = sessionRepository,
         syncAssets = syncAssets,
         deviceRequestSigner = deviceRequestSigner,

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/network/NetworkMonitor.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/network/NetworkMonitor.kt
@@ -1,0 +1,40 @@
+package com.gemwallet.android.data.repositories.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class NetworkMonitor(context: Context) {
+
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val _isOnline = MutableStateFlow(isCurrentlyOnline())
+    val isOnline: StateFlow<Boolean> = _isOnline.asStateFlow()
+
+    init {
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        connectivityManager.registerNetworkCallback(request, object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                _isOnline.value = true
+            }
+
+            override fun onLost(network: Network) {
+                _isOnline.value = isCurrentlyOnline()
+            }
+        })
+    }
+
+    private fun isCurrentlyOnline(): Boolean {
+        val active = connectivityManager.activeNetwork ?: return false
+        val caps = connectivityManager.getNetworkCapabilities(active) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.data.repositories.stream
 import android.util.Log
 import com.gemwallet.android.Constants
 import com.gemwallet.android.application.assets.coordinators.SyncAssets
+import com.gemwallet.android.data.repositories.network.NetworkMonitor
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.services.gemapi.http.DeviceRequestSigner
 import com.gemwallet.android.serializer.StreamEventSerializer
@@ -23,16 +24,18 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.encodeToString
 
 class StreamObserverService(
+    private val networkMonitor: NetworkMonitor,
     private val sessionRepository: SessionRepository,
     private val syncAssets: SyncAssets,
     private val deviceRequestSigner: DeviceRequestSigner,
@@ -43,7 +46,7 @@ class StreamObserverService(
 ) {
     private var connectionJob: Job? = null
     private var currentWalletId: String? = null
-    private var reconnectAttempt = 0
+    @Volatile private var reconnectAttempt = 0
 
     private val client = HttpClient(CIO) {
         install(WebSockets) {
@@ -51,7 +54,17 @@ class StreamObserverService(
         }
     }
 
+    private val reconnectTrigger = Channel<Unit>(Channel.CONFLATED)
+
     init {
+        scope.launch {
+            networkMonitor.isOnline.collect { online ->
+                if (online) {
+                    reconnectAttempt = 0
+                    reconnectTrigger.trySend(Unit)
+                }
+            }
+        }
         scope.launch {
             sessionRepository.session().collectLatest { session ->
                 val walletId = session?.wallet?.id
@@ -82,6 +95,8 @@ class StreamObserverService(
                 return@launch
             }
 
+            while (reconnectTrigger.tryReceive().isSuccess) Unit
+
             while (isActive) {
                 try {
                     client.wss(
@@ -92,13 +107,15 @@ class StreamObserverService(
                         request = { addDeviceAuthHeaders() },
                     ) {
                         reconnectAttempt = 0
+                        while (reconnectTrigger.tryReceive().isSuccess) Unit
                         observeConnection()
                     }
                 } catch (err: Throwable) {
                     Log.e(TAG, "Connection error", err)
                 }
-                delay(reconnection.reconnectAfterMs(reconnectAttempt))
-                reconnectAttempt++
+                val delayMs = reconnection.reconnectAfterMs(reconnectAttempt)
+                val woken = withTimeoutOrNull(delayMs) { reconnectTrigger.receive() }
+                if (woken == null) reconnectAttempt++
             }
         }
     }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamSubscriptionService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamSubscriptionService.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class StreamSubscriptionService(
     private val assetsDao: AssetsDao,
@@ -24,7 +26,8 @@ class StreamSubscriptionService(
     val messageFlow: SharedFlow<StreamMessage> = _messageFlow
 
     private val subscribedAssetIds = mutableSetOf<AssetId>()
-    private var currentWalletId: String? = null
+    private val mutex = Mutex()
+    @Volatile private var currentWalletId: String? = null
 
     fun setupAssets(walletId: String) {
         currentWalletId = walletId
@@ -35,8 +38,10 @@ class StreamSubscriptionService(
         val walletId = currentWalletId ?: return@launch
         try {
             val assets = observableAssets(walletId)
-            subscribedAssetIds.clear()
-            subscribedAssetIds.addAll(assets)
+            mutex.withLock {
+                subscribedAssetIds.clear()
+                subscribedAssetIds.addAll(assets)
+            }
             _messageFlow.emit(
                 StreamMessage.SubscribePrices(data = StreamMessagePrices(assets = assets))
             )
@@ -54,7 +59,9 @@ class StreamSubscriptionService(
     }
 
     fun addAssetIds(ids: List<AssetId>) = scope.launch {
-        val newIds = ids.filter { subscribedAssetIds.add(it) }
+        val newIds = mutex.withLock {
+            ids.filter { subscribedAssetIds.add(it) }
+        }
         if (newIds.isNotEmpty()) {
             _messageFlow.emit(
                 StreamMessage.AddPrices(data = StreamMessagePrices(assets = newIds))


### PR DESCRIPTION
- Add NetworkMonitor wrapping ConnectivityManager with StateFlow<Boolean>
- Wake stream reconnect backoff via Channel signal on network available
- Guard subscribed asset IDs with Mutex to avoid races during resubscribe
- Declare ACCESS_NETWORK_STATE permission