### PR TITLE
Stream reconnect backoff at 30s

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
@@ -14,6 +14,7 @@ import com.gemwallet.android.application.transactions.coordinators.SyncTransacti
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.assets.UpdateBalances
 import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.data.repositories.stream.ExponentialReconnection
 import com.gemwallet.android.data.repositories.stream.StreamEventHandler
 import com.gemwallet.android.data.repositories.stream.StreamObserverService
 import com.gemwallet.android.data.repositories.stream.StreamSubscriptionService
@@ -140,6 +141,7 @@ object AssetsModule {
         deviceRequestSigner = deviceRequestSigner,
         subscriptionService = streamSubscriptionService,
         eventHandler = eventHandler,
+        reconnection = ExponentialReconnection(maxDelay = 30.0),
     )
 
     @Provides


### PR DESCRIPTION
Reduce max backoff between WebSocket reconnect attempts from 60s to 30s so the price stream resumes within half a minute after network recovers, without depending on ConnectivityManager signals.