### PR TITLE
Fix splash icon size and shape consistency

### DIFF
--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -3,9 +3,10 @@
 
     <style name="Theme.Wallet" parent="Theme.Material3.DayNight.NoActionBar" />
 
-    <style name="Theme.Wallet.Starting" parent="Theme.SplashScreen">
+    <style name="Theme.Wallet.Starting" parent="Theme.SplashScreen.IconBackground">
         <item name="windowSplashScreenBackground">@color/splash_background</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_screen</item>
+        <item name="windowSplashScreenIconBackgroundColor">@android:color/transparent</item>
         <item name="postSplashScreenTheme">@style/Theme.Wallet</item>
     </style>
 </resources>

--- a/android/ui/src/main/res/drawable/ic_splash_screen.xml
+++ b/android/ui/src/main/res/drawable/ic_splash_screen.xml
@@ -1,16 +1,16 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="288dp"
-    android:height="288dp"
-    android:viewportWidth="288"
-    android:viewportHeight="288">
+    android:width="240dp"
+    android:height="240dp"
+    android:viewportWidth="240"
+    android:viewportHeight="240">
     <path
-        android:pathData="M144,144m-90,0a90,90 0,1 1,180 0a90,90 0,1 1,-180 0"
+        android:pathData="M120,120m-67,0a67,67 0,1 1,134 0a67,67 0,1 1,-134 0"
         android:fillColor="#FF405FED" />
     <group
-        android:translateX="36"
-        android:translateY="36"
-        android:scaleX="2.0"
-        android:scaleY="2.0">
+        android:translateX="20.6"
+        android:translateY="20.6"
+        android:scaleX="1.842"
+        android:scaleY="1.842">
         <path
             android:pathData="M53.79,71.59L78,51.05H30L53.79,71.59Z"
             android:fillColor="#ffffff"


### PR DESCRIPTION
Restore Theme.SplashScreen.IconBackground parent so the system reserves its fixed-size icon container (consistent across initial/branded modes and devices). Set iconBackgroundColor to transparent — the system still applies its shape mask (circle on Pixel, rounded-square on Xiaomi/MIUI), but with a transparent fill the OEM shape is invisible. The drawable itself bakes the blue circle and gem, so users see the same circular icon on every device.