### PR TITLE
Preload perpetual markets when enabling Perpetuals toggle

### DIFF
--- a/ios/Gem/Services/ServicesFactory.swift
+++ b/ios/Gem/Services/ServicesFactory.swift
@@ -306,6 +306,7 @@ struct ServicesFactory {
             streamObserverService: streamObserverService,
             streamSubscriptionService: streamSubscriptionService,
             hyperliquidObserverService: hyperliquidObserverService,
+            perpetualService: perpetualService,
         )
 
         let viewModelFactory = ViewModelFactory(

--- a/ios/Packages/FeatureServices/AppService/AppLifecycleService.swift
+++ b/ios/Packages/FeatureServices/AppService/AppLifecycleService.swift
@@ -16,6 +16,7 @@ public actor AppLifecycleService: Sendable {
     private let streamObserverService: StreamObserverService
     private let streamSubscriptionService: StreamSubscriptionService
     private let hyperliquidObserverService: any PerpetualObservable
+    private let perpetualService: any PerpetualServiceable
 
     private var currentWallet: Wallet?
 
@@ -26,6 +27,7 @@ public actor AppLifecycleService: Sendable {
         streamObserverService: StreamObserverService,
         streamSubscriptionService: StreamSubscriptionService,
         hyperliquidObserverService: any PerpetualObservable,
+        perpetualService: any PerpetualServiceable,
     ) {
         self.preferences = preferences
         self.connectionsService = connectionsService
@@ -33,6 +35,7 @@ public actor AppLifecycleService: Sendable {
         self.streamObserverService = streamObserverService
         self.streamSubscriptionService = streamSubscriptionService
         self.hyperliquidObserverService = hyperliquidObserverService
+        self.perpetualService = perpetualService
     }
 
     public func setup() async {
@@ -51,6 +54,9 @@ public actor AppLifecycleService: Sendable {
     }
 
     public func updatePerpetualConnection() async {
+        if preferences.isPerpetualEnabled {
+            await updatePerpetualMarkets()
+        }
         await connectPerpetual()
     }
 
@@ -109,6 +115,17 @@ extension AppLifecycleService {
             await hyperliquidObserverService.setup(for: wallet)
         } else {
             await hyperliquidObserverService.disconnect()
+        }
+    }
+
+    private func updatePerpetualMarkets() async {
+        guard preferences.perpetualMarketsUpdatedAt.isOutdated(byHours: 1) else { return }
+
+        do {
+            try await perpetualService.updateMarkets()
+            preferences.perpetualMarketsUpdatedAt = .now
+        } catch {
+            debugLog("AppLifecycleService updatePerpetualMarkets error: \(error)")
         }
     }
 

--- a/ios/Packages/FeatureServices/AppService/TestKit/AppLifecycleService+TestKit.swift
+++ b/ios/Packages/FeatureServices/AppService/TestKit/AppLifecycleService+TestKit.swift
@@ -21,6 +21,7 @@ public extension AppLifecycleService {
         streamObserverService: StreamObserverService = .mock(),
         streamSubscriptionService: StreamSubscriptionService = .mock(),
         hyperliquidObserverService: PerpetualObserverMock = PerpetualObserverMock(),
+        perpetualService: any PerpetualServiceable = PerpetualServiceMock(),
     ) -> AppLifecycleService {
         AppLifecycleService(
             preferences: preferences,
@@ -29,6 +30,7 @@ public extension AppLifecycleService {
             streamObserverService: streamObserverService,
             streamSubscriptionService: streamSubscriptionService,
             hyperliquidObserverService: hyperliquidObserverService,
+            perpetualService: perpetualService,
         )
     }
 }


### PR DESCRIPTION
Hyperliquid clearinghouseState positions hit FOREIGN KEY constraint when perpetuals/assets metadata is missing in DB