### PR TITLE
Android: fix prices missing on first wallet on clean install

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
@@ -25,10 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 
@@ -76,12 +73,6 @@ class StreamObserverService(
         if (connectionJob != null) return
 
         connectionJob = scope.launch(Dispatchers.IO) {
-            val hasWallet = sessionRepository.session().firstOrNull()?.wallet != null
-            if (!hasWallet) {
-                connectionJob = null
-                return@launch
-            }
-
             while (isActive) {
                 try {
                     client.wss(
@@ -111,16 +102,15 @@ class StreamObserverService(
 
     private suspend fun DefaultClientWebSocketSession.observeConnection() {
         launch {
-            subscriptionService.messageFlow
-                .onSubscription { subscriptionService.resubscribe() }
-                .collect { message ->
-                    try {
-                        send(jsonEncoder.encodeToString<StreamMessage>(message))
-                    } catch (err: Throwable) {
-                        Log.e(TAG, "Send message error", err)
-                    }
+            for (message in subscriptionService.messages) {
+                try {
+                    send(jsonEncoder.encodeToString<StreamMessage>(message))
+                } catch (err: Throwable) {
+                    Log.e(TAG, "Send message error", err)
                 }
+            }
         }
+        subscriptionService.resubscribe()
         for (frame in incoming) {
             if (frame is Frame.Text) {
                 val text = frame.readText()

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamSubscriptionService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamSubscriptionService.kt
@@ -1,47 +1,55 @@
 package com.gemwallet.android.data.repositories.stream
 
 import android.util.Log
+import com.gemwallet.android.data.repositories.assets.visibleByDefault
 import com.gemwallet.android.data.service.store.database.AssetsDao
 import com.gemwallet.android.data.service.store.database.PriceAlertsDao
 import com.gemwallet.android.ext.toAssetId
-import com.gemwallet.android.data.repositories.assets.visibleByDefault
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.StreamMessage
 import com.wallet.core.primitives.StreamMessagePrices
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class StreamSubscriptionService(
     private val assetsDao: AssetsDao,
     private val priceAlertsDao: PriceAlertsDao,
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
 ) {
-    private val _messageFlow = MutableSharedFlow<StreamMessage>()
-    val messageFlow: SharedFlow<StreamMessage> = _messageFlow
+    private val outgoing = Channel<StreamMessage>(Channel.UNLIMITED)
+    val messages: ReceiveChannel<StreamMessage> = outgoing
 
+    private val mutex = Mutex()
     private val subscribedAssetIds = mutableSetOf<AssetId>()
     private var currentWalletId: String? = null
 
-    fun setupAssets(walletId: String) {
+    suspend fun setupAssets(walletId: String) {
         currentWalletId = walletId
         resubscribe()
     }
 
-    fun resubscribe() = scope.launch {
-        val walletId = currentWalletId ?: return@launch
+    suspend fun resubscribe() {
+        val walletId = currentWalletId ?: return
         try {
             val assets = observableAssets(walletId)
-            subscribedAssetIds.clear()
-            subscribedAssetIds.addAll(assets)
-            _messageFlow.emit(
-                StreamMessage.SubscribePrices(data = StreamMessagePrices(assets = assets))
-            )
+            mutex.withLock {
+                subscribedAssetIds.clear()
+                subscribedAssetIds.addAll(assets)
+                outgoing.send(StreamMessage.SubscribePrices(StreamMessagePrices(assets)))
+            }
         } catch (err: Throwable) {
             Log.e(TAG, "Resubscribe error", err)
+        }
+    }
+
+    suspend fun addAssetIds(ids: List<AssetId>) {
+        mutex.withLock {
+            val newIds = ids.filter { subscribedAssetIds.add(it) }
+            if (newIds.isNotEmpty()) {
+                outgoing.send(StreamMessage.AddPrices(StreamMessagePrices(newIds)))
+            }
         }
     }
 
@@ -51,15 +59,6 @@ class StreamSubscriptionService(
             ?.mapNotNull { it.assetId.toAssetId() } ?: emptyList()
         return (ids + priceAlerts).takeIf { it.isNotEmpty() }
             ?: visibleByDefault.map { AssetId(it) }
-    }
-
-    fun addAssetIds(ids: List<AssetId>) = scope.launch {
-        val newIds = ids.filter { subscribedAssetIds.add(it) }
-        if (newIds.isNotEmpty()) {
-            _messageFlow.emit(
-                StreamMessage.AddPrices(data = StreamMessagePrices(assets = newIds))
-            )
-        }
     }
 
     companion object {

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
@@ -271,7 +271,7 @@ class AssetsRepositoryTest {
                 isVisible = true,
             )
         }
-        verify { streamSubscriptionService.addAssetIds(listOf(asset.id)) }
+        coVerify { streamSubscriptionService.addAssetIds(listOf(asset.id)) }
     }
 
     @Test
@@ -291,7 +291,7 @@ class AssetsRepositoryTest {
                 isVisible = false,
             )
         }
-        verify(exactly = 0) { streamSubscriptionService.addAssetIds(any()) }
+        coVerify(exactly = 0) { streamSubscriptionService.addAssetIds(any()) }
     }
 
     @Test

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/stream/StreamSubscriptionServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/stream/StreamSubscriptionServiceTest.kt
@@ -2,13 +2,12 @@ package com.gemwallet.android.data.repositories.stream
 
 import com.gemwallet.android.data.service.store.database.AssetsDao
 import com.gemwallet.android.data.service.store.database.PriceAlertsDao
+import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.StreamMessage
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -19,24 +18,48 @@ class StreamSubscriptionServiceTest {
     private val assetsDao = mockk<AssetsDao>()
     private val priceAlertsDao = mockk<PriceAlertsDao>()
 
+    private fun service() = StreamSubscriptionService(
+        assetsDao = assetsDao,
+        priceAlertsDao = priceAlertsDao,
+    )
+
     @Test
-    fun `resubscribe emits full subscription to active collector`() = runTest {
+    fun `setupAssets enqueues subscribe message`() = runTest {
         coEvery { assetsDao.getAssetsPriceUpdate("wallet-1") } returns listOf("bitcoin")
         every { priceAlertsDao.getAlerts() } returns flowOf(emptyList())
-        val service = StreamSubscriptionService(
-            assetsDao = assetsDao,
-            priceAlertsDao = priceAlertsDao,
-            scope = this,
-        )
+        val service = service()
 
         service.setupAssets("wallet-1")
-        val messages = mutableListOf<StreamMessage>()
-        val collector = async { service.messageFlow.toList(messages) }
 
-        service.resubscribe().join()
-        collector.cancel()
-
-        val subscribe = messages.last() as StreamMessage.SubscribePrices
+        val subscribe = service.messages.receive() as StreamMessage.SubscribePrices
         assertEquals(listOf(Chain.Bitcoin), subscribe.data.assets.map { it.chain })
+    }
+
+    @Test
+    fun `messages sent before consumer attaches are buffered`() = runTest {
+        coEvery { assetsDao.getAssetsPriceUpdate("wallet-1") } returns listOf("bitcoin")
+        every { priceAlertsDao.getAlerts() } returns flowOf(emptyList())
+        val service = service()
+
+        service.setupAssets("wallet-1")
+        service.addAssetIds(listOf(AssetId(Chain.Ethereum)))
+
+        val subscribe = service.messages.receive() as StreamMessage.SubscribePrices
+        val add = service.messages.receive() as StreamMessage.AddPrices
+        assertEquals(listOf(Chain.Bitcoin), subscribe.data.assets.map { it.chain })
+        assertEquals(listOf(Chain.Ethereum), add.data.assets.map { it.chain })
+    }
+
+    @Test
+    fun `addAssetIds skips already subscribed ids`() = runTest {
+        every { priceAlertsDao.getAlerts() } returns flowOf(emptyList())
+        val service = service()
+
+        val id = AssetId(Chain.Ethereum)
+        service.addAssetIds(listOf(id))
+        service.addAssetIds(listOf(id))
+
+        service.messages.receive() as StreamMessage.AddPrices
+        assertEquals(null, service.messages.tryReceive().getOrNull())
     }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where the home screen on Android shows no prices after creating a wallet on a clean install. Visiting an asset detail screen would force the price in via REST, masking the root cause. iOS doesn't have this bug.

## Root cause

Two independent issues piled on top of each other:

1. **`MutableSharedFlow` was silently dropping messages.** `StreamSubscriptionService` used `MutableSharedFlow<StreamMessage>()` (replay=0, no buffer) as the outgoing message channel. With no subscriber, `emit` succeeds and the value is dropped — so any `SubscribePrices` sent before `observeConnection` attached its collector vanished. The `onSubscription { resubscribe() }` rescue ran on a separate scope via fire-and-forget `launch`, leaving subtle timing gaps.

2. **`start()` had a race with `App.onActivityResumed`.** It read `sessionRepository.session().firstOrNull()?.wallet` synchronously inside the launched coroutine. If the activity resumed before the session `StateFlow` (built via `flatMapLatest` over Room) had its first non-null value, `hasWallet` was false, `connectionJob` was nulled, and the session collector's later `if (connectionJob == null) start()` check could miss the window — leaving the WebSocket permanently unconnected.