### PR TITLE
iOS: Add to Contacts from confirm scene recipient row

### DIFF
--- a/ios/Features/Contacts/Sources/Scenes/ContactsNavigationView.swift
+++ b/ios/Features/Contacts/Sources/Scenes/ContactsNavigationView.swift
@@ -31,7 +31,7 @@ public struct ContactsNavigationView: View {
             }
             .sheet(isPresented: $model.isPresentingAddContact) {
                 NavigationStack {
-                    manageContact(for: .add)
+                    manageContact(for: .add())
                         .toolbarDismissItem(type: .close, placement: .cancellationAction)
                 }
             }

--- a/ios/Features/Contacts/Sources/ViewModels/ManageContactViewModel.swift
+++ b/ios/Features/Contacts/Sources/ViewModels/ManageContactViewModel.swift
@@ -16,7 +16,7 @@ import Validators
 @MainActor
 public final class ManageContactViewModel {
     public enum Mode {
-        case add
+        case add(ChainRecipient? = nil)
         case edit(ContactData)
 
         var contact: Contact? {
@@ -53,8 +53,11 @@ public final class ManageContactViewModel {
         )
 
         switch mode {
-        case .add:
+        case let .add(input):
             contactId = UUID().uuidString
+            addresses = input.map {
+                [ContactAddress.new(contactId: contactId, chain: $0.chain, address: $0.recipient.address, memo: $0.recipient.memo)]
+            } ?? []
         case let .edit(contactData):
             contactId = contactData.contact.id
             nameInputModel.text = contactData.contact.name

--- a/ios/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/ios/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -4,6 +4,7 @@ import Components
 import Localization
 import Primitives
 import PrimitivesComponents
+import Store
 import Style
 import Swap
 import SwiftUI
@@ -34,6 +35,7 @@ public struct ConfirmTransferScene: View {
         .navigationBarTitleDisplayMode(.inline)
         .activityIndicator(isLoading: model.confirmingState.isLoading, message: model.progressMessage)
         .alertSheet($model.isPresentingAlertMessage)
+        .bindQuery(model.recipientAddressNameQuery)
     }
 }
 

--- a/ios/Features/Transfer/Sources/Types/ConfirmTransferSheetType.swift
+++ b/ios/Features/Transfer/Sources/Types/ConfirmTransferSheetType.swift
@@ -14,6 +14,7 @@ public enum ConfirmTransferSheetType: Identifiable, Sendable {
     case fiatConnect(assetAddress: AssetAddress, wallet: Wallet)
     case swapDetails
     case perpetualDetails(PerpetualDetailsViewModel)
+    case addContact(ChainRecipient)
 
     public var id: String {
         switch self {
@@ -24,6 +25,7 @@ public enum ConfirmTransferSheetType: Identifiable, Sendable {
         case .fiatConnect: "fiat-connect"
         case .swapDetails: "swap-details"
         case let .perpetualDetails(model): "perpetual-details-\(model.id)"
+        case let .addContact(input): "add-contact-\(input.chain.rawValue)-\(input.recipient.address)"
         }
     }
 }

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmRecipientViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmRecipientViewModel.swift
@@ -10,11 +10,18 @@ struct ConfirmRecipientViewModel {
     private let model: TransferDataViewModel
     private let addressName: AddressName?
     private let addressLink: BlockExplorerLink
+    private let onAddContact: VoidAction
 
-    init(model: TransferDataViewModel, addressName: AddressName?, addressLink: BlockExplorerLink) {
+    init(
+        model: TransferDataViewModel,
+        addressName: AddressName?,
+        addressLink: BlockExplorerLink,
+        onAddContact: VoidAction = nil,
+    ) {
         self.model = model
         self.addressName = addressName
         self.addressLink = addressLink
+        self.onAddContact = onAddContact
     }
 }
 
@@ -35,6 +42,7 @@ extension ConfirmRecipientViewModel: ItemModelProvidable {
                 ),
                 mode: .nameOrAddress,
                 addressLink: addressLink,
+                onAddContact: addressName?.type == nil ? onAddContact : nil,
             ),
         )
     }

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
@@ -10,6 +10,7 @@ import Localization
 import Preferences
 import Primitives
 import PrimitivesComponents
+import Store
 import Swap
 import SwiftUI
 import Validators
@@ -41,6 +42,8 @@ public final class ConfirmTransferSceneViewModel {
 
     public var isPresentingSheet: ConfirmTransferSheetType?
     public var isPresentingAlertMessage: AlertMessage?
+
+    public let recipientAddressNameQuery: ObservableQuery<AddressNameRequest>
 
     private let confirmService: ConfirmService
     private let simulationService: ConfirmSimulationService
@@ -78,6 +81,12 @@ public final class ConfirmTransferSceneViewModel {
             feeAsset: data.type.asset.feeAsset,
             priority: confirmService.defaultPriority(for: data.type),
             currency: Currency(rawValue: Preferences.standard.currency) ?? .usd,
+        )
+
+        let recipientAddress = data.recipientData.recipient.address
+        recipientAddressNameQuery = ObservableQuery(
+            AddressNameRequest(chain: data.chain, address: recipientAddress),
+            initialValue: try? confirmService.getAddressName(chain: data.chain, address: recipientAddress),
         )
 
         metadata = try? confirmService.getMetadata(wallet: wallet, data: data)
@@ -226,8 +235,9 @@ extension ConfirmTransferSceneViewModel: ListSectionProvideable {
         case .recipient:
             ConfirmRecipientViewModel(
                 model: dataModel,
-                addressName: try? confirmService.getAddressName(chain: dataModel.chain, address: dataModel.recipient.address),
+                addressName: recipientAddressNameQuery.value,
                 addressLink: confirmService.getExplorerLink(chain: dataModel.chain, address: dataModel.recipient.address),
+                onAddContact: onSelectAddRecipientToContacts,
             )
         case .memo:
             ConfirmMemoViewModel(type: transferData.type, recipientData: transferData.recipientData)
@@ -332,6 +342,10 @@ extension ConfirmTransferSceneViewModel {
 
     func onSelectPerpetualDetails(_ model: PerpetualDetailsViewModel) {
         isPresentingSheet = .perpetualDetails(model)
+    }
+
+    func onSelectAddRecipientToContacts() {
+        isPresentingSheet = .addContact(ChainRecipient(recipient: dataModel.recipient, chain: dataModel.chain))
     }
 
     func onChangeFeePriority() {

--- a/ios/Gem/Navigation/Transfer/ConfirmTransferNavigationView.swift
+++ b/ios/Gem/Navigation/Transfer/ConfirmTransferNavigationView.swift
@@ -1,9 +1,11 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Components
+import Contacts
 import FiatConnect
 import InfoSheet
 import Perpetuals
+import Primitives
 import PrimitivesComponents
 import Style
 import Swap
@@ -12,6 +14,8 @@ import Transfer
 
 struct ConfirmTransferNavigationView: View {
     @Environment(\.viewModelFactory) private var viewModelFactory
+    @Environment(\.contactService) private var contactService
+    @Environment(\.nameService) private var nameService
 
     @State var model: ConfirmTransferSceneViewModel
 
@@ -57,6 +61,17 @@ struct ConfirmTransferNavigationView: View {
                         PerpetualDetailsView(model: model)
                             .presentationDetentsForCurrentDeviceSize(expandable: true)
                             .presentationBackground(Colors.grayBackground)
+                    }
+                case let .addContact(input):
+                    NavigationStack {
+                        ManageContactScene(
+                            model: ManageContactViewModel(
+                                service: contactService,
+                                nameService: nameService,
+                                mode: .add(input),
+                            ),
+                        )
+                        .toolbarDismissItem(type: .close, placement: .cancellationAction)
                     }
                 }
             }

--- a/ios/Packages/Primitives/Sources/ChainRecipient.swift
+++ b/ios/Packages/Primitives/Sources/ChainRecipient.swift
@@ -1,0 +1,13 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public struct ChainRecipient: Sendable, Hashable {
+    public let recipient: Recipient
+    public let chain: Chain
+
+    public init(recipient: Recipient, chain: Chain) {
+        self.recipient = recipient
+        self.chain = chain
+    }
+}

--- a/ios/Packages/PrimitivesComponents/Sources/Components/AddressListItemView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/AddressListItemView.swift
@@ -1,9 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Components
-import Localization
-import Primitives
-import Style
 import SwiftUI
 
 public struct AddressListItemView: View {
@@ -39,8 +36,8 @@ public struct AddressListItemView: View {
         ]
         if let onAddContact = model.onAddContact {
             items.append(.custom(
-                title: Localized.Contacts.addToContacts,
-                systemImage: SystemImage.personBadgePlus,
+                title: model.addToContactsTitle,
+                systemImage: model.addToContactsImage,
                 action: onAddContact,
             ))
         }

--- a/ios/Packages/PrimitivesComponents/Sources/Components/AddressListItemView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/AddressListItemView.swift
@@ -28,10 +28,22 @@ public struct AddressListItemView: View {
                 showAddress.toggle()
             }
         }
-        .contextMenu([
+        .contextMenu(contextMenuItems)
+        .safariSheet(url: $isPresentingUrl)
+    }
+
+    private var contextMenuItems: [ContextMenuItemType] {
+        var items: [ContextMenuItemType] = [
             .copy(value: model.account.address),
             .url(title: model.addressExplorerText, onOpen: { isPresentingUrl = model.addressExplorerUrl }),
-        ])
-        .safariSheet(url: $isPresentingUrl)
+        ]
+        if let onAddContact = model.onAddContact {
+            items.append(.custom(
+                title: Localized.Contacts.addToContacts,
+                systemImage: SystemImage.personBadgePlus,
+                action: onAddContact,
+            ))
+        }
+        return items
     }
 }

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/AddressListItemViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/AddressListItemViewModel.swift
@@ -31,6 +31,7 @@ public struct AddressListItemViewModel {
     public let title: String
     public let account: SimpleAccount
     public let mode: Mode
+    public let onAddContact: VoidAction
     private let addressLink: BlockExplorerLink
 
     public init(
@@ -38,11 +39,13 @@ public struct AddressListItemViewModel {
         account: SimpleAccount,
         mode: Mode,
         addressLink: BlockExplorerLink,
+        onAddContact: VoidAction = nil,
     ) {
         self.title = title
         self.account = account
         self.mode = mode
         self.addressLink = addressLink
+        self.onAddContact = onAddContact
     }
 
     public var subtitle: String {

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/AddressListItemViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/AddressListItemViewModel.swift
@@ -82,6 +82,14 @@ public struct AddressListItemViewModel {
         addressLink.url
     }
 
+    public var addToContactsTitle: String {
+        Localized.Contacts.addToContacts
+    }
+
+    public var addToContactsImage: String {
+        SystemImage.personBadgePlus
+    }
+
     public var canToggleAddress: Bool {
         guard let name = account.name, name.isNotEmpty else {
             return false

--- a/ios/Packages/Store/Sources/Models/AddressRecord.swift
+++ b/ios/Packages/Store/Sources/Models/AddressRecord.swift
@@ -42,7 +42,7 @@ extension AddressRecord: CreateTable {
 }
 
 extension AddressRecord {
-    func asPrimitive() -> AddressName {
+    func mapToAddressName() -> AddressName {
         AddressName(
             chain: chain,
             address: address,

--- a/ios/Packages/Store/Sources/Requests/AddressNameRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/AddressNameRequest.swift
@@ -1,0 +1,25 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import GRDB
+import Primitives
+
+public struct AddressNameRequest: DatabaseQueryable {
+    public let chain: Chain
+    public let address: String
+
+    public init(chain: Chain, address: String) {
+        self.chain = chain
+        self.address = address
+    }
+
+    public func fetch(_ db: Database) throws -> AddressName? {
+        try AddressRecord
+            .filter(AddressRecord.Columns.chain == chain.rawValue)
+            .filter(AddressRecord.Columns.address == address)
+            .fetchOne(db)?
+            .asPrimitive()
+    }
+}
+
+extension AddressNameRequest: Equatable {}

--- a/ios/Packages/Store/Sources/Requests/AddressNameRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/AddressNameRequest.swift
@@ -18,7 +18,7 @@ public struct AddressNameRequest: DatabaseQueryable {
             .filter(AddressRecord.Columns.chain == chain.rawValue)
             .filter(AddressRecord.Columns.address == address)
             .fetchOne(db)?
-            .asPrimitive()
+            .mapToAddressName()
     }
 }
 

--- a/ios/Packages/Store/Sources/Stores/AddressStore.swift
+++ b/ios/Packages/Store/Sources/Stores/AddressStore.swift
@@ -40,7 +40,7 @@ public struct AddressStore: Sendable {
                 .filter(AddressRecord.Columns.chain == chain.rawValue)
                 .filter(AddressRecord.Columns.address == address)
                 .fetchOne(db)?
-                .asPrimitive()
+                .mapToAddressName()
         }
     }
 }

--- a/ios/Packages/Store/Sources/Stores/ContactStore.swift
+++ b/ios/Packages/Store/Sources/Stores/ContactStore.swift
@@ -54,7 +54,20 @@ public struct ContactStore: Sendable {
     @discardableResult
     public func deleteContact(id: String) throws -> Bool {
         try db.write { db in
-            try ContactRecord.deleteOne(db, key: id)
+            let addressesByChain = try ContactAddressRecord
+                .filter(ContactAddressRecord.Columns.contactId == id)
+                .fetchAll(db)
+                .reduce(into: [Chain: [String]]()) { $0[$1.chain, default: []].append($1.address) }
+
+            for (chain, addresses) in addressesByChain {
+                try AddressRecord
+                    .filter(AddressRecord.Columns.chain == chain.rawValue)
+                    .filter(addresses.contains(AddressRecord.Columns.address))
+                    .filter(AddressRecord.Columns.type == AddressType.contact.rawValue)
+                    .deleteAll(db)
+            }
+
+            return try ContactRecord.deleteOne(db, key: id)
         }
     }
 }

--- a/ios/Packages/Store/Sources/Types/TransactionInfo.swift
+++ b/ios/Packages/Store/Sources/Types/TransactionInfo.swift
@@ -26,8 +26,8 @@ extension TransactionInfo {
             feePrice: feePrice?.mapToPrice(),
             assets: assets.map { $0.mapToAsset() },
             prices: prices.map { $0.mapToAssetPrice() },
-            fromAddress: fromAddress?.asPrimitive(),
-            toAddress: toAddress?.asPrimitive(),
+            fromAddress: fromAddress?.mapToAddressName(),
+            toAddress: toAddress?.mapToAddressName(),
         )
     }
 }

--- a/ios/Packages/Store/Tests/StoreTests/ContactStoreTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/ContactStoreTests.swift
@@ -1,0 +1,60 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import PrimitivesTestKit
+@testable import Store
+import StoreTestKit
+import Testing
+
+struct ContactStoreTests {
+    @Test
+    func deleteContactRemovesAddressName() throws {
+        let test = try setupTest(
+            chain: .bitcoin,
+            address: "bc1qml9s2f9k8wc0882x63lyplzp97srzg2c39fyaw",
+            addressType: .contact,
+        )
+
+        try test.contactStore.deleteContact(id: test.contact.id)
+
+        #expect(try test.addressStore.getAddressName(chain: test.chain, address: test.address) == nil)
+    }
+
+    @Test
+    func deleteContactPreservesNonContactAddressName() throws {
+        let test = try setupTest(
+            chain: .ethereum,
+            address: "0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7",
+            addressType: .contract,
+        )
+
+        try test.contactStore.deleteContact(id: test.contact.id)
+
+        #expect(try test.addressStore.getAddressName(chain: test.chain, address: test.address)?.type == .contract)
+    }
+}
+
+// MARK: - Private
+
+extension ContactStoreTests {
+    private func setupTest(
+        chain: Chain,
+        address: String,
+        addressType: AddressType,
+    ) throws -> (contactStore: ContactStore, addressStore: AddressStore, contact: Contact, chain: Chain, address: String) {
+        let db = DB.mockWithChains([chain])
+        let contactStore = ContactStore(db: db)
+        let addressStore = AddressStore(db: db)
+        let contact = Contact.mock()
+
+        try contactStore.addContact(contact, addresses: [
+            .mock(contactId: contact.id, address: address, chain: chain),
+        ])
+        try addressStore.addAddressNames([
+            .mock(chain: chain, address: address, name: contact.name, type: addressType),
+        ])
+
+        return (contactStore, addressStore, contact, chain, address)
+    }
+}


### PR DESCRIPTION
## Summary

- Long-press on the recipient row in `ConfirmTransferScene` opens "Add to Contacts" with the recipient's chain and address pre-filled (hidden if already a contact).
- Confirm scene's recipient name now updates reactively via a GRDB `ObservableQuery` over the `addresses` table — saving or deleting a contact refreshes the row instantly.
- Fix `ContactStore.deleteContact` so it also removes the corresponding `addresses` rows (with `type = .contact`) in the same transaction. Previously only the `contacts` table was cleaned, leaving an orphan `AddressName` that kept showing the deleted contact's name in the confirm scene.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 16 36 44" src="https://github.com/user-attachments/assets/0ae11cfe-9163-410a-aaa1-c405720f8879" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-04 at 16 37 01" src="https://github.com/user-attachments/assets/837df4c3-daf8-45f0-b56c-1bb156a3da8b" />


Closes #249