### PR TITLE
Android: Match checkmark size on Accept Terms screen

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/features/onboarding/AcceptTermsScreen.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/onboarding/AcceptTermsScreen.kt
@@ -43,12 +43,12 @@ import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.actions.CancelAction
 import com.gemwallet.android.ui.open
 import com.gemwallet.android.ui.theme.Spacer16
-import com.gemwallet.android.ui.theme.compactIconSize
 import com.gemwallet.android.ui.theme.WalletTheme
 import com.gemwallet.android.ui.theme.defaultPadding
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.paddingHalfSmall
 import com.gemwallet.android.ui.theme.sceneContentPadding
+import com.gemwallet.android.ui.theme.smallIconSize
 import uniffi.gemstone.PublicUrl
 
 @Composable
@@ -136,14 +136,14 @@ private fun LazyListScope.termItem(
         ) {
             Row(modifier = Modifier.defaultPadding(), verticalAlignment = Alignment.CenterVertically) {
                 Box(
-                    modifier = Modifier.size(compactIconSize),
+                    modifier = Modifier.size(smallIconSize),
                     contentAlignment = Alignment.Center,
                 ) {
                     if (isUnderstand) {
                         SelectionCheckmark()
                     } else {
                         Icon(
-                            modifier = Modifier.size(compactIconSize),
+                            modifier = Modifier.size(smallIconSize),
                             imageVector = Icons.Outlined.Circle,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.secondary,


### PR DESCRIPTION
## Summary
- Resolves the size mismatch between checked and unchecked icons on the Accept Terms screen.
- `SelectionCheckmark` fills 100% of its box; Material's `Icons.Outlined.Circle` leaves ~17% padding inside its viewBox, so at the same `compactIconSize` the two icons rendered at visibly different diameters.
- Bumps the outer `Box` and the outlined icon to `smallIconSize` (24.dp) so the outlined circle's visible diameter matches the 20.dp filled checkmark.

Closes #257
<img width="320" alt="Screenshot_1777969434" src="https://github.com/user-attachments/assets/248f7cc0-775c-4134-8195-2a69a9d6b1e0" />

