### PR TITLE
Don't start stream observer during onboarding

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
@@ -71,6 +71,7 @@ class StreamObserverService(
 
     fun start() {
         if (connectionJob != null) return
+        if (sessionRepository.session().value?.wallet == null) return
 
         connectionJob = scope.launch(Dispatchers.IO) {
             while (isActive) {

--- a/ios/Packages/FeatureServices/AppService/AppLifecycleService.swift
+++ b/ios/Packages/FeatureServices/AppService/AppLifecycleService.swift
@@ -47,7 +47,8 @@ public actor AppLifecycleService: Sendable {
         currentWallet = wallet
         async let assets: () = setupPriceAssets(wallet: wallet)
         async let perpetual: () = connectPerpetual()
-        _ = await (assets, perpetual)
+        async let stream: () = connectStreamObserver()
+        _ = await (assets, perpetual, stream)
     }
 
     public func updatePerpetualConnection() async {
@@ -98,10 +99,15 @@ extension AppLifecycleService {
     }
 
     private func connectObservers() async {
-        async let price: () = streamObserverService.connect()
+        async let stream: () = connectStreamObserver()
         async let perpetual: () = connectPerpetual()
         async let nodeAuthToken: () = deviceObserverService.startNodeAuthTokenUpdates()
-        _ = await (price, perpetual, nodeAuthToken)
+        _ = await (stream, perpetual, nodeAuthToken)
+    }
+
+    private func connectStreamObserver() async {
+        guard currentWallet != nil else { return }
+        await streamObserverService.connect()
     }
 
     private func connectPerpetual() async {


### PR DESCRIPTION
## Summary

Stream observer was opening the price/balance/tx WebSocket during onboarding when no wallet exists yet. Gate the connect on wallet presence on both platforms.

- **iOS**: `AppLifecycleService.connectObservers()` now routes through `connectStreamObserver()` which guards on `currentWallet != nil`. Also called from `setupWallet()` so it kicks in when the wallet first appears.
- **Android**: `StreamObserverService.start()` returns early if `sessionRepository.session().value?.wallet == null`. The existing `init`-block session collector already calls `start()` when a wallet appears, so wallet creation / import / switching keep working through the normal path.

Closes #256