### PR TITLE
Make perpetuals preference wallet-aware

### DIFF
--- a/ios/Features/Assets/Sources/ViewModels/AssetSceneBannersViewModel.swift
+++ b/ios/Features/Assets/Sources/ViewModels/AssetSceneBannersViewModel.swift
@@ -8,13 +8,16 @@ import PrimitivesComponents
 @Observable
 @MainActor
 final class AssetSceneBannersViewModel: Sendable {
+    private let wallet: Wallet
     private let assetData: AssetData
     private let banners: [Banner]
 
     init(
+        wallet: Wallet,
         assetData: AssetData,
         banners: [Banner],
     ) {
+        self.wallet = wallet
         self.assetData = assetData
         self.banners = banners
     }
@@ -36,7 +39,8 @@ final class AssetSceneBannersViewModel: Sendable {
 
     private func shouldShowBanner(_ banner: Banner) -> Bool {
         switch banner.event {
-        case .enableNotifications, .accountBlockedMultiSignature, .tradePerpetuals: true
+        case .enableNotifications, .accountBlockedMultiSignature: true
+        case .tradePerpetuals: wallet.supportsPerpetuals
         case .accountActivation: assetData.balance.available == 0
         case .stake: assetData.balance.staked.isZero && assetData.balance.frozen.isZero
         case .activateAsset: !assetData.metadata.isActive

--- a/ios/Features/Assets/Sources/ViewModels/AssetSceneBannersViewModel.swift
+++ b/ios/Features/Assets/Sources/ViewModels/AssetSceneBannersViewModel.swift
@@ -40,7 +40,7 @@ final class AssetSceneBannersViewModel: Sendable {
     private func shouldShowBanner(_ banner: Banner) -> Bool {
         switch banner.event {
         case .enableNotifications, .accountBlockedMultiSignature: true
-        case .tradePerpetuals: wallet.supportsPerpetuals
+        case .tradePerpetuals: wallet.hasPerpetualsSupport
         case .accountActivation: assetData.balance.available == 0
         case .stake: assetData.balance.staked.isZero && assetData.balance.frozen.isZero
         case .activateAsset: !assetData.metadata.isActive

--- a/ios/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/ios/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -218,7 +218,7 @@ public final class AssetSceneViewModel: Sendable {
     }
 
     var assetBannerViewModel: AssetSceneBannersViewModel {
-        AssetSceneBannersViewModel(assetData: assetData, banners: banners)
+        AssetSceneBannersViewModel(wallet: wallet, assetData: assetData, banners: banners)
     }
 
     var assetHeaderModel: AssetHeaderViewModel {

--- a/ios/Features/Assets/Tests/AssetsTests/AssetBannersViewModelTests.swift
+++ b/ios/Features/Assets/Tests/AssetsTests/AssetBannersViewModelTests.swift
@@ -10,40 +10,42 @@ import Testing
 struct AssetBannersViewModelTests {
     @Test
     func stakingBannerFiltering() {
-        let withStake = AssetSceneBannersViewModel(assetData: .mock(balance: Balance(staked: BigInt(100))), banners: [.mock(event: .stake)])
+        let withStake = AssetSceneBannersViewModel(wallet: .mock(), assetData: .mock(balance: Balance(staked: BigInt(100))), banners: [.mock(event: .stake)])
         #expect(withStake.allBanners.isEmpty)
 
-        let noStake = AssetSceneBannersViewModel(assetData: .mock(balance: Balance(staked: .zero)), banners: [.mock(event: .stake)])
+        let noStake = AssetSceneBannersViewModel(wallet: .mock(), assetData: .mock(balance: Balance(staked: .zero)), banners: [.mock(event: .stake)])
         #expect(noStake.allBanners.count == 1)
     }
 
     @Test
     func activateAssetBanner() {
-        let inactive = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(isActive: false)), banners: [])
+        let inactive = AssetSceneBannersViewModel(wallet: .mock(), assetData: .mock(metadata: .mock(isActive: false)), banners: [])
         #expect(inactive.allBanners.count == 1)
         #expect(inactive.allBanners.first?.event == .activateAsset)
 
-        let active = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(isActive: true)), banners: [])
+        let active = AssetSceneBannersViewModel(wallet: .mock(), assetData: .mock(metadata: .mock(isActive: true)), banners: [])
         #expect(active.allBanners.isEmpty)
     }
 
     @Test
     func suspiciousAssetBanner() {
-        let suspicious = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(rankScore: 5)), banners: [])
+        let suspicious = AssetSceneBannersViewModel(wallet: .mock(), assetData: .mock(metadata: .mock(rankScore: 5)), banners: [])
         #expect(suspicious.allBanners.count == 1)
         #expect(suspicious.allBanners.first?.event == .suspiciousAsset)
 
-        #expect(AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(rankScore: 50)), banners: []).allBanners.isEmpty)
+        #expect(AssetSceneBannersViewModel(wallet: .mock(), assetData: .mock(metadata: .mock(rankScore: 50)), banners: []).allBanners.isEmpty)
     }
 
     @Test
     func accountActivationBanner() {
         #expect(AssetSceneBannersViewModel(
+            wallet: .mock(),
             assetData: .mock(asset: .mockXRP(), balance: .zero, metadata: .mock(rankScore: 16)),
             banners: [.mock(event: .accountActivation)],
         ).allBanners.first?.event == .accountActivation)
 
         #expect(AssetSceneBannersViewModel(
+            wallet: .mock(),
             assetData: .mock(balance: Balance(available: BigInt(1)), metadata: .mock(rankScore: 16)),
             banners: [.mock(event: .accountActivation)],
         ).allBanners.isEmpty)
@@ -52,6 +54,7 @@ struct AssetBannersViewModelTests {
     @Test
     func nonClosableBannersShowFirst() {
         let model = AssetSceneBannersViewModel(
+            wallet: .mock(),
             assetData: .mock(metadata: .mock(rankScore: 5)),
             banners: [.mock(event: .stake, state: .active), .mock(event: .accountActivation, state: .alwaysActive)],
         )
@@ -65,6 +68,7 @@ struct AssetBannersViewModelTests {
     @Test
     func priorityBannerReturnsHighestPriority() {
         let model = AssetSceneBannersViewModel(
+            wallet: .mock(),
             assetData: .mock(),
             banners: [
                 .mock(event: .stake, state: .active),
@@ -74,5 +78,19 @@ struct AssetBannersViewModelTests {
         )
 
         #expect(model.allBanners.first?.state == .alwaysActive)
+    }
+
+    @Test(arguments: [
+        (Wallet.mock(type: .multicoin, accounts: [.mock(chain: .hyperCore, address: "hc1")]), true),
+        (Wallet.mock(type: .single, accounts: [.mock(chain: .bitcoin, address: "bc1")]), false),
+    ])
+    func showPerpetualsBanner(wallet: Wallet, expected: Bool) {
+        let model = AssetSceneBannersViewModel(
+            wallet: wallet,
+            assetData: .mock(metadata: .mock(isActive: true, rankScore: 50)),
+            banners: [.mock(event: .tradePerpetuals)],
+        )
+        let hasPerpBanner = model.allBanners.contains { $0.event == .tradePerpetuals }
+        #expect(hasPerpBanner == expected)
     }
 }

--- a/ios/Features/WalletTab/Sources/ViewModels/PortfolioSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/PortfolioSceneViewModel.swift
@@ -50,7 +50,7 @@ public final class PortfolioSceneViewModel: ChartListViewable {
     }
 
     var showSegmentedControl: Bool {
-        preferences.isPerpetualEnabled && wallet.isMultiCoins && wallet.hyperliquidAccount != nil
+        preferences.showPerpetuals(for: wallet)
     }
 
     var navigationTitle: String {

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -101,7 +101,7 @@ public final class WalletSceneViewModel: Sendable {
     }
 
     var showPerpetuals: Bool {
-        observablePreferences.isPerpetualEnabled && wallet.isMultiCoins
+        observablePreferences.showPerpetuals(for: wallet)
     }
 
     var currencyCode: String {

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
@@ -128,7 +128,7 @@ public final class WalletSearchSceneViewModel: Sendable {
     }
 
     var showPerpetuals: Bool {
-        sections.perpetuals.isNotEmpty && preferences.isPerpetualEnabled
+        sections.perpetuals.isNotEmpty && preferences.showPerpetuals(for: wallet)
     }
 
     var showLoading: Bool {
@@ -144,7 +144,7 @@ public final class WalletSearchSceneViewModel: Sendable {
     }
 
     var showPinnedPerpetuals: Bool {
-        sections.pinnedPerpetuals.isNotEmpty && preferences.isPerpetualEnabled
+        sections.pinnedPerpetuals.isNotEmpty && preferences.showPerpetuals(for: wallet)
     }
 
     var showAssets: Bool {

--- a/ios/Features/WalletTab/Tests/WalletSearchSceneViewModelTests.swift
+++ b/ios/Features/WalletTab/Tests/WalletSearchSceneViewModelTests.swift
@@ -48,6 +48,27 @@ struct WalletSearchSceneViewModelTests {
         #expect(model.hasMorePerpetuals == true)
     }
 
+    @Test(arguments: [
+        Wallet.mock(type: .single, accounts: [.mock(chain: .bitcoin, address: "bc1")]),
+        Wallet.mock(type: .view, accounts: [.mock(chain: .ethereum, address: "0x1")]),
+        Wallet.mock(type: .multicoin, accounts: [.mock(chain: .ethereum, address: "0x1")]),
+    ])
+    func hidesPerpetualsForUnsupportedWallet(wallet: Wallet) {
+        let model = WalletSearchSceneViewModel.mock(
+            wallet: wallet,
+            preferences: .mock(isPerpetualEnabled: true),
+        )
+        model.searchQuery.value = WalletSearchResult(
+            assets: [],
+            perpetuals: [
+                .mock(metadata: .mock(isPinned: false)),
+                .mock(metadata: .mock(isPinned: true)),
+            ],
+        )
+        #expect(model.showPerpetuals == false)
+        #expect(model.showPinnedPerpetuals == false)
+    }
+
     @Test
     func pinAssetEnablesAsset() async {
         let db = DB.mockAssets()

--- a/ios/Packages/FeatureServices/AppService/AppLifecycleService.swift
+++ b/ios/Packages/FeatureServices/AppService/AppLifecycleService.swift
@@ -105,7 +105,7 @@ extension AppLifecycleService {
     }
 
     private func connectPerpetual() async {
-        if let wallet = currentWallet, wallet.isMultiCoins, preferences.isPerpetualEnabled {
+        if let wallet = currentWallet, preferences.showPerpetuals(for: wallet) {
             await hyperliquidObserverService.setup(for: wallet)
         } else {
             await hyperliquidObserverService.disconnect()

--- a/ios/Packages/FeatureServices/AppService/Tests/AppLifecycleServiceTests.swift
+++ b/ios/Packages/FeatureServices/AppService/Tests/AppLifecycleServiceTests.swift
@@ -14,7 +14,7 @@ struct AppLifecycleServiceTests {
     func setupWalletConnectsHyperliquidForMultiCoinWallet() async {
         let (service, observer, _) = makeService(perpetualEnabled: true)
 
-        await service.setupWallet(.mock(type: .multicoin))
+        await service.setupWallet(.mock(type: .multicoin, accounts: [.mock(chain: .hyperliquid)]))
 
         #expect(await observer.isConnected == true)
     }
@@ -31,7 +31,7 @@ struct AppLifecycleServiceTests {
     @Test
     func setupWalletDisconnectsWhenSwitchingToSingleChainWallet() async {
         let (service, observer, _) = makeService(perpetualEnabled: true)
-        await service.setupWallet(.mock(type: .multicoin))
+        await service.setupWallet(.mock(type: .multicoin, accounts: [.mock(chain: .hyperliquid)]))
 
         await service.setupWallet(.mock(type: .single))
 
@@ -42,7 +42,7 @@ struct AppLifecycleServiceTests {
     func setupWalletSkipsHyperliquidWhenDisabled() async {
         let (service, observer, _) = makeService(perpetualEnabled: false)
 
-        await service.setupWallet(.mock(type: .multicoin))
+        await service.setupWallet(.mock(type: .multicoin, accounts: [.mock(chain: .hyperliquid)]))
 
         #expect(await observer.isConnected == false)
     }
@@ -50,7 +50,7 @@ struct AppLifecycleServiceTests {
     @Test
     func updatePerpetualConnectionDisconnectsWhenDisabled() async {
         let (service, observer, preferences) = makeService(perpetualEnabled: true)
-        await service.setupWallet(.mock(type: .multicoin))
+        await service.setupWallet(.mock(type: .multicoin, accounts: [.mock(chain: .hyperliquid)]))
 
         preferences.isPerpetualEnabled = false
         await service.updatePerpetualConnection()

--- a/ios/Packages/Preferences/Sources/ObservablePreferences.swift
+++ b/ios/Packages/Preferences/Sources/ObservablePreferences.swift
@@ -1,5 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
+import Primitives
 import SwiftUI
 
 @Observable
@@ -105,6 +106,11 @@ public final class ObservablePreferences: Sendable {
                 preferences.perpetualLeverage = newValue
             }
         }
+    }
+
+    public func showPerpetuals(for wallet: Wallet) -> Bool {
+        access(keyPath: \.isPerpetualEnabled)
+        return preferences.showPerpetuals(for: wallet)
     }
 }
 

--- a/ios/Packages/Preferences/Sources/Preferences.swift
+++ b/ios/Packages/Preferences/Sources/Preferences.swift
@@ -190,6 +190,6 @@ public final class Preferences: @unchecked Sendable {
     }
 
     public func showPerpetuals(for wallet: Wallet) -> Bool {
-        isPerpetualEnabled && wallet.supportsPerpetuals
+        isPerpetualEnabled && wallet.hasPerpetualsSupport
     }
 }

--- a/ios/Packages/Preferences/Sources/Preferences.swift
+++ b/ios/Packages/Preferences/Sources/Preferences.swift
@@ -188,4 +188,8 @@ public final class Preferences: @unchecked Sendable {
     public func explorerName(chain: Chain) -> String? {
         defaults.string(forKey: "\(ExplorerKeys.explorerName)_\(chain.rawValue)")
     }
+
+    public func showPerpetuals(for wallet: Wallet) -> Bool {
+        isPerpetualEnabled && wallet.supportsPerpetuals
+    }
 }

--- a/ios/Packages/Primitives/Sources/Extensions/Wallet+Primitives.swift
+++ b/ios/Packages/Primitives/Sources/Extensions/Wallet+Primitives.swift
@@ -43,7 +43,8 @@ public extension Wallet {
         }
     }
 
-    var supportsPerpetuals: Bool {
+
+    var hasPerpetualsSupport: Bool {
         isMultiCoins && hyperliquidAccount != nil
     }
 }

--- a/ios/Packages/Primitives/Sources/Extensions/Wallet+Primitives.swift
+++ b/ios/Packages/Primitives/Sources/Extensions/Wallet+Primitives.swift
@@ -42,6 +42,10 @@ public extension Wallet {
             $0.chain == .arbitrum || $0.chain == .hyperCore || $0.chain == .hyperliquid
         }
     }
+
+    var supportsPerpetuals: Bool {
+        isMultiCoins && hyperliquidAccount != nil
+    }
 }
 
 /// factory

--- a/ios/Packages/Primitives/Tests/PrimitivesTests/Extensions/Wallet+PrimitivesTests.swift
+++ b/ios/Packages/Primitives/Tests/PrimitivesTests/Extensions/Wallet+PrimitivesTests.swift
@@ -27,13 +27,20 @@ struct Wallet_PrimitivesTests {
     }
 
     @Test(arguments: [
-        (WalletType.multicoin, Chain.hyperCore, true),
-        (WalletType.multicoin, Chain.ethereum, false),
-        (WalletType.single, Chain.bitcoin, false),
+        (WalletType.multicoin, [Chain.hyperCore], true),
+        (WalletType.multicoin, [Chain.arbitrum], true),
+        (WalletType.multicoin, [Chain.hyperliquid], true),
+        (WalletType.multicoin, [Chain.ethereum], false),
+        (WalletType.multicoin, [], false),
+        (WalletType.single, [Chain.hyperCore], false),
+        (WalletType.single, [Chain.arbitrum], false),
+        (WalletType.single, [Chain.bitcoin], false),
+        (WalletType.privateKey, [Chain.hyperCore], false),
+        (WalletType.view, [Chain.hyperCore], false),
     ])
-    func supportsPerpetuals(type: WalletType, chain: Chain, expected: Bool) {
-        let wallet = Wallet.mock(type: type, accounts: [.mock(chain: chain, address: "addr")])
-        #expect(wallet.supportsPerpetuals == expected)
+    func hasPerpetualsSupport(type: WalletType, chains: [Chain], expected: Bool) {
+        let wallet = Wallet.mock(type: type, accounts: chains.map { .mock(chain: $0, address: "addr") })
+        #expect(wallet.hasPerpetualsSupport == expected)
     }
 
     @Test

--- a/ios/Packages/Primitives/Tests/PrimitivesTests/Extensions/Wallet+PrimitivesTests.swift
+++ b/ios/Packages/Primitives/Tests/PrimitivesTests/Extensions/Wallet+PrimitivesTests.swift
@@ -26,6 +26,16 @@ struct Wallet_PrimitivesTests {
         #expect(result[1] == AddressChains(address: "bc1", chains: [.bitcoin]))
     }
 
+    @Test(arguments: [
+        (WalletType.multicoin, Chain.hyperCore, true),
+        (WalletType.multicoin, Chain.ethereum, false),
+        (WalletType.single, Chain.bitcoin, false),
+    ])
+    func supportsPerpetuals(type: WalletType, chain: Chain, expected: Bool) {
+        let wallet = Wallet.mock(type: type, accounts: [.mock(chain: chain, address: "addr")])
+        #expect(wallet.supportsPerpetuals == expected)
+    }
+
     @Test
     func walletIdFromType() throws {
         #expect(throws: Error.self) {


### PR DESCRIPTION
closes #251

Perpetuals UI now respects both the user preference and the wallet itself. If the wallet can't support perps (e.g. single-chain imports), perps are hidden everywhere — banners, wallet scenes, asset screen — and the Hyperliquid connection is dropped.

Single-chain wallets like btc-only used to show the perp UI. Now perps are hidden for those wallets.