### PR TITLE
Show transactions immediately on activity tab open

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/App.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/App.kt
@@ -11,6 +11,7 @@ import coil3.disk.directory
 import coil3.memory.MemoryCache
 import coil3.svg.SvgDecoder
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetualPositions
+import com.gemwallet.android.application.transactions.coordinators.GetTransactions
 import com.gemwallet.android.data.repositories.stream.StreamObserverService
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
@@ -22,6 +23,8 @@ class App : Application(), SingletonImageLoader.Factory, Application.ActivityLif
     lateinit var streamObserver: StreamObserverService
     @Inject
     lateinit var syncPerpetualPositions: SyncPerpetualPositions
+    @Inject
+    lateinit var getTransactions: GetTransactions
 
     override fun onCreate() {
         super.onCreate()

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionsImpl.kt
@@ -19,14 +19,26 @@ import com.wallet.core.primitives.TransactionId
 import com.wallet.core.primitives.TransactionState
 import com.wallet.core.primitives.TransactionSwapMetadata
 import com.wallet.core.primitives.TransactionType
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 class GetTransactionsImpl(
     private val transactionsRepository: TransactionRepository,
+    scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
 ) : GetTransactions {
+
+    private val transactions: StateFlow<List<TransactionDataAggregate>> =
+        transactionsRepository.getTransactions(emptyList())
+            .map { items -> items.map { TransactionDataAggregateImpl(it) } }
+            .stateIn(scope, SharingStarted.Eagerly, emptyList())
+
+    override fun transactions(): StateFlow<List<TransactionDataAggregate>> = transactions
 
     override fun getTransactions(
         filters: List<TransactionsRequestFilter>,

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/wallet_import/services/ImportWalletService.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/wallet_import/services/ImportWalletService.kt
@@ -18,6 +18,7 @@ import com.gemwallet.android.ext.identifier
 import com.gemwallet.android.ext.toAssetId
 import com.gemwallet.android.ext.type
 import com.wallet.core.primitives.AssetSubtype
+import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.Wallet
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -25,6 +26,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.firstOrNull
@@ -51,24 +53,11 @@ class ImportWalletService(
             syncSubscription.syncSubscription(listOf(wallet))
             val currency = sessionRepository.getCurrentCurrency()
             try {
-                val availableAssetsId = getAvailableAssetIds(wallet.id)
-                val assetIds = availableAssetsId.mapNotNull { it.toAssetId() }
-                val tokenIds = assetIds.filter { it.type() != AssetSubtype.NATIVE }
-
-                searchTokensCase.search(tokenIds, currency)
-                val assets = assetsRepository.getTokensInfo(assetIds.map { it.identifier }).firstOrNull().orEmpty()
-                assets.forEach { assetInfo ->
-                    val asset = assetInfo.asset
-                    wallet.getAccount(asset.chain) ?: return@forEach
-                    assetsRepository.linkAssetToWallet(
-                        walletId = wallet.id,
-                        assetId = asset.id,
-                        visible = true,
-                    )
+                coroutineScope {
+                    launch { discoverAssets(wallet, currency) }
+                    launch { syncTransactions.syncTransactions(wallet) }
+                    launch { syncNfts.syncNfts(wallet) }
                 }
-                assetsRepository.sync()
-                syncTransactions.syncTransactions(wallet)
-                syncNfts.syncNfts(wallet)
             } catch (err: Throwable) {
                 Log.d("IMPORT_ERROR", "Error:", err)
             } finally {
@@ -76,6 +65,25 @@ class ImportWalletService(
             }
         }
         jobs.update { it.toMutableMap().apply { put(wallet.id, job) } }
+    }
+
+    private suspend fun discoverAssets(wallet: Wallet, currency: Currency) {
+        val availableAssetsId = getAvailableAssetIds(wallet.id)
+        val assetIds = availableAssetsId.mapNotNull { it.toAssetId() }
+        val tokenIds = assetIds.filter { it.type() != AssetSubtype.NATIVE }
+
+        searchTokensCase.search(tokenIds, currency)
+        val assets = assetsRepository.getTokensInfo(assetIds.map { it.identifier }).firstOrNull().orEmpty()
+        assets.forEach { assetInfo ->
+            val asset = assetInfo.asset
+            wallet.getAccount(asset.chain) ?: return@forEach
+            assetsRepository.linkAssetToWallet(
+                walletId = wallet.id,
+                assetId = asset.id,
+                visible = true,
+            )
+        }
+        assetsRepository.sync()
     }
 
     override fun getImportState(walletId: String): Flow<ImportWalletState> = jobs.mapLatest { entries ->

--- a/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModel.kt
+++ b/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModel.kt
@@ -1,6 +1,5 @@
 package com.gemwallet.android.features.activities.viewmodels
 
-import android.text.format.DateUtils
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.transactions.coordinators.GetTransactions
@@ -20,7 +19,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -60,11 +58,12 @@ class TransactionsViewModel @Inject constructor(
             ),
         )
     }
-    .onEach {
-        _state.update { false }
-    }
     .distinctUntilChanged()
-    .stateIn(viewModelScope, started = SharingStarted.Eagerly, emptyList())
+    .stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = getTransactions.transactions().value,
+    )
 
     init {
         refresh()

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/transactions/coordinators/GetTransactions.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/transactions/coordinators/GetTransactions.kt
@@ -2,9 +2,12 @@ package com.gemwallet.android.application.transactions.coordinators
 
 import com.gemwallet.android.domains.transaction.aggregates.TransactionDataAggregate
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 interface GetTransactions {
     fun getTransactions(
         filters: List<TransactionsRequestFilter> = emptyList(),
     ): Flow<List<TransactionDataAggregate>>
+
+    fun transactions(): StateFlow<List<TransactionDataAggregate>>
 }

--- a/ios/Packages/FeatureServices/DiscoverAssetsService/AssetDiscoveryService.swift
+++ b/ios/Packages/FeatureServices/DiscoverAssetsService/AssetDiscoveryService.swift
@@ -33,9 +33,10 @@ public struct AssetDiscoveryService: AssetDiscoverable {
     public func discoverAssets(wallet: Wallet) async throws {
         let preferences = WalletPreferences(walletId: wallet.walletId)
 
-        try await discoverAssets(wallet: wallet, preferences: preferences)
-        try await discoverTransactions(wallet: wallet, preferences: preferences)
-        try await discoverNFTs(wallet: wallet, preferences: preferences)
+        async let assets: () = discoverAssets(wallet: wallet, preferences: preferences)
+        async let transactions: () = discoverTransactions(wallet: wallet, preferences: preferences)
+        async let nfts: () = discoverNFTs(wallet: wallet, preferences: preferences)
+        _ = try await (assets, transactions, nfts)
     }
 
     private func discoverAssets(wallet: Wallet, preferences: WalletPreferences) async throws {


### PR DESCRIPTION
Closes #255

Two parallel issues caused empty state to flash before transactions appeared:

1. On first import, asset discovery, transactions and NFT sync ran sequentially — transactions arrived after wallet load. Run all three in parallel (async let on iOS, coroutineScope { launch } on Android).

2. On Android, TransactionsViewModel was created lazily on tab click, and its Room flow added an async hop before first emission. Add a hot StateFlow in GetTransactionsImpl. ViewModel reads .value synchronously for stateIn initialValue, so the first frame already has cached transactions.