### PR TITLE
Drop direct repository deps from asset detail view models

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetByIdImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetByIdImpl.kt
@@ -1,0 +1,14 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.GetAssetById
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.wallet.core.primitives.Asset
+import com.wallet.core.primitives.AssetId
+import kotlinx.coroutines.flow.Flow
+
+class GetAssetByIdImpl(
+    private val assetsRepository: AssetsRepository,
+) : GetAssetById {
+    override fun invoke(assetId: AssetId): Flow<Asset?> =
+        assetsRepository.asset(assetId)
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetLinksImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetLinksImpl.kt
@@ -1,0 +1,14 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.GetAssetLinks
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.AssetLink
+import kotlinx.coroutines.flow.Flow
+
+class GetAssetLinksImpl(
+    private val assetsRepository: AssetsRepository,
+) : GetAssetLinks {
+    override fun invoke(assetId: AssetId): Flow<List<AssetLink>> =
+        assetsRepository.getAssetLinks(assetId)
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetMarketImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetMarketImpl.kt
@@ -1,0 +1,14 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.GetAssetMarket
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.AssetMarket
+import kotlinx.coroutines.flow.Flow
+
+class GetAssetMarketImpl(
+    private val assetsRepository: AssetsRepository,
+) : GetAssetMarket {
+    override fun invoke(assetId: AssetId): Flow<AssetMarket?> =
+        assetsRepository.getAssetMarket(assetId)
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetTokenInfoImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetTokenInfoImpl.kt
@@ -1,0 +1,14 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.GetAssetTokenInfo
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.model.AssetInfo
+import com.wallet.core.primitives.AssetId
+import kotlinx.coroutines.flow.Flow
+
+class GetAssetTokenInfoImpl(
+    private val assetsRepository: AssetsRepository,
+) : GetAssetTokenInfo {
+    override fun invoke(assetId: AssetId): Flow<AssetInfo?> =
+        assetsRepository.getTokenInfo(assetId)
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetModule.kt
@@ -2,7 +2,11 @@ package com.gemwallet.android.data.coordinators.di
 
 import com.gemwallet.android.application.assets.coordinators.EnableAsset
 import com.gemwallet.android.application.assets.coordinators.GetActiveAssetsInfo
+import com.gemwallet.android.application.assets.coordinators.GetAssetById
 import com.gemwallet.android.application.assets.coordinators.GetAssetChartData
+import com.gemwallet.android.application.assets.coordinators.GetAssetLinks
+import com.gemwallet.android.application.assets.coordinators.GetAssetMarket
+import com.gemwallet.android.application.assets.coordinators.GetAssetTokenInfo
 import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
 import com.gemwallet.android.application.assets.coordinators.GetImportInProgress
 import com.gemwallet.android.application.assets.coordinators.GetShowWelcomeBanner
@@ -21,7 +25,11 @@ import com.gemwallet.android.cases.banners.HasMultiSign
 import com.gemwallet.android.cases.tokens.SyncAssetPrices
 import com.gemwallet.android.data.coordinators.asset.EnableAssetImpl
 import com.gemwallet.android.data.coordinators.asset.GetActiveAssetsInfoImpl
+import com.gemwallet.android.data.coordinators.asset.GetAssetByIdImpl
 import com.gemwallet.android.data.coordinators.asset.GetAssetChartDataImpl
+import com.gemwallet.android.data.coordinators.asset.GetAssetLinksImpl
+import com.gemwallet.android.data.coordinators.asset.GetAssetMarketImpl
+import com.gemwallet.android.data.coordinators.asset.GetAssetTokenInfoImpl
 import com.gemwallet.android.data.coordinators.asset.GetHideBalancesStateImpl
 import com.gemwallet.android.data.coordinators.asset.GetImportInProgressImpl
 import com.gemwallet.android.data.coordinators.asset.GetShowWelcomeBannerImpl
@@ -62,6 +70,26 @@ object AssetModule {
     @Singleton
     fun provideGetActiveAssetsInfo(assetsRepository: AssetsRepository): GetActiveAssetsInfo =
         GetActiveAssetsInfoImpl(assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideGetAssetTokenInfo(assetsRepository: AssetsRepository): GetAssetTokenInfo =
+        GetAssetTokenInfoImpl(assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideGetAssetById(assetsRepository: AssetsRepository): GetAssetById =
+        GetAssetByIdImpl(assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideGetAssetLinks(assetsRepository: AssetsRepository): GetAssetLinks =
+        GetAssetLinksImpl(assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideGetAssetMarket(assetsRepository: AssetsRepository): GetAssetMarket =
+        GetAssetMarketImpl(assetsRepository)
 
     @Provides
     @Singleton

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PriceAlertModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PriceAlertModule.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.data.coordinators.di
 import com.gemwallet.android.application.pricealerts.coordinators.ExcludePriceAlert
 import com.gemwallet.android.application.pricealerts.coordinators.GetAssetPriceAlertState
 import com.gemwallet.android.application.pricealerts.coordinators.GetPriceAlerts
+import com.gemwallet.android.application.pricealerts.coordinators.HasAssetPriceAlerts
 import com.gemwallet.android.application.pricealerts.coordinators.IncludePriceAlert
 import com.gemwallet.android.application.pricealerts.coordinators.PriceAlertsStateCoordinator
 import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAlerts
@@ -10,6 +11,7 @@ import com.gemwallet.android.cases.device.SyncDeviceInfo
 import com.gemwallet.android.data.coordinators.pricealerts.ExcludePriceAlertImpl
 import com.gemwallet.android.data.coordinators.pricealerts.GetAssetPriceAlertStateImpl
 import com.gemwallet.android.data.coordinators.pricealerts.GetPriceAlertsImpl
+import com.gemwallet.android.data.coordinators.pricealerts.HasAssetPriceAlertsImpl
 import com.gemwallet.android.data.coordinators.pricealerts.IncludePriceAlertImpl
 import com.gemwallet.android.data.coordinators.pricealerts.PriceAlertsStateCoordinatorImpl
 import com.gemwallet.android.data.coordinators.pricealerts.UpdatePriceAlertsImpl
@@ -103,4 +105,10 @@ object PriceAlertModule {
             priceAlertRepository = priceAlertRepository,
         )
     }
+
+    @Provides
+    @Singleton
+    fun provideHasAssetPriceAlerts(
+        priceAlertRepository: PriceAlertRepository,
+    ): HasAssetPriceAlerts = HasAssetPriceAlertsImpl(priceAlertRepository)
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/pricealerts/HasAssetPriceAlertsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/pricealerts/HasAssetPriceAlertsImpl.kt
@@ -1,0 +1,12 @@
+package com.gemwallet.android.data.coordinators.pricealerts
+
+import com.gemwallet.android.application.pricealerts.coordinators.HasAssetPriceAlerts
+import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
+import com.wallet.core.primitives.AssetId
+
+class HasAssetPriceAlertsImpl(
+    private val priceAlertRepository: PriceAlertRepository,
+) : HasAssetPriceAlerts {
+    override suspend fun invoke(assetId: AssetId): Boolean =
+        priceAlertRepository.hasAssetPriceAlerts(assetId)
+}

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/AssetChartViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/AssetChartViewModel.kt
@@ -3,15 +3,16 @@ package com.gemwallet.android.features.asset.viewmodels.chart.viewmodels
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.assets.coordinators.GetAssetById
+import com.gemwallet.android.application.assets.coordinators.GetAssetLinks
+import com.gemwallet.android.application.assets.coordinators.GetAssetMarket
 import com.gemwallet.android.application.pricealerts.coordinators.GetPriceAlerts
+import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
 import com.gemwallet.android.cases.nodes.GetCurrentBlockExplorer
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.features.asset.viewmodels.chart.models.AssetMarketUIModel
 import com.gemwallet.android.features.asset.viewmodels.chart.models.toModel
 import com.gemwallet.android.ui.models.navigation.requireAssetId
 import com.wallet.core.primitives.AssetId
-import com.wallet.core.primitives.Currency
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -22,10 +23,12 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AssetChartViewModel internal constructor(
-    assetsRepository: AssetsRepository,
+    getAssetById: GetAssetById,
+    getAssetLinks: GetAssetLinks,
+    getAssetMarket: GetAssetMarket,
     getCurrentBlockExplorer: GetCurrentBlockExplorer,
     getPriceAlerts: GetPriceAlerts,
-    sessionRepository: SessionRepository,
+    getCurrentCurrency: GetCurrentCurrency,
     val assetId: AssetId,
 ) : ViewModel() {
 
@@ -35,11 +38,11 @@ class AssetChartViewModel internal constructor(
         .map { it.size }
         .stateIn(viewModelScope, SharingStarted.Eagerly, 0)
 
-    private val asset = assetsRepository.asset(assetId)
+    private val asset = getAssetById(assetId)
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    private val links = assetsRepository.getAssetLinks(assetId)
-    private val market = assetsRepository.getAssetMarket(assetId)
+    private val links = getAssetLinks(assetId)
+    private val market = getAssetMarket(assetId)
 
     val title = asset
         .map { it?.name.orEmpty() }
@@ -50,7 +53,7 @@ class AssetChartViewModel internal constructor(
         asset,
         links,
         market,
-        sessionRepository.getCurrency().distinctUntilChanged(),
+        getCurrentCurrency.getCurrency().distinctUntilChanged(),
     ) { asset, links, market, currency ->
         asset?.let {
             AssetMarketUIModel(
@@ -67,16 +70,20 @@ class AssetChartViewModel internal constructor(
 
     @Inject
     constructor(
-        assetsRepository: AssetsRepository,
+        getAssetById: GetAssetById,
+        getAssetLinks: GetAssetLinks,
+        getAssetMarket: GetAssetMarket,
         getCurrentBlockExplorer: GetCurrentBlockExplorer,
         getPriceAlerts: GetPriceAlerts,
-        sessionRepository: SessionRepository,
+        getCurrentCurrency: GetCurrentCurrency,
         savedStateHandle: SavedStateHandle,
     ) : this(
-        assetsRepository = assetsRepository,
+        getAssetById = getAssetById,
+        getAssetLinks = getAssetLinks,
+        getAssetMarket = getAssetMarket,
         getCurrentBlockExplorer = getCurrentBlockExplorer,
         getPriceAlerts = getPriceAlerts,
-        sessionRepository = sessionRepository,
+        getCurrentCurrency = getCurrentCurrency,
         assetId = savedStateHandle.requireAssetId(),
     )
 }

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/ChartViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/ChartViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.assets.coordinators.GetAssetChartData
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.application.assets.coordinators.GetAssetTokenInfo
+import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
 import com.gemwallet.android.features.asset.viewmodels.chart.models.ChartUIModel
 import com.gemwallet.android.features.asset.viewmodels.chart.models.from
 import com.gemwallet.android.ui.models.navigation.requireAssetId
@@ -33,12 +33,12 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class ChartViewModel internal constructor(
-    assetsRepository: AssetsRepository,
-    sessionRepository: SessionRepository,
+    getAssetTokenInfo: GetAssetTokenInfo,
+    getCurrentCurrency: GetCurrentCurrency,
     private val getAssetChartData: GetAssetChartData,
     private val assetId: AssetId,
 ) : ViewModel() {
-    private val assetPriceInfo = assetsRepository.getTokenInfo(assetId)
+    private val assetPriceInfo = getAssetTokenInfo(assetId)
         .map { it?.price }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
     private val selectedPeriod = MutableStateFlow(ChartPeriod.Day)
@@ -54,7 +54,7 @@ class ChartViewModel internal constructor(
 
     private val chartPrices = combine(
         selectedPeriod,
-        sessionRepository.getCurrency().distinctUntilChanged(),
+        getCurrentCurrency.getCurrency().distinctUntilChanged(),
         refreshTrigger,
     ) { period, currency, _ -> period to currency }
         .mapLatest { (period, currency) ->
@@ -77,7 +77,7 @@ class ChartViewModel internal constructor(
         assetPriceInfo,
         selectedPeriod,
         chartPrices,
-        sessionRepository.getCurrency().distinctUntilChanged(),
+        getCurrentCurrency.getCurrency().distinctUntilChanged(),
     ) { priceInfo, period, prices, currency ->
         ChartUIModel.from(prices, priceInfo, period, currency)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ChartUIModel())
@@ -102,13 +102,13 @@ class ChartViewModel internal constructor(
 
     @Inject
     constructor(
-        assetsRepository: AssetsRepository,
-        sessionRepository: SessionRepository,
+        getAssetTokenInfo: GetAssetTokenInfo,
+        getCurrentCurrency: GetCurrentCurrency,
         getAssetChartData: GetAssetChartData,
         savedStateHandle: SavedStateHandle,
     ) : this(
-        assetsRepository = assetsRepository,
-        sessionRepository = sessionRepository,
+        getAssetTokenInfo = getAssetTokenInfo,
+        getCurrentCurrency = getCurrentCurrency,
         getAssetChartData = getAssetChartData,
         assetId = savedStateHandle.requireAssetId(),
     )

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
@@ -4,18 +4,19 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.assets.coordinators.EnableAsset
+import com.gemwallet.android.application.assets.coordinators.GetAssetTokenInfo
 import com.gemwallet.android.application.assets.coordinators.SyncAssetInfo
+import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
 import com.gemwallet.android.application.pricealerts.coordinators.GetPriceAlerts
+import com.gemwallet.android.application.pricealerts.coordinators.HasAssetPriceAlerts
 import com.gemwallet.android.application.pricealerts.coordinators.PriceAlertsStateCoordinator
 import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAlerts
+import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.application.transactions.coordinators.GetTransactions
 import com.gemwallet.android.application.transactions.coordinators.TransactionsRequestFilter
 import com.gemwallet.android.cases.banners.HasMultiSign
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
 import com.gemwallet.android.cases.nodes.GetCurrentBlockExplorer
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.asset.getIconUrl
 import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
@@ -66,14 +67,15 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class AssetDetailsViewModel @Inject constructor(
-    sessionRepository: SessionRepository,
+    getSession: GetSession,
     savedStateHandle: SavedStateHandle,
-    private val assetsRepository: AssetsRepository,
+    private val getAssetTokenInfo: GetAssetTokenInfo,
+    private val toggleAssetPin: ToggleAssetPin,
     private val enableAsset: EnableAsset,
     private val syncAssetInfo: SyncAssetInfo,
     private val getTransactions: GetTransactions,
     private val priceAlertsStateCoordinator: PriceAlertsStateCoordinator,
-    private val priceAlertRepository: PriceAlertRepository,
+    private val hasAssetPriceAlerts: HasAssetPriceAlerts,
     private val updatePriceAlerts: UpdatePriceAlerts,
     private val getPriceAlerts: GetPriceAlerts,
     private val getCurrentBlockExplorer: GetCurrentBlockExplorer,
@@ -82,8 +84,7 @@ class AssetDetailsViewModel @Inject constructor(
 ) : ViewModel() {
     private var syncJob: Job? = null
 
-    val session = sessionRepository.session()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+    val session = getSession()
 
     val isRefreshing = MutableStateFlow(false)
 
@@ -97,7 +98,7 @@ class AssetDetailsViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Eagerly, routeAssetId)
 
     private val assetInfo = assetId
-        .flatMapLatest { assetsRepository.getTokenInfo(it).filterNotNull() }
+        .flatMapLatest { getAssetTokenInfo(it).filterNotNull() }
 
     val isOperationEnabled = session.filterNotNull().flatMapLatest {
         hasMultiSign.hasMultiSign(it.wallet).mapLatest { !it }
@@ -181,7 +182,7 @@ class AssetDetailsViewModel @Inject constructor(
     }
 
     private fun refreshPriceAlertsIfNeeded(assetId: AssetId) = viewModelScope.launch(Dispatchers.IO) {
-        if (priceAlertRepository.hasAssetPriceAlerts(assetId)) {
+        if (hasAssetPriceAlerts(assetId)) {
             runCatching { updatePriceAlerts.update(assetId) }
         }
     }
@@ -200,7 +201,7 @@ class AssetDetailsViewModel @Inject constructor(
         val assetInfo = model.value?.assetInfo ?: return@launch
         val assetId = assetInfo.id()
         wallet.getAccount(assetId) ?: return@launch
-        assetsRepository.togglePin(wallet.id, assetId)
+        toggleAssetPin(assetId)
     }
 
     fun add() = viewModelScope.launch(Dispatchers.IO) {

--- a/android/features/asset/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/AssetChartViewModelTest.kt
+++ b/android/features/asset/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/AssetChartViewModelTest.kt
@@ -2,10 +2,12 @@ package com.gemwallet.android.features.asset.viewmodels.chart.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.assets.coordinators.GetAssetById
+import com.gemwallet.android.application.assets.coordinators.GetAssetLinks
+import com.gemwallet.android.application.assets.coordinators.GetAssetMarket
 import com.gemwallet.android.application.pricealerts.coordinators.GetPriceAlerts
+import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
 import com.gemwallet.android.cases.nodes.GetCurrentBlockExplorer
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.domains.pricealerts.aggregates.PriceAlertDataAggregate
 import com.gemwallet.android.testkit.mockAssetLink
 import com.gemwallet.android.testkit.mockAssetMarket
@@ -42,22 +44,23 @@ class AssetChartViewModelTest {
     private val marketFlow = MutableStateFlow<AssetMarket?>(null)
     private val currencyFlow = MutableStateFlow(Currency.USD)
 
-    private val assetsRepository = mockk<AssetsRepository>(relaxed = true) {
-        every { asset(asset.id) } returns assetFlow
-        every { getAssetLinks(asset.id) } returns linksFlow
-        every { getAssetMarket(asset.id) } returns marketFlow
-    }
+    private val getAssetById = mockk<GetAssetById>(relaxed = true)
+    private val getAssetLinks = mockk<GetAssetLinks>(relaxed = true)
+    private val getAssetMarket = mockk<GetAssetMarket>(relaxed = true)
     private val getCurrentBlockExplorer = mockk<GetCurrentBlockExplorer>(relaxed = true) {
         every { getCurrentBlockExplorer(asset.id.chain) } returns "Solscan"
     }
     private val getPriceAlerts = mockk<GetPriceAlerts>(relaxed = true)
-    private val sessionRepository = mockk<SessionRepository>(relaxed = true) {
+    private val getCurrentCurrency = mockk<GetCurrentCurrency>(relaxed = true) {
         every { getCurrency() } returns currencyFlow
     }
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        every { getAssetById(asset.id) } returns assetFlow
+        every { getAssetLinks(asset.id) } returns linksFlow
+        every { getAssetMarket(asset.id) } returns marketFlow
         every { getPriceAlerts(asset.id) } returns MutableStateFlow<List<PriceAlertDataAggregate>>(emptyList())
     }
 
@@ -70,13 +73,7 @@ class AssetChartViewModelTest {
 
     @Test
     fun `local asset bootstraps ui without waiting for market or links`() = runTest(testDispatcher) {
-        val viewModel = AssetChartViewModel(
-            assetsRepository = assetsRepository,
-            getCurrentBlockExplorer = getCurrentBlockExplorer,
-            getPriceAlerts = getPriceAlerts,
-            sessionRepository = sessionRepository,
-            assetId = asset.id,
-        ).also(viewModels::add)
+        val viewModel = createViewModel()
         val uiModel = viewModel.marketUIModel.first { it != null }!!
 
         assertEquals(asset, uiModel.asset)
@@ -89,13 +86,7 @@ class AssetChartViewModelTest {
 
     @Test
     fun `local asset bootstraps title`() = runTest(testDispatcher) {
-        val viewModel = AssetChartViewModel(
-            assetsRepository = assetsRepository,
-            getCurrentBlockExplorer = getCurrentBlockExplorer,
-            getPriceAlerts = getPriceAlerts,
-            sessionRepository = sessionRepository,
-            assetId = asset.id,
-        ).also(viewModels::add)
+        val viewModel = createViewModel()
 
         val title = viewModel.title.first { it.isNotBlank() }
 
@@ -104,13 +95,7 @@ class AssetChartViewModelTest {
 
     @Test
     fun `repo updates populate market and links without changing bootstrap asset`() = runTest(testDispatcher) {
-        val viewModel = AssetChartViewModel(
-            assetsRepository = assetsRepository,
-            getCurrentBlockExplorer = getCurrentBlockExplorer,
-            getPriceAlerts = getPriceAlerts,
-            sessionRepository = sessionRepository,
-            assetId = asset.id,
-        ).also(viewModels::add)
+        val viewModel = createViewModel()
         advanceUntilIdle()
 
         val market = mockAssetMarket(marketCap = 1234.0)
@@ -128,4 +113,14 @@ class AssetChartViewModelTest {
         assertEquals(market, uiModel.marketInfo)
         assertEquals(Currency.EUR, uiModel.currency)
     }
+
+    private fun createViewModel(): AssetChartViewModel = AssetChartViewModel(
+        getAssetById = getAssetById,
+        getAssetLinks = getAssetLinks,
+        getAssetMarket = getAssetMarket,
+        getCurrentBlockExplorer = getCurrentBlockExplorer,
+        getPriceAlerts = getPriceAlerts,
+        getCurrentCurrency = getCurrentCurrency,
+        assetId = asset.id,
+    ).also(viewModels::add)
 }

--- a/android/features/asset/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/ChartViewModelTest.kt
+++ b/android/features/asset/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/ChartViewModelTest.kt
@@ -3,8 +3,8 @@ package com.gemwallet.android.features.asset.viewmodels.chart.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.assets.coordinators.GetAssetChartData
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.application.assets.coordinators.GetAssetTokenInfo
+import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.testkit.mockAssetInfo
 import com.gemwallet.android.testkit.mockAssetSolanaUSDC
@@ -39,8 +39,8 @@ class ChartViewModelTest {
     private val currencyFlow = MutableStateFlow(Currency.USD)
     private val viewModels = mutableListOf<ViewModel>()
 
-    private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
-    private val sessionRepository = mockk<SessionRepository>(relaxed = true) {
+    private val getAssetTokenInfo = mockk<GetAssetTokenInfo>(relaxed = true)
+    private val getCurrentCurrency = mockk<GetCurrentCurrency>(relaxed = true) {
         every { getCurrency() } returns currencyFlow
     }
     private val getAssetChartData = mockk<GetAssetChartData>(relaxed = true)
@@ -61,7 +61,7 @@ class ChartViewModelTest {
     fun `historical chart renders when token info flow emits null`() = runTest(testDispatcher) {
         val prices = mockChartPrices(values = listOf(10f, 12f, 14f))
         val tokenInfoFlow = MutableStateFlow<AssetInfo?>(null)
-        every { assetsRepository.getTokenInfo(asset.id) } returns tokenInfoFlow
+        every { getAssetTokenInfo(asset.id) } returns tokenInfoFlow
         coEvery { getAssetChartData.getAssetChartData(asset.id, ChartPeriod.Day, Currency.USD) } returns prices
 
         val viewModel = createViewModel(tokenInfoFlow)
@@ -76,7 +76,7 @@ class ChartViewModelTest {
     fun `current point overlay is skipped when local price info is missing`() = runTest(testDispatcher) {
         val prices = mockChartPrices(values = listOf(100f, 105f, 110f))
         val tokenInfoFlow = MutableStateFlow<AssetInfo?>(mockAssetInfo(asset = asset))
-        every { assetsRepository.getTokenInfo(asset.id) } returns tokenInfoFlow
+        every { getAssetTokenInfo(asset.id) } returns tokenInfoFlow
         coEvery { getAssetChartData.getAssetChartData(asset.id, ChartPeriod.Day, Currency.USD) } returns prices
 
         val viewModel = createViewModel(tokenInfoFlow)
@@ -90,7 +90,7 @@ class ChartViewModelTest {
     fun `initial request uses currency flow without waiting for session object`() = runTest(testDispatcher) {
         val prices = mockChartPrices(values = listOf(1f, 2f))
         val tokenInfoFlow = MutableStateFlow<AssetInfo?>(null)
-        every { assetsRepository.getTokenInfo(asset.id) } returns tokenInfoFlow
+        every { getAssetTokenInfo(asset.id) } returns tokenInfoFlow
         coEvery { getAssetChartData.getAssetChartData(asset.id, ChartPeriod.Day, Currency.USD) } returns prices
 
         val viewModel = createViewModel(tokenInfoFlow)
@@ -104,10 +104,10 @@ class ChartViewModelTest {
     }
 
     private fun createViewModel(tokenInfoFlow: MutableStateFlow<AssetInfo?>): ChartViewModel {
-        every { assetsRepository.getTokenInfo(asset.id) } returns tokenInfoFlow
+        every { getAssetTokenInfo(asset.id) } returns tokenInfoFlow
         return ChartViewModel(
-            assetsRepository = assetsRepository,
-            sessionRepository = sessionRepository,
+            getAssetTokenInfo = getAssetTokenInfo,
+            getCurrentCurrency = getCurrentCurrency,
             getAssetChartData = getAssetChartData,
             assetId = asset.id,
         ).also(viewModels::add)

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetAssetById.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetAssetById.kt
@@ -1,0 +1,9 @@
+package com.gemwallet.android.application.assets.coordinators
+
+import com.wallet.core.primitives.Asset
+import com.wallet.core.primitives.AssetId
+import kotlinx.coroutines.flow.Flow
+
+interface GetAssetById {
+    operator fun invoke(assetId: AssetId): Flow<Asset?>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetAssetLinks.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetAssetLinks.kt
@@ -1,0 +1,9 @@
+package com.gemwallet.android.application.assets.coordinators
+
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.AssetLink
+import kotlinx.coroutines.flow.Flow
+
+interface GetAssetLinks {
+    operator fun invoke(assetId: AssetId): Flow<List<AssetLink>>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetAssetMarket.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetAssetMarket.kt
@@ -1,0 +1,9 @@
+package com.gemwallet.android.application.assets.coordinators
+
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.AssetMarket
+import kotlinx.coroutines.flow.Flow
+
+interface GetAssetMarket {
+    operator fun invoke(assetId: AssetId): Flow<AssetMarket?>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetAssetTokenInfo.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetAssetTokenInfo.kt
@@ -1,0 +1,9 @@
+package com.gemwallet.android.application.assets.coordinators
+
+import com.gemwallet.android.model.AssetInfo
+import com.wallet.core.primitives.AssetId
+import kotlinx.coroutines.flow.Flow
+
+interface GetAssetTokenInfo {
+    operator fun invoke(assetId: AssetId): Flow<AssetInfo?>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/pricealerts/coordinators/HasAssetPriceAlerts.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/pricealerts/coordinators/HasAssetPriceAlerts.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.pricealerts.coordinators
+
+import com.wallet.core.primitives.AssetId
+
+interface HasAssetPriceAlerts {
+    suspend operator fun invoke(assetId: AssetId): Boolean
+}


### PR DESCRIPTION
AssetDetailsViewModel, AssetChartViewModel, and ChartViewModel no longer inject AssetsRepository, SessionRepository, or PriceAlertRepository. They now depend only on coordinators, in line with the rest of the migrated feature modules.

Adds five new coordinators: GetAssetTokenInfo, GetAssetById, GetAssetLinks, GetAssetMarket (assets), and HasAssetPriceAlerts (pricealerts), wired up via existing Hilt modules.