### PR TITLE
Make lock window properties read-only & fix resume bug

### DIFF
--- a/ios/Features/LockManager/Sources/Protocols/LockWindowManageable.swift
+++ b/ios/Features/LockManager/Sources/Protocols/LockWindowManageable.swift
@@ -4,8 +4,8 @@ import SwiftUI
 
 @MainActor
 public protocol LockWindowManageable: Observable {
-    var lockModel: LockSceneViewModel { get set }
-    var overlayWindow: UIWindow? { get set }
+    var lockModel: LockSceneViewModel { get }
+    var overlayWindow: UIWindow? { get }
 
     var showLockScreen: Bool { get }
     var isPrivacyLockVisible: Bool { get }

--- a/ios/Features/LockManager/Sources/Scenes/LockScreenScene.swift
+++ b/ios/Features/LockManager/Sources/Scenes/LockScreenScene.swift
@@ -5,68 +5,48 @@ import Style
 import SwiftUI
 
 struct LockScreenScene: View {
-    @State private var model: LockSceneViewModel
-
-    init(model: LockSceneViewModel) {
-        self.model = model
-    }
+    let model: LockSceneViewModel
 
     var body: some View {
-        ZStack {
-            placeholderView
-                .overlay(alignment: .bottom) {
-                    unlockButton
+        placeholderView
+            .overlay(alignment: .bottom) { unlockButton }
+            .animation(.smooth, value: model.isLocked)
+            .frame(maxWidth: .infinity)
+            .onChange(of: model.state, initial: true) { _, newState in
+                if newState == .locked {
+                    unlock()
                 }
-                .onAppear {
-                    if model.isLocked {
-                        unlock()
-                    }
-                }
-        }
-        .animation(.smooth, value: model.isLocked)
-        .frame(maxWidth: .infinity)
-        .onChange(of: model.isLocked) { _, newState in
-            if newState {
-                unlock()
             }
-        }
     }
 }
 
 // MARK: - UI Components
 
 extension LockScreenScene {
+    @ViewBuilder
     private var unlockButton: some View {
-        VStack(spacing: .medium) {
-            if model.state == .lockedCanceled {
-                Button(action: unlock) {
-                    HStack {
-                        if let image = model.unlockImage {
-                            Image(systemName: image)
-                        }
-                        Text(model.unlockTitle)
+        if model.state == .lockedCanceled {
+            Button(action: unlock) {
+                HStack {
+                    if let image = model.unlockImage {
+                        Image(systemName: image)
                     }
+                    Text(model.unlockTitle)
                 }
-                .buttonStyle(.blue())
-                .frame(maxWidth: .scene.button.maxWidth)
-                .padding()
             }
+            .buttonStyle(.blue())
+            .frame(maxWidth: .scene.button.maxWidth)
+            .padding()
         }
     }
 
-    var placeholderView: some View {
+    private var placeholderView: some View {
         LogoView()
             .background(Colors.white)
     }
-}
 
-// MARK: - Actions
-
-extension LockScreenScene {
     private func unlock() {
-        Task {
-            await model.unlock()
-        }
+        Task { await model.unlock() }
     }
 }
 

--- a/ios/Features/LockManager/Sources/ViewModels/LockSceneViewModel.swift
+++ b/ios/Features/LockManager/Sources/ViewModels/LockSceneViewModel.swift
@@ -88,15 +88,14 @@ extension LockSceneViewModel {
             }
         case .active:
             showPlaceholderPreview = false
-            if inBackground {
-                inBackground = false
-            }
             if state == .unlocked, shouldLock {
                 state = .locked
+            } else if inBackground, state == .unlocking {
+                state = .locked
             }
+            inBackground = false
         case .inactive:
             showPlaceholderPreview = true
-            break
         @unknown default:
             break
         }

--- a/ios/Features/LockManager/Tests/LockSceneViewModelTests.swift
+++ b/ios/Features/LockManager/Tests/LockSceneViewModelTests.swift
@@ -387,7 +387,7 @@ struct LockSceneViewModelTests {
             availableAuth: .biometrics,
         )
         let viewModel = LockSceneViewModel(service: mockService)
-        let initialStates: [LockSceneState] = [.locked, .unlocking, .lockedCanceled]
+        let initialStates: [LockSceneState] = [.locked, .lockedCanceled]
 
         for state in initialStates {
             viewModel.state = state
@@ -397,6 +397,21 @@ struct LockSceneViewModelTests {
             viewModel.handleSceneChange(to: .active)
             #expect(viewModel.state == state)
         }
+    }
+
+    @Test
+    func resumeFromBackgroundDemotesStuckUnlocking() {
+        let mockService = MockBiometryAuthenticationService(
+            isAuthEnabled: true,
+            availableAuth: .biometrics,
+        )
+        let viewModel = LockSceneViewModel(service: mockService)
+        viewModel.state = .unlocking
+
+        viewModel.handleSceneChange(to: .background)
+        viewModel.handleSceneChange(to: .active)
+
+        #expect(viewModel.state == .locked)
     }
 
     @Test

--- a/ios/Features/LockManager/Tests/LockWindowManagerMock.swift
+++ b/ios/Features/LockManager/Tests/LockWindowManagerMock.swift
@@ -53,7 +53,6 @@ final class LockWindowManagerMock: LockWindowManageable {
         guard !lockModel.isPrivacyLockVisible else { return }
         overlayWindow?.alpha = 0
         overlayWindow?.isHidden = true
-        overlayWindow = nil
     }
 
     private static func makeWindow(model: LockSceneViewModel, visible: Bool) -> UIWindow {

--- a/ios/Features/LockManager/Tests/LockWindowManagerTests.swift
+++ b/ios/Features/LockManager/Tests/LockWindowManagerTests.swift
@@ -34,7 +34,7 @@ struct LockWindowManagerTests {
     }
 
     @Test
-    func dismissAfterUnlockRemovesWindow() {
+    func dismissAfterUnlockHidesWindow() {
         let manager = LockWindowManagerMock.mock()
         manager.toggleLock(show: true)
 
@@ -42,7 +42,24 @@ struct LockWindowManagerTests {
         manager.lockModel.lastUnlockTime = .distantFuture
         manager.toggleLock(show: false)
 
-        #expect(manager.overlayWindow == nil)
+        #expect(manager.overlayWindow != nil)
+        #expect(manager.overlayWindow?.alpha == 0)
+        #expect(manager.overlayWindow?.isHidden == true)
+    }
+
+    @Test
+    func resumeFromBackgroundWithStuckUnlockingKeepsLockVisible() {
+        let manager = LockWindowManagerMock.mock()
+        manager.toggleLock(show: true)
+        manager.lockModel.state = .unlocking
+
+        manager.setPhase(phase: .background)
+        manager.setPhase(phase: .active)
+
+        #expect(manager.lockModel.state == .locked)
+        #expect(manager.showLockScreen)
+        #expect(manager.overlayWindow?.isHidden == false)
+        #expect(manager.overlayWindow?.alpha == 1)
     }
 
     @Test


### PR DESCRIPTION
Change LockWindowManageable to expose lockModel and overlayWindow as read-only to better enforce ownership. Refactor LockScreenScene to use an immutable model, simplify view builders, and streamline animation/onChange logic. Fix LockSceneViewModel scene-handling so a stuck .unlocking state is demoted to .locked when resuming to .active and inBackground is reset correctly. Adjust LockWindowManagerMock to hide the overlay window (alpha/isHidden) instead of nil-ing it, and update tests to reflect the new behavior (rename expectation for dismiss to assert hiding, remove .unlocking from initial states test, and add tests ensuring resume-from-background demotes stuck unlocking and keeps the lock window visible). Small formatting and async call simplifications included.

closes #245 