### PR TITLE
Fix asset search ordering

### DIFF
--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
@@ -447,6 +447,44 @@ class AssetsRepositoryTest {
     }
 
     @Test
+    fun swapSearch_usesPriorityDaoAndPreservesOrderWhenPrioritiesExist() = runBlocking {
+        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
+        every { sessionRepository.session() } returns sessionFlow
+        every { assetsPriorityDao.hasPriorities("usd") } returns flowOf(2)
+
+        val wallet = mockWallet(
+            id = "wallet-1",
+            accounts = listOf(mockAccount(chain = Chain.Solana)),
+        )
+        val highPriorityAsset = mockAssetSolana()
+        val lowPriorityAsset = mockAssetSolanaUSDC()
+
+        every {
+            assetsDao.swapSearchWithPriority(
+                query = "usd",
+                byChains = listOf(Chain.Solana),
+                byAssets = emptyList(),
+            )
+        } returns flowOf(
+            listOf(
+                mockDbAssetInfo(asset = highPriorityAsset, walletId = "wallet-1", visible = true, sessionId = 1),
+                mockDbAssetInfo(asset = lowPriorityAsset, walletId = "wallet-1", visible = true, sessionId = 1),
+            )
+        )
+
+        val subject = createSubject()
+        val result = subject.swapSearch(
+            wallet = wallet,
+            query = "usd",
+            byChains = listOf(Chain.Solana),
+            byAssets = emptyList(),
+            tags = emptyList(),
+        ).first()
+
+        assertEquals(listOf(highPriorityAsset.id, lowPriorityAsset.id), result.map { it.asset.id })
+    }
+
+    @Test
     fun getAssetsInfo_returnsStoreRowsWithoutRepositoryDedupe() = runBlocking {
         every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/tokens/TokensRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/tokens/TokensRepositoryTest.kt
@@ -76,6 +76,34 @@ class TokensRepositoryTest {
     }
 
     @Test
+    fun search_storesPriorityByResponseOrderNotByAssetRank() = runTest {
+        val firstResult = mockAssetBasic(asset = mockAssetEthereum(), rank = 10)
+        val secondResult = mockAssetBasic(asset = mockAsset(), rank = 999)
+        coEvery {
+            searchAssets.search(
+                query = "usdt arbitrum",
+                chains = emptyList(),
+                tags = emptyList(),
+            )
+        } returns listOf(firstResult, secondResult)
+        every { pricesDao.getRates(Currency.USD) } returns flowOf(DbFiatRate(Currency.USD, 1.0))
+
+        subject.search(
+            query = "usdt arbitrum",
+            currency = Currency.USD,
+            chains = emptyList(),
+            tags = emptyList(),
+        )
+
+        val priorities = slot<List<DbAssetPriority>>()
+        coVerify { assetsPriorityDao.put(capture(priorities)) }
+        val captured = priorities.captured
+
+        assertEquals(listOf(firstResult.asset.id.toIdentifier(), secondResult.asset.id.toIdentifier()), captured.map { it.assetId })
+        assertTrue("first response item must outrank later items", captured[0].priority < captured[1].priority)
+    }
+
+    @Test
     fun searchByAssetIds_usesSearchAssetsGetAssets() = runTest {
         val asset = mockAsset()
         val assetBasic = mockAssetBasic(asset = asset, rank = 100)

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
@@ -267,7 +267,7 @@ interface AssetsDao {
             AND (walletId = (SELECT wallet_id FROM session WHERE session.id = 1) OR walletId IS NULL)
             AND assetRank > 0
             AND assets_priority.`query` = :query
-            ORDER BY balanceFiatTotalAmount DESC, assets_priority.priority DESC, assetRank DESC
+            ORDER BY balanceFiatTotalAmount DESC, assets_priority.priority ASC, assetRank DESC
         """)
     fun searchWithPriority(query: String, exclude: List<String> = emptyList()): Flow<List<DbAssetInfo>>
 
@@ -290,7 +290,7 @@ interface AssetsDao {
             assetRank > 0
             AND
             assets_priority.`query` = :query
-            ORDER BY balanceFiatTotalAmount DESC, assets_priority.priority DESC, assetRank DESC
+            ORDER BY balanceFiatTotalAmount DESC, assets_priority.priority ASC, assetRank DESC
             
         """)
     fun searchByAllWalletsWithPriority(query: String): Flow<List<DbAssetInfo>>
@@ -314,7 +314,7 @@ interface AssetsDao {
             (chain IN (:byChains) OR id IN (:byAssets) )
             AND assetRank > 0
             AND assets_priority.`query` = :query
-            ORDER BY balanceFiatTotalAmount DESC, assetRank DESC
+            ORDER BY balanceFiatTotalAmount DESC, assets_priority.priority ASC, assetRank DESC
         """)
     fun swapSearchWithPriority(query: String, byChains: List<Chain>, byAssets: List<String>): Flow<List<DbAssetInfo>>
 

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsPriorityDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsPriorityDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy.Companion.REPLACE
 import androidx.room.Query
+import androidx.room.Transaction
 import com.gemwallet.android.data.service.store.database.entities.DbAssetPriority
 import kotlinx.coroutines.flow.Flow
 
@@ -11,7 +12,16 @@ import kotlinx.coroutines.flow.Flow
 interface AssetsPriorityDao {
 
     @Insert(onConflict = REPLACE)
-    suspend fun put(priorities: List<DbAssetPriority>)
+    suspend fun insert(priorities: List<DbAssetPriority>)
+
+    @Query("DELETE FROM assets_priority WHERE `query` = :query")
+    suspend fun deleteByQuery(query: String)
+
+    @Transaction
+    suspend fun put(priorities: List<DbAssetPriority>) {
+        priorities.firstOrNull()?.query?.let { deleteByQuery(it) }
+        insert(priorities)
+    }
 
     @Query("""
         SELECT COUNT(asset_id) FROM assets_priority WHERE `query` = :query

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbAssetPriority.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbAssetPriority.kt
@@ -15,12 +15,10 @@ data class DbAssetPriority(
     val priority: Int,
 )
 
-fun AssetBasic.toRecordPriority(query: String): DbAssetPriority {
-    return DbAssetPriority(
+fun List<AssetBasic>.toRecordPriority(query: String): List<DbAssetPriority> = mapIndexed { index, basic ->
+    DbAssetPriority(
         query = query,
-        assetId = asset.id.toIdentifier(),
-        priority = score.rank,
+        assetId = basic.asset.id.toIdentifier(),
+        priority = index,
     )
 }
-
-fun List<AssetBasic>.toRecordPriority(query: String) = map { it.toRecordPriority(query) }

--- a/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/AssetSelectScene.kt
+++ b/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/AssetSelectScene.kt
@@ -277,7 +277,7 @@ private fun LazyListScope.assets(
 
     item { PinnedAssetsHeaderItem(group) }
 
-    itemsPositioned(items, key = { index, item -> "${item.asset.id.toIdentifier()}-${group.name}" }) { position, item ->
+    itemsPositioned(items) { position, item ->
         AssetSelectRow(
             position = position,
             item = item,

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/BaseAssetSelectViewModel.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/BaseAssetSelectViewModel.kt
@@ -18,7 +18,6 @@ import com.gemwallet.android.model.RecentType
 import com.gemwallet.android.model.Session
 import com.gemwallet.android.ui.components.list_item.AssetInfoUIModel
 import com.gemwallet.android.ui.components.list_item.AssetItemUIModel
-import com.gemwallet.android.features.asset_select.viewmodels.models.SearchState
 import com.gemwallet.android.features.asset_select.viewmodels.models.SelectAssetFilters
 import com.gemwallet.android.features.asset_select.viewmodels.models.SelectSearch
 import com.gemwallet.android.features.asset_select.viewmodels.models.UIState
@@ -28,6 +27,7 @@ import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.AssetTag
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.Currency
+import com.wallet.core.primitives.Wallet
 import com.wallet.core.primitives.WalletType
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
@@ -64,84 +64,68 @@ open class BaseAssetSelectViewModel(
     private val session = getSession()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    private val searchState = MutableStateFlow(SearchState.Init)
+    private val noResultsQuery = MutableStateFlow<String?>(null)
 
     val availableChains = session
         .map { session -> session?.wallet?.accounts?.map { it.chain } ?: emptyList() }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
+    private val currentQuery = snapshotFlow { queryState.text.toString() }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, "")
+
     private val filters = combine(
         session,
-        snapshotFlow { queryState.text.toString() },
+        currentQuery,
         selectedTag,
         chainFilter,
         balanceFilter,
     ) { session, query, tag, chainFilter, hasBalance ->
-        SelectAssetFilters(
-            session = session,
-            query = query,
-            tag = tag,
-            chainFilter = chainFilter,
-            hasBalance = hasBalance,
-        )
-    }.onEach { filters ->
-        searchState.update { if (it != SearchState.Init) SearchState.Searching else it }
-        request(filters.query, filters.tag, filters.session)
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+        SelectAssetFilters(session = session, query = query, chainFilter = chainFilter, hasBalance = hasBalance, tag = tag)
+    }.onEach { request(it.query, it.tag, it.session) }
+    .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     private val assets = combine(
         filters,
         search.items(filters),
-    ) { filters, items ->
-        val chainFilter = filters?.chainFilter
-        val balanceFilter = filters?.hasBalance ?: false
-        val hasChainFilter = chainFilter?.isNotEmpty() ?: false
+        noResultsQuery,
+    ) { filters, items, noResultsQuery ->
+        val query = filters?.query.orEmpty()
+        if (query.isNotEmpty() && noResultsQuery != null) return@combine emptyList()
 
-        items.filter {
-            (!hasChainFilter || chainFilter.contains(it.id().chain))
-                    && (!balanceFilter || it.balance.totalAmount > 0.0)
-        }
-    }
-    .map { items ->
+        val chainFilter = filters?.chainFilter.orEmpty()
+        val balanceFilter = filters?.hasBalance == true
         val wallet = session.value?.wallet
-        items.map { item ->
-            val info = if (item.owner == null && wallet != null) {
-                item.copy(owner = wallet.getAccount(item.asset.id.chain))
-            } else {
-                item
+        items
+            .filter { (chainFilter.isEmpty() || it.id().chain in chainFilter) && (!balanceFilter || it.balance.totalAmount > 0.0) }
+            .map { item ->
+                val owner = item.owner ?: wallet?.getAccount(item.asset.id.chain)
+                AssetInfoUIModel(if (item.owner == owner) item else item.copy(owner = owner))
             }
-            AssetInfoUIModel(info)
-        }
     }
-//    .onEach { searchState.update { SearchState.Idle } }
     .flowOn(Dispatchers.IO)
     .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList<AssetItemUIModel>())
 
     val popular = assets.map { items ->
         items.filter {
-            listOf(
-                AssetId(Chain.Ethereum),
-                AssetId(Chain.Bitcoin),
-                AssetId(Chain.Solana),
-            ).contains(it.asset.id)
+            it.asset.id in listOf(AssetId(Chain.Ethereum), AssetId(Chain.Bitcoin), AssetId(Chain.Solana))
         }.toImmutableList()
     }
     .flowOn(Dispatchers.IO)
     .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList<AssetItemUIModel>().toImmutableList())
 
-    val pinned = assets.map { items: List<AssetItemUIModel> ->
+    val pinned = assets.map { items ->
         items.filter { it.metadata?.isPinned == true && it.metadata?.isBalanceEnabled == true }.toImmutableList()
     }
     .flowOn(Dispatchers.IO)
     .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList<AssetItemUIModel>().toImmutableList())
 
-    val unpinned = assets.map { items: List<AssetItemUIModel> ->
+    val unpinned = assets.map { items ->
         items.filter { it.metadata?.isPinned != true || it.metadata?.isBalanceEnabled != true }.toImmutableList()
     }
     .flowOn(Dispatchers.IO)
     .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList<AssetItemUIModel>().toImmutableList())
 
-    val recent = snapshotFlow { queryState.text.toString() }
+    val recent = currentQuery
         .flatMapLatest { query ->
             if (query.isNotEmpty() || !showRecents) {
                 flow { emit(emptyList()) }
@@ -153,10 +137,11 @@ open class BaseAssetSelectViewModel(
     .flowOn(Dispatchers.IO)
     .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList<Asset>().toImmutableList())
 
-    val uiState = assets.combine(searchState) { assets, searchState ->
+    val uiState = combine(assets, currentQuery, noResultsQuery) { assets, query, noResultsQuery ->
         when {
-            searchState != SearchState.Idle && searchState != SearchState.Init -> UIState.Loading
-            assets.isEmpty() && searchState == SearchState.Idle -> UIState.Empty
+            assets.isNotEmpty() -> UIState.Idle
+            query.isNotEmpty() && query == noResultsQuery -> UIState.Empty
+            query.isNotEmpty() -> UIState.Loading
             else -> UIState.Idle
         }
     }
@@ -212,14 +197,20 @@ open class BaseAssetSelectViewModel(
     }
 
     private fun request(query: String, tags: AssetTag?, session: Session?) = viewModelScope.launch(Dispatchers.IO) {
-        delay(250)
-        searchTokensCase.search(
+        delay(SEARCH_DEBOUNCE_MS)
+        val ok = searchTokensCase.search(
             query = query,
             currency = session?.currency ?: Currency.USD,
-            chains = session?.wallet?.takeIf { it.type == WalletType.Multicoin }?.accounts?.map { it.chain } ?: emptyList(),
+            chains = walletSearchChains(session?.wallet),
             tags = tags?.let { listOf(it) } ?: emptyList(),
         )
-        searchState.update { SearchState.Idle }
+        noResultsQuery.value = if (ok) null else query
+    }
+
+    private fun walletSearchChains(wallet: Wallet?): List<Chain> = when (wallet?.type) {
+        WalletType.Multicoin -> emptyList()
+        WalletType.Single, WalletType.PrivateKey, WalletType.View -> listOfNotNull(wallet.accounts.firstOrNull()?.chain)
+        null -> emptyList()
     }
 
     fun updateRecent(assetId: AssetId, type: RecentType) = viewModelScope.launch(Dispatchers.IO) {
@@ -230,4 +221,8 @@ open class BaseAssetSelectViewModel(
     open val showRecents: Boolean get() = true
 
     open fun assetFilters(): Set<AssetFilter> = emptySet()
+
+    private companion object {
+        private const val SEARCH_DEBOUNCE_MS = 250L
+    }
 }

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/models/BaseSelectSearch.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/models/BaseSelectSearch.kt
@@ -4,6 +4,7 @@ import com.gemwallet.android.application.asset_select.coordinators.SearchSelectA
 import com.gemwallet.android.model.AssetInfo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -13,7 +14,9 @@ open class BaseSelectSearch(
 
     override fun items(filters: Flow<SelectAssetFilters?>): Flow<List<AssetInfo>> {
         return filters.flatMapLatest { filters ->
-            searchSelectAssets(filters?.query ?: "", filters?.tag?.let { listOf(it) } ?: emptyList())
+            val query = filters?.query.orEmpty()
+            searchSelectAssets(query, filters?.tag?.let { listOf(it) } ?: emptyList())
+                .filter { items -> query.isEmpty() || items.isNotEmpty() }
         }
     }
 }


### PR DESCRIPTION
- Use response index (not score.rank) as priority, sort ASC to match iOS
- DELETE before INSERT in assets_priority @Transaction to clear stale
- Drop default LazyColumn keys to disable scroll anchoring on prepend
- Replace searchState enum with noResultsQuery signal for empty UI state
- Filter empty intermediate emissions in BaseSelectSearch.items

Close: https://github.com/gemwalletcom/wallet/issues/184

<img width="320" alt="Screenshot_20260507_151821" src="https://github.com/user-attachments/assets/e7103e9a-4844-4a09-9b0f-133c2ea3ab55" />
