### PR TITLE
Fix WalletConnect sequential requests on Android

### DIFF
--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
@@ -16,7 +16,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -64,7 +64,7 @@ fun RequestScene(
     val viewModel: WCRequestViewModel = hiltViewModel()
     val context = LocalContext.current
 
-    LaunchedEffect(request.topic, request.request.id) {
+    DisposableEffect(request.topic, request.request.id) {
         viewModel.onRequest(request, verifyContext) { error ->
             when (error) {
                 BridgeRequestError.ScamSession -> Toast.makeText(
@@ -75,6 +75,8 @@ fun RequestScene(
                 else -> Unit
             }
         }
+
+        onDispose { viewModel.reset() }
     }
 
     val sceneState by viewModel.sceneState.collectAsStateWithLifecycle()

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
@@ -296,6 +296,12 @@ class WCRequestViewModel @Inject constructor(
         )
     }
 
+    fun reset() {
+        requestJob?.cancel()
+        requestJob = null
+        state.update { RequestViewModelState() }
+    }
+
     private fun validateChain(chain: Chain, session: WalletConnectionSession) {
         if (!session.chains.contains(chain)) {
             throw BridgeRequestError.UnresolvedChainId


### PR DESCRIPTION
Restore DisposableEffect + WCRequestViewModel.reset() so stale state (canceled, request, wallet, chain) is cleared between session requests.

Without this, after signing a request the second one (e.g. swap after approve) immediately self-dismissed: the activity-scoped WCRequestViewModel still had canceled=true from the previous request, so the new RequestScene composition observed Cancel and triggered onCancel() before LaunchedEffect could run.

Reverts the part of 2d4b6df7a that replaced DisposableEffect with LaunchedEffect and dropped reset() as "unused" - it was not unused, onDispose called it.