### PR TITLE
Show Tron resources for TRC20 tokens on Android

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetChainAssetInfoImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetChainAssetInfoImpl.kt
@@ -1,0 +1,28 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.application.assets.coordinators.GetChainAssetInfo
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.ext.type
+import com.gemwallet.android.model.ChainAssetInfo
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.AssetSubtype
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+
+class GetChainAssetInfoImpl(
+    private val assetsRepository: AssetsRepository,
+) : GetChainAssetInfo {
+    override fun invoke(assetId: AssetId): Flow<ChainAssetInfo?> {
+        val assetInfo = assetsRepository.getTokenInfo(assetId)
+        return when (assetId.type()) {
+            AssetSubtype.NATIVE -> assetInfo.map { it?.let { ChainAssetInfo(it, it) } }
+            AssetSubtype.TOKEN -> combine(
+                assetInfo,
+                assetsRepository.getTokenInfo(AssetId(assetId.chain)),
+            ) { asset, fee ->
+                if (asset == null || fee == null) null else ChainAssetInfo(asset, fee)
+            }
+        }
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetModule.kt
@@ -7,6 +7,7 @@ import com.gemwallet.android.application.assets.coordinators.GetAssetChartData
 import com.gemwallet.android.application.assets.coordinators.GetAssetLinks
 import com.gemwallet.android.application.assets.coordinators.GetAssetMarket
 import com.gemwallet.android.application.assets.coordinators.GetAssetTokenInfo
+import com.gemwallet.android.application.assets.coordinators.GetChainAssetInfo
 import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
 import com.gemwallet.android.application.assets.coordinators.GetImportInProgress
 import com.gemwallet.android.application.assets.coordinators.GetShowWelcomeBanner
@@ -30,6 +31,7 @@ import com.gemwallet.android.data.coordinators.asset.GetAssetChartDataImpl
 import com.gemwallet.android.data.coordinators.asset.GetAssetLinksImpl
 import com.gemwallet.android.data.coordinators.asset.GetAssetMarketImpl
 import com.gemwallet.android.data.coordinators.asset.GetAssetTokenInfoImpl
+import com.gemwallet.android.data.coordinators.asset.GetChainAssetInfoImpl
 import com.gemwallet.android.data.coordinators.asset.GetHideBalancesStateImpl
 import com.gemwallet.android.data.coordinators.asset.GetImportInProgressImpl
 import com.gemwallet.android.data.coordinators.asset.GetShowWelcomeBannerImpl
@@ -75,6 +77,11 @@ object AssetModule {
     @Singleton
     fun provideGetAssetTokenInfo(assetsRepository: AssetsRepository): GetAssetTokenInfo =
         GetAssetTokenInfoImpl(assetsRepository)
+
+    @Provides
+    @Singleton
+    fun provideGetChainAssetInfo(assetsRepository: AssetsRepository): GetChainAssetInfo =
+        GetChainAssetInfoImpl(assetsRepository)
 
     @Provides
     @Singleton

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.assets.coordinators.EnableAsset
-import com.gemwallet.android.application.assets.coordinators.GetAssetTokenInfo
+import com.gemwallet.android.application.assets.coordinators.GetChainAssetInfo
 import com.gemwallet.android.application.assets.coordinators.SyncAssetInfo
 import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
 import com.gemwallet.android.application.pricealerts.coordinators.GetPriceAlerts
@@ -27,7 +27,7 @@ import com.gemwallet.android.ext.asset
 import com.gemwallet.android.ext.getAccount
 import com.gemwallet.android.ext.isStaked
 import com.gemwallet.android.ext.type
-import com.gemwallet.android.model.AssetInfo
+import com.gemwallet.android.model.ChainAssetInfo
 import com.gemwallet.android.model.availableFormatted
 import com.gemwallet.android.model.format
 import com.gemwallet.android.model.getStackedAmount
@@ -67,7 +67,7 @@ import javax.inject.Inject
 class AssetDetailsViewModel @Inject constructor(
     getSession: GetSession,
     savedStateHandle: SavedStateHandle,
-    private val getAssetTokenInfo: GetAssetTokenInfo,
+    private val getChainAssetInfo: GetChainAssetInfo,
     private val toggleAssetPin: ToggleAssetPin,
     private val enableAsset: EnableAsset,
     private val syncAssetInfo: SyncAssetInfo,
@@ -88,7 +88,7 @@ class AssetDetailsViewModel @Inject constructor(
 
     private val assetId = savedStateHandle.requireAssetId()
 
-    private val assetInfo = getAssetTokenInfo(assetId)
+    private val chainAssetInfo = getChainAssetInfo(assetId)
         .onStart {
             val wallet = session.value?.wallet ?: return@onStart
             priceAlertsStateCoordinator.priceAlertState(PriceAlertsStateEvent.Request(assetId))
@@ -101,15 +101,14 @@ class AssetDetailsViewModel @Inject constructor(
     }
     .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
-    private val model = assetInfo
-        .map {
-            val explorerName = getCurrentBlockExplorer.getCurrentBlockExplorer(it.asset.chain)
-            Model(
-                assetInfo = it,
-                explorerName = explorerName,
-                updatedAt = System.currentTimeMillis()
-            )
-        }
+    private val model = chainAssetInfo.map { chainInfo ->
+        val explorerName = getCurrentBlockExplorer.getCurrentBlockExplorer(chainInfo.assetInfo.asset.chain)
+        Model(
+            chainAssetInfo = chainInfo,
+            explorerName = explorerName,
+            updatedAt = System.currentTimeMillis()
+        )
+    }
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
@@ -191,7 +190,7 @@ class AssetDetailsViewModel @Inject constructor(
 
     fun pin() = viewModelScope.launch(Dispatchers.IO) {
         val wallet = session.value?.wallet ?: return@launch
-        val assetInfo = model.value?.assetInfo ?: return@launch
+        val assetInfo = model.value?.chainAssetInfo?.assetInfo ?: return@launch
         val assetId = assetInfo.id()
         wallet.getAccount(assetId) ?: return@launch
         toggleAssetPin(assetId)
@@ -199,7 +198,7 @@ class AssetDetailsViewModel @Inject constructor(
 
     fun add() = viewModelScope.launch(Dispatchers.IO) {
         val session = session.value ?: return@launch
-        val assetInfo = model.value?.assetInfo ?: return@launch
+        val assetInfo = model.value?.chainAssetInfo?.assetInfo ?: return@launch
 
         add(session.wallet, assetInfo.id())
     }
@@ -210,12 +209,13 @@ class AssetDetailsViewModel @Inject constructor(
     }
 
     private data class Model(
-        val assetInfo: AssetInfo,
+        val chainAssetInfo: ChainAssetInfo,
         val updatedAt: Long,
         val explorerName: String,
     ) {
         fun toUIState(): AssetInfoUIModel {
-            val assetInfo = assetInfo
+            val assetInfo = chainAssetInfo.assetInfo
+            val feeAssetInfo = chainAssetInfo.feeAssetInfo
             val price = assetInfo.price?.price?.price ?: 0.0
             val currency = assetInfo.price?.currency ?: Currency.USD
             val asset = assetInfo.asset
@@ -250,7 +250,7 @@ class AssetDetailsViewModel @Inject constructor(
                     totalBalance = balances.totalFormatted(),
                     totalFiat = fiatTotal,
                     owner = assetInfo.owner?.address ?: "",
-                    balanceMetadata = assetInfo.balance.metadata,
+                    balanceMetadata = feeAssetInfo.balance.metadata,
                     hasBalanceDetails = StakeChain.isStaked(asset.id.chain) || balances.balanceAmount.reserved != 0.0,
                     available = if (balances.balanceAmount.available != total) {
                         balances.availableFormatted()

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetChainAssetInfo.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetChainAssetInfo.kt
@@ -1,0 +1,9 @@
+package com.gemwallet.android.application.assets.coordinators
+
+import com.gemwallet.android.model.ChainAssetInfo
+import com.wallet.core.primitives.AssetId
+import kotlinx.coroutines.flow.Flow
+
+interface GetChainAssetInfo {
+    operator fun invoke(assetId: AssetId): Flow<ChainAssetInfo?>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/ChainAssetInfo.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/ChainAssetInfo.kt
@@ -1,0 +1,6 @@
+package com.gemwallet.android.model
+
+data class ChainAssetInfo(
+    val assetInfo: AssetInfo,
+    val feeAssetInfo: AssetInfo,
+)


### PR DESCRIPTION
Add GetChainAssetInfo coordinator that pairs an asset with its chain native asset, mirroring iOS ChainAssetRequest. The asset detail screen now reads balance metadata from feeAssetInfo, so TRC20 tokens on Tron show the Energy / Bandwidth section (previously missing because the metadata only lives on the native TRX balance).

Closes #284

<img width="320" alt="Screenshot_20260512_152128" src="https://github.com/user-attachments/assets/d84b3489-3d99-4dc3-9ad4-88c21205d4e4" />
