### PR TITLE
Show single staking CTA with APR on asset detail

### DIFF
--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/components/BannerItem.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/components/BannerItem.kt
@@ -23,7 +23,7 @@ internal fun BannerItem(
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     BannersScene(
-        asset = assetInfo.asset,
+        assetInfo = assetInfo,
         onClick = {
             when (it.event) {
                 BannerEvent.Stake -> onStake(assetInfo.asset.id)

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
@@ -257,12 +257,8 @@ class AssetDetailsViewModel @Inject constructor(
                     } else {
                         ""
                     },
-                    stake = if (asset.id.type() == AssetSubtype.NATIVE && StakeChain.isStaked(asset.id.chain)) {
-                        if (stakeBalance == 0.0) {
-                            "APR ${(assetInfo.stakeApr ?: 0.0).formatAsPercentage(style = PercentageFormatterStyle.PercentSignLess)}"
-                        } else {
-                            balances.totalStakeFormatted()
-                        }
+                    stake = if (asset.id.type() == AssetSubtype.NATIVE && StakeChain.isStaked(asset.id.chain) && stakeBalance > 0.0) {
+                        balances.totalStakeFormatted()
                     } else {
                         ""
                     },

--- a/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsScreen.kt
+++ b/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsScreen.kt
@@ -159,7 +159,7 @@ fun AssetsScreen(
                 }
                 item(key = BannersItemKey) {
                     BannersScene(
-                        asset = null,
+                        assetInfo = null,
                         onClick = { banner ->
                             when (banner.event) {
                                 BannerEvent.AccountBlockedMultiSignature ->

--- a/android/features/banner/presents/src/main/kotlin/com/gemwallet/android/features/banner/views/BannersScene.kt
+++ b/android/features/banner/presents/src/main/kotlin/com/gemwallet/android/features/banner/views/BannersScene.kt
@@ -30,8 +30,11 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.asset.getIconUrl
+import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
+import com.gemwallet.android.domains.percentage.formatAsPercentage
 import com.gemwallet.android.ext.asset
 import com.gemwallet.android.ext.toIdentifier
+import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.image.IconWithBadge
 import com.gemwallet.android.ui.components.list_item.listItem
@@ -41,18 +44,18 @@ import com.gemwallet.android.ui.theme.Spacer8
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.paddingMiddle
 import com.gemwallet.android.features.banner.viewmodels.BannersViewModel
-import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.Banner
 import com.wallet.core.primitives.BannerEvent
 import com.wallet.core.primitives.BannerState
 
 @Composable
 fun BannersScene(
-    asset: Asset?,
+    assetInfo: AssetInfo?,
     onClick: (Banner) -> Unit,
     isGlobal: Boolean = false,
     viewModel: BannersViewModel = hiltViewModel(),
 ) {
+    val asset = assetInfo?.asset
     LaunchedEffect(asset?.id?.toIdentifier(), isGlobal) {
         viewModel.init(asset, isGlobal)
     }
@@ -69,7 +72,9 @@ fun BannersScene(
             val (title, description) = when (banner.event) {
                 BannerEvent.Stake -> Pair(
                     stringResource(R.string.banner_stake_title, asset?.name ?: ""),
-                    stringResource(R.string.banner_stake_description, asset?.name ?: "")
+                    assetInfo?.stakeApr?.takeIf { it > 0.0 }?.let {
+                        "Earn ~${it.formatAsPercentage(style = PercentageFormatterStyle.PercentSignLess)} APR while you sleep."
+                    } ?: stringResource(R.string.banner_stake_description, asset?.name ?: ""),
                 )
                 BannerEvent.AccountActivation -> Pair(
                     stringResource(R.string.banner_account_activation_title, asset?.name ?: ""),

--- a/ios/Features/Assets/Sources/Scenes/AssetScene.swift
+++ b/ios/Features/Assets/Sources/Scenes/AssetScene.swift
@@ -33,6 +33,7 @@ public struct AssetScene: View {
                 Section {
                     BannerView(
                         banner: banner,
+                        assetData: model.assetData,
                         action: model.onSelectBanner,
                     )
                 }
@@ -139,9 +140,6 @@ public struct AssetScene: View {
                         }
                     }
                 }
-            } else if model.assetDataModel.isStakeEnabled {
-                stakeViewEmpty
-                    .listRowInsets(.assetListRowInsets)
             }
 
             if model.showEarnButton {
@@ -203,21 +201,6 @@ extension AssetScene {
             subtitle: model.networkField.value.text,
             assetImage: model.networkAssetImage,
             imageSize: .list.image,
-        )
-    }
-
-    private var stakeViewEmpty: some View {
-        NavigationCustomLink(
-            with: HStack(spacing: .space12) {
-                EmojiView(color: Colors.grayVeryLight, emoji: "💰")
-                    .frame(size: .image.asset)
-                ListItemView(
-                    title: model.balanceTitle(for: .stake),
-                    subtitle: model.aprModel(for: .stake).text,
-                    subtitleStyle: model.aprModel(for: .stake).subtitle.style,
-                )
-            },
-            action: { model.onSelectHeader(.stake) },
         )
     }
 }

--- a/ios/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/ios/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -289,7 +289,7 @@ public final class AssetSceneViewModel: Sendable {
 
     func showProviderBalance(for type: StakeProviderType) -> Bool {
         switch type {
-        case .stake: assetDataModel.isStakeEnabled || assetData.balances.contains(where: { Self.showStakedBalanceTypes.contains($0.key) && $0.value > 0 })
+        case .stake: assetData.balances.contains(where: { Self.showStakedBalanceTypes.contains($0.key) && $0.value > 0 })
         #if DEBUG
             case .earn: assetData.balance.earn > .zero
         #else

--- a/ios/Features/Assets/Tests/AssetsTests/AssetSceneViewModelTests.swift
+++ b/ios/Features/Assets/Tests/AssetsTests/AssetSceneViewModelTests.swift
@@ -55,7 +55,8 @@ struct AssetSceneViewModelTests {
 
     @Test
     func showProviderBalance() {
-        #expect(AssetSceneViewModel.mock(.mock(metadata: .mock(isStakeEnabled: true))).showProviderBalance(for: .stake) == true)
+        #expect(AssetSceneViewModel.mock(.mock(metadata: .mock(isStakeEnabled: true))).showProviderBalance(for: .stake) == false)
+        #expect(AssetSceneViewModel.mock(.mock(balance: .mock(staked: BigInt(100)), metadata: .mock(isStakeEnabled: true))).showProviderBalance(for: .stake) == true)
         #expect(AssetSceneViewModel.mock(.mock(balance: .mock(staked: BigInt(100)), metadata: .mock(isStakeEnabled: false))).showProviderBalance(for: .stake) == true)
         #expect(AssetSceneViewModel.mock(.mock(metadata: .mock(isStakeEnabled: false))).showProviderBalance(for: .stake) == false)
         #expect(AssetSceneViewModel.mock(.mock(balance: .mock(earn: BigInt(100)))).showProviderBalance(for: .earn) == true)

--- a/ios/Packages/PrimitivesComponents/Sources/Components/BannerView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/BannerView.swift
@@ -12,9 +12,10 @@ public struct BannerView: View {
 
     public init(
         banner: Banner,
+        assetData: AssetData? = nil,
         action: @escaping (BannerAction) -> Void,
     ) {
-        model = BannerViewModel(banner: banner)
+        model = BannerViewModel(banner: banner, assetData: assetData)
         self.action = action
     }
 

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/BannerViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/BannerViewModel.swift
@@ -16,9 +16,11 @@ struct BannerViewModel {
     }
 
     private let banner: Banner
+    private let assetData: AssetData?
 
-    init(banner: Banner) {
+    init(banner: Banner, assetData: AssetData? = nil) {
         self.banner = banner
+        self.assetData = assetData
     }
 
     var image: AssetImage? {
@@ -68,6 +70,9 @@ struct BannerViewModel {
         case .stake:
             guard let asset else {
                 return .none
+            }
+            if let apr = assetData?.metadata.stakingApr, apr > 0 {
+                return "Earn ~\(CurrencyFormatter.percentSignLess.string(apr)) APR while you sleep."
             }
             return Localized.Banner.Stake.description(asset.symbol)
         case .accountActivation:


### PR DESCRIPTION
Drop the duplicate "Stake — APR X%" row from the balances section on both platforms; keep only the top banner. When stakingApr > 0 the banner now reads "Earn ~X% APR while you sleep." (hardcoded for now pending copy review), otherwise falls back to the existing description.

- [ ] Localize

Closes #181

<img width="320" alt="Screenshot_20260512_183508" src="https://github.com/user-attachments/assets/f63f52bf-095e-4ef2-a550-0c1c52ef68a1" />
<img width="320" alt="Screenshot_20260512_183508" src="https://github.com/user-attachments/assets/f63f52bf-095e-4ef2-a550-0c1c52ef68a1" />


