### PR TITLE
Make delegationId optional in SavedStateHandle

### DIFF
--- a/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/viewmodels/DelegationViewModel.kt
+++ b/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/viewmodels/DelegationViewModel.kt
@@ -51,7 +51,7 @@ class DelegationViewModel @Inject constructor(
 ) : ViewModel() {
 
     val validatorId = MutableStateFlow(savedStateHandle.requireString(RouteArgument.ValidatorId))
-    val delegationId = MutableStateFlow(savedStateHandle.requireString(RouteArgument.DelegationId))
+    val delegationId = MutableStateFlow(savedStateHandle.getString(RouteArgument.DelegationId))
 
     val delegation = combine(validatorId, delegationId) { validatorId, delegationId -> Pair(validatorId, delegationId) }
         .flatMapLatest {
@@ -249,3 +249,6 @@ private fun SavedStateHandle.requireString(argument: RouteArgument): String {
     check(value.isNotBlank()) { "Blank route argument: ${argument.key}" }
     return value
 }
+
+private fun SavedStateHandle.getString(argument: RouteArgument): String =
+    get<String>(argument.key).orEmpty()


### PR DESCRIPTION
Initialize delegationId using a new SavedStateHandle.getString extension that returns an empty string instead of throwing. This avoids crashes when the DelegationId route argument is missing while keeping requireString for other mandatory arguments. Adds a small helper extension: getString(argument) = get<String>(key).orEmpty().