### PR TITLE
Move fee/amount formatting from ConfirmViewModel into UI models

### DIFF
--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -167,7 +167,7 @@ fun ConfirmScreen(
                     amountModel?.txType == TransactionType.TransferNFT -> amountModel?.nftAsset?.let { NftHead(it) }
 
                     else -> AmountListHead(
-                        amount = amountModel?.amount ?: "",
+                        amount = amountModel?.cryptoAmount ?: "",
                         equivalent = amountModel?.amountEquivalent,
                         icon = amountModel?.asset?.asset,
                     )

--- a/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
+++ b/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
@@ -19,7 +19,6 @@ import com.gemwallet.android.model.ConfirmParams
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.SignerParams
 import com.gemwallet.android.model.ValueFormatter
-import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.ui.models.navigation.RouteArgument
 import com.gemwallet.android.ui.models.swap.SwapDetailsUIModelFactory
 import com.gemwallet.android.ui.models.swap.SwapDetailsUIModelInput
@@ -67,8 +66,6 @@ class ConfirmViewModel @Inject constructor(
     private val getCurrentBlockExplorer: GetCurrentBlockExplorer,
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
-
-    private val formatter = ValueFormatter(style = ValueFormatter.Style.Full)
 
     private val restart = MutableStateFlow(false)
     val state = MutableStateFlow<ConfirmState>(ConfirmState.Prepare)
@@ -175,22 +172,18 @@ class ConfirmViewModel @Inject constructor(
         }
 
         val amount = Crypto(signerParams?.finalAmount ?: request.amount)
-        val price = assetInfo.price?.price?.price ?: 0.0
-        val currency = assetInfo.price?.currency ?: Currency.USD
-        val decimals = assetInfo.asset.decimals
-        val symbol = assetInfo.asset.symbol
 
         AmountUIModel(
             txType = request.getTxType(),
-            amount = formatter.string(amount.atomicValue, decimals, symbol),
-            amountEquivalent = CurrencyFormatter(currency = currency).string(amount.convert(decimals, price).atomicValue),
+            amount = amount.atomicValue,
             asset = assetInfo,
             fromAsset = assetInfo,
             fromAmount = amount.atomicValue.toString(),
             toAsset = toAssetInfo,
             toAmount = (request as? ConfirmParams.SwapParams)?.toAmount?.toString(),
             nftAsset = (request as? ConfirmParams.NftParams)?.nftAsset,
-            currency = currency,
+            price = assetInfo.price?.price?.price,
+            currency = assetInfo.price?.currency ?: Currency.USD,
         )
     }
     .stateIn(viewModelScope, SharingStarted.Eagerly, null)
@@ -210,8 +203,7 @@ class ConfirmViewModel @Inject constructor(
         if (amount == null || feeAssetInfo == null) {
             return@combine ""
         }
-        val feeAmount = Crypto(amount)
-        ValueFormatter(style = ValueFormatter.Style.Auto).string(feeAmount.atomicValue, feeAssetInfo.asset)
+        ValueFormatter(style = ValueFormatter.Style.Auto).string(amount, feeAssetInfo.asset)
     }
     .stateIn(viewModelScope, SharingStarted.Eagerly, "")
 
@@ -222,14 +214,6 @@ class ConfirmViewModel @Inject constructor(
         } else if (amount == null || feeAssetInfo == null) {
             if (state is ConfirmState.Error) FeeUIModel.Error else FeeUIModel.Calculating
         } else {
-            val feeAmount = Crypto(amount)
-            val currency = feeAssetInfo.price?.currency ?: Currency.USD
-            val feeDecimals = feeAssetInfo.asset.decimals
-            val feeCrypto = formatter.string(feeAmount.atomicValue, feeAssetInfo.asset)
-            val feeFiat = feeAssetInfo.price?.let {
-                CurrencyFormatter(currency = currency).string(feeAmount.convert(feeDecimals, it.price.price).atomicValue) // TODO: Move to UI - Model
-            } ?: ""
-
             try {
                 val sendAssetInfo = assetsInfo.value?.getByAssetId(signerParams.input.assetId)
                 if (sendAssetInfo != null) {
@@ -246,9 +230,9 @@ class ConfirmViewModel @Inject constructor(
 
             FeeUIModel.FeeInfo(
                 amount = amount,
-                cryptoAmount = feeCrypto,
-                fiatAmount = feeFiat,
                 feeAsset = feeAssetInfo.asset,
+                price = feeAssetInfo.price?.price?.price,
+                currency = feeAssetInfo.price?.currency ?: Currency.USD,
                 priority = signerParams.fee().priority,
             )
         }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/AmountUIModel.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/AmountUIModel.kt
@@ -1,19 +1,34 @@
 package com.gemwallet.android.domains.confirm
 
 import com.gemwallet.android.model.AssetInfo
+import com.gemwallet.android.model.Crypto
+import com.gemwallet.android.model.CurrencyFormatter
+import com.gemwallet.android.model.ValueFormatter
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.NFTAsset
 import com.wallet.core.primitives.TransactionType
+import java.math.BigInteger
 
 class AmountUIModel(
     val txType: TransactionType,
-    val amount: String,
-    val amountEquivalent: String,
+    val amount: BigInteger,
     val asset: AssetInfo,
     val fromAsset: AssetInfo,
     val toAsset: AssetInfo?,
     val fromAmount: String,
     val toAmount: String?,
     val nftAsset: NFTAsset?,
+    val price: Double?,
     val currency: Currency = Currency.USD,
-)
+) {
+    val cryptoAmount: String by lazy {
+        ValueFormatter(style = ValueFormatter.Style.Full)
+            .string(amount, asset.asset.decimals, asset.asset.symbol)
+    }
+
+    val amountEquivalent: String by lazy {
+        if (price == null) ""
+        else CurrencyFormatter(currency = currency)
+            .string(Crypto(amount).convert(asset.asset.decimals, price).atomicValue)
+    }
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeUIModel.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeUIModel.kt
@@ -1,6 +1,10 @@
 package com.gemwallet.android.domains.confirm
 
+import com.gemwallet.android.model.Crypto
+import com.gemwallet.android.model.CurrencyFormatter
+import com.gemwallet.android.model.ValueFormatter
 import com.wallet.core.primitives.Asset
+import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.FeePriority
 import java.math.BigInteger
 
@@ -9,9 +13,19 @@ sealed interface FeeUIModel {
     data object Error : FeeUIModel
     class FeeInfo(
         val amount: BigInteger,
-        val cryptoAmount: String,
-        val fiatAmount: String,
         val feeAsset: Asset,
+        val price: Double?,
+        val currency: Currency,
         val priority: FeePriority,
-    ) : FeeUIModel
+    ) : FeeUIModel {
+        val cryptoAmount: String by lazy {
+            ValueFormatter(style = ValueFormatter.Style.Full).string(amount, feeAsset)
+        }
+
+        val fiatAmount: String by lazy {
+            if (price == null) ""
+            else CurrencyFormatter(currency = currency)
+                .string(Crypto(amount).convert(feeAsset.decimals, price).atomicValue)
+        }
+    }
 }

--- a/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/confirm/AmountUIModelTest.kt
+++ b/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/confirm/AmountUIModelTest.kt
@@ -1,0 +1,45 @@
+package com.gemwallet.android.domains.confirm
+
+import com.gemwallet.android.testkit.mockAssetInfo
+import com.gemwallet.android.testkit.mockAssetSolana
+import com.wallet.core.primitives.Currency
+import com.wallet.core.primitives.TransactionType
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.math.BigInteger
+import java.util.Locale
+
+class AmountUIModelTest {
+
+    private var originalLocale: Locale = Locale.getDefault()
+
+    @Before fun setUp() {
+        originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+    }
+
+    @After fun tearDown() {
+        Locale.setDefault(originalLocale)
+    }
+
+    private fun model(price: Double?) = AmountUIModel(
+        txType = TransactionType.Transfer,
+        amount = BigInteger("1000000000"),
+        asset = mockAssetInfo(asset = mockAssetSolana()),
+        fromAsset = mockAssetInfo(asset = mockAssetSolana()),
+        toAsset = null,
+        fromAmount = "1000000000",
+        toAmount = null,
+        nftAsset = null,
+        price = price,
+        currency = Currency.USD,
+    )
+
+    @Test fun formatsCryptoAndEquivalent() {
+        assertEquals("1 SOL", model(price = null).cryptoAmount)
+        assertEquals("", model(price = null).amountEquivalent)
+        assertEquals("$200.00", model(price = 200.0).amountEquivalent)
+    }
+}

--- a/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/confirm/FeeUIModelTest.kt
+++ b/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/confirm/FeeUIModelTest.kt
@@ -1,0 +1,39 @@
+package com.gemwallet.android.domains.confirm
+
+import com.gemwallet.android.testkit.mockAssetSolana
+import com.wallet.core.primitives.Currency
+import com.wallet.core.primitives.FeePriority
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.math.BigInteger
+import java.util.Locale
+
+class FeeUIModelTest {
+
+    private var originalLocale: Locale = Locale.getDefault()
+
+    @Before fun setUp() {
+        originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+    }
+
+    @After fun tearDown() {
+        Locale.setDefault(originalLocale)
+    }
+
+    private fun feeInfo(price: Double?) = FeeUIModel.FeeInfo(
+        amount = BigInteger("1000000000"),
+        feeAsset = mockAssetSolana(),
+        price = price,
+        currency = Currency.USD,
+        priority = FeePriority.Normal,
+    )
+
+    @Test fun formatsCryptoAndFiat() {
+        assertEquals("1 SOL", feeInfo(price = null).cryptoAmount)
+        assertEquals("", feeInfo(price = null).fiatAmount)
+        assertEquals("$200.00", feeInfo(price = 200.0).fiatAmount)
+    }
+}


### PR DESCRIPTION
## Summary
- `FeeUIModel.FeeInfo` and `AmountUIModel` now hold raw `amount` / `price` / `currency` and format `cryptoAmount` / `fiatAmount` lazily.
- `ConfirmViewModel` exposes domain values; dropped the `formatter` field and inline `CurrencyFormatter(...)` construction. `validateBalance` stays where it is.
- Removed the `// TODO: Move to UI - Model` at `ConfirmViewModel.kt:230`.

## Behavior change
For an asset with no price, `amountEquivalent` is now empty instead of `"$0.00"` (was computed with `price = 0.0` fallback).

Closes #331