### PR TITLE
Fix SolanaSignerTests build after solana nft metadata change

### DIFF
--- a/ios/Packages/Signer/Tests/SignerTests/SolanaSignerTests.swift
+++ b/ios/Packages/Signer/Tests/SignerTests/SolanaSignerTests.swift
@@ -27,6 +27,7 @@ struct SolanaSignerTests {
                 senderTokenAddress: nil,
                 recipientTokenAddress: nil,
                 tokenProgram: nil,
+                nft: nil,
                 blockHash: "8ntZRPm8pbf4R4pTWsVnTdgqXA35yYXSz8TxUzwBhXEK",
             ),
         )
@@ -51,6 +52,7 @@ struct SolanaSignerTests {
                 senderTokenAddress: "DVWPV7brSbPDkA7a3qdn6UJsVc3J3DyhQhjNaZeZqwzo",
                 recipientTokenAddress: "8ntZRPm8pbf4R4pTWsVnTdgqXA35yYXSz8TxUzwBhXEK",
                 tokenProgram: .token,
+                nft: nil,
                 blockHash: "8ntZRPm8pbf4R4pTWsVnTdgqXA35yYXSz8TxUzwBhXEK",
             ),
         )
@@ -75,6 +77,7 @@ struct SolanaSignerTests {
                 senderTokenAddress: "DVWPV7brSbPDkA7a3qdn6UJsVc3J3DyhQhjNaZeZqwzo",
                 recipientTokenAddress: nil,
                 tokenProgram: .token,
+                nft: nil,
                 blockHash: "8ntZRPm8pbf4R4pTWsVnTdgqXA35yYXSz8TxUzwBhXEK",
             ),
         )


### PR DESCRIPTION
Solana NFT support added an `nft` parameter to the TransactionLoadMetadata.solana case, but the SolanaSignerTests call sites were not updated, breaking the SignerTests build.

Pass `nft: nil` for the three existing non-NFT transfer cases; the signed transaction output is unchanged.