### PR TITLE
Drop "Balance:" prefix from amount field subtitle (iOS parity, #316)

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/PropertyAssetInfoItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/PropertyAssetInfoItem.kt
@@ -31,7 +31,7 @@ fun PropertyAssetInfoItem(
     ListItem(
         leading = { AssetIcon(asset) },
         title = { ListItemTitleText(asset.name) },
-        subtitle = { ListItemSupportText(stringResource(id = R.string.transfer_balance, availableAmount)) },
+        subtitle = { ListItemSupportText(availableAmount) },
         listPosition = ListPosition.Single,
         trailing = {
             Button(

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/PropertyAssetInfoItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/PropertyAssetInfoItem.kt
@@ -31,7 +31,7 @@ fun PropertyAssetInfoItem(
     ListItem(
         leading = { AssetIcon(asset) },
         title = { ListItemTitleText(asset.name) },
-        subtitle = { ListItemSupportText(availableAmount) },
+        subtitle = { ListItemSupportText(stringResource(id = R.string.transfer_balance, availableAmount)) },
         listPosition = ListPosition.Single,
         trailing = {
             Button(

--- a/ios/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -92,11 +92,12 @@ public final class AmountSceneViewModel {
     }
 
     var balanceText: String {
-        ValueFormatter(style: .auto).string(
+        let value = ValueFormatter(style: .auto).string(
             provider.availableValue(from: assetData),
             decimals: asset.decimals.asInt,
             currency: asset.symbol,
         )
+        return Localized.Transfer.balance(value)
     }
 
     var actionButtonState: ButtonState {


### PR DESCRIPTION
iOS shows just the formatted balance value (e.g. "0.02076 ETH") in the AssetBalanceView under the send/stake/perpetual amount input. Android was wrapping the same value with R.string.transfer_balance ("Balance: %s"). Drop the wrapper here; swap keeps the prefix since that surface still uses the Balance: prefix on iOS.

images:


<img width="360" alt="Screenshot_20260520_184428" src="https://github.com/user-attachments/assets/96f30302-aaaa-4b7f-a925-c02974a30fc1" />

closes #316 