### PR TITLE
Add Swap Again button to transaction details

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionDetailsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionDetailsImpl.kt
@@ -254,6 +254,7 @@ class TransactionDetailsAggregateImpl(
         get() = buildList {
             add(ValueGroup(listOf(amount)))
             swapProgress?.let { add(ValueGroup(listOf(it))) }
+            swapAgain?.let { add(ValueGroup(listOf(it))) }
             add(
                 ValueGroup(
                     listOfNotNull(
@@ -286,6 +287,18 @@ class TransactionDetailsAggregateImpl(
                 fromValue = metadata.fromValue,
                 providerName = provider.name,
                 state = data.transaction.state,
+            )
+        }
+
+    override val swapAgain: TransactionDetailsValue.SwapAgain?
+        get() {
+            if (data.transaction.type != TransactionType.Swap) return null
+            if (data.transaction.state != TransactionState.Confirmed) return null
+            val metadata = swapMetadata ?: return null
+
+            return TransactionDetailsValue.SwapAgain(
+                fromAssetId = metadata.fromAsset,
+                toAssetId = metadata.toAsset,
             )
         }
 

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/transaction/TransactionDetailsAggregateImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/transaction/TransactionDetailsAggregateImplTest.kt
@@ -424,7 +424,8 @@ class TransactionDetailsAggregateImplTest {
         Assert.assertEquals("1000000000000000000", progress?.fromValue)
         Assert.assertEquals("NEAR Intents", progress?.providerName)
         Assert.assertEquals(TransactionState.Confirmed, progress?.state)
-        Assert.assertEquals(5, aggregate.valueGroups.size)
+        Assert.assertEquals(6, aggregate.valueGroups.size)
+        Assert.assertTrue(aggregate.valueGroups[2].items.single() is TransactionDetailsValue.SwapAgain)
     }
 
     @Test
@@ -541,6 +542,83 @@ class TransactionDetailsAggregateImplTest {
 
         Assert.assertNotNull(aggregate.swapProgress)
         Assert.assertEquals(5, aggregate.valueGroups.size)
+    }
+
+    @Test
+    fun testSwapAgain_confirmedSwap() {
+        val swapMetadata = TransactionSwapMetadata(
+            fromAsset = ethAsset.id,
+            toAsset = usdtAsset.id,
+            fromValue = "1000000000000000000",
+            toValue = "3000000000",
+            provider = SwapProvider.UniswapV3.string,
+        )
+        val transaction = createTransaction(
+            type = TransactionType.Swap,
+            state = TransactionState.Confirmed,
+            assetId = ethAsset.id,
+            metadata = jsonEncoder.encodeToString(TransactionSwapMetadata.serializer(), swapMetadata),
+        )
+        val aggregate = createAggregate(
+            data = createTransactionExtended(transaction, asset = ethAsset, assets = listOf(ethAsset, usdtAsset)),
+            associatedAssets = listOf(createAssetInfo(ethAsset), createAssetInfo(usdtAsset)),
+            swapMetadata = swapMetadata,
+        )
+
+        val swapAgain = aggregate.swapAgain
+        Assert.assertNotNull(swapAgain)
+        Assert.assertEquals(ethAsset.id, swapAgain?.fromAssetId)
+        Assert.assertEquals(usdtAsset.id, swapAgain?.toAssetId)
+        Assert.assertTrue(aggregate.valueGroups.any { it.items.singleOrNull() is TransactionDetailsValue.SwapAgain })
+    }
+
+    @Test
+    fun testSwapAgain_hiddenForPendingSwap() {
+        val swapMetadata = TransactionSwapMetadata(
+            fromAsset = ethAsset.id,
+            toAsset = usdtAsset.id,
+            fromValue = "1000000000000000000",
+            toValue = "3000000000",
+        )
+        val transaction = createTransaction(
+            type = TransactionType.Swap,
+            state = TransactionState.Pending,
+            assetId = ethAsset.id,
+            metadata = jsonEncoder.encodeToString(TransactionSwapMetadata.serializer(), swapMetadata),
+        )
+        val aggregate = createAggregate(
+            data = createTransactionExtended(transaction, asset = ethAsset),
+            swapMetadata = swapMetadata,
+        )
+
+        Assert.assertNull(aggregate.swapAgain)
+        Assert.assertFalse(aggregate.valueGroups.any { it.items.singleOrNull() is TransactionDetailsValue.SwapAgain })
+    }
+
+    @Test
+    fun testSwapAgain_hiddenForMissingMetadata() {
+        val transaction = createTransaction(
+            type = TransactionType.Swap,
+            state = TransactionState.Confirmed,
+            metadata = null,
+        )
+        val aggregate = createAggregate(
+            data = createTransactionExtended(transaction, asset = ethAsset),
+            swapMetadata = null,
+        )
+
+        Assert.assertNull(aggregate.swapAgain)
+    }
+
+    @Test
+    fun testSwapAgain_hiddenForNonSwapTransaction() {
+        val transaction = createTransaction(
+            type = TransactionType.Transfer,
+            state = TransactionState.Confirmed,
+        )
+        val aggregate = createAggregate(createTransactionExtended(transaction))
+
+        Assert.assertNull(aggregate.swapAgain)
     }
 
     @Test

--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsScene.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.features.activities.presents.details
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Share
@@ -17,6 +18,7 @@ import com.gemwallet.android.features.activities.presents.details.components.Swa
 import com.gemwallet.android.features.activities.presents.details.components.TransactionExplorer
 import com.gemwallet.android.features.activities.presents.details.components.TransactionStatusProperty
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.list_head.AmountListHead
 import com.gemwallet.android.ui.components.list_head.NftHead
 import com.gemwallet.android.ui.components.list_head.SwapListHead
@@ -26,6 +28,8 @@ import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkIte
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
 import com.gemwallet.android.ui.components.list_item.transaction.getTitle
 import com.gemwallet.android.ui.components.screen.Scene
+import com.gemwallet.android.ui.theme.padding16
+import com.gemwallet.android.ui.theme.paddingSmall
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.Resource
 import com.wallet.core.primitives.TransactionType
@@ -100,6 +104,18 @@ internal fun TransactionDetailsScene(
                         is TransactionDetailsValue.Network -> PropertyNetworkItem(item.data.chain, listPosition = position)
                         is TransactionDetailsValue.Status -> TransactionStatusProperty(data.asset, item, position)
                         is TransactionDetailsValue.SwapProgress -> SwapProgressItem(item)
+                        is TransactionDetailsValue.SwapAgain -> MainActionButton(
+                            title = stringResource(R.string.transaction_swap_again),
+                            modifier = Modifier.padding(horizontal = padding16, vertical = paddingSmall),
+                            onClick = {
+                                onAction(
+                                    TransactionDetailsAction.OpenSwap(
+                                        fromAssetId = item.fromAssetId,
+                                        toAssetId = item.toAssetId,
+                                    )
+                                )
+                            },
+                        )
                     }
                 }
             }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/transaction/aggregates/TransactionDetailsAggregate.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/transaction/aggregates/TransactionDetailsAggregate.kt
@@ -25,6 +25,7 @@ interface TransactionDetailsAggregate {
     val date: TransactionDetailsValue.Date
     val status: TransactionDetailsValue.Status
     val swapProgress: TransactionDetailsValue.SwapProgress?
+    val swapAgain: TransactionDetailsValue.SwapAgain?
     val memo: TransactionDetailsValue.Memo?
     val resourceType: TransactionDetailsValue.ResourceType?
     val network: TransactionDetailsValue.Network

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/transaction/values/TransactionDetailsValue.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/transaction/values/TransactionDetailsValue.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.domains.transaction.values
 import com.gemwallet.android.model.AssetInfo
 import com.wallet.core.primitives.AddressType
 import com.wallet.core.primitives.Asset
+import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.BlockExplorerLink
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.Resource
@@ -82,6 +83,11 @@ sealed interface TransactionDetailsValue {
         val fromValue: String,
         val providerName: String,
         val state: TransactionState,
+    ) : TransactionDetailsValue
+
+    class SwapAgain(
+        val fromAssetId: AssetId,
+        val toAssetId: AssetId,
     ) : TransactionDetailsValue
 
     class Memo(val data: String) : TransactionDetailsValue


### PR DESCRIPTION
## Summary
- Adds a "Swap Again" button to the transaction details screen for
  confirmed swap transactions, mirroring the existing iOS feature.
- Tapping it opens the Swap screen pre-filled with the original
  from/to asset pair (taken from the transaction's swap metadata).
- The button is shown only when the transaction is a swap, its state
  is `Confirmed`, and swap metadata is present — same gate as iOS.

Closes #166

<img width="320" alt="Screenshot_20260520_223711" src="https://github.com/user-attachments/assets/78d196e8-2d30-4ee1-aeb1-427be1588c27" />

