### PR TITLE
Scroll assets list to top only on wallet change

### DIFF
--- a/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsScreen.kt
+++ b/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.StrokeCap
@@ -98,8 +100,13 @@ fun AssetsScreen(
     }
 
     val currentWalletId by viewModel.currentWalletId.collectAsStateWithLifecycle()
+    var previousWalletId by rememberSaveable { mutableStateOf<String?>(null) }
     LaunchedEffect(currentWalletId) {
-        if (currentWalletId != null) listState.scrollToItem(0)
+        val walletId = currentWalletId?.id ?: return@LaunchedEffect
+        if (previousWalletId != null && previousWalletId != walletId) {
+            listState.scrollToItem(0)
+        }
+        previousWalletId = walletId
     }
 
     Scaffold(


### PR DESCRIPTION
## Summary

Returning from asset details reset the wallet assets list scroll position back to the top.

The `LaunchedEffect` that scrolls the list to the top re-ran on every recomposition — including when the screen re-entered composition after returning from asset details — not only on an actual wallet change. It now tracks the previously rendered wallet id and scrolls only when the wallet actually changes.