### PR TITLE
Add recipient context menu and wallet icon to Confirm scene

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/confirm/BuildConfirmPropertiesImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/confirm/BuildConfirmPropertiesImpl.kt
@@ -32,7 +32,7 @@ class BuildConfirmPropertiesImpl(
         val explorerName = getCurrentBlockExplorer.getCurrentBlockExplorer(chain)
         val chainExplorer = Explorer(chain.string)
         return mutableListOf<ConfirmProperty?>().apply {
-            add(ConfirmProperty.Source(assetInfo.walletName))
+            add(ConfirmProperty.Source(assetInfo.walletName, assetInfo.walletType, assetInfo.owner?.chain))
             val addressName = request.destination()?.address
                 ?.takeIf { it.isNotEmpty() }
                 ?.let { getAddressName.getAddressName(chain, it) }

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -47,12 +47,14 @@ import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.list_head.AmountListHead
 import com.gemwallet.android.ui.components.list_head.NftHead
 import com.gemwallet.android.ui.components.list_head.SwapListHead
+import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
 import com.gemwallet.android.ui.components.list_item.property.PropertyDataText
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkFee
 import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyTitleText
 import com.gemwallet.android.ui.components.list_item.transaction.getTitle
+import com.gemwallet.android.ui.components.list_item.walletItemIconModel
 import com.gemwallet.android.ui.components.progress.CircularProgressIndicator14
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet
 import com.gemwallet.android.ui.components.screen.Scene
@@ -187,7 +189,17 @@ fun ConfirmScreen(
                     is ConfirmProperty.Destination -> PropertyDestination(item, listPosition)
                     is ConfirmProperty.Memo -> PropertyItem(R.string.transfer_memo, item.data, listPosition = listPosition)
                     is ConfirmProperty.Network -> PropertyNetworkItem(item.data, listPosition)
-                    is ConfirmProperty.Source -> PropertyItem(R.string.common_wallet, item.data, listPosition = listPosition)
+                    is ConfirmProperty.Source -> PropertyItem(
+                        title = { PropertyTitleText(R.string.common_wallet) },
+                        data = {
+                            val walletIcon = walletItemIconModel(item.walletType, item.walletChain)
+                            PropertyDataText(
+                                text = item.data,
+                                badge = walletIcon?.let { { DataBadgeChevron(icon = it, isShowChevron = false) } },
+                            )
+                        },
+                        listPosition = listPosition,
+                    )
                 }
             }
             itemsIndexed(detailElements) { index, item ->

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/PropertyDestination.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/PropertyDestination.kt
@@ -23,26 +23,13 @@ fun PropertyDestination(
 
     when (model) {
         is ConfirmProperty.Destination.Transfer -> {
-            val domain = model.domain
-            if (domain != null) {
-                PropertyItem(
-                    title = { PropertyTitleText(R.string.transaction_recipient) },
-                    data = {
-                        Column(horizontalAlignment = Alignment.End) {
-                            Row(horizontalArrangement = Arrangement.End) { PropertyDataText(model.displayData()) }
-                        }
-                    },
-                    listPosition = listPosition,
-                )
-            } else {
-                AddressPropertyItem(
-                    title = R.string.transaction_recipient,
-                    displayText = AddressFormatter(model.address).value(),
-                    copyValue = model.address,
-                    explorerLink = model.explorerLink,
-                    listPosition = listPosition,
-                )
-            }
+            AddressPropertyItem(
+                title = R.string.transaction_recipient,
+                displayText = model.domain ?: AddressFormatter(model.address).value(),
+                copyValue = model.address,
+                explorerLink = model.explorerLink,
+                listPosition = listPosition,
+            )
         }
         is ConfirmProperty.Destination.Stake -> {
             val address = model.address

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/ConfirmProperty.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/ConfirmProperty.kt
@@ -4,10 +4,12 @@ import com.gemwallet.android.model.ConfirmParams
 import com.wallet.core.primitives.AddressName
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.BlockExplorerLink
+import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.DelegationValidator
+import com.wallet.core.primitives.WalletType
 
 sealed interface ConfirmProperty {
-    class Source(val data: String) : ConfirmProperty
+    class Source(val data: String, val walletType: WalletType, val walletChain: Chain?) : ConfirmProperty
     class Network(val data: Asset) : ConfirmProperty
     class Memo(val data: String) : ConfirmProperty
 


### PR DESCRIPTION
## Summary
Consolidates the Android Confirm transfer scene with iOS:
- **Recipient context menu** — the recipient row now always uses `AddressPropertyItem`,
  so it has a Copy / View-on-explorer context menu (long press) and an explorer chevron
  even when an address name is shown instead of the raw address. Previously the named
  case rendered as plain text with no menu.
- **Wallet icon** — the Wallet row renders the wallet icon (chain icon / multicoin logo)
  next to its name, matching the Network row and iOS.
  
  Close: https://github.com/gemwalletcom/wallet/issues/288
  
  
<img width="320" alt="Screenshot_1779379317" src="https://github.com/user-attachments/assets/65883c32-5536-4fcf-aaf2-ab0c20831380" />
<img width="320" alt="Screenshot_1779379321" src="https://github.com/user-attachments/assets/5e23c81a-25b8-45c7-bf8b-de0a4e007ff9" />
