### PR TITLE
Fix foreign key crash when opening an unknown asset

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/SyncAssetInfoImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/SyncAssetInfoImpl.kt
@@ -35,7 +35,7 @@ class SyncAssetInfoImpl(
             async { assetsRepository.updateBalances(assetId) }
             async {
                 val assetFull = loadAssetMetadata(assetId) ?: return@async
-                assetsRepository.updateAssetMetadata(assetFull)
+                assetsRepository.saveAssetMetadata(assetFull)
             }
         }
     }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/SyncAssetInfoImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/SyncAssetInfoImplTest.kt
@@ -86,7 +86,7 @@ class SyncAssetInfoImplTest {
             )
         }
         coVerify { assetsRepository.updateBalances(asset.id) }
-        coVerify { assetsRepository.updateAssetMetadata(assetFull) }
+        coVerify { assetsRepository.saveAssetMetadata(assetFull) }
         coVerify { streamSubscriptionService.addAssetIds(listOf(asset.id)) }
     }
 
@@ -115,7 +115,7 @@ class SyncAssetInfoImplTest {
             )
         }
         coVerify { assetsRepository.updateBalances(asset.id) }
-        coVerify { assetsRepository.updateAssetMetadata(assetFull) }
+        coVerify { assetsRepository.saveAssetMetadata(assetFull) }
         coVerify { streamSubscriptionService.addAssetIds(listOf(asset.id)) }
     }
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
@@ -128,7 +128,7 @@ class AssetsRepository @Inject constructor(
         getAssetsInfo().firstOrNull()?.updateBalances()?.awaitAll()
     }
 
-    suspend fun updateAssetMetadata(assetFull: AssetFull) = withContext(Dispatchers.IO) {
+    suspend fun saveAssetMetadata(assetFull: AssetFull) = withContext(Dispatchers.IO) {
         val assetId = assetFull.asset.id
         val assetIdIdentifier = assetId.toIdentifier()
         val currency = sessionRepository.getCurrentCurrency()
@@ -140,16 +140,14 @@ class AssetsRepository @Inject constructor(
             updatedAt = System.currentTimeMillis(),
         )
         val linkRecords = assetFull.links.toAssetLinkRecord(assetId)
-        assetsDao.update(record)
-        runCatching { assetsDao.addLinks(linkRecords) }
-            .onFailure { Log.e(TAG, "Failed to update asset links for $assetIdIdentifier", it) }
+        val marketRecord = rate?.let { assetFull.toMarketRecord(it.rate) }
+        assetsDao.upsertAssetMetadata(record, linkRecords, marketRecord)
         rate?.let { fiatRate ->
             val currentPrice = pricesDao.getByAssets(listOf(assetIdIdentifier)).firstOrNull()
             val priceRecord = assetFull.toPriceRecord(fiatRate)
             if (priceRecord != null && (currentPrice == null || currentPrice.currency != priceRecord.currency || currentPrice.value == null)) {
                 pricesDao.insert(priceRecord)
             }
-            assetFull.toMarketRecord(fiatRate.rate)?.let { assetsDao.setMarket(it) }
         }
     }
 

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
@@ -173,7 +173,7 @@ class AssetsRepositoryTest {
     }
 
     @Test
-    fun updateAssetMetadata_storesLinksPriceAndMarketFromAssetResponse() = runBlocking {
+    fun saveAssetMetadata_storesLinksPriceAndMarketFromAssetResponse() = runBlocking {
         every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
 
@@ -207,17 +207,15 @@ class AssetsRepositoryTest {
         coEvery { pricesDao.getByAssets(listOf("solana")) } returns emptyList()
 
         val subject = createSubject()
-        subject.updateAssetMetadata(assetFull)
+        subject.saveAssetMetadata(assetFull)
 
         val linksSlot = slot<List<DbAssetLink>>()
         val assetSlot = slot<DbAsset>()
         val priceSlot = slot<DbPrice>()
         val marketSlot = slot<DbAssetMarket>()
 
-        coVerify { assetsDao.update(capture(assetSlot)) }
-        coVerify { assetsDao.addLinks(capture(linksSlot)) }
+        coVerify { assetsDao.upsertAssetMetadata(capture(assetSlot), capture(linksSlot), capture(marketSlot)) }
         coVerify { pricesDao.insert(capture(priceSlot)) }
-        coVerify { assetsDao.setMarket(capture(marketSlot)) }
 
         assertEquals("solana", assetSlot.captured.id)
         assertEquals(false, assetSlot.captured.isSwapEnabled)
@@ -236,6 +234,31 @@ class AssetsRepositoryTest {
         assertEquals(100.0, marketSlot.captured.totalVolume ?: 0.0, 0.0)
         assertEquals(150.0, marketSlot.captured.allTimeHigh ?: 0.0, 0.0)
         assertEquals(25.0, marketSlot.captured.allTimeLow ?: 0.0, 0.0)
+    }
+
+    @Test
+    fun saveAssetMetadata_persistsUnknownAssetAndMarketInOneAtomicCall() = runBlocking {
+        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
+        every { sessionRepository.session() } returns sessionFlow
+
+        val asset = mockAssetSolanaUSDC()
+        val assetFull = mockAssetFull(
+            asset = asset,
+            market = mockAssetMarket(marketCap = 1_000.0),
+        )
+        coEvery { sessionRepository.getCurrentCurrency() } returns Currency.USD
+        every { pricesDao.getRates(Currency.USD) } returns flowOf(null)
+
+        val subject = createSubject()
+        subject.saveAssetMetadata(assetFull)
+
+        val assetSlot = slot<DbAsset>()
+        val marketSlot = slot<DbAssetMarket>()
+        coVerify(exactly = 1) { assetsDao.upsertAssetMetadata(capture(assetSlot), any(), capture(marketSlot)) }
+        coVerify(exactly = 0) { assetsDao.setMarket(any()) }
+
+        assertEquals(asset.id.toIdentifier(), assetSlot.captured.id)
+        assertEquals(asset.id.toIdentifier(), marketSlot.captured.assetId)
     }
 
     @Test

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
@@ -6,6 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
+import androidx.room.Upsert
 import com.gemwallet.android.data.service.store.database.entities.DbAsset
 import com.gemwallet.android.data.service.store.database.entities.DbAssetBasicUpdate
 import com.gemwallet.android.data.service.store.database.entities.DbAssetInfo
@@ -92,17 +93,28 @@ interface AssetsDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(asset: List<DbAsset>)
 
+    @Upsert
+    suspend fun upsert(asset: DbAsset)
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertBalance(balance: DbBalance)
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(links: List<DbAssetLink>, market: DbAssetMarket)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun addLinks(links: List<DbAssetLink>)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun setMarket(market: DbAssetMarket)
+
+    @Transaction
+    suspend fun upsertAssetMetadata(
+        asset: DbAsset,
+        links: List<DbAssetLink>,
+        market: DbAssetMarket?,
+    ) {
+        upsert(asset)
+        addLinks(links)
+        market?.let { setMarket(it) }
+    }
 
     @Query("""
         UPDATE balances SET
@@ -169,9 +181,6 @@ interface AssetsDao {
             listPosition = balance.listPosition,
         )
     }
-
-    @Update
-    fun update(asset: DbAsset)
 
     @Update(entity = DbAsset::class)
     suspend fun updateBasicAssets(assets: List<DbAssetBasicUpdate>)


### PR DESCRIPTION
Opening an asset that isn't in the wallet's local DB crashed with
`SQLiteConstraintException: FOREIGN KEY constraint failed`.

`updateAssetMetadata` ran Room `@Update` on the asset row — a no-op when
the row doesn't exist — then inserted `asset_market` referencing the
missing asset.

The fetched `AssetFull` is now persisted as one atomic aggregate: the
asset root is upserted first, then links and market in a single
`@Transaction`.

Closes #372