### PR TITLE
Consolidate asset scene staking UI on iOS and Android

### DIFF
--- a/android/features/banner/presents/src/main/kotlin/com/gemwallet/android/features/banner/views/BannerItemUIModel.kt
+++ b/android/features/banner/presents/src/main/kotlin/com/gemwallet/android/features/banner/views/BannerItemUIModel.kt
@@ -1,0 +1,85 @@
+package com.gemwallet.android.features.banner.views
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import com.gemwallet.android.domains.asset.chain
+import com.gemwallet.android.domains.asset.getIconUrl
+import com.gemwallet.android.ext.asset
+import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.theme.Emoji
+import com.wallet.core.primitives.Asset
+import com.wallet.core.primitives.Banner
+import com.wallet.core.primitives.BannerEvent
+import com.wallet.core.primitives.BannerState
+
+internal data class BannerItemUIModel(
+    val title: String,
+    val subtitle: String,
+    val icon: BannerIcon,
+    val canClose: Boolean,
+)
+
+internal sealed interface BannerIcon {
+    @JvmInline value class Emoji(val value: String) : BannerIcon
+    @JvmInline value class Url(val value: String) : BannerIcon
+    @JvmInline value class Vector(val image: ImageVector) : BannerIcon
+}
+
+@Composable
+internal fun bannerItemUIModel(
+    banner: Banner,
+    asset: Asset?,
+    getActivationFee: (Asset?) -> String,
+): BannerItemUIModel {
+    val assetName = asset?.name.orEmpty()
+    val (title, subtitle) = when (banner.event) {
+        BannerEvent.Stake -> Pair(
+            stringResource(R.string.banner_stake_title, assetName),
+            stringResource(R.string.banner_stake_description, assetName),
+        )
+        BannerEvent.AccountActivation -> Pair(
+            stringResource(R.string.banner_account_activation_title, assetName),
+            stringResource(
+                R.string.banner_account_activation_description,
+                assetName,
+                getActivationFee(asset),
+            ),
+        )
+        BannerEvent.EnableNotifications -> Pair(
+            stringResource(R.string.banner_enable_notifications_title, assetName),
+            stringResource(R.string.banner_enable_notifications_description),
+        )
+        BannerEvent.AccountBlockedMultiSignature -> Pair(
+            stringResource(R.string.common_warning),
+            stringResource(R.string.warnings_multi_signature_blocked, asset?.chain ?: ""),
+        )
+        BannerEvent.ActivateAsset -> Pair(
+            stringResource(R.string.transfer_activate_asset_title),
+            stringResource(
+                R.string.banner_activate_asset_description,
+                assetName,
+                asset?.id?.chain?.asset()?.name ?: "",
+            ),
+        )
+        BannerEvent.SuspiciousAsset,
+        BannerEvent.Onboarding,
+        BannerEvent.TradePerpetuals -> TODO()
+    }
+    val icon: BannerIcon = when (banner.event) {
+        BannerEvent.Stake -> BannerIcon.Emoji(Emoji.moneyBag)
+        BannerEvent.AccountBlockedMultiSignature -> BannerIcon.Vector(Icons.Outlined.Warning)
+        else -> BannerIcon.Url(
+            asset?.getIconUrl()
+                ?: "android.resource://com.gemwallet.android/${R.drawable.brandmark}",
+        )
+    }
+    return BannerItemUIModel(
+        title = title,
+        subtitle = subtitle,
+        icon = icon,
+        canClose = banner.state != BannerState.AlwaysActive,
+    )
+}

--- a/android/features/banner/presents/src/main/kotlin/com/gemwallet/android/features/banner/views/BannersScene.kt
+++ b/android/features/banner/presents/src/main/kotlin/com/gemwallet/android/features/banner/views/BannersScene.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
@@ -22,29 +23,27 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.gemwallet.android.domains.asset.chain
-import com.gemwallet.android.domains.asset.getIconUrl
-import com.gemwallet.android.ext.asset
 import com.gemwallet.android.ext.toIdentifier
-import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.image.IconWithBadge
 import com.gemwallet.android.ui.components.list_item.listItem
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.theme.Spacer16
-import com.gemwallet.android.ui.theme.Spacer8
+import com.gemwallet.android.ui.theme.listItemIconSize
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.paddingMiddle
+import com.gemwallet.android.ui.theme.smallIconSize
+import com.gemwallet.android.ui.theme.space2
 import com.gemwallet.android.features.banner.viewmodels.BannersViewModel
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.Banner
-import com.wallet.core.primitives.BannerEvent
-import com.wallet.core.primitives.BannerState
+
+private val bannerEmojiFontSize = 32.sp
 
 @Composable
 fun BannersScene(
@@ -65,89 +64,86 @@ fun BannersScene(
     }
     HorizontalPager(pageState, pageSpacing = paddingDefault) { page ->
         val banner = banners[page]
+        val model = bannerItemUIModel(banner, asset, viewModel::getActivationFee)
         Box(modifier = Modifier.listItem(ListPosition.Single).clickable { onClick(banner) }) {
-            val (title, description) = when (banner.event) {
-                BannerEvent.Stake -> Pair(
-                    stringResource(R.string.banner_stake_title, asset?.name ?: ""),
-                    stringResource(R.string.banner_stake_description, asset?.name ?: "")
-                )
-                BannerEvent.AccountActivation -> Pair(
-                    stringResource(R.string.banner_account_activation_title, asset?.name ?: ""),
-                    stringResource(R.string.banner_account_activation_description, asset?.name ?: "",
-                        viewModel.getActivationFee(asset)
-                ))
-                BannerEvent.EnableNotifications -> Pair(
-                    stringResource(R.string.banner_enable_notifications_title, asset?.name ?: ""),
-                    stringResource(R.string.banner_enable_notifications_description)
-                )
-                BannerEvent.AccountBlockedMultiSignature -> Pair(
-                    stringResource(R.string.common_warning),
-                    stringResource(R.string.warnings_multi_signature_blocked, asset?.chain ?: "")
-                )
-                BannerEvent.ActivateAsset -> Pair(
-                    stringResource(R.string.transfer_activate_asset_title),
-                    stringResource(R.string.banner_activate_asset_description, asset?.name ?: "", asset?.id?.chain?.asset()?.name ?: ""),
-                )
-
-                BannerEvent.SuspiciousAsset -> TODO()
-                BannerEvent.Onboarding -> TODO()
-                BannerEvent.TradePerpetuals -> TODO()
-            }
             BannerText(
-                title = title,
-                subtitle = description,
-                iconUrl = asset?.getIconUrl()
-                    ?: "android.resource://com.gemwallet.android/${R.drawable.brandmark}",
-                state = banner.state,
-            ) { viewModel.onCancel(banner) }
+                model = model,
+                onCancel = { viewModel.onCancel(banner) },
+            )
         }
     }
 }
 
 @Composable
 private fun BannerText(
-    title: String,
-    subtitle: String,
-    iconUrl: String,
-    state: BannerState,
+    model: BannerItemUIModel,
     onCancel: () -> Unit,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Spacer16()
-        IconWithBadge(icon = iconUrl, placeholder = iconUrl, size = 36.dp)
-        Spacer16()
-        Column(
-            modifier = Modifier.weight(1f).padding(top = 14.dp, end = 0.dp, bottom = paddingMiddle),
-            verticalArrangement = Arrangement.Center,
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = title,
-                maxLines = 1,
-                softWrap = false,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.W500),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                modifier = Modifier.padding(top = 0.dp, bottom = 2.dp),
-                text = subtitle,
-                overflow = TextOverflow.Ellipsis,
-                color = MaterialTheme.colorScheme.secondary,
-                style = MaterialTheme.typography.bodyMedium,
-            )
-        }
-        if (state != BannerState.AlwaysActive) {
-            Spacer8()
-            IconButton(onClick = onCancel) {
-                Icon(imageVector = Icons.Default.Close, contentDescription = "cancel_banner")
-            }
-        } else {
             Spacer16()
+            BannerIconView(model.icon)
+            Spacer16()
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(
+                        top = paddingMiddle,
+                        end = if (model.canClose) smallIconSize + paddingDefault else paddingDefault,
+                        bottom = paddingMiddle,
+                    ),
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = model.title,
+                    maxLines = 1,
+                    softWrap = false,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.W500),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.height(space2))
+                Text(
+                    modifier = Modifier.padding(bottom = space2),
+                    text = model.subtitle,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.colorScheme.secondary,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
         }
+        if (model.canClose) {
+            IconButton(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = paddingMiddle, end = paddingMiddle)
+                    .size(smallIconSize),
+                onClick = onCancel,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "cancel_banner",
+                    tint = MaterialTheme.colorScheme.secondary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BannerIconView(icon: BannerIcon) {
+    when (icon) {
+        is BannerIcon.Emoji -> Text(text = icon.value, fontSize = bannerEmojiFontSize)
+        is BannerIcon.Url -> IconWithBadge(icon = icon.value, placeholder = icon.value, size = listItemIconSize)
+        is BannerIcon.Vector -> Icon(
+            modifier = Modifier.size(listItemIconSize),
+            imageVector = icon.image,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.secondary,
+        )
     }
 }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_head/AmountListHead.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_head/AmountListHead.kt
@@ -139,7 +139,7 @@ fun AmountListHead(
                         textAlign = TextAlign.Center,
                         color = MaterialTheme.colorScheme.secondary,
                         style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.W400,
+                        fontWeight = FontWeight.Medium,
                     )
                 }
                 changedValue?.let { value ->
@@ -365,9 +365,9 @@ fun AmountHeadAction(
         )
         Text(
             text = title,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = MaterialTheme.colorScheme.secondary,
             style = MaterialTheme.typography.titleMedium.copy(
-                fontWeight = FontWeight.W400,
+                fontWeight = FontWeight.Medium,
             ),
             autoSize = ActionTextAutoSize(
                 minFontSize = 8.sp,

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/theme/Emoji.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/theme/Emoji.kt
@@ -10,4 +10,5 @@ object Emoji {
     const val checkmark = "✅"
     const val reject = "❌"
     const val rocket = "\uD83D\uDE80"
+    const val moneyBag = "\uD83D\uDCB0"
 }

--- a/ios/Features/Assets/Sources/Scenes/AssetScene.swift
+++ b/ios/Features/Assets/Sources/Scenes/AssetScene.swift
@@ -140,8 +140,15 @@ public struct AssetScene: View {
                     }
                 }
             } else if model.assetDataModel.isStakeEnabled {
-                stakeViewEmpty
-                    .listRowInsets(.assetListRowInsets)
+                Section(model.balancesTitle) {
+                    NavigationCustomLink(
+                        with: ListItemView(
+                            title: model.balanceTitle(for: .stake),
+                            subtitle: model.aprModel(for: .stake).text,
+                        ),
+                        action: { model.onSelectHeader(.stake) },
+                    )
+                }
             }
 
             if model.showEarnButton {
@@ -203,21 +210,6 @@ extension AssetScene {
             subtitle: model.networkField.value.text,
             assetImage: model.networkAssetImage,
             imageSize: .list.image,
-        )
-    }
-
-    private var stakeViewEmpty: some View {
-        NavigationCustomLink(
-            with: HStack(spacing: .space12) {
-                EmojiView(color: Colors.grayVeryLight, emoji: "💰")
-                    .frame(size: .image.asset)
-                ListItemView(
-                    title: model.balanceTitle(for: .stake),
-                    subtitle: model.aprModel(for: .stake).text,
-                    subtitleStyle: model.aprModel(for: .stake).subtitle.style,
-                )
-            },
-            action: { model.onSelectHeader(.stake) },
         )
     }
 }

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/BannerViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/BannerViewModel.swift
@@ -23,7 +23,9 @@ struct BannerViewModel {
 
     var image: AssetImage? {
         switch banner.event {
-        case .stake, .accountActivation, .activateAsset:
+        case .stake:
+            return AssetImage(type: Emoji.WalletAvatar.moneyBag.rawValue)
+        case .accountActivation, .activateAsset:
             guard let asset else {
                 return .none
             }


### PR DESCRIPTION
## Summary

- Replace the duplicate "Start staking" CTA on the asset detail scene with a single banner (now using the 💰 money bag emoji) plus a plain "Stake — APR x%" row inside the Balances section
- Bring Android up to the iOS reference: top-right close button with padding, secondary-colored Medium-weight action button titles, Medium-weight fiat subtitle
- Introduce `BannerItemUIModel` so `BannersScene` stops branching on `BannerEvent` inline (mirrors iOS `BannerViewModel`)

## Screenshots
<img width="640" alt="Screenshot 2026-05-25 at 1 56 19 PM" src="https://github.com/user-attachments/assets/a3525e7e-1fc2-4b8f-8094-1411d230a8dd" />

replace Gem icon for android
<img width="640" alt="Screenshot 2026-05-25 at 2 34 41 PM" src="https://github.com/user-attachments/assets/8e6a71b6-9d78-4641-8afb-cf1ddadb776f" />


Closes #181
Closes #282