### PR TITLE
Push transaction chain and type filters down to SQL

### DIFF
--- a/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModel.kt
+++ b/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.transactions.coordinators.GetTransactions
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
+import com.gemwallet.android.application.transactions.coordinators.TransactionsRequestFilter
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.ui.models.TransactionTypeFilter
 import com.wallet.core.primitives.Chain
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -50,16 +52,16 @@ class TransactionsViewModel @Inject constructor(
     private var lastSyncedWalletId: WalletId? = null
 
     val transactions = combine(
-        getTransactions.transactions(),
         chainsFilter,
         typeFilter,
-    ) { items, chains, types ->
-        val allowedTypes = types.flatMap { it.types }.toSet()
-        items.filter {
-            (chains.isEmpty() || it.asset.id.chain in chains) &&
-                (allowedTypes.isEmpty() || it.type in allowedTypes)
+    ) { chains, types ->
+        buildList<TransactionsRequestFilter> {
+            if (chains.isNotEmpty()) add(TransactionsRequestFilter.Chains(chains))
+            val allowedTypes = types.flatMap { it.types }
+            if (allowedTypes.isNotEmpty()) add(TransactionsRequestFilter.Types(allowedTypes))
         }
     }
+    .flatMapLatest { filters -> getTransactions.getTransactions(filters) }
     .stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,


### PR DESCRIPTION
## Summary
- Activity screen built a single eager StateFlow with no filters and applied chain/type selection in-memory on top, after `LIMIT 50`. With recent traffic on other chains a wallet would see only the few matching rows that happened to fall in the unfiltered top 50 — e.g. one Bitcoin transaction instead of all of them.
- Filters are now reactively rebuilt from `chainsFilter` and `typeFilter` and flowed through `getTransactions(filters)`, so the `WHERE` clause runs before `LIMIT` — matching iOS behavior.

Closes #381
<img width="320" alt="Screenshot_1779725172" src="https://github.com/user-attachments/assets/5064a1d4-54c3-4d47-aac1-2d90460c36b6" />

