### PR TITLE
Fix amount input ticker visibility and locale-aware symbol position

### DIFF
--- a/ios/Features/FiatConnect/Sources/Types/FiatCurrencyInputConfig.swift
+++ b/ios/Features/FiatConnect/Sources/Types/FiatCurrencyInputConfig.swift
@@ -1,15 +1,23 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Components
+import Formatters
 import Primitives
 import SwiftUI
 
 struct FiatCurrencyInputConfig: CurrencyInputConfigurable {
     var secondaryText: String
-    var currencySymbol: String
+    let currencyFormatter: CurrencyFormatter
+
+    var currencySymbol: String {
+        currencyFormatter.symbol
+    }
 
     var currencyPosition: CurrencyTextField.CurrencyPosition {
-        .leading
+        switch currencyFormatter.symbolPosition {
+        case .leading: .leading
+        case .trailing: .trailing
+        }
     }
 
     var placeholder: String {
@@ -20,14 +28,12 @@ struct FiatCurrencyInputConfig: CurrencyInputConfigurable {
         .decimalPad
     }
 
-    var sanitizer: ((String) -> String)? {
-        { input in
-            var filtered = input.filter { "0123456789".contains($0) }
-            while filtered.first == "0", filtered.count == 1 {
-                filtered.removeFirst()
-            }
-            return filtered
+    func sanitize(_ raw: String) -> String {
+        var filtered = raw.filter { "0123456789".contains($0) }
+        while filtered.first == "0", filtered.count == 1 {
+            filtered.removeFirst()
         }
+        return filtered
     }
 
     var actionStyle: CurrencyInputActionStyle?

--- a/ios/Features/FiatConnect/Sources/ViewModels/FiatSceneViewModel.swift
+++ b/ios/Features/FiatConnect/Sources/ViewModels/FiatSceneViewModel.swift
@@ -130,7 +130,7 @@ public final class FiatSceneViewModel {
     }
 
     var currencyInputConfig: any CurrencyInputConfigurable {
-        FiatCurrencyInputConfig(secondaryText: currentViewModel.cryptoAmountValue, currencySymbol: currencyFormatter.symbol)
+        FiatCurrencyInputConfig(secondaryText: currentViewModel.cryptoAmountValue, currencyFormatter: currencyFormatter)
     }
 
     var actionButtonTitle: String {

--- a/ios/Features/PriceAlerts/Sources/Types/SetPriceAlertCurrencyInputConfig.swift
+++ b/ios/Features/PriceAlerts/Sources/Types/SetPriceAlertCurrencyInputConfig.swift
@@ -15,7 +15,6 @@ struct SetPriceAlertCurrencyInputConfig: CurrencyInputConfigurable {
     let assetData: AssetData
     let formatter: CurrencyFormatter
     let onTapActionButton: VoidAction
-    let sanitizer: ((String) -> String)? = nil
 
     var placeholder: String {
         switch type {
@@ -33,7 +32,11 @@ struct SetPriceAlertCurrencyInputConfig: CurrencyInputConfigurable {
 
     var currencyPosition: Components.CurrencyTextField.CurrencyPosition {
         switch type {
-        case .price: .leading
+        case .price:
+            switch formatter.symbolPosition {
+            case .leading: .leading
+            case .trailing: .trailing
+            }
         case .percentage: .trailing
         }
     }

--- a/ios/Features/Transfer/Sources/Types/AmountInputConfig.swift
+++ b/ios/Features/Transfer/Sources/Types/AmountInputConfig.swift
@@ -33,7 +33,11 @@ struct AmountInputConfig: CurrencyInputConfigurable {
     var currencyPosition: CurrencyTextField.CurrencyPosition {
         switch inputType {
         case .asset: .trailing
-        case .fiat: .leading
+        case .fiat:
+            switch currencyFormatter.symbolPosition {
+            case .leading: .leading
+            case .trailing: .trailing
+            }
         }
     }
 
@@ -54,7 +58,7 @@ struct AmountInputConfig: CurrencyInputConfigurable {
         }
     }
 
-    var sanitizer: ((String) -> String)? {
-        { numberSanitizer.sanitize($0) }
+    func sanitize(_ raw: String) -> String {
+        numberSanitizer.sanitize(raw)
     }
 }

--- a/ios/Packages/Components/Sources/CurrencyInputView.swift
+++ b/ios/Packages/Components/Sources/CurrencyInputView.swift
@@ -9,81 +9,44 @@ public protocol CurrencyInputConfigurable {
     var currencyPosition: CurrencyTextField.CurrencyPosition { get }
     var secondaryText: String { get }
     var keyboardType: UIKeyboardType { get }
-    var sanitizer: ((String) -> String)? { get }
     var actionStyle: CurrencyInputActionStyle? { get }
     var onTapActionButton: (() -> Void)? { get }
+
+    func sanitize(_ raw: String) -> String
+}
+
+public extension CurrencyInputConfigurable {
+    func sanitize(_ raw: String) -> String { raw }
 }
 
 public struct CurrencyInputView: View {
     @Binding var text: String
 
-    private let placeholder: String
-    private let currencySymbol: String
-    private let currencyPosition: CurrencyTextField.CurrencyPosition
-    private let secondaryText: String
-    private let keyboardType: UIKeyboardType
-    private let actionStyle: CurrencyInputActionStyle?
-    private let onTapActionButton: (() -> Void)?
-    private let sanitizer: ((String) -> String)?
-
-    public init(
-        placeholder: String = "0",
-        text: Binding<String>,
-        currencySymbol: String,
-        currencyPosition: CurrencyTextField.CurrencyPosition,
-        secondaryText: String,
-        keyboardType: UIKeyboardType,
-        actionStyle: CurrencyInputActionStyle? = nil,
-        onTapActionButton: (() -> Void)? = nil,
-        sanitizer: ((String) -> String)? = nil,
-    ) {
-        _text = text
-        self.secondaryText = secondaryText
-        self.placeholder = placeholder
-        self.keyboardType = keyboardType
-        self.currencySymbol = currencySymbol
-        self.currencyPosition = currencyPosition
-        self.actionStyle = actionStyle
-        self.onTapActionButton = onTapActionButton
-        self.sanitizer = sanitizer
-    }
+    private let config: CurrencyInputConfigurable
 
     public init(text: Binding<String>, config: CurrencyInputConfigurable) {
-        self.init(
-            placeholder: config.placeholder,
-            text: text,
-            currencySymbol: config.currencySymbol,
-            currencyPosition: config.currencyPosition,
-            secondaryText: config.secondaryText,
-            keyboardType: config.keyboardType,
-            actionStyle: config.actionStyle,
-            onTapActionButton: config.onTapActionButton,
-            sanitizer: config.sanitizer,
-        )
+        _text = text
+        self.config = config
     }
 
     public var body: some View {
         VStack(alignment: .center, spacing: .small) {
             HStack(spacing: .small) {
-                if let actionStyle, actionStyle.position == .amount {
+                if let actionStyle = config.actionStyle, actionStyle.position == .amount {
                     actionButton(for: actionStyle.position)
                 }
 
                 CurrencyTextField(
-                    placeholder,
                     text: $text,
-                    currencySymbol: currencySymbol,
-                    currencyPosition: currencyPosition,
-                    keyboardType: keyboardType,
+                    currencySymbol: config.currencySymbol,
+                    currencyPosition: config.currencyPosition,
+                    placeholder: config.placeholder,
+                    keyboardType: config.keyboardType,
+                    sanitize: config.sanitize,
                 )
-                .ifLet(sanitizer) { view, sanitize in
-                    view.onChange(of: text) { _, newValue in
-                        text = sanitize(newValue)
-                    }
-                }
             }
 
-            if let actionStyle, actionStyle.position == .secondary {
+            if let actionStyle = config.actionStyle, actionStyle.position == .secondary {
                 actionButton(for: actionStyle.position)
             } else {
                 secondaryTextView
@@ -96,7 +59,7 @@ public struct CurrencyInputView: View {
 
     func actionButton(for position: CurrencyInputActionPosition) -> some View {
         Button {
-            onTapActionButton?()
+            config.onTapActionButton?()
         } label: {
             switch position {
             case .amount:
@@ -109,12 +72,12 @@ public struct CurrencyInputView: View {
             }
         }
         .buttonStyle(.plain)
-        .disabled(actionStyle == nil)
+        .disabled(config.actionStyle == nil)
     }
 
     @ViewBuilder
     var actionImage: some View {
-        if let actionStyle {
+        if let actionStyle = config.actionStyle {
             actionStyle.image
                 .resizable()
                 .frame(width: actionStyle.imageSize, height: actionStyle.imageSize)
@@ -123,7 +86,7 @@ public struct CurrencyInputView: View {
     }
 
     var secondaryTextView: some View {
-        Text(secondaryText)
+        Text(config.secondaryText)
             .textStyle(.calloutSecondary.weight(.medium))
             .frame(minHeight: .list.image)
     }

--- a/ios/Packages/Components/Sources/TextFields/CurrencyTextField.swift
+++ b/ios/Packages/Components/Sources/TextFields/CurrencyTextField.swift
@@ -2,74 +2,135 @@
 
 import Style
 import SwiftUI
+import UIKit
 
-public struct CurrencyTextField: View {
-    @Environment(\.isEnabled) var isEnabled
-
+public struct CurrencyTextField: UIViewRepresentable {
     public enum CurrencyPosition {
         case leading
         case trailing
     }
 
-    private enum Constants {
-        static let minWidth: CGFloat = 40
-        static let maxWidth: CGFloat = 210
-        static var height: CGFloat {
-            UIFont.systemFont(ofSize: 44, weight: .semibold).lineHeight
-        }
-    }
-
     @Binding var text: String
 
+    private let currencyPosition: CurrencyPosition
     private let currencySymbol: String
     private let placeholder: String
     private let keyboardType: UIKeyboardType
-    private let currencyPosition: CurrencyPosition
+    private let sanitize: (String) -> String
 
     public init(
-        _ placeholder: String,
         text: Binding<String>,
         currencySymbol: String,
         currencyPosition: CurrencyPosition,
+        placeholder: String,
         keyboardType: UIKeyboardType,
+        sanitize: @escaping (String) -> String,
     ) {
         _text = text
+        self.currencyPosition = currencyPosition
+        self.currencySymbol = switch currencyPosition {
+        case .leading: "\(currencySymbol) "
+        case .trailing: " \(currencySymbol)"
+        }
         self.placeholder = placeholder
         self.keyboardType = keyboardType
-        self.currencySymbol = currencySymbol
-        self.currencyPosition = currencyPosition
+        self.sanitize = sanitize
     }
 
-    public var body: some View {
-        HStack(alignment: .center, spacing: .zero) {
-            if currencyPosition == .leading {
-                currencySymbolView
-            }
-            TextField(placeholder, text: $text)
-                .keyboardType(keyboardType)
-                .foregroundStyle(Colors.black)
-                .font(.app.display)
-                .multilineTextAlignment(.center)
-                .textFieldStyle(.plain)
-                .lineLimit(1)
-                .padding(currencyPosition == .leading ? .leading : .trailing, .tiny)
-                .frame(minWidth: Constants.minWidth, maxWidth: Constants.maxWidth)
-                .fixedSize(horizontal: true, vertical: false)
-                .disabled(!isEnabled)
+    public func makeUIView(context: Context) -> UITextField {
+        let field = UITextField()
+        field.delegate = context.coordinator
+        field.keyboardType = keyboardType
+        field.textAlignment = .center
+        field.font = .systemFont(ofSize: 44, weight: .semibold)
+        field.adjustsFontSizeToFitWidth = true
+        field.minimumFontSize = 22
+        field.attributedText = composedText
+        return field
+    }
 
-            if currencyPosition == .trailing {
-                currencySymbolView
-            }
+    public func updateUIView(_ field: UITextField, context: Context) {
+        context.coordinator.parent = self
+        let composed = composedText
+        guard field.attributedText?.string != composed.string else { return }
+        field.attributedText = composed
+        moveCaretToEnd(field)
+    }
+
+    public func sizeThatFits(_ proposal: ProposedViewSize, uiView _: UITextField, context _: Context) -> CGSize? {
+        CGSize(
+            width: proposal.width ?? UIView.layoutFittingExpandedSize.width,
+            height: UIFont.systemFont(ofSize: 44, weight: .semibold).lineHeight,
+        )
+    }
+
+    public func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+
+    private func strip(_ composed: String) -> String {
+        switch currencyPosition {
+        case .leading:
+            composed.hasPrefix(currencySymbol) ? String(composed.dropFirst(currencySymbol.count)) : composed
+        case .trailing:
+            composed.hasSuffix(currencySymbol) ? String(composed.dropLast(currencySymbol.count)) : composed
         }
-        .frame(height: Constants.height) // TODO: Remove after fix bug: https://developer.apple.com/forums/thread/806828
     }
 
-    private var currencySymbolView: some View {
-        Text(currencySymbol)
-            .font(.app.display)
-            .foregroundStyle(Colors.black)
-            .lineLimit(1)
-            .fixedSize()
+    private var composedText: NSAttributedString {
+        let symbol = NSAttributedString(string: currencySymbol, attributes: [.foregroundColor: Colors.black.uiColor])
+        let digits = NSAttributedString(string: text.isEmpty ? placeholder : text, attributes: [.foregroundColor: text.isEmpty ? .placeholderText : Colors.black.uiColor])
+        let result = NSMutableAttributedString()
+        switch currencyPosition {
+        case .leading:
+            result.append(symbol)
+            result.append(digits)
+        case .trailing:
+            result.append(digits)
+            result.append(symbol)
+        }
+        return result
+    }
+
+    private func moveCaretToEnd(_ field: UITextField) {
+        let total = ((field.text ?? "") as NSString).length
+        let offset = switch currencyPosition {
+        case .leading: total
+        case .trailing: total - (currencySymbol as NSString).length
+        }
+        guard let position = field.position(from: field.beginningOfDocument, offset: offset) else { return }
+        if let current = field.selectedTextRange,
+           field.compare(current.start, to: position) == .orderedSame,
+           field.compare(current.end, to: position) == .orderedSame {
+            return
+        }
+        field.selectedTextRange = field.textRange(from: position, to: position)
+    }
+}
+
+public extension CurrencyTextField {
+    final class Coordinator: NSObject, UITextFieldDelegate {
+        var parent: CurrencyTextField
+
+        init(parent: CurrencyTextField) { self.parent = parent }
+
+        public func textField(
+            _ field: UITextField,
+            shouldChangeCharactersIn range: NSRange,
+            replacementString string: String,
+        ) -> Bool {
+            if parent.text.isEmpty {
+                let sanitized = parent.sanitize(string)
+                if parent.text != sanitized { parent.text = sanitized }
+                return false
+            }
+            let proposed = ((field.text ?? "") as NSString).replacingCharacters(in: range, with: string)
+            let sanitized = parent.sanitize(parent.strip(proposed))
+            if parent.text != sanitized { parent.text = sanitized }
+            return false
+        }
+
+        public func textFieldDidChangeSelection(_ field: UITextField) {
+            parent.moveCaretToEnd(field)
+        }
     }
 }
 
@@ -78,7 +139,7 @@ public struct CurrencyTextField: View {
     @Previewable @State var textTrailing = "100"
 
     return VStack {
-        CurrencyTextField("0", text: $textLeading, currencySymbol: "$", currencyPosition: .leading, keyboardType: .numberPad)
-        CurrencyTextField("0", text: $textTrailing, currencySymbol: "$", currencyPosition: .trailing, keyboardType: .decimalPad)
+        CurrencyTextField(text: $textLeading, currencySymbol: "$", currencyPosition: .leading, placeholder: "0", keyboardType: .numberPad, sanitize: { $0 })
+        CurrencyTextField(text: $textTrailing, currencySymbol: "$", currencyPosition: .trailing, placeholder: "0", keyboardType: .decimalPad, sanitize: { $0 })
     }
 }

--- a/ios/Packages/Formatters/Sources/CurrencyFormatter.swift
+++ b/ios/Packages/Formatters/Sources/CurrencyFormatter.swift
@@ -9,6 +9,11 @@ public enum CurrencyFormatterType: Sendable, Hashable {
     case abbreviated
 }
 
+public enum CurrencySymbolPosition: Sendable, Hashable {
+    case leading
+    case trailing
+}
+
 public struct CurrencyFormatter: Sendable, Hashable {
     private let locale: Locale
     private let type: CurrencyFormatterType
@@ -30,6 +35,14 @@ public struct CurrencyFormatter: Sendable, Hashable {
         formatter.numberStyle = .currency
         formatter.currencyCode = currencyCode
         return formatter.currencySymbol
+    }
+
+    public var symbolPosition: CurrencySymbolPosition {
+        let formatter = NumberFormatter()
+        formatter.locale = locale
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        return formatter.positivePrefix.contains(formatter.currencySymbol) ? .leading : .trailing
     }
 
     public func string(_ value: Double) -> String {

--- a/ios/Packages/Formatters/Tests/FormattersTests/CurrencyFormatterTests.swift
+++ b/ios/Packages/Formatters/Tests/FormattersTests/CurrencyFormatterTests.swift
@@ -50,6 +50,15 @@ final class CurrencyFormatterTests {
     }
 
     @Test
+    func symbolPosition() {
+        #expect(CurrencyFormatter(locale: .US, currencyCode: Currency.usd.rawValue).symbolPosition == .leading)
+        #expect(CurrencyFormatter(locale: .UK, currencyCode: Currency.gbp.rawValue).symbolPosition == .leading)
+        #expect(CurrencyFormatter(locale: Locale(identifier: "fr_FR"), currencyCode: "EUR").symbolPosition == .trailing)
+        #expect(CurrencyFormatter(locale: Locale(identifier: "de_DE"), currencyCode: "EUR").symbolPosition == .trailing)
+        #expect(CurrencyFormatter(locale: Locale(identifier: "ja_JP"), currencyCode: "JPY").symbolPosition == .leading)
+    }
+
+    @Test
     func testAbbreviated() {
         #expect(abbreviatedFormatterUS.string(0) == "$0.00")
         #expect(abbreviatedFormatterUS.string(12) == "$12.00")


### PR DESCRIPTION
## Summary
- Rewrite `CurrencyTextField` as `UIViewRepresentable` with `adjustsFontSizeToFitWidth` so the currency symbol stays glued to the digits and both shrink together when the amount is long.
- Use `NumberFormatter.positivePrefix` to derive the currency symbol position per locale instead of hardcoding `.leading` for fiat — `$50` for `en_US`, `50 €` for `fr_FR`, `50 ₽` for `ru_RU`.
- Slim `CurrencyInputConfigurable`: composing/stripping and live formatting moved into `CurrencyTextField`; sanitizer is now a protocol method with an identity default.

Closes #287, closes #333.

## iOS

https://github.com/user-attachments/assets/1e1ed028-0709-4616-a863-f03f69bac468

