### PR TITLE
Show chain badge for non-transfer activity rows on iOS

### DIFF
--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
@@ -67,7 +67,7 @@ public struct TransactionViewModel: Sendable {
              .stakeUnfreeze,
              .perpetualModifyPosition,
              .earnDeposit,
-             .earnWithdraw: .none
+             .earnWithdraw: AssetIdViewModel(assetId: assetId).assetImage.chainPlaceholder
         }
     }
 


### PR DESCRIPTION
## Summary
- Match Android in the Activity list: `transfer`/`transferNFT`/`smartContractCall` keep the in/out arrow overlay, while `swap`, `stake*`, `tokenApproval`, `earn*`, `perpetual*`, and `assetActivation` now fall back to the chain placeholder from `AssetIdViewModel`, so token rows expose their network.
- Android already produced this behavior via `AssetIcon` + `supportIcon` in `TransactionItem.kt`; only iOS needed to be aligned.

Closes #283
<img width="640" alt="Screenshot 2026-05-26 at 3 09 41 PM" src="https://github.com/user-attachments/assets/2e8dc709-ab50-45f1-8c20-a26037703378" />

