### PR TITLE
Improve UTXO sending: Send Max recovery on dust

### DIFF
--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/clients/bitcoin/BitcoinGatewayEstimateFee.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/clients/bitcoin/BitcoinGatewayEstimateFee.kt
@@ -92,9 +92,8 @@ class BitcoinGatewayEstimateFee : GemGatewayEstimateFee {
         val plan = AnySigner.plan(input, coinType, Bitcoin.TransactionPlan.parser())
         when (plan.error) {
             Common.SigningError.OK -> { /* continue */ }
-            Common.SigningError.Error_not_enough_utxos,
-            Common.SigningError.Error_dust_amount_requested,
-            Common.SigningError.Error_missing_input_utxos -> throw GatewayException.PlatformException(GemPlatformErrors.Dust.message)
+            Common.SigningError.Error_dust_amount_requested -> throw GatewayException.PlatformException(GemPlatformErrors.Dust.message)
+            Common.SigningError.Error_not_enough_utxos -> throw GatewayException.PlatformException(GemPlatformErrors.DustChange.message)
             else -> throw GatewayException.PlatformException(plan.error.name)
         }
 

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -347,8 +347,11 @@ private fun ConfirmDetailElementBottomSheet(
 @Composable
 fun ConfirmState.buttonLabel(): String {
     return when (this) {
-        is ConfirmState.BroadcastError,
-        is ConfirmState.Error -> stringResource(R.string.common_try_again)
+        is ConfirmState.Error -> when (message) {
+            is ConfirmError.DustChange -> stringResource(R.string.transfer_max)
+            else -> stringResource(R.string.common_try_again)
+        }
+        is ConfirmState.BroadcastError -> stringResource(R.string.common_try_again)
         is ConfirmState.FatalError -> message
         ConfirmState.Prepare,
         ConfirmState.Ready,
@@ -369,6 +372,7 @@ fun ConfirmError.toLabel() = when (this) {
     is ConfirmError.SignFail -> stringResource(R.string.errors_transfer_error)
     is ConfirmError.RecipientEmpty -> "${stringResource(R.string.errors_transfer_error)}: recipient can't be empty"
     is ConfirmError.DustThreshold -> stringResource(id = R.string.errors_dust_threshold_short)
+    is ConfirmError.DustChange -> stringResource(id = R.string.errors_dust_change_short)
     is ConfirmError.None -> stringResource(id = R.string.transfer_confirm)
     is ConfirmError.MinimumAccountBalanceTooLow -> stringResource(R.string.transfer_minimum_account_balance, asset.symbol)
 }

--- a/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmErrorMapper.kt
+++ b/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmErrorMapper.kt
@@ -7,8 +7,11 @@ import com.wallet.core.primitives.Chain
 import uniffi.gemstone.GatewayException
 
 internal fun Throwable.toPreloadConfirmError(chain: Chain): ConfirmError {
-    if (this is GatewayException.PlatformException && msg == GemPlatformErrors.Dust.message) {
-        return ConfirmError.DustThreshold(chain)
+    if (this is GatewayException.PlatformException) {
+        when (msg) {
+            GemPlatformErrors.Dust.message -> return ConfirmError.DustThreshold(chain)
+            GemPlatformErrors.DustChange.message -> return ConfirmError.DustChange(chain)
+        }
     }
     return toGemNetworkError()
         ?.let { ConfirmError.NetworkError(it) }

--- a/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
+++ b/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
@@ -271,8 +271,12 @@ class ConfirmViewModel @Inject constructor(
     }
 
     fun send(finishAction: FinishConfirmAction) = viewModelScope.launch(Dispatchers.IO) {
-        if (state.value is ConfirmState.Error) {
-            restart.update { !it }
+        val currentState = state.value
+        if (currentState is ConfirmState.Error) {
+            when (currentState.message) {
+                is ConfirmError.DustChange -> applySendMax()
+                else -> restart.update { !it }
+            }
             return@launch
         }
         state.update { ConfirmState.Sending }
@@ -304,6 +308,15 @@ class ConfirmViewModel @Inject constructor(
 
     private suspend fun getBalance(assetInfo: AssetInfo, params: ConfirmParams): BigInteger {
         return transactionBalanceService.getBalance(assetInfo, params)
+    }
+
+    private suspend fun applySendMax() {
+        val params = request.value as? ConfirmParams.TransferParams.Native ?: return
+        val assetInfo = assetsInfo.value?.getByAssetId(params.assetId) ?: return
+        state.update { ConfirmState.Prepare }
+        val balance = getBalance(assetInfo, params)
+        savedStateHandle[RouteArgument.Params.key] = params.withAmount(balance, useMaxAmount = true).pack()
+        restart.update { !it }
     }
 
     private fun List<AssetInfo>.getByAssetId(assetId: AssetId): AssetInfo? {

--- a/android/features/confirm/viewmodels/src/test/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmErrorMapperTest.kt
+++ b/android/features/confirm/viewmodels/src/test/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmErrorMapperTest.kt
@@ -30,6 +30,14 @@ class ConfirmErrorMapperTest {
     }
 
     @Test
+    fun preloadMapsDustChangeError() {
+        val error = GatewayException.PlatformException(GemPlatformErrors.DustChange.message)
+            .toPreloadConfirmError(Chain.Bitcoin)
+
+        assertTrue(error is ConfirmError.DustChange)
+    }
+
+    @Test
     fun broadcastMapsGatewayNetworkExceptionToNetworkError() {
         val error = GatewayException.NetworkException("Network error: offline")
             .toBroadcastConfirmError()

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/ConfirmError.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/ConfirmError.kt
@@ -17,4 +17,5 @@ sealed class ConfirmError : Exception() {
     class BroadcastError(val details: String) : ConfirmError()
     class NetworkError(val error: GemNetworkError) : ConfirmError()
     class DustThreshold(val chain: Chain) : ConfirmError()
+    class DustChange(val chain: Chain) : ConfirmError()
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/ConfirmParams.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/ConfirmParams.kt
@@ -236,6 +236,15 @@ sealed class ConfirmParams() {
         ) : TransferParams() {
             override fun toDto(): GemTransactionInputType = GemTransactionInputType.Transfer(asset.toGem())
 
+            fun withAmount(amount: BigInteger, useMaxAmount: Boolean = this.useMaxAmount) = Native(
+                asset = asset,
+                from = from,
+                amount = amount,
+                destination = destination,
+                memo = memo,
+                inputType = inputType,
+                useMaxAmount = useMaxAmount,
+            )
         }
 
         @Serializable

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/GemPlatformErrors.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/GemPlatformErrors.kt
@@ -2,4 +2,5 @@ package com.gemwallet.android.model
 
 enum class GemPlatformErrors(val message: String) {
     Dust("dust_error"),
+    DustChange("dust_change"),
 }

--- a/android/ui/src/main/res/values-ar/strings.xml
+++ b/android/ui/src/main/res/values-ar/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">الحد الأدنى للرصيد</string>
   <string name="asset.buy_asset">شراء %s</string>
   <string name="wallet.import_address_warning">يمكنك عرض الأرصدة والمعاملات لهذا العنوان، ولكن **لا يمكنك إرسال أو بيع الأموال**.</string>
-  <string name="info.stake_minimum_amount.title">الحد الأدنى للمبلغ</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">في %s في الشبكة، الحد الأدنى لمتطلبات التخزين هو %s.</string>
   <string name="asset.add_to_wallet">أضف إلى المحفظة</string>
   <string name="asset.hide_from_wallet">إخفاء من المحفظة</string>
   <string name="common.details">تفاصيل</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">تم استرداد المبلغ</string>
+  <string name="errors.dust_change_short">الرصيد المتبقي بعد هذا التحويل سيكون ضئيلاً جداً (غبار). حاول إرسال الحد الأقصى للمبلغ.</string>
 </resources>

--- a/android/ui/src/main/res/values-bn/strings.xml
+++ b/android/ui/src/main/res/values-bn/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">ন্যূনতম ব্যালেন্স</string>
   <string name="asset.buy_asset">%s কিনুন</string>
   <string name="wallet.import_address_warning">আপনি এই ঠিকানার ব্যালেন্স এবং লেনদেন দেখতে পারবেন, কিন্তু **তহবিল পাঠাতে বা বিক্রি করতে পারবেন না**।</string>
-  <string name="info.stake_minimum_amount.title">সর্বনিম্ন পরিমাণ</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">উপরে %s নেটওয়ার্ক, ন্যূনতম স্টেকিং প্রয়োজনীয়তা হল %s.</string>
   <string name="asset.add_to_wallet">ওয়ালেটে যোগ করুন</string>
   <string name="asset.hide_from_wallet">মানিব্যাগ থেকে লুকান</string>
   <string name="common.details">বিস্তারিত</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">ফেরত দেওয়া হয়েছে</string>
+  <string name="errors.dust_change_short">এই ট্রান্সফারের পর অবশিষ্ট ব্যালেন্স নষ্ট হয়ে যাবে। সর্বোচ্চ পরিমাণ পাঠানোর চেষ্টা করুন।</string>
 </resources>

--- a/android/ui/src/main/res/values-cs/strings.xml
+++ b/android/ui/src/main/res/values-cs/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Minimální zůstatek</string>
   <string name="asset.buy_asset">Koupit %s</string>
   <string name="wallet.import_address_warning">Pro tuto adresu si můžete prohlížet zůstatky a transakce, ale **nemůžete posílat ani prodávat finanční prostředky**.</string>
-  <string name="info.stake_minimum_amount.title">Minimální částka</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Na %s síť, minimální požadavek na staking je %s.</string>
   <string name="asset.add_to_wallet">Přidat do peněženky</string>
   <string name="asset.hide_from_wallet">Skrýt z peněženky</string>
   <string name="common.details">Podrobnosti</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Vráceno</string>
+  <string name="errors.dust_change_short">Zbývající zůstatek po tomto převodu by byl prach. Zkuste poslat maximální částku.</string>
 </resources>

--- a/android/ui/src/main/res/values-da/strings.xml
+++ b/android/ui/src/main/res/values-da/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Minimumsaldo</string>
   <string name="asset.buy_asset">Køb %s</string>
   <string name="wallet.import_address_warning">Du kan se saldi og transaktioner for denne adresse, men **kan ikke sende eller sælge penge**.</string>
-  <string name="info.stake_minimum_amount.title">Minimumsbeløb</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">På den %s netværk, minimumskravet til staking er %s.</string>
   <string name="asset.add_to_wallet">Tilføj til tegnebog</string>
   <string name="asset.hide_from_wallet">Skjul fra tegnebogen</string>
   <string name="common.details">Detaljer</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Refunderet</string>
+  <string name="errors.dust_change_short">Den resterende saldo efter denne overførsel vil være støv. Prøv at sende det maksimale beløb.</string>
 </resources>

--- a/android/ui/src/main/res/values-de/strings.xml
+++ b/android/ui/src/main/res/values-de/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Mindestguthaben</string>
   <string name="asset.buy_asset">Kaufen %s</string>
   <string name="wallet.import_address_warning">Sie können Guthaben und Transaktionen für diese Adresse anzeigen, aber **kein Geld senden oder verkaufen**.</string>
-  <string name="info.stake_minimum_amount.title">Mindestbetrag</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Auf dem %s Im Netzwerk beträgt die Mindesteinsatzanforderung %sDie</string>
   <string name="asset.add_to_wallet">Zum Wallet hinzufügen</string>
   <string name="asset.hide_from_wallet">Vor der Brieftasche verstecken</string>
   <string name="common.details">Details</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Rückerstattung</string>
+  <string name="errors.dust_change_short">Der Restbetrag nach dieser Überweisung wäre wertlos. Versuchen Sie, den Höchstbetrag zu senden.</string>
 </resources>

--- a/android/ui/src/main/res/values-es/strings.xml
+++ b/android/ui/src/main/res/values-es/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Saldo mínimo</string>
   <string name="asset.buy_asset">Comprar %s</string>
   <string name="wallet.import_address_warning">Puede ver los saldos y las transacciones de esta dirección, pero **no puede enviar ni vender fondos**.</string>
-  <string name="info.stake_minimum_amount.title">Cantidad mínima</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">En el %s red, el requisito mínimo de participación es %s.</string>
   <string name="asset.add_to_wallet">Añadir a la billetera</string>
   <string name="asset.hide_from_wallet">Ocultar de la billetera</string>
   <string name="common.details">Detalles</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Reintegrado</string>
+  <string name="errors.dust_change_short">El saldo restante tras esta transferencia sería insignificante. Intenta enviar la cantidad máxima.</string>
 </resources>

--- a/android/ui/src/main/res/values-fa/strings.xml
+++ b/android/ui/src/main/res/values-fa/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">حداقل موجودی</string>
   <string name="asset.buy_asset">خرید %s</string>
   <string name="wallet.import_address_warning">شما می‌توانید موجودی و تراکنش‌های این آدرس را مشاهده کنید، اما **نمی‌توانید وجه ارسال یا بفروشید**.</string>
-  <string name="info.stake_minimum_amount.title">حداقل مقدار</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">روی %s شبکه، حداقل الزام استیکینگ %s.</string>
   <string name="asset.add_to_wallet">اضافه کردن به کیف پول</string>
   <string name="asset.hide_from_wallet">پنهان شدن از کیف پول</string>
   <string name="common.details">جزئیات</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">بازپرداخت شد</string>
+  <string name="errors.dust_change_short">موجودی باقی مانده پس از این انتقال، داست (dast) خواهد بود. سعی کنید حداکثر مبلغ را ارسال کنید.</string>
 </resources>

--- a/android/ui/src/main/res/values-fil/strings.xml
+++ b/android/ui/src/main/res/values-fil/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Minimum na balanse</string>
   <string name="asset.buy_asset">Bumili ng %s</string>
   <string name="wallet.import_address_warning">Maaari mong tingnan ang mga balanse at transaksyon para sa address na ito, ngunit **hindi maaaring magpadala o magbenta ng mga pondo**.</string>
-  <string name="info.stake_minimum_amount.title">Minimum na halaga</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Sa %s network, ang minimum na kinakailangan sa staking ay %s.</string>
   <string name="asset.add_to_wallet">Idagdag sa wallet</string>
   <string name="asset.hide_from_wallet">Itago sa wallet</string>
   <string name="common.details">Mga Detalye</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Na-refund</string>
+  <string name="errors.dust_change_short">Ang natitirang balanse pagkatapos ng paglilipat na ito ay magiging alikabok lamang. Subukang ipadala ang pinakamataas na halaga.</string>
 </resources>

--- a/android/ui/src/main/res/values-fr/strings.xml
+++ b/android/ui/src/main/res/values-fr/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Solde minimum</string>
   <string name="asset.buy_asset">Achetez %s</string>
   <string name="wallet.import_address_warning">Vous pouvez consulter les soldes et les transactions pour cette adresse, mais **vous ne pouvez pas envoyer ou vendre des fonds**.</string>
-  <string name="info.stake_minimum_amount.title">Montant minimum</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Sur le %s sur le réseau, l\'exigence de mise minimale est %s.</string>
   <string name="asset.add_to_wallet">Ajouter au portefeuille</string>
   <string name="asset.hide_from_wallet">Se cacher du portefeuille</string>
   <string name="common.details">Détails</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Remboursé</string>
+  <string name="errors.dust_change_short">Le solde restant après ce virement sera inutilisable. Essayez d\'envoyer le montant maximum.</string>
 </resources>

--- a/android/ui/src/main/res/values-ha/strings.xml
+++ b/android/ui/src/main/res/values-ha/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Minimum balance</string>
   <string name="asset.buy_asset">Buy %s</string>
   <string name="wallet.import_address_warning">You can view balances and transactions for this address, but **cannot send or sell funds**.</string>
-  <string name="info.stake_minimum_amount.title">Minimum Amount</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">A kan %s hanyar sadarwa, mafi ƙarancin buƙatar saka hannun jari shine %s.</string>
   <string name="asset.add_to_wallet">Add to wallet</string>
   <string name="asset.hide_from_wallet">Hide from wallet</string>
   <string name="common.details">Details</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">An mayar da kuɗi</string>
+  <string name="errors.dust_change_short">Sauran ragowar bayan wannan canja wurin zai zama ƙura. Gwada aika matsakaicin adadin.</string>
 </resources>

--- a/android/ui/src/main/res/values-hi/strings.xml
+++ b/android/ui/src/main/res/values-hi/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">न्यूनतम शेष</string>
   <string name="asset.buy_asset">%s खरीदें</string>
   <string name="wallet.import_address_warning">आप इस पते के लिए शेष राशि और लेनदेन देख सकते हैं, लेकिन **धन भेज या बेच नहीं सकते**।</string>
-  <string name="info.stake_minimum_amount.title">न्यूनतम राशि</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">पर %s नेटवर्क के लिए, न्यूनतम स्टेकिंग आवश्यकता है %s.</string>
   <string name="asset.add_to_wallet">वॉलेट में जोड़ें</string>
   <string name="asset.hide_from_wallet">बटुए से छिपाएँ</string>
   <string name="common.details">विवरण</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">वापसी की गई है</string>
+  <string name="errors.dust_change_short">इस हस्तांतरण के बाद बची हुई राशि नगण्य हो जाएगी। अधिकतम राशि भेजने का प्रयास करें।</string>
 </resources>

--- a/android/ui/src/main/res/values-id/strings.xml
+++ b/android/ui/src/main/res/values-id/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Saldo minimum</string>
   <string name="asset.buy_asset">Beli %s</string>
   <string name="wallet.import_address_warning">Anda dapat melihat saldo dan transaksi untuk alamat ini, tetapi **tidak dapat mengirim atau menjual dana**.</string>
-  <string name="info.stake_minimum_amount.title">Jumlah minimum</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Pada %s jaringan, persyaratan staking minimum adalah %s.</string>
   <string name="asset.add_to_wallet">Tambahkan ke dompet</string>
   <string name="asset.hide_from_wallet">Sembunyikan dari dompet</string>
   <string name="common.details">Rincian</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Dikembalikan</string>
+  <string name="errors.dust_change_short">Saldo yang tersisa setelah transfer ini akan menjadi nol. Cobalah mengirimkan jumlah maksimum.</string>
 </resources>

--- a/android/ui/src/main/res/values-it/strings.xml
+++ b/android/ui/src/main/res/values-it/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Saldo minimo</string>
   <string name="asset.buy_asset">Acquista %s</string>
   <string name="wallet.import_address_warning">Puoi visualizzare i saldi e le transazioni per questo indirizzo, ma **non puoi inviare o vendere fondi**.</string>
-  <string name="info.stake_minimum_amount.title">Importo minimo</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Sul %s rete, il requisito minimo di staking è %s.</string>
   <string name="asset.add_to_wallet">Aggiungi al portafoglio</string>
   <string name="asset.hide_from_wallet">Nascondi dal portafoglio</string>
   <string name="common.details">Dettagli</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Rimborso effettuato</string>
+  <string name="errors.dust_change_short">Il saldo rimanente dopo questo trasferimento andrebbe perso. Prova a inviare l\'importo massimo.</string>
 </resources>

--- a/android/ui/src/main/res/values-iw/strings.xml
+++ b/android/ui/src/main/res/values-iw/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">יתרה מינימלית</string>
   <string name="asset.buy_asset">קנה %s</string>
   <string name="wallet.import_address_warning">ניתן לצפות ביתרות ועסקאות עבור כתובת זו, אך **לא ניתן לשלוח או למכור כספים**.</string>
-  <string name="info.stake_minimum_amount.title">סכום מינימלי</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">על ה %s רשת, דרישת ההימור המינימלית היא %s.</string>
   <string name="asset.add_to_wallet">הוסף לארנק</string>
   <string name="asset.hide_from_wallet">הסתר מהארנק</string>
   <string name="common.details">פרטים</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">החזר כספי</string>
+  <string name="errors.dust_change_short">היתרה שנותרה לאחר העברה זו תהיה אבק. נסה לשלוח את הסכום המקסימלי.</string>
 </resources>

--- a/android/ui/src/main/res/values-ja/strings.xml
+++ b/android/ui/src/main/res/values-ja/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">最低残高</string>
   <string name="asset.buy_asset">%sを購入</string>
   <string name="wallet.import_address_warning">このアドレスの残高と取引は表示できますが、**資金を送信または売却することはできません**。</string>
-  <string name="info.stake_minimum_amount.title">最低金額</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">オンザ %s ネットワークの最小ステーキング要件は %s。</string>
   <string name="asset.add_to_wallet">ウォレットに追加</string>
   <string name="asset.hide_from_wallet">ウォレットから隠す</string>
   <string name="common.details">ディテール</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">返金済み</string>
+  <string name="errors.dust_change_short">この送金後の残高は微々たるものになります。できるだけ高額を送金してみてください。</string>
 </resources>

--- a/android/ui/src/main/res/values-ko/strings.xml
+++ b/android/ui/src/main/res/values-ko/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">최소 잔액</string>
   <string name="asset.buy_asset">%s 구매</string>
   <string name="wallet.import_address_warning">이 주소에 대한 잔액과 거래 내역은 볼 수 있지만, **자금을 보내거나 판매할 수는 없습니다**.</string>
-  <string name="info.stake_minimum_amount.title">최소 금액</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">위에 %s 네트워크에서 최소 스테이킹 요구 사항은 다음과 같습니다. %s.</string>
   <string name="asset.add_to_wallet">지갑에 추가</string>
   <string name="asset.hide_from_wallet">지갑에서 숨기기</string>
   <string name="common.details">세부</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">환불됨</string>
+  <string name="errors.dust_change_short">이체 후 남는 잔액은 거의 없을 겁니다. 최대 금액을 보내보세요.</string>
 </resources>

--- a/android/ui/src/main/res/values-nl/strings.xml
+++ b/android/ui/src/main/res/values-nl/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Minimumsaldo</string>
   <string name="asset.buy_asset">Koop %s</string>
   <string name="wallet.import_address_warning">U kunt het saldo en de transacties voor dit adres bekijken, maar u kunt geen geld verzenden of verkopen.</string>
-  <string name="info.stake_minimum_amount.title">Minimumbedrag</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Op de %s netwerk, de minimale inzetvereiste is %s.</string>
   <string name="asset.add_to_wallet">Toevoegen aan portemonnee</string>
   <string name="asset.hide_from_wallet">Verbergen voor portemonnee</string>
   <string name="common.details">Details</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Terugbetaald</string>
+  <string name="errors.dust_change_short">Het resterende bedrag na deze overschrijving zou waardeloos zijn. Probeer het maximale bedrag over te maken.</string>
 </resources>

--- a/android/ui/src/main/res/values-pl/strings.xml
+++ b/android/ui/src/main/res/values-pl/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Minimalne saldo</string>
   <string name="asset.buy_asset">Kup %s</string>
   <string name="wallet.import_address_warning">Możesz przeglądać salda i transakcje dla tego adresu, ale **nie możesz wysyłać ani sprzedawać środków**.</string>
-  <string name="info.stake_minimum_amount.title">Minimalna kwota</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Na %s sieć, minimalne wymagania dotyczące stakowania to %s.</string>
   <string name="asset.add_to_wallet">Dodaj do portfela</string>
   <string name="asset.hide_from_wallet">Ukryj w portfelu</string>
   <string name="common.details">Bliższe dane</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Zwrócono</string>
+  <string name="errors.dust_change_short">Saldo pozostałe po tym przelewie będzie równe kurzowi. Spróbuj wysłać maksymalną kwotę.</string>
 </resources>

--- a/android/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/android/ui/src/main/res/values-pt-rBR/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Saldo mínimo</string>
   <string name="asset.buy_asset">Comprar %s</string>
   <string name="wallet.import_address_warning">Você pode visualizar saldos e transações para este endereço, mas **não pode enviar ou vender fundos**.</string>
-  <string name="info.stake_minimum_amount.title">Quantidade mínima</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">No %s Na rede, o requisito mínimo de staking é %s.</string>
   <string name="asset.add_to_wallet">Adicionar à carteira</string>
   <string name="asset.hide_from_wallet">Esconder da carteira</string>
   <string name="common.details">Detalhes</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Reembolsado</string>
+  <string name="errors.dust_change_short">O saldo restante após essa transferência será insignificante. Tente enviar o valor máximo.</string>
 </resources>

--- a/android/ui/src/main/res/values-ro/strings.xml
+++ b/android/ui/src/main/res/values-ro/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Sold minim</string>
   <string name="asset.buy_asset">Cumpără %s</string>
   <string name="wallet.import_address_warning">Puteți vizualiza soldurile și tranzacțiile pentru această adresă, dar **nu puteți trimite sau vinde fonduri**.</string>
-  <string name="info.stake_minimum_amount.title">Suma minimă</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Pe %s rețea, cerința minimă de miză este %s.</string>
   <string name="asset.add_to_wallet">Adaugă în portofel</string>
   <string name="asset.hide_from_wallet">Ascunde din portofel</string>
   <string name="common.details">Detalii</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Rambursat</string>
+  <string name="errors.dust_change_short">Soldul rămas după acest transfer ar fi praf. Încercați să trimiteți suma maximă.</string>
 </resources>

--- a/android/ui/src/main/res/values-ru/strings.xml
+++ b/android/ui/src/main/res/values-ru/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Минимальный баланс</string>
   <string name="asset.buy_asset">Купить %s</string>
   <string name="wallet.import_address_warning">Вы можете просматривать балансы и транзакции для этого адреса, но **не можете отправлять или продавать средства**.</string>
-  <string name="info.stake_minimum_amount.title">Минимальная сумма</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">На %s в сети минимальные требования к стейкингу составляют %s.</string>
   <string name="asset.add_to_wallet">Добавить в кошелек</string>
   <string name="asset.hide_from_wallet">Скрыть из кошелька</string>
   <string name="common.details">Детали</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Возврат средств</string>
+  <string name="errors.dust_change_short">Остаток после этого перевода будет слишком мал (пыль). Попробуйте отправить максимальную сумму.</string>
 </resources>

--- a/android/ui/src/main/res/values-sw/strings.xml
+++ b/android/ui/src/main/res/values-sw/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Kiwango cha chini cha usawa</string>
   <string name="asset.buy_asset">Nunua %s</string>
   <string name="wallet.import_address_warning">Unaweza kuangalia salio na miamala ya anwani hii, lakini **haiwezi kutuma au kuuza fedha**.</string>
-  <string name="info.stake_minimum_amount.title">Kiasi cha chini</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Juu ya %s mtandao, sharti la chini kabisa la kuweka dau ni %s.</string>
   <string name="asset.add_to_wallet">Ongeza kwenye mkoba</string>
   <string name="asset.hide_from_wallet">Ficha kutoka kwa mkoba</string>
   <string name="common.details">Maelezo</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Imerejeshwa</string>
+  <string name="errors.dust_change_short">Salio lililobaki baada ya uhamisho huu litakuwa vumbi. Jaribu kutuma kiasi cha juu zaidi.</string>
 </resources>

--- a/android/ui/src/main/res/values-th/strings.xml
+++ b/android/ui/src/main/res/values-th/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">ยอดคงเหลือขั้นต่ำ</string>
   <string name="asset.buy_asset">ซื้อ %s</string>
   <string name="wallet.import_address_warning">คุณสามารถดูยอดคงเหลือและธุรกรรมสำหรับที่อยู่นี้ แต่ **ไม่สามารถส่งหรือขายเงินได้**</string>
-  <string name="info.stake_minimum_amount.title">จำนวนเงินขั้นต่ำ</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">บน %s เครือข่ายนี้ ข้อกำหนดการวางเดิมพันขั้นต่ำคือ %s-</string>
   <string name="asset.add_to_wallet">เพิ่มลงในกระเป๋าสตางค์</string>
   <string name="asset.hide_from_wallet">ซ่อนจากกระเป๋าสตางค์</string>
   <string name="common.details">รายละเอียด</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">ได้รับเงินคืน</string>
+  <string name="errors.dust_change_short">ยอดเงินคงเหลือหลังจากโอนครั้งนี้จะไม่มีค่าอะไรเลย ลองโอนเงินจำนวนสูงสุดดู</string>
 </resources>

--- a/android/ui/src/main/res/values-tr/strings.xml
+++ b/android/ui/src/main/res/values-tr/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Minimum bakiye</string>
   <string name="asset.buy_asset">%s satın al</string>
   <string name="wallet.import_address_warning">Bu adrese ait bakiyeleri ve işlemleri görüntüleyebilirsiniz, ancak **para gönderemez veya satamazsınız**.</string>
-  <string name="info.stake_minimum_amount.title">Asgari tutar</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Üzerinde %s Ağda, minimum staking gereksinimi şöyledir: %s.</string>
   <string name="asset.add_to_wallet">Cüzdana ekle</string>
   <string name="asset.hide_from_wallet">Cüzdandan gizle</string>
   <string name="common.details">Detaylar</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Para iadesi yapıldı</string>
+  <string name="errors.dust_change_short">Bu transferden sonra kalan bakiye önemsiz olacaktır. Maksimum miktarı göndermeyi deneyin.</string>
 </resources>

--- a/android/ui/src/main/res/values-uk/strings.xml
+++ b/android/ui/src/main/res/values-uk/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Мінімальний баланс</string>
   <string name="asset.buy_asset">Купити %s</string>
   <string name="wallet.import_address_warning">Ви можете переглядати баланси та транзакції для цієї адреси, але **не можете надсилати або продавати кошти**.</string>
-  <string name="info.stake_minimum_amount.title">Мінімальна сума</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">На %s мережі, мінімальна вимога до стейкінгу становить %s.</string>
   <string name="asset.add_to_wallet">Додати до гаманця</string>
   <string name="asset.hide_from_wallet">Приховати від гаманця</string>
   <string name="common.details">Деталі</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Повернено кошти</string>
+  <string name="errors.dust_change_short">Залишок після цього переказу перетвориться на пил. Спробуйте надіслати максимальну суму.</string>
 </resources>

--- a/android/ui/src/main/res/values-ur/strings.xml
+++ b/android/ui/src/main/res/values-ur/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">کم از کم بیلنس</string>
   <string name="asset.buy_asset">خریدیں %s</string>
   <string name="wallet.import_address_warning">آپ اس پتے کے بیلنس اور لین دین دیکھ سکتے ہیں، لیکن **فنڈز بھیج یا فروخت نہیں کر سکتے**۔</string>
-  <string name="info.stake_minimum_amount.title">کم از کم رقم</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">پر %s نیٹ ورک، اسٹیکنگ کی کم از کم ضرورت ہے۔ %s.</string>
   <string name="asset.add_to_wallet">بٹوے میں شامل کریں۔</string>
   <string name="asset.hide_from_wallet">بٹوے سے چھپائیں۔</string>
   <string name="common.details">تفصیلات</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">رقم کی واپسی</string>
+  <string name="errors.dust_change_short">اس منتقلی کے بعد باقی ماندہ رقم خاک ہو گی۔ زیادہ سے زیادہ رقم بھیجنے کی کوشش کریں۔</string>
 </resources>

--- a/android/ui/src/main/res/values-vi/strings.xml
+++ b/android/ui/src/main/res/values-vi/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">Số dư tối thiểu</string>
   <string name="asset.buy_asset">Mua %s</string>
   <string name="wallet.import_address_warning">Bạn có thể xem số dư và giao dịch của địa chỉ này, nhưng **không thể gửi hoặc bán tiền**.</string>
-  <string name="info.stake_minimum_amount.title">Số tiền tối thiểu</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">Trên %s mạng lưới, yêu cầu đặt cọc tối thiểu là %s.</string>
   <string name="asset.add_to_wallet">Thêm vào ví</string>
   <string name="asset.hide_from_wallet">Ẩn khỏi ví</string>
   <string name="common.details">Chi tiết</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Đã hoàn tiền</string>
+  <string name="errors.dust_change_short">Số dư còn lại sau lần chuyển khoản này sẽ chẳng đáng là bao. Hãy thử chuyển số tiền tối đa.</string>
 </resources>

--- a/android/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/android/ui/src/main/res/values-zh-rCN/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">最低余额</string>
   <string name="asset.buy_asset">购买%s</string>
   <string name="wallet.import_address_warning">您可以查看此地址的余额和交易，但**不能发送或出售资金**。</string>
-  <string name="info.stake_minimum_amount.title">最低金额</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">在 %s 在网络中，最低质押要求是 %s。</string>
   <string name="asset.add_to_wallet">添加到钱包</string>
   <string name="asset.hide_from_wallet">隐藏钱包</string>
   <string name="common.details">详情</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">已退款</string>
+  <string name="errors.dust_change_short">转账后的剩余余额将过小（被视为粉尘）。请尝试发送最大金额。</string>
 </resources>

--- a/android/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/android/ui/src/main/res/values-zh-rTW/strings.xml
@@ -406,8 +406,6 @@
   <string name="info.account_minimum_balance.title">最低餘額</string>
   <string name="asset.buy_asset">購買%s</string>
   <string name="wallet.import_address_warning">您可以查看此地址的餘額和交易，但**不能發送或出售資金**。</string>
-  <string name="info.stake_minimum_amount.title">最低金額</string>
-  <string name="info.stake_minimum_amount.description" formatted="false">在 %s 在網路中，最低質押要求是 %s。</string>
   <string name="asset.add_to_wallet">加入錢包</string>
   <string name="asset.hide_from_wallet">隱藏錢包</string>
   <string name="common.details">詳情</string>
@@ -595,7 +593,7 @@
   <string name="info.funding_apr.title">Funding APR</string>
   <string name="info.funding_apr.description">The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.</string>
   <string name="info.minimum_amount.title">Minimum Amount</string>
-  <string name="info.minimum_amount.stake_description" formatted="false">On the %s network, the minimum staking requirement is %s.</string>
-  <string name="info.minimum_amount.perpetual_description" formatted="false">On the %s network, the minimum perpetual order is %s.</string>
+  <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">已退款</string>
+  <string name="errors.dust_change_short">轉帳後的剩餘餘額將過小（被視為粉塵）。請嘗試發送最大金額。</string>
 </resources>

--- a/android/ui/src/main/res/values/strings.xml
+++ b/android/ui/src/main/res/values/strings.xml
@@ -595,4 +595,5 @@
   <string name="info.minimum_amount.title">Minimum Amount</string>
   <string name="info.minimum_amount.description" formatted="false">On the %s network, the minimum amount for this transaction is %s.</string>
   <string name="transaction.status.refunded">Refunded</string>
+  <string name="errors.dust_change_short">The remaining balance after this transfer would be dust. Try sending the maximum amount.</string>
 </resources>

--- a/ios/Features/Transfer/Sources/Types/ChainCoreError+Localizations.swift
+++ b/ios/Features/Transfer/Sources/Types/ChainCoreError+Localizations.swift
@@ -10,6 +10,7 @@ extension ChainCoreError: @retroactive LocalizedError {
         case .cantEstimateFee, .feeRateMissed: Localized.Errors.unableEstimateNetworkFee
         case .incorrectAmount: Localized.Errors.invalidAmount
         case .dustThreshold: Localized.Errors.dustThresholdShort
+        case .dustChange: Localized.Errors.dustChangeShort
         }
     }
 }

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmButtonViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmButtonViewModel.swift
@@ -1,5 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
+import Blockchain
 import Components
 import Localization
 import Primitives
@@ -7,9 +8,15 @@ import Style
 import SwiftUI
 
 struct ConfirmButtonViewModel: StateButtonViewable {
-    private let onAction: @MainActor @Sendable () -> Void
+    enum Mode {
+        case confirm
+        case tryAgain
+        case sendMax
+    }
+
     private let state: StateViewType<TransactionInputViewModel>
     private let isDisabled: Bool
+    private let onAction: @MainActor @Sendable (Mode) -> Void
 
     let icon: Image?
 
@@ -17,7 +24,7 @@ struct ConfirmButtonViewModel: StateButtonViewable {
         state: StateViewType<TransactionInputViewModel>,
         icon: Image?,
         isDisabled: Bool = false,
-        onAction: @MainActor @Sendable @escaping () -> Void,
+        onAction: @MainActor @Sendable @escaping (Mode) -> Void,
     ) {
         self.state = state
         self.icon = icon
@@ -25,8 +32,18 @@ struct ConfirmButtonViewModel: StateButtonViewable {
         self.onAction = onAction
     }
 
+    var mode: Mode {
+        if case let .data(data) = state, data.isReady { return .confirm }
+        if case let .error(error) = state, ChainCoreError.fromError(error) == .dustChange { return .sendMax }
+        return .tryAgain
+    }
+
     var title: String {
-        state.isError ? Localized.Common.tryAgain : Localized.Transfer.confirm
+        switch mode {
+        case .confirm: Localized.Transfer.confirm
+        case .tryAgain: Localized.Common.tryAgain
+        case .sendMax: Localized.Transfer.max
+        }
     }
 
     var type: ButtonType {
@@ -35,6 +52,6 @@ struct ConfirmButtonViewModel: StateButtonViewable {
     }
 
     func action() {
-        onAction()
+        onAction(mode)
     }
 }

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmErrorViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmErrorViewModel.swift
@@ -26,7 +26,7 @@ extension ConfirmErrorViewModel: ItemModelProvidable {
         return .error(
             title: Localized.Errors.errorOccured,
             error: ChainCoreError.fromError(error) ?? error,
-            onInfoAction: { onSelectListError(error) },
+            onInfoAction: infoAction(for: error),
         )
     }
 }
@@ -38,5 +38,12 @@ extension ConfirmErrorViewModel {
         if case let .error(error) = state { return error }
         if case let .failure(error) = state.value?.transferAmount { return error }
         return nil
+    }
+
+    private func infoAction(for error: Error) -> VoidAction {
+        switch ChainCoreError.fromError(error) {
+        case .dustChange: nil
+        case .dustThreshold, .feeRateMissed, .cantEstimateFee, .incorrectAmount, .none: { onSelectListError(error) }
+        }
     }
 }

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
@@ -54,7 +54,7 @@ public final class ConfirmTransferSceneViewModel {
     private let simulation: SimulationResult?
     private var simulationState: ConfirmSimulationState
 
-    private let transferData: TransferData
+    private var transferData: TransferData
     private var metadata: TransferDataMetadata?
 
     public init(
@@ -150,12 +150,12 @@ public final class ConfirmTransferSceneViewModel {
             state: state,
             icon: confirmButtonIcon,
             isDisabled: isButtonDisabled,
-            onAction: { [weak self] in
+            onAction: { [weak self] mode in
                 guard let self else { return }
-                if case let .data(data) = state, data.isReady {
-                    onSelectConfirmTransfer()
-                } else {
-                    fetch()
+                switch mode {
+                case .confirm: onSelectConfirmTransfer()
+                case .sendMax: onSelectSendMax()
+                case .tryAgain: fetch()
                 }
             },
         )
@@ -290,7 +290,7 @@ extension ConfirmTransferSceneViewModel {
                 case .dustThreshold:
                     let asset = dataModel.asset
                     isPresentingSheet = .info(.dustThreshold(asset.chain, image: AssetViewModel(asset: asset).assetImage))
-                case .feeRateMissed, .cantEstimateFee, .incorrectAmount:
+                case .dustChange, .feeRateMissed, .cantEstimateFee, .incorrectAmount:
                     break
                 }
             }
@@ -357,7 +357,14 @@ extension ConfirmTransferSceneViewModel {
             await fetchData()
         }
     }
+
+    func onSelectSendMax() {
+        guard let available = metadata?.assetBalance.available else { return }
+        transferData = transferData.withValue(available)
+        fetch()
+    }
 }
+
 
 // MARK: - Private
 

--- a/ios/Features/Transfer/Tests/ViewModels/ConfirmButtonViewModelTests.swift
+++ b/ios/Features/Transfer/Tests/ViewModels/ConfirmButtonViewModelTests.swift
@@ -9,26 +9,18 @@ import TransferTestKit
 
 struct ConfirmButtonViewModelTests {
     @Test
-    func loaded() {
-        let model = ConfirmButtonViewModel(state: .data(TransactionInputViewModel.mock()), icon: nil, onAction: {})
-        #expect(model.title == Localized.Transfer.confirm)
+    func titles() {
+        let confirm = ConfirmButtonViewModel(state: .data(TransactionInputViewModel.mock()), icon: nil, onAction: { _ in })
+        let tryAgain = ConfirmButtonViewModel(state: .error(AnyError("test")), icon: nil, onAction: { _ in })
+        #expect(confirm.title == Localized.Transfer.confirm)
+        #expect(tryAgain.title == Localized.Common.tryAgain)
     }
 
     @Test
-    func error() {
-        let model = ConfirmButtonViewModel(state: .error(AnyError("test")), icon: nil, onAction: {})
-        #expect(model.title == Localized.Common.tryAgain)
-    }
-
-    @Test
-    func disabledWhenForceDisabled() {
-        let model = ConfirmButtonViewModel(state: .data(TransactionInputViewModel.mock()), icon: nil, isDisabled: true, onAction: {})
-        #expect(model.type.isDisabled)
-    }
-
-    @Test
-    func enabledWhenNotForceDisabled() {
-        let model = ConfirmButtonViewModel(state: .data(TransactionInputViewModel.mock()), icon: nil, isDisabled: false, onAction: {})
-        #expect(!model.type.isDisabled)
+    func disabled() {
+        let forced = ConfirmButtonViewModel(state: .data(TransactionInputViewModel.mock()), icon: nil, isDisabled: true, onAction: { _ in })
+        let enabled = ConfirmButtonViewModel(state: .data(TransactionInputViewModel.mock()), icon: nil, isDisabled: false, onAction: { _ in })
+        #expect(forced.type.isDisabled)
+        #expect(!enabled.type.isDisabled)
     }
 }

--- a/ios/Packages/Blockchain/Sources/ChainCoreError.swift
+++ b/ios/Packages/Blockchain/Sources/ChainCoreError.swift
@@ -10,12 +10,13 @@ public enum ChainCoreError: String, Error, Equatable {
     case cantEstimateFee
     case incorrectAmount
     case dustThreshold
+    case dustChange
 
     static func fromWalletCore(_ error: CommonSigningError) throws {
         let chainError: ChainCoreError? = switch error {
-        case .errorDustAmountRequested,
-             .errorNotEnoughUtxos,
-             .errorMissingInputUtxos: ChainCoreError.dustThreshold
+        case .errorDustAmountRequested: ChainCoreError.dustThreshold
+        case .errorNotEnoughUtxos: ChainCoreError.dustChange
+        case .errorMissingInputUtxos: ChainCoreError.cantEstimateFee
         case .ok: .none
         default: ChainCoreError.cantEstimateFee
         }
@@ -26,12 +27,12 @@ public enum ChainCoreError: String, Error, Equatable {
     }
 
     public static func fromError(_ error: Error) -> ChainCoreError? {
-        for errorCase in [ChainCoreError.dustThreshold, .feeRateMissed, .cantEstimateFee, .incorrectAmount] {
-            if error.localizedDescription.contains(errorCase.rawValue) {
-                return errorCase
-            }
+        if let chainError = error as? ChainCoreError {
+            return chainError
         }
-
+        if let gateway = error as? Gemstone.GatewayError, case let .PlatformError(msg) = gateway {
+            return ChainCoreError(rawValue: msg)
+        }
         return nil
     }
 }

--- a/ios/Packages/Blockchain/Tests/BlockchainTests/ChainCoreErrorTests.swift
+++ b/ios/Packages/Blockchain/Tests/BlockchainTests/ChainCoreErrorTests.swift
@@ -1,0 +1,18 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+@testable import Blockchain
+import Foundation
+import Gemstone
+import Testing
+
+struct ChainCoreErrorTests {
+    @Test
+    func fromError() {
+        #expect(ChainCoreError.fromError(ChainCoreError.dustChange) == .dustChange)
+        #expect(ChainCoreError.fromError(ChainCoreError.dustThreshold) == .dustThreshold)
+        #expect(ChainCoreError.fromError(Gemstone.GatewayError.PlatformError(msg: "dustChange")) == .dustChange)
+        #expect(ChainCoreError.fromError(Gemstone.GatewayError.PlatformError(msg: "dustThreshold")) == .dustThreshold)
+        #expect(ChainCoreError.fromError(Gemstone.GatewayError.PlatformError(msg: "garbage")) == nil)
+        #expect(ChainCoreError.fromError(NSError(domain: "test", code: 0)) == nil)
+    }
+}

--- a/ios/Packages/Localization/Sources/Localized.swift
+++ b/ios/Packages/Localization/Sources/Localized.swift
@@ -399,6 +399,8 @@ public enum Localized {
     public static let decoding = Localized.tr("Localizable", "errors.decoding", fallback: "Decoding Error")
     /// Failed to decode the QR code. Please try again with a different QR code.
     public static let decodingQr = Localized.tr("Localizable", "errors.decoding_qr", fallback: "Failed to decode the QR code. Please try again with a different QR code.")
+    /// The remaining balance after this transfer would be dust. Try sending the maximum amount.
+    public static let dustChangeShort = Localized.tr("Localizable", "errors.dust_change_short", fallback: "The remaining balance after this transfer would be dust. Try sending the maximum amount.")
     /// The transaction failed because the amount is too small to meet the %@ network’s minimum requirement (dust threshold). This limit ensures the transaction value covers the fees and processing costs.
     public static func dustThreshold(_ p1: Any) -> String {
       return Localized.tr("Localizable", "errors.dust_threshold", String(describing: p1), fallback: "The transaction failed because the amount is too small to meet the %@ network’s minimum requirement (dust threshold). This limit ensures the transaction value covers the fees and processing costs.")

--- a/ios/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "الحد الأدنى للرصيد";
 "asset.buy_asset" = "شراء %@";
 "wallet.import_address_warning" = "يمكنك عرض الأرصدة والمعاملات لهذا العنوان، ولكن **لا يمكنك إرسال أو بيع الأموال**.";
-"info.stake_minimum_amount.title" = "الحد الأدنى للمبلغ";
-"info.stake_minimum_amount.description" = "في %@ في الشبكة، الحد الأدنى لمتطلبات التخزين هو %@.";
 "asset.add_to_wallet" = "أضف إلى المحفظة";
 "asset.hide_from_wallet" = "إخفاء من المحفظة";
 "common.details" = "تفاصيل";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
-"transaction.status.refunded" = "Refunded";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
+"transaction.status.refunded" = "تم استرداد المبلغ";
+"errors.dust_change_short" = "الرصيد المتبقي بعد هذا التحويل سيكون ضئيلاً جداً (غبار). حاول إرسال الحد الأقصى للمبلغ.";

--- a/ios/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "ন্যূনতম ব্যালেন্স";
 "asset.buy_asset" = "%@ কিনুন";
 "wallet.import_address_warning" = "আপনি এই ঠিকানার ব্যালেন্স এবং লেনদেন দেখতে পারবেন, কিন্তু **তহবিল পাঠাতে বা বিক্রি করতে পারবেন না**।";
-"info.stake_minimum_amount.title" = "সর্বনিম্ন পরিমাণ";
-"info.stake_minimum_amount.description" = "উপরে %@ নেটওয়ার্ক, ন্যূনতম স্টেকিং প্রয়োজনীয়তা হল %@.";
 "asset.add_to_wallet" = "ওয়ালেটে যোগ করুন";
 "asset.hide_from_wallet" = "মানিব্যাগ থেকে লুকান";
 "common.details" = "বিস্তারিত";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
-"transaction.status.refunded" = "Refunded";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
+"transaction.status.refunded" = "ফেরত দেওয়া হয়েছে";
+"errors.dust_change_short" = "এই ট্রান্সফারের পর অবশিষ্ট ব্যালেন্স নষ্ট হয়ে যাবে। সর্বোচ্চ পরিমাণ পাঠানোর চেষ্টা করুন।";

--- a/ios/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Minimální zůstatek";
 "asset.buy_asset" = "Koupit %@";
 "wallet.import_address_warning" = "Pro tuto adresu si můžete prohlížet zůstatky a transakce, ale **nemůžete posílat ani prodávat finanční prostředky**.";
-"info.stake_minimum_amount.title" = "Minimální částka";
-"info.stake_minimum_amount.description" = "Na %@ síť, minimální požadavek na staking je %@.";
 "asset.add_to_wallet" = "Přidat do peněženky";
 "asset.hide_from_wallet" = "Skrýt z peněženky";
 "common.details" = "Podrobnosti";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
-"transaction.status.refunded" = "Refunded";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
+"transaction.status.refunded" = "Vráceno";
+"errors.dust_change_short" = "Zbývající zůstatek po tomto převodu by byl prach. Zkuste poslat maximální částku.";

--- a/ios/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Minimumsaldo";
 "asset.buy_asset" = "Køb %@";
 "wallet.import_address_warning" = "Du kan se saldi og transaktioner for denne adresse, men **kan ikke sende eller sælge penge**.";
-"info.stake_minimum_amount.title" = "Minimumsbeløb";
-"info.stake_minimum_amount.description" = "På den %@ netværk, minimumskravet til staking er %@.";
 "asset.add_to_wallet" = "Tilføj til tegnebog";
 "asset.hide_from_wallet" = "Skjul fra tegnebogen";
 "common.details" = "Detaljer";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
-"transaction.status.refunded" = "Refunded";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
+"transaction.status.refunded" = "Refunderet";
+"errors.dust_change_short" = "Den resterende saldo efter denne overførsel vil være støv. Prøv at sende det maksimale beløb.";

--- a/ios/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Mindestguthaben";
 "asset.buy_asset" = "Kaufen %@";
 "wallet.import_address_warning" = "Sie können Guthaben und Transaktionen für diese Adresse anzeigen, aber **kein Geld senden oder verkaufen**.";
-"info.stake_minimum_amount.title" = "Mindestbetrag";
-"info.stake_minimum_amount.description" = "Auf dem %@ Im Netzwerk beträgt die Mindesteinsatzanforderung %@Die";
 "asset.add_to_wallet" = "Zum Wallet hinzufügen";
 "asset.hide_from_wallet" = "Vor der Brieftasche verstecken";
 "common.details" = "Details";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Rückerstattung";
+"errors.dust_change_short" = "Der Restbetrag nach dieser Überweisung wäre wertlos. Versuchen Sie, den Höchstbetrag zu senden.";

--- a/ios/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -572,3 +572,4 @@
 "info.minimum_amount.title" = "Minimum Amount";
 "info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Refunded";
+"errors.dust_change_short" = "The remaining balance after this transfer would be dust. Try sending the maximum amount.";

--- a/ios/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Saldo mínimo";
 "asset.buy_asset" = "Comprar %@";
 "wallet.import_address_warning" = "Puede ver los saldos y las transacciones de esta dirección, pero **no puede enviar ni vender fondos**.";
-"info.stake_minimum_amount.title" = "Cantidad mínima";
-"info.stake_minimum_amount.description" = "En el %@ red, el requisito mínimo de participación es %@.";
 "asset.add_to_wallet" = "Añadir a la billetera";
 "asset.hide_from_wallet" = "Ocultar de la billetera";
 "common.details" = "Detalles";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
-"transaction.status.refunded" = "Refunded";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
+"transaction.status.refunded" = "Reintegrado";
+"errors.dust_change_short" = "El saldo restante tras esta transferencia sería insignificante. Intenta enviar la cantidad máxima.";

--- a/ios/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "حداقل موجودی";
 "asset.buy_asset" = "خرید %@";
 "wallet.import_address_warning" = "شما می‌توانید موجودی و تراکنش‌های این آدرس را مشاهده کنید، اما **نمی‌توانید وجه ارسال یا بفروشید**.";
-"info.stake_minimum_amount.title" = "حداقل مقدار";
-"info.stake_minimum_amount.description" = "روی %@ شبکه، حداقل الزام استیکینگ %@.";
 "asset.add_to_wallet" = "اضافه کردن به کیف پول";
 "asset.hide_from_wallet" = "پنهان شدن از کیف پول";
 "common.details" = "جزئیات";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "بازپرداخت شد";
+"errors.dust_change_short" = "موجودی باقی مانده پس از این انتقال، داست (dast) خواهد بود. سعی کنید حداکثر مبلغ را ارسال کنید.";

--- a/ios/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Minimum na balanse";
 "asset.buy_asset" = "Bumili ng %@";
 "wallet.import_address_warning" = "Maaari mong tingnan ang mga balanse at transaksyon para sa address na ito, ngunit **hindi maaaring magpadala o magbenta ng mga pondo**.";
-"info.stake_minimum_amount.title" = "Minimum na halaga";
-"info.stake_minimum_amount.description" = "Sa %@ network, ang minimum na kinakailangan sa staking ay %@.";
 "asset.add_to_wallet" = "Idagdag sa wallet";
 "asset.hide_from_wallet" = "Itago sa wallet";
 "common.details" = "Mga Detalye";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
-"transaction.status.refunded" = "Refunded";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
+"transaction.status.refunded" = "Na-refund";
+"errors.dust_change_short" = "Ang natitirang balanse pagkatapos ng paglilipat na ito ay magiging alikabok lamang. Subukang ipadala ang pinakamataas na halaga.";

--- a/ios/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Solde minimum";
 "asset.buy_asset" = "Achetez %@";
 "wallet.import_address_warning" = "Vous pouvez consulter les soldes et les transactions pour cette adresse, mais **vous ne pouvez pas envoyer ou vendre des fonds**.";
-"info.stake_minimum_amount.title" = "Montant minimum";
-"info.stake_minimum_amount.description" = "Sur le %@ sur le réseau, l'exigence de mise minimale est %@.";
 "asset.add_to_wallet" = "Ajouter au portefeuille";
 "asset.hide_from_wallet" = "Se cacher du portefeuille";
 "common.details" = "Détails";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Remboursé";
+"errors.dust_change_short" = "Le solde restant après ce virement sera inutilisable. Essayez d'envoyer le montant maximum.";

--- a/ios/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Minimum balance";
 "asset.buy_asset" = "Buy %@";
 "wallet.import_address_warning" = "You can view balances and transactions for this address, but **cannot send or sell funds**.";
-"info.stake_minimum_amount.title" = "Minimum Amount";
-"info.stake_minimum_amount.description" = "A kan %@ hanyar sadarwa, mafi ƙarancin buƙatar saka hannun jari shine %@.";
 "asset.add_to_wallet" = "Add to wallet";
 "asset.hide_from_wallet" = "Hide from wallet";
 "common.details" = "Details";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
-"transaction.status.refunded" = "Refunded";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
+"transaction.status.refunded" = "An mayar da kuɗi";
+"errors.dust_change_short" = "Sauran ragowar bayan wannan canja wurin zai zama ƙura. Gwada aika matsakaicin adadin.";

--- a/ios/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "יתרה מינימלית";
 "asset.buy_asset" = "קנה %@";
 "wallet.import_address_warning" = "ניתן לצפות ביתרות ועסקאות עבור כתובת זו, אך **לא ניתן לשלוח או למכור כספים**.";
-"info.stake_minimum_amount.title" = "סכום מינימלי";
-"info.stake_minimum_amount.description" = "על ה %@ רשת, דרישת ההימור המינימלית היא %@.";
 "asset.add_to_wallet" = "הוסף לארנק";
 "asset.hide_from_wallet" = "הסתר מהארנק";
 "common.details" = "פרטים";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "החזר כספי";
+"errors.dust_change_short" = "היתרה שנותרה לאחר העברה זו תהיה אבק. נסה לשלוח את הסכום המקסימלי.";

--- a/ios/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "न्यूनतम शेष";
 "asset.buy_asset" = "%@ खरीदें";
 "wallet.import_address_warning" = "आप इस पते के लिए शेष राशि और लेनदेन देख सकते हैं, लेकिन **धन भेज या बेच नहीं सकते**।";
-"info.stake_minimum_amount.title" = "न्यूनतम राशि";
-"info.stake_minimum_amount.description" = "पर %@ नेटवर्क के लिए, न्यूनतम स्टेकिंग आवश्यकता है %@.";
 "asset.add_to_wallet" = "वॉलेट में जोड़ें";
 "asset.hide_from_wallet" = "बटुए से छिपाएँ";
 "common.details" = "विवरण";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
-"transaction.status.refunded" = "Refunded";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
+"transaction.status.refunded" = "वापसी की गई है";
+"errors.dust_change_short" = "इस हस्तांतरण के बाद बची हुई राशि नगण्य हो जाएगी। अधिकतम राशि भेजने का प्रयास करें।";

--- a/ios/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Saldo minimum";
 "asset.buy_asset" = "Beli %@";
 "wallet.import_address_warning" = "Anda dapat melihat saldo dan transaksi untuk alamat ini, tetapi **tidak dapat mengirim atau menjual dana**.";
-"info.stake_minimum_amount.title" = "Jumlah minimum";
-"info.stake_minimum_amount.description" = "Pada %@ jaringan, persyaratan staking minimum adalah %@.";
 "asset.add_to_wallet" = "Tambahkan ke dompet";
 "asset.hide_from_wallet" = "Sembunyikan dari dompet";
 "common.details" = "Rincian";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Dikembalikan";
+"errors.dust_change_short" = "Saldo yang tersisa setelah transfer ini akan menjadi nol. Cobalah mengirimkan jumlah maksimum.";

--- a/ios/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Saldo minimo";
 "asset.buy_asset" = "Acquista %@";
 "wallet.import_address_warning" = "Puoi visualizzare i saldi e le transazioni per questo indirizzo, ma **non puoi inviare o vendere fondi**.";
-"info.stake_minimum_amount.title" = "Importo minimo";
-"info.stake_minimum_amount.description" = "Sul %@ rete, il requisito minimo di staking è %@.";
 "asset.add_to_wallet" = "Aggiungi al portafoglio";
 "asset.hide_from_wallet" = "Nascondi dal portafoglio";
 "common.details" = "Dettagli";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Rimborso effettuato";
+"errors.dust_change_short" = "Il saldo rimanente dopo questo trasferimento andrebbe perso. Prova a inviare l'importo massimo.";

--- a/ios/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "最低残高";
 "asset.buy_asset" = "%@を購入";
 "wallet.import_address_warning" = "このアドレスの残高と取引は表示できますが、**資金を送信または売却することはできません**。";
-"info.stake_minimum_amount.title" = "最低金額";
-"info.stake_minimum_amount.description" = "オンザ %@ ネットワークの最小ステーキング要件は %@。";
 "asset.add_to_wallet" = "ウォレットに追加";
 "asset.hide_from_wallet" = "ウォレットから隠す";
 "common.details" = "ディテール";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "返金済み";
+"errors.dust_change_short" = "この送金後の残高は微々たるものになります。できるだけ高額を送金してみてください。";

--- a/ios/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "최소 잔액";
 "asset.buy_asset" = "%@ 구매";
 "wallet.import_address_warning" = "이 주소에 대한 잔액과 거래 내역은 볼 수 있지만, **자금을 보내거나 판매할 수는 없습니다**.";
-"info.stake_minimum_amount.title" = "최소 금액";
-"info.stake_minimum_amount.description" = "위에 %@ 네트워크에서 최소 스테이킹 요구 사항은 다음과 같습니다. %@.";
 "asset.add_to_wallet" = "지갑에 추가";
 "asset.hide_from_wallet" = "지갑에서 숨기기";
 "common.details" = "세부";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "환불됨";
+"errors.dust_change_short" = "이체 후 남는 잔액은 거의 없을 겁니다. 최대 금액을 보내보세요.";

--- a/ios/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Minimumsaldo";
 "asset.buy_asset" = "Koop %@";
 "wallet.import_address_warning" = "U kunt het saldo en de transacties voor dit adres bekijken, maar u kunt geen geld verzenden of verkopen.";
-"info.stake_minimum_amount.title" = "Minimumbedrag";
-"info.stake_minimum_amount.description" = "Op de %@ netwerk, de minimale inzetvereiste is %@.";
 "asset.add_to_wallet" = "Toevoegen aan portemonnee";
 "asset.hide_from_wallet" = "Verbergen voor portemonnee";
 "common.details" = "Details";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Terugbetaald";
+"errors.dust_change_short" = "Het resterende bedrag na deze overschrijving zou waardeloos zijn. Probeer het maximale bedrag over te maken.";

--- a/ios/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Minimalne saldo";
 "asset.buy_asset" = "Kup %@";
 "wallet.import_address_warning" = "Możesz przeglądać salda i transakcje dla tego adresu, ale **nie możesz wysyłać ani sprzedawać środków**.";
-"info.stake_minimum_amount.title" = "Minimalna kwota";
-"info.stake_minimum_amount.description" = "Na %@ sieć, minimalne wymagania dotyczące stakowania to %@.";
 "asset.add_to_wallet" = "Dodaj do portfela";
 "asset.hide_from_wallet" = "Ukryj w portfelu";
 "common.details" = "Bliższe dane";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Zwrócono";
+"errors.dust_change_short" = "Saldo pozostałe po tym przelewie będzie równe kurzowi. Spróbuj wysłać maksymalną kwotę.";

--- a/ios/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Saldo mínimo";
 "asset.buy_asset" = "Comprar %@";
 "wallet.import_address_warning" = "Você pode visualizar saldos e transações para este endereço, mas **não pode enviar ou vender fundos**.";
-"info.stake_minimum_amount.title" = "Quantidade mínima";
-"info.stake_minimum_amount.description" = "No %@ Na rede, o requisito mínimo de staking é %@.";
 "asset.add_to_wallet" = "Adicionar à carteira";
 "asset.hide_from_wallet" = "Esconder da carteira";
 "common.details" = "Detalhes";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Reembolsado";
+"errors.dust_change_short" = "O saldo restante após essa transferência será insignificante. Tente enviar o valor máximo.";

--- a/ios/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Sold minim";
 "asset.buy_asset" = "Cumpără %@";
 "wallet.import_address_warning" = "Puteți vizualiza soldurile și tranzacțiile pentru această adresă, dar **nu puteți trimite sau vinde fonduri**.";
-"info.stake_minimum_amount.title" = "Suma minimă";
-"info.stake_minimum_amount.description" = "Pe %@ rețea, cerința minimă de miză este %@.";
 "asset.add_to_wallet" = "Adaugă în portofel";
 "asset.hide_from_wallet" = "Ascunde din portofel";
 "common.details" = "Detalii";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Rambursat";
+"errors.dust_change_short" = "Soldul rămas după acest transfer ar fi praf. Încercați să trimiteți suma maximă.";

--- a/ios/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Минимальный баланс";
 "asset.buy_asset" = "Купить %@";
 "wallet.import_address_warning" = "Вы можете просматривать балансы и транзакции для этого адреса, но **не можете отправлять или продавать средства**.";
-"info.stake_minimum_amount.title" = "Минимальная сумма";
-"info.stake_minimum_amount.description" = "На %@ в сети минимальные требования к стейкингу составляют %@.";
 "asset.add_to_wallet" = "Добавить в кошелек";
 "asset.hide_from_wallet" = "Скрыть из кошелька";
 "common.details" = "Детали";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Возврат средств";
+"errors.dust_change_short" = "Остаток после этого перевода будет слишком мал (пыль). Попробуйте отправить максимальную сумму.";

--- a/ios/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Kiwango cha chini cha usawa";
 "asset.buy_asset" = "Nunua %@";
 "wallet.import_address_warning" = "Unaweza kuangalia salio na miamala ya anwani hii, lakini **haiwezi kutuma au kuuza fedha**.";
-"info.stake_minimum_amount.title" = "Kiasi cha chini";
-"info.stake_minimum_amount.description" = "Juu ya %@ mtandao, sharti la chini kabisa la kuweka dau ni %@.";
 "asset.add_to_wallet" = "Ongeza kwenye mkoba";
 "asset.hide_from_wallet" = "Ficha kutoka kwa mkoba";
 "common.details" = "Maelezo";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Imerejeshwa";
+"errors.dust_change_short" = "Salio lililobaki baada ya uhamisho huu litakuwa vumbi. Jaribu kutuma kiasi cha juu zaidi.";

--- a/ios/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "ยอดคงเหลือขั้นต่ำ";
 "asset.buy_asset" = "ซื้อ %@";
 "wallet.import_address_warning" = "คุณสามารถดูยอดคงเหลือและธุรกรรมสำหรับที่อยู่นี้ แต่ **ไม่สามารถส่งหรือขายเงินได้**";
-"info.stake_minimum_amount.title" = "จำนวนเงินขั้นต่ำ";
-"info.stake_minimum_amount.description" = "บน %@ เครือข่ายนี้ ข้อกำหนดการวางเดิมพันขั้นต่ำคือ %@-";
 "asset.add_to_wallet" = "เพิ่มลงในกระเป๋าสตางค์";
 "asset.hide_from_wallet" = "ซ่อนจากกระเป๋าสตางค์";
 "common.details" = "รายละเอียด";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "ได้รับเงินคืน";
+"errors.dust_change_short" = "ยอดเงินคงเหลือหลังจากโอนครั้งนี้จะไม่มีค่าอะไรเลย ลองโอนเงินจำนวนสูงสุดดู";

--- a/ios/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Minimum bakiye";
 "asset.buy_asset" = "%@ satın al";
 "wallet.import_address_warning" = "Bu adrese ait bakiyeleri ve işlemleri görüntüleyebilirsiniz, ancak **para gönderemez veya satamazsınız**.";
-"info.stake_minimum_amount.title" = "Asgari tutar";
-"info.stake_minimum_amount.description" = "Üzerinde %@ Ağda, minimum staking gereksinimi şöyledir: %@.";
 "asset.add_to_wallet" = "Cüzdana ekle";
 "asset.hide_from_wallet" = "Cüzdandan gizle";
 "common.details" = "Detaylar";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Para iadesi yapıldı";
+"errors.dust_change_short" = "Bu transferden sonra kalan bakiye önemsiz olacaktır. Maksimum miktarı göndermeyi deneyin.";

--- a/ios/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Мінімальний баланс";
 "asset.buy_asset" = "Купити %@";
 "wallet.import_address_warning" = "Ви можете переглядати баланси та транзакції для цієї адреси, але **не можете надсилати або продавати кошти**.";
-"info.stake_minimum_amount.title" = "Мінімальна сума";
-"info.stake_minimum_amount.description" = "На %@ мережі, мінімальна вимога до стейкінгу становить %@.";
 "asset.add_to_wallet" = "Додати до гаманця";
 "asset.hide_from_wallet" = "Приховати від гаманця";
 "common.details" = "Деталі";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Повернено кошти";
+"errors.dust_change_short" = "Залишок після цього переказу перетвориться на пил. Спробуйте надіслати максимальну суму.";

--- a/ios/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "کم از کم بیلنس";
 "asset.buy_asset" = "خریدیں %@";
 "wallet.import_address_warning" = "آپ اس پتے کے بیلنس اور لین دین دیکھ سکتے ہیں، لیکن **فنڈز بھیج یا فروخت نہیں کر سکتے**۔";
-"info.stake_minimum_amount.title" = "کم از کم رقم";
-"info.stake_minimum_amount.description" = "پر %@ نیٹ ورک، اسٹیکنگ کی کم از کم ضرورت ہے۔ %@.";
 "asset.add_to_wallet" = "بٹوے میں شامل کریں۔";
 "asset.hide_from_wallet" = "بٹوے سے چھپائیں۔";
 "common.details" = "تفصیلات";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "رقم کی واپسی";
+"errors.dust_change_short" = "اس منتقلی کے بعد باقی ماندہ رقم خاک ہو گی۔ زیادہ سے زیادہ رقم بھیجنے کی کوشش کریں۔";

--- a/ios/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "Số dư tối thiểu";
 "asset.buy_asset" = "Mua %@";
 "wallet.import_address_warning" = "Bạn có thể xem số dư và giao dịch của địa chỉ này, nhưng **không thể gửi hoặc bán tiền**.";
-"info.stake_minimum_amount.title" = "Số tiền tối thiểu";
-"info.stake_minimum_amount.description" = "Trên %@ mạng lưới, yêu cầu đặt cọc tối thiểu là %@.";
 "asset.add_to_wallet" = "Thêm vào ví";
 "asset.hide_from_wallet" = "Ẩn khỏi ví";
 "common.details" = "Chi tiết";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "Đã hoàn tiền";
+"errors.dust_change_short" = "Số dư còn lại sau lần chuyển khoản này sẽ chẳng đáng là bao. Hãy thử chuyển số tiền tối đa.";

--- a/ios/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "最低余额";
 "asset.buy_asset" = "购买%@";
 "wallet.import_address_warning" = "您可以查看此地址的余额和交易，但**不能发送或出售资金**。";
-"info.stake_minimum_amount.title" = "最低金额";
-"info.stake_minimum_amount.description" = "在 %@ 在网络中，最低质押要求是 %@。";
 "asset.add_to_wallet" = "添加到钱包";
 "asset.hide_from_wallet" = "隐藏钱包";
 "common.details" = "详情";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "已退款";
+"errors.dust_change_short" = "转账后的剩余余额将过小（被视为粉尘）。请尝试发送最大金额。";

--- a/ios/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -385,8 +385,6 @@
 "info.account_minimum_balance.title" = "最低餘額";
 "asset.buy_asset" = "購買%@";
 "wallet.import_address_warning" = "您可以查看此地址的餘額和交易，但**不能發送或出售資金**。";
-"info.stake_minimum_amount.title" = "最低金額";
-"info.stake_minimum_amount.description" = "在 %@ 在網路中，最低質押要求是 %@。";
 "asset.add_to_wallet" = "加入錢包";
 "asset.hide_from_wallet" = "隱藏錢包";
 "common.details" = "詳情";
@@ -572,6 +570,6 @@
 "info.funding_apr.title" = "Funding APR";
 "info.funding_apr.description" = "The annualized rate at which longs pay shorts (if negative, shorts pay longs). There are no fees associated with funding, which is a peer-to-peer transfer between users to push prices towards the spot price.";
 "info.minimum_amount.title" = "Minimum Amount";
-"info.minimum_amount.stake_description" = "On the %@ network, the minimum staking requirement is %@.";
-"info.minimum_amount.perpetual_description" = "On the %@ network, the minimum perpetual order is %@.";
+"info.minimum_amount.description" = "On the %@ network, the minimum amount for this transaction is %@.";
 "transaction.status.refunded" = "已退款";
+"errors.dust_change_short" = "轉帳後的剩餘餘額將過小（被視為粉塵）。請嘗試發送最大金額。";

--- a/ios/Packages/Primitives/Sources/TransferData.swift
+++ b/ios/Packages/Primitives/Sources/TransferData.swift
@@ -28,4 +28,13 @@ public struct TransferData: Identifiable, Sendable, Hashable {
     public var chain: Chain {
         type.chain
     }
+
+    public func withValue(_ value: BigInt) -> TransferData {
+        TransferData(
+            type: type,
+            recipientData: recipientData,
+            value: value,
+            canChangeValue: canChangeValue,
+        )
+    }
 }


### PR DESCRIPTION
Closes #213

When a UTXO transfer (Bitcoin, Litecoin, Doge, etc.) would leave dust as change, the confirm screen now offers a **Max** button that adjusts the amount to send the full balance instead of failing with a dust error.

The pre-existing dust error (the amount itself is below the network's dust threshold, e.g. sending 1 cent) is unchanged and still shows the explanatory info sheet.

Both iOS and Android.

<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-05-27 at 23 08 14" src="https://github.com/user-attachments/assets/09f374e4-2f48-430a-b399-87888e171dea" />
<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-05-27 at 23 08 31" src="https://github.com/user-attachments/assets/e965b398-6564-4c59-9538-0910fa90abe9" />
<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-05-27 at 23 08 37" src="https://github.com/user-attachments/assets/6ab06c59-64ea-4213-91fd-f37853f02a78" />
