### PR TITLE
Refactor Wallet Core usage from android device auth flow

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/GetAuthPayloadImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/GetAuthPayloadImpl.kt
@@ -4,19 +4,17 @@ import com.gemwallet.android.application.GetAuthPayload
 import com.gemwallet.android.application.PasswordStore
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
 import com.gemwallet.android.blockchain.operators.LoadPrivateKeyOperator
-import com.gemwallet.android.blockchain.operators.walletcore.WCChainTypeProxy
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
-import com.gemwallet.android.domains.referral.values.ReferralError
 import com.gemwallet.android.ext.getAccount
-import com.gemwallet.android.math.append0x
-import com.gemwallet.android.math.hex
+import com.gemwallet.android.ext.referralChain
 import com.wallet.core.primitives.AuthPayload
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.Wallet
 import uniffi.gemstone.GemAuthNonce
-import wallet.core.jni.PrivateKey
-import java.util.Arrays
+import uniffi.gemstone.createAuthMessage
+import uniffi.gemstone.signAuthMessageHash
 import java.io.IOException
+import java.util.Arrays
 
 class GetAuthPayloadImpl(
     private val gemDeviceApiClient: GemDeviceApiClient,
@@ -25,7 +23,8 @@ class GetAuthPayloadImpl(
     private val loadPrivateKeyOperator: LoadPrivateKeyOperator,
 ) : GetAuthPayload {
 
-    override suspend fun getAuthPayload(wallet: Wallet, chain: Chain): AuthPayload {
+    override suspend fun getAuthPayload(wallet: Wallet): AuthPayload {
+        val chain = Chain.referralChain
         val account = wallet.getAccount(chain) ?: throw Exception() // TODO
         val deviceId = getDeviceId.getDeviceId()
         val key = loadPrivateKeyOperator(
@@ -36,14 +35,12 @@ class GetAuthPayloadImpl(
 
         try {
             val nonce = gemDeviceApiClient.getAuthNonce() ?: throw IOException("Auth nonce unavailable")
-            val message = uniffi.gemstone.createAuthMessage(
-                chain = Chain.Ethereum.string,
+            val message = createAuthMessage(
                 address = account.address,
                 authNonce = GemAuthNonce(nonce.nonce, nonce.timestamp)
             )
 
-            val signature = PrivateKey(key).sign(message.hash, WCChainTypeProxy()(chain).curve())
-                .hex.append0x()
+            val signature = signAuthMessageHash(message.hash, key)
             return AuthPayload(
                 deviceId = deviceId,
                 chain = account.chain,

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/GetDeviceIdImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/GetDeviceIdImpl.kt
@@ -2,10 +2,8 @@ package com.gemwallet.android.data.coordinators.device
 
 import com.gemwallet.android.application.SecurityStore
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
-import com.gemwallet.android.math.hex
+import com.gemwallet.android.data.services.gemapi.DeviceKeyPair
 import kotlinx.coroutines.runBlocking
-import wallet.core.jni.Curve
-import wallet.core.jni.HDWallet
 
 class GetDeviceIdImpl(
     private val store: SecurityStore<Any>
@@ -24,9 +22,9 @@ class GetDeviceIdImpl(
             return data
         } catch (_: Throwable) {}
 
-        val deviceKey = HDWallet(128, "").getMasterKey(Curve.ED25519)
-        val privateKey = deviceKey.data().hex
-        val publicKey = deviceKey.publicKeyEd25519.data().hex
+        val deviceKey = DeviceKeyPair.generate()
+        val privateKey = deviceKey.privateKeyHex
+        val publicKey = deviceKey.publicKeyHex
 
         store.putValue(Keys.PrivateKey, privateKey)
         store.putValue(Keys.PublicKey, publicKey)

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/referral/CreateReferralImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/referral/CreateReferralImpl.kt
@@ -3,11 +3,7 @@ package com.gemwallet.android.data.coordinators.referral
 import com.gemwallet.android.application.GetAuthPayload
 import com.gemwallet.android.application.referral.coordinators.CreateReferral
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
-import com.gemwallet.android.domains.referral.values.ReferralError
-import com.gemwallet.android.ext.getAccount
-import com.gemwallet.android.ext.referralChain
 import com.wallet.core.primitives.AuthenticatedRequest
-import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.ReferralCode
 import com.wallet.core.primitives.Rewards
 import com.wallet.core.primitives.Wallet
@@ -20,8 +16,7 @@ class CreateReferralImpl(
 
 
     override suspend fun createReferral(code: String, wallet: Wallet): Rewards {
-        val account = wallet.getAccount(Chain.referralChain) ?: throw ReferralError.BadWallet
-        val authPayload = getAuthPayload.getAuthPayload(wallet, account.chain)
+        val authPayload = getAuthPayload.getAuthPayload(wallet)
         return gemDeviceApiClient.createReferral(
             walletId = wallet.id,
             body = AuthenticatedRequest(

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/referral/RedeemImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/referral/RedeemImpl.kt
@@ -7,9 +7,7 @@ import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
 import com.gemwallet.android.domains.referral.values.ReferralError
 import com.gemwallet.android.ext.getAccount
-import com.gemwallet.android.ext.referralChain
 import com.wallet.core.primitives.AuthenticatedRequest
-import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.RedemptionRequest
 import com.wallet.core.primitives.RedemptionResult
 import com.wallet.core.primitives.RewardRedemptionOption
@@ -25,8 +23,7 @@ class RedeemImpl(
 ) : Redeem {
 
     override suspend fun redeem(wallet: Wallet, rewards: Rewards, option: RewardRedemptionOption): RedemptionResult {
-        val account = wallet.getAccount(Chain.referralChain) ?: throw ReferralError.BadWallet
-        val authPayload = getAuthPayload.getAuthPayload(wallet, account.chain)
+        val authPayload = getAuthPayload.getAuthPayload(wallet)
         if (rewards.points < option.points) {
             throw ReferralError.InsufficientPoints
         }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/referral/UseReferralCodeImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/referral/UseReferralCodeImpl.kt
@@ -3,11 +3,7 @@ package com.gemwallet.android.data.coordinators.referral
 import com.gemwallet.android.application.GetAuthPayload
 import com.gemwallet.android.application.referral.coordinators.UseReferralCode
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
-import com.gemwallet.android.domains.referral.values.ReferralError
-import com.gemwallet.android.ext.getAccount
-import com.gemwallet.android.ext.referralChain
 import com.wallet.core.primitives.AuthenticatedRequest
-import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.ReferralCode
 import com.wallet.core.primitives.Wallet
 
@@ -18,8 +14,7 @@ class UseReferralCodeImpl(
 
 
     override suspend fun useReferralCode(code: String, wallet: Wallet): Boolean {
-        val account = wallet.getAccount(Chain.referralChain) ?: throw ReferralError.BadWallet
-        val auth = getAuthPayload.getAuthPayload(wallet, account.chain)
+        val auth = getAuthPayload.getAuthPayload(wallet)
         gemDeviceApiClient.useReferralCode(
             walletId = wallet.id,
             body = AuthenticatedRequest(

--- a/android/data/services/remote-gem/build.gradle.kts
+++ b/android/data/services/remote-gem/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
 
     implementation(libs.ktx.core)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.tink)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/android/data/services/remote-gem/build.gradle.kts
+++ b/android/data/services/remote-gem/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.tink)
 
     testImplementation(libs.junit)
+    testImplementation(testFixtures(project(":gemcore")))
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/DeviceKeyPair.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/DeviceKeyPair.kt
@@ -1,0 +1,52 @@
+package com.gemwallet.android.data.services.gemapi
+
+import com.gemwallet.android.math.fromHex
+import com.gemwallet.android.math.hex
+import com.google.crypto.tink.subtle.Ed25519Sign
+import java.security.GeneralSecurityException
+import java.util.Arrays
+
+class DeviceKeyPair private constructor(
+    private val privateKey: ByteArray,
+    private val publicKey: ByteArray,
+) {
+    val privateKeyHex: String
+        get() = privateKey.hex
+
+    val publicKeyHex: String
+        get() = publicKey.hex
+
+    fun sign(message: ByteArray): String {
+        return Ed25519Sign(privateKey).sign(message).hex
+    }
+
+    companion object {
+        fun generate(): DeviceKeyPair {
+            val keyPair = Ed25519Sign.KeyPair.newKeyPair()
+            return DeviceKeyPair(
+                privateKey = keyPair.privateKey,
+                publicKey = keyPair.publicKey,
+            )
+        }
+
+        fun fromHex(privateKeyHex: String): DeviceKeyPair {
+            val privateKey = try {
+                privateKeyHex.fromHex()
+            } catch (err: IllegalArgumentException) {
+                throw IllegalArgumentException("Invalid device private key", err)
+            }
+            val seed = privateKey.copyOf()
+            return try {
+                DeviceKeyPair(
+                    privateKey = privateKey,
+                    publicKey = Ed25519Sign.KeyPair.newKeyPairFromSeed(seed).publicKey,
+                )
+            } catch (err: GeneralSecurityException) {
+                Arrays.fill(privateKey, 0)
+                throw IllegalArgumentException("Invalid device private key", err)
+            } finally {
+                Arrays.fill(seed, 0)
+            }
+        }
+    }
+}

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSigner.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSigner.kt
@@ -1,12 +1,10 @@
 package com.gemwallet.android.data.services.gemapi.http
 
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
-import com.gemwallet.android.math.fromHex
+import com.gemwallet.android.data.services.gemapi.DeviceKeyPair
 import com.gemwallet.android.math.hex
+import java.security.MessageDigest
 import java.util.Base64
-import wallet.core.jni.Curve
-import wallet.core.jni.Hash
-import wallet.core.jni.PrivateKey
 
 data class DeviceSignature(
     val authorization: String,
@@ -17,37 +15,43 @@ data class DeviceSignature(
 }
 
 class DeviceRequestSigner(
-    private val getDeviceId: GetDeviceId,
+    getDeviceId: GetDeviceId,
 ) {
+    private val deviceKeyPair = DeviceKeyPair.fromHex(getDeviceId.getDeviceKey())
     private var bodyHash: (ByteArray) -> String = { body: ByteArray ->
-        Hash.sha256(body).hex
+        sha256Hex(body)
     }
-    private var signMessage: (String, ByteArray) -> String = { privateKeyHex: String, message: ByteArray ->
-        PrivateKey(privateKeyHex.fromHex()).sign(message, Curve.ED25519).hex
+    private var signMessage: (DeviceKeyPair, ByteArray) -> String = { deviceKeyPair, message ->
+        deviceKeyPair.sign(message)
     }
     private var currentTimeMillis: () -> Long = System::currentTimeMillis
 
     fun sign(method: String, path: String, body: ByteArray? = null, walletId: String = ""): DeviceSignature {
-        val publicKeyHex = getDeviceId.getDeviceId()
         val bodyHash = bodyHash(body ?: ByteArray(0))
         val timestamp = currentTimeMillis().toString()
 
         val message = "${timestamp}.${method}.${path}.${walletId}.${bodyHash}"
-        val signatureHex = signMessage(getDeviceId.getDeviceKey(), message.toByteArray())
+        val signatureHex = signMessage(deviceKeyPair, message.toByteArray())
 
-        val payload = "${publicKeyHex}.${timestamp}.${walletId}.${bodyHash}.${signatureHex}"
+        val payload = "${deviceKeyPair.publicKeyHex}.${timestamp}.${walletId}.${bodyHash}.${signatureHex}"
         val encoded = Base64.getEncoder().encodeToString(payload.toByteArray())
         return DeviceSignature(authorization = "Gem $encoded")
     }
 
     internal constructor(
         getDeviceId: GetDeviceId,
-        bodyHash: (ByteArray) -> String,
-        signMessage: (String, ByteArray) -> String,
-        currentTimeMillis: () -> Long,
+        bodyHash: (ByteArray) -> String = { body -> sha256Hex(body) },
+        signMessage: (DeviceKeyPair, ByteArray) -> String = { deviceKeyPair, message ->
+            deviceKeyPair.sign(message)
+        },
+        currentTimeMillis: () -> Long = System::currentTimeMillis,
     ) : this(getDeviceId) {
         this.bodyHash = bodyHash
         this.signMessage = signMessage
         this.currentTimeMillis = currentTimeMillis
     }
+}
+
+private fun sha256Hex(body: ByteArray): String {
+    return MessageDigest.getInstance("SHA-256").digest(body).hex
 }

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSigner.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSigner.kt
@@ -2,8 +2,7 @@ package com.gemwallet.android.data.services.gemapi.http
 
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
 import com.gemwallet.android.data.services.gemapi.DeviceKeyPair
-import com.gemwallet.android.math.hex
-import java.security.MessageDigest
+import com.gemwallet.android.math.sha256Hex
 import java.util.Base64
 
 data class DeviceSignature(
@@ -19,7 +18,7 @@ class DeviceRequestSigner(
 ) {
     private val deviceKeyPair = DeviceKeyPair.fromHex(getDeviceId.getDeviceKey())
     private var bodyHash: (ByteArray) -> String = { body: ByteArray ->
-        sha256Hex(body)
+        body.sha256Hex()
     }
     private var signMessage: (DeviceKeyPair, ByteArray) -> String = { deviceKeyPair, message ->
         deviceKeyPair.sign(message)
@@ -40,7 +39,7 @@ class DeviceRequestSigner(
 
     internal constructor(
         getDeviceId: GetDeviceId,
-        bodyHash: (ByteArray) -> String = { body -> sha256Hex(body) },
+        bodyHash: (ByteArray) -> String = { body -> body.sha256Hex() },
         signMessage: (DeviceKeyPair, ByteArray) -> String = { deviceKeyPair, message ->
             deviceKeyPair.sign(message)
         },
@@ -50,8 +49,4 @@ class DeviceRequestSigner(
         this.signMessage = signMessage
         this.currentTimeMillis = currentTimeMillis
     }
-}
-
-private fun sha256Hex(body: ByteArray): String {
-    return MessageDigest.getInstance("SHA-256").digest(body).hex
 }

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/DeviceKeyPairFixture.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/DeviceKeyPairFixture.kt
@@ -1,0 +1,8 @@
+package com.gemwallet.android.data.services.gemapi
+
+internal object DeviceKeyPairFixture {
+    val privateKeyHex = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"
+    val publicKeyHex = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+    val deviceAuthMessage = "device-auth".toByteArray()
+    val deviceAuthSignatureHex = "121bb28074b00114a7b267ae8a6292c9ffe56db6254b0c65389fd726dbdeffe95b15e6f48d3a3980f7a983da44a3de24c0771d0d8723cef2ced6d08d343a2101"
+}

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/DeviceKeyPairTest.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/DeviceKeyPairTest.kt
@@ -1,0 +1,42 @@
+package com.gemwallet.android.data.services.gemapi
+
+import com.gemwallet.android.math.fromHex
+import com.google.crypto.tink.subtle.Ed25519Verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class DeviceKeyPairTest {
+
+    @Test
+    fun generateCreatesVerifiableEd25519KeyPair() {
+        val keyPair = DeviceKeyPair.generate()
+        val publicKey = keyPair.publicKeyHex.fromHex()
+
+        val signature = keyPair.sign(DeviceKeyPairFixture.deviceAuthMessage).fromHex()
+
+        Ed25519Verify(publicKey).verify(signature, DeviceKeyPairFixture.deviceAuthMessage)
+        assertEquals(64, keyPair.privateKeyHex.length)
+        assertEquals(64, keyPair.publicKeyHex.length)
+    }
+
+    @Test
+    fun fromHexUsesDecodedEd25519PrivateKey() {
+        val keyPair = DeviceKeyPair.fromHex(DeviceKeyPairFixture.privateKeyHex)
+        val publicKey = DeviceKeyPairFixture.publicKeyHex.fromHex()
+
+        val signatureHex = keyPair.sign(DeviceKeyPairFixture.deviceAuthMessage)
+
+        assertEquals(DeviceKeyPairFixture.privateKeyHex, keyPair.privateKeyHex)
+        assertEquals(DeviceKeyPairFixture.publicKeyHex, keyPair.publicKeyHex)
+        assertEquals(DeviceKeyPairFixture.deviceAuthSignatureHex, signatureHex)
+        Ed25519Verify(publicKey).verify(signatureHex.fromHex(), DeviceKeyPairFixture.deviceAuthMessage)
+    }
+
+    @Test
+    fun fromHexRejectsInvalidPrivateKeyHex() {
+        assertThrows(IllegalArgumentException::class.java) {
+            DeviceKeyPair.fromHex("abcd")
+        }
+    }
+}

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSignerFixture.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSignerFixture.kt
@@ -10,12 +10,12 @@ internal fun mockDeviceRequestSigner(
     currentTimeMillis = currentTimeMillis,
 )
 
-internal fun mockGetDeviceId(): GetDeviceId = FakeGetDeviceId(
+internal fun mockGetDeviceId(): GetDeviceId = MockGetDeviceId(
     deviceId = DeviceKeyPairFixture.publicKeyHex,
     deviceKey = DeviceKeyPairFixture.privateKeyHex,
 )
 
-private class FakeGetDeviceId(
+private class MockGetDeviceId(
     private val deviceId: String,
     private val deviceKey: String,
 ) : GetDeviceId {

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSignerFixture.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSignerFixture.kt
@@ -1,0 +1,25 @@
+package com.gemwallet.android.data.services.gemapi.http
+
+import com.gemwallet.android.application.device.coordinators.GetDeviceId
+import com.gemwallet.android.data.services.gemapi.DeviceKeyPairFixture
+
+internal fun mockDeviceRequestSigner(
+    currentTimeMillis: () -> Long = { 123L },
+): DeviceRequestSigner = DeviceRequestSigner(
+    getDeviceId = mockGetDeviceId(),
+    currentTimeMillis = currentTimeMillis,
+)
+
+internal fun mockGetDeviceId(): GetDeviceId = FakeGetDeviceId(
+    deviceId = DeviceKeyPairFixture.publicKeyHex,
+    deviceKey = DeviceKeyPairFixture.privateKeyHex,
+)
+
+private class FakeGetDeviceId(
+    private val deviceId: String,
+    private val deviceKey: String,
+) : GetDeviceId {
+    override fun getDeviceId(): String = deviceId
+
+    override fun getDeviceKey(): String = deviceKey
+}

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSignerTest.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSignerTest.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.data.services.gemapi.http
 
 import com.gemwallet.android.data.services.gemapi.DeviceKeyPairFixture
+import com.gemwallet.android.testkit.mockMulticoinWalletId
 import java.util.Base64
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -27,7 +28,7 @@ class DeviceRequestSignerTest {
             },
             currentTimeMillis = { 123L },
         )
-        val walletId = "multicoin_0xabc"
+        val walletId = mockMulticoinWalletId().id
         val body = """{"device":"android"}""".toByteArray()
 
         val signature = signer.sign(
@@ -49,7 +50,7 @@ class DeviceRequestSignerTest {
 
     @Test
     fun signUsesEd25519AndSha256() {
-        val walletId = "multicoin_0xabc"
+        val walletId = mockMulticoinWalletId().id
         val signer = mockDeviceRequestSigner()
 
         val signature = signer.sign(

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSignerTest.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRequestSignerTest.kt
@@ -1,6 +1,6 @@
 package com.gemwallet.android.data.services.gemapi.http
 
-import com.gemwallet.android.application.device.coordinators.GetDeviceId
+import com.gemwallet.android.data.services.gemapi.DeviceKeyPairFixture
 import java.util.Base64
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -12,19 +12,16 @@ class DeviceRequestSignerTest {
     @Test
     fun signBuildsExpectedAuthorizationPayload() {
         var hashedBody: ByteArray? = null
-        var signedPrivateKeyHex: String? = null
+        var signedPublicKeyHex: String? = null
         var signedMessage: ByteArray? = null
         val signer = DeviceRequestSigner(
-            getDeviceId = FakeGetDeviceId(
-                deviceId = "publickeyhex",
-                deviceKey = "privatekeyhex",
-            ),
+            getDeviceId = mockGetDeviceId(),
             bodyHash = { body ->
                 hashedBody = body
                 "bodyhash"
             },
-            signMessage = { privateKeyHex, message ->
-                signedPrivateKeyHex = privateKeyHex
+            signMessage = { deviceKeyPair, message ->
+                signedPublicKeyHex = deviceKeyPair.publicKeyHex
                 signedMessage = message
                 "signaturehex"
             },
@@ -44,18 +41,33 @@ class DeviceRequestSignerTest {
 
         val payload = String(Base64.getDecoder().decode(signature.authorization.removePrefix("Gem ")))
 
-        assertEquals("publickeyhex.123.$walletId.bodyhash.signaturehex", payload)
-        assertEquals("privatekeyhex", signedPrivateKeyHex)
+        assertEquals("${DeviceKeyPairFixture.publicKeyHex}.123.$walletId.bodyhash.signaturehex", payload)
+        assertEquals(DeviceKeyPairFixture.publicKeyHex, signedPublicKeyHex)
         assertEquals("123.POST./v2/devices.$walletId.bodyhash", String(signedMessage!!))
         assertArrayEquals(body, hashedBody)
     }
-}
 
-private class FakeGetDeviceId(
-    private val deviceId: String,
-    private val deviceKey: String,
-) : GetDeviceId {
-    override fun getDeviceId(): String = deviceId
+    @Test
+    fun signUsesEd25519AndSha256() {
+        val walletId = "multicoin_0xabc"
+        val signer = mockDeviceRequestSigner()
 
-    override fun getDeviceKey(): String = deviceKey
+        val signature = signer.sign(
+            method = "POST",
+            path = "/v2/devices",
+            body = """{"device":"android"}""".toByteArray(),
+            walletId = walletId,
+        )
+
+        val payload = String(Base64.getDecoder().decode(signature.authorization.removePrefix("Gem ")))
+        val expectedPayload = listOf(
+            DeviceKeyPairFixture.publicKeyHex,
+            "123",
+            walletId,
+            "f7f90abc33e204d8a7f7821efc63eae3f72a0513161b92d61156528860f1d75b",
+            "0435dc3dbeff5d054e09d990ffb10d000d50d7a9e92f98da69ad4d57d4ee503c38aa48d9f0a329be7a564c56e0a58e2de1c9a408c356fe5ff075a997fe2e1b0b",
+        ).joinToString(".")
+
+        assertEquals(expectedPayload, payload)
+    }
 }

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptorTest.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptorTest.kt
@@ -1,6 +1,6 @@
 package com.gemwallet.android.data.services.gemapi.http
 
-import com.gemwallet.android.application.device.coordinators.GetDeviceId
+import com.gemwallet.android.data.services.gemapi.DeviceKeyPairFixture
 import com.wallet.core.primitives.WalletId
 import java.util.Base64
 import java.util.concurrent.TimeUnit
@@ -22,10 +22,7 @@ class SecurityInterceptorTest {
     fun interceptSignsWalletIdFromRequestTagAndBody() {
         var hashedBody: ByteArray? = null
         val signer = DeviceRequestSigner(
-            getDeviceId = FakeSecurityGetDeviceId(
-                deviceId = "publickeyhex",
-                deviceKey = "privatekeyhex",
-            ),
+            getDeviceId = mockGetDeviceId(),
             bodyHash = { body ->
                 hashedBody = body
                 "bodyhash"
@@ -46,7 +43,7 @@ class SecurityInterceptorTest {
         val authorization = signedRequest.header("Authorization")!!
         val payload = String(Base64.getDecoder().decode(authorization.removePrefix("Gem ")))
 
-        assertEquals("publickeyhex.123.multicoin_0xabc.bodyhash.signaturehex", payload)
+        assertEquals("${DeviceKeyPairFixture.publicKeyHex}.123.multicoin_0xabc.bodyhash.signaturehex", payload)
         assertNull(signedRequest.header("x-wallet-id"))
         assertEquals(body, hashedBody!!.toString(Charsets.UTF_8))
     }
@@ -84,13 +81,4 @@ private class FakeChain(
     override fun writeTimeoutMillis(): Int = 0
 
     override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = this
-}
-
-private class FakeSecurityGetDeviceId(
-    private val deviceId: String,
-    private val deviceKey: String,
-) : GetDeviceId {
-    override fun getDeviceId(): String = deviceId
-
-    override fun getDeviceKey(): String = deviceKey
 }

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptorTest.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptorTest.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.data.services.gemapi.http
 
 import com.gemwallet.android.data.services.gemapi.DeviceKeyPairFixture
+import com.gemwallet.android.testkit.mockMulticoinWalletId
 import com.wallet.core.primitives.WalletId
 import java.util.Base64
 import java.util.concurrent.TimeUnit
@@ -30,11 +31,12 @@ class SecurityInterceptorTest {
             signMessage = { _, _ -> "signaturehex" },
             currentTimeMillis = { 123L },
         )
+        val walletId = mockMulticoinWalletId()
         val body = """{"device":"android"}"""
         val request = Request.Builder()
             .url("https://api.gemwallet.com/v2/devices/rewards")
             .post(body.toRequestBody("application/json".toMediaType()))
-            .tag(WalletId::class.java, WalletId("multicoin_0xabc"))
+            .tag(WalletId::class.java, walletId)
             .build()
 
         val chain = FakeChain(request)
@@ -43,7 +45,7 @@ class SecurityInterceptorTest {
         val authorization = signedRequest.header("Authorization")!!
         val payload = String(Base64.getDecoder().decode(authorization.removePrefix("Gem ")))
 
-        assertEquals("${DeviceKeyPairFixture.publicKeyHex}.123.multicoin_0xabc.bodyhash.signaturehex", payload)
+        assertEquals("${DeviceKeyPairFixture.publicKeyHex}.123.${walletId.id}.bodyhash.signaturehex", payload)
         assertNull(signedRequest.header("x-wallet-id"))
         assertEquals(body, hashedBody!!.toString(Charsets.UTF_8))
     }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/GetAuthPayload.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/GetAuthPayload.kt
@@ -1,9 +1,8 @@
 package com.gemwallet.android.application
 
 import com.wallet.core.primitives.AuthPayload
-import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.Wallet
 
 interface GetAuthPayload {
-    suspend fun getAuthPayload(wallet: Wallet, chain: Chain): AuthPayload
+    suspend fun getAuthPayload(wallet: Wallet): AuthPayload
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/math/Hash.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/math/Hash.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.math
+
+import java.security.MessageDigest
+
+fun ByteArray.sha256Hex(): String {
+    return MessageDigest.getInstance("SHA-256").digest(this).hex
+}

--- a/android/gemcore/src/testFixtures/kotlin/com/gemwallet/android/testkit/WalletMock.kt
+++ b/android/gemcore/src/testFixtures/kotlin/com/gemwallet/android/testkit/WalletMock.kt
@@ -8,6 +8,8 @@ import com.wallet.core.primitives.WalletType
 
 fun mockWalletId(id: String = "wallet-1") = WalletId(id)
 
+fun mockMulticoinWalletId(address: String = "0xabc") = mockWalletId("multicoin_$address")
+
 fun mockWallet(
     id: String = "wallet-1",
     name: String = "Wallet",

--- a/core/crates/gem_auth/Cargo.toml
+++ b/core/crates/gem_auth/Cargo.toml
@@ -24,3 +24,4 @@ jsonwebtoken = { workspace = true, optional = true }
 [dev-dependencies]
 alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }
+primitives = { path = "../primitives", features = ["testkit"] }

--- a/core/crates/gem_auth/src/signature.rs
+++ b/core/crates/gem_auth/src/signature.rs
@@ -50,12 +50,7 @@ mod tests {
     use super::*;
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
-    use primitives::{AuthNonce, Chain};
-
-    const TEST_PRIVATE_KEY: [u8; 32] = [
-        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
-        0x1d, 0x1e, 0x1f, 0x20,
-    ];
+    use primitives::{AuthNonce, Chain, testkit::signer_mock::TEST_PRIVATE_KEY};
 
     fn sign_auth_message(auth_message: &AuthMessage, signer: &PrivateKeySigner) -> String {
         let message = serde_json::to_string(auth_message).unwrap();

--- a/core/gemstone/src/auth.rs
+++ b/core/gemstone/src/auth.rs
@@ -1,5 +1,10 @@
+use crate::GemstoneError;
 use gem_auth::create_auth_hash;
-use primitives::{AuthMessage, AuthNonce, Chain};
+use primitives::{AuthMessage, AuthNonce, Chain, hex::encode_with_0x};
+use signer::Signer;
+use zeroize::Zeroizing;
+
+const AUTH_SIGNING_BYTES_LENGTH: usize = 32;
 
 pub type GemAuthNonce = AuthNonce;
 
@@ -16,9 +21,9 @@ pub struct GemAuthMessage {
 }
 
 #[uniffi::export]
-pub fn create_auth_message(chain: Chain, address: &str, auth_nonce: GemAuthNonce) -> GemAuthMessage {
+pub fn create_auth_message(address: &str, auth_nonce: GemAuthNonce) -> GemAuthMessage {
     let auth_message = AuthMessage {
-        chain,
+        chain: Chain::Ethereum,
         address: address.to_string(),
         auth_nonce,
     };
@@ -26,5 +31,55 @@ pub fn create_auth_message(chain: Chain, address: &str, auth_nonce: GemAuthNonce
     GemAuthMessage {
         message: data.message,
         hash: data.hash.to_vec(),
+    }
+}
+
+#[uniffi::export]
+pub fn sign_auth_message_hash(hash: Vec<u8>, private_key: Vec<u8>) -> Result<String, GemstoneError> {
+    let private_key = Zeroizing::new(private_key);
+    if hash.len() != AUTH_SIGNING_BYTES_LENGTH || private_key.len() != AUTH_SIGNING_BYTES_LENGTH {
+        return Err(GemstoneError::from("Invalid auth message signing input"));
+    }
+    let signature = Signer::sign_ethereum_digest(&hash, private_key.as_slice())?;
+    Ok(encode_with_0x(&signature))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, keccak256};
+    use gem_auth::verify_auth_signature;
+    use primitives::testkit::signer_mock::TEST_PRIVATE_KEY;
+    use signer::secp256k1_uncompressed_public_key;
+
+    #[test]
+    fn test_sign_auth_message_hash() {
+        let address = address_from_private_key(&TEST_PRIVATE_KEY);
+        let auth_nonce = AuthNonce {
+            nonce: "test-nonce-123".to_string(),
+            timestamp: 1734100000,
+        };
+        let auth_message = AuthMessage {
+            chain: Chain::Ethereum,
+            address: address.clone(),
+            auth_nonce: auth_nonce.clone(),
+        };
+        let message = create_auth_message(&address, auth_nonce);
+
+        let signature = sign_auth_message_hash(message.hash, TEST_PRIVATE_KEY.to_vec()).unwrap();
+
+        assert!(verify_auth_signature(&auth_message, &signature));
+    }
+
+    #[test]
+    fn test_sign_auth_message_hash_rejects_invalid_input_length() {
+        assert!(sign_auth_message_hash(vec![0; 31], TEST_PRIVATE_KEY.to_vec()).is_err());
+        assert!(sign_auth_message_hash(vec![0; 32], vec![0; 31]).is_err());
+    }
+
+    fn address_from_private_key(private_key: &[u8]) -> String {
+        let public_key = secp256k1_uncompressed_public_key(private_key).unwrap();
+        let hash = keccak256(&public_key[1..]);
+        Address::from_slice(&hash[12..]).to_checksum(None)
     }
 }

--- a/ios/Packages/FeatureServices/AuthService/AuthService.swift
+++ b/ios/Packages/FeatureServices/AuthService/AuthService.swift
@@ -33,15 +33,17 @@ public struct AuthService: AuthServiceable, Sendable {
         let account = try wallet.account(for: chain)
 
         let authNonce = try await apiService.getAuthNonce()
-        let authMessage = Gemstone.createAuthMessage(chain: chain.rawValue, address: account.address, authNonce: authNonce.map())
-        let signature = try await keystore.sign(hash: Data(authMessage.hash), wallet: wallet, chain: chain)
+        let authMessage = Gemstone.createAuthMessage(address: account.address, authNonce: authNonce.map())
+        var privateKey = try await keystore.getPrivateKey(wallet: wallet, chain: chain)
+        defer { privateKey.zeroize() }
+        let signature = try Gemstone.signAuthMessageHash(hash: Data(authMessage.hash), privateKey: privateKey)
 
         return AuthPayload(
             deviceId: deviceId,
             chain: chain,
             address: account.address,
             nonce: authNonce.nonce,
-            signature: signature.hexString.append0x,
+            signature: signature,
         )
     }
 }


### PR DESCRIPTION
- Add `DeviceKeyPair` and remove Wallet Core usage
- remove `chain` from create and sign auth message