### PR TITLE
Refactor Android WC bridge to use session.topic

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/BridgesRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/BridgesRepository.kt
@@ -8,6 +8,7 @@ import com.gemwallet.android.data.service.store.database.ConnectionsDao
 import com.gemwallet.android.data.service.store.database.entities.DbConnection
 import com.gemwallet.android.data.service.store.database.entities.toDTO
 import com.gemwallet.android.data.service.store.database.entities.toRecord
+import com.gemwallet.android.ext.canSign
 import com.gemwallet.android.ext.walletConnectAppName
 import com.gemwallet.android.ext.walletConnectIcon
 import com.reown.android.Core
@@ -32,7 +33,6 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BridgesRepository(
@@ -63,7 +63,7 @@ class BridgesRepository(
         scope.launch(Dispatchers.IO) {
             bridgeEvents.collect { event ->
                 when (val model = event.model) {
-                    is Wallet.Model.Session -> updateSession(model)
+                    is Wallet.Model.SettledSessionResponse.Result -> addConnection(model.session)
                     is Wallet.Model.SessionDelete.Success -> sync()
                     else -> Unit
                 }
@@ -117,27 +117,23 @@ class BridgesRepository(
     }
 
     suspend fun getConnectionByTopic(topic: String): WalletConnection? {
-        val sessions = runCatching { WalletKit.getListOfActiveSessions().filter { wcSession -> wcSession.metaData != null } }
-            .getOrNull() ?: return null // TODO Apply chains to local
-        val localConnections = getConnections().firstOrNull() ?: emptyList()
-        val session = sessions.firstOrNull { it.topic == topic }
-        val sessionChains = session?.namespaces?.values
-            ?.fold(emptyList<String>(), { acc, item -> acc + (item.chains ?: emptyList()) })
-            ?.mapNotNull { Chain.getNamespace(it) }
-            ?: emptyList()
-        return localConnections.firstOrNull { it.session.sessionId == session?.pairingTopic }
-            ?.let { connection ->
-                connection.copy(
-                    session = connection.session.copy(
-                        chains = sessionChains,
-                        metadata = session?.metaData?.toConnectionMetadata()
-                            ?: connection.session.metadata,
-                    )
-                )
-            }
+        val record = connectionsDao.getBySessionId(topic) ?: return null
+        val session = activeSessions().firstOrNull { it.topic == topic } ?: return null
+        val wallet = walletsRepository.getAll().firstOrNull()
+            ?.firstOrNull { it.id.id == record.walletId } ?: return null
+        val connection = record.toDTO(wallet)
+        val chains = session.namespaces.values
+            .flatMap { it.chains ?: emptyList() }
+            .mapNotNull { Chain.getNamespace(it) }
+        return connection.copy(
+            session = connection.session.copy(
+                chains = chains,
+                metadata = session.metaData?.toConnectionMetadata() ?: connection.session.metadata,
+            )
+        )
     }
 
-    suspend fun getConnections(connectionId: String): Flow<WalletConnection?> {
+    fun getConnection(connectionId: String): Flow<WalletConnection?> {
         return walletsRepository.getAll().flatMapLatest { wallets ->
             connectionsDao.getConnection(connectionId).map { room ->
                 val wallet = wallets.firstOrNull { it.id.id == room?.walletId } ?: return@map null
@@ -148,43 +144,35 @@ class BridgesRepository(
 
     private suspend fun sync() {
         val local = getConnections().firstOrNull() ?: emptyList()
-        val sessions = runCatching { WalletKit.getListOfActiveSessions().filter { wcSession -> wcSession.metaData != null } }
-            .getOrNull() ?: return
-
-        val unknownSessions = local.filter { local -> !sessions.any { local.session.sessionId == it.pairingTopic } }
-
+        val sessions = activeSessions()
+        val unknownSessions = local.filter { local -> !sessions.any { local.session.sessionId == it.topic } }
         if (unknownSessions.isNotEmpty()) {
             connectionsDao.deleteAll(unknownSessions.map { it.toRecord() })
         }
     }
 
     private fun handlePendingRequests() {
-        val sessions = runCatching { WalletKit.getListOfActiveSessions().filter { wcSession -> wcSession.metaData != null } }
-            .getOrNull() ?: return
-        for (session in sessions) {
+        for (session in activeSessions()) {
             val request = WalletKit.getPendingListOfSessionRequests(session.topic)
                 .firstOrNull() ?: continue
-
             val verifyContext = WalletKit.getVerifyContext(request.request.id) ?: continue
             WalletConnectDelegate.onSessionRequest(request, verifyContext)
         }
     }
 
     private fun pingActiveSessions() {
-        val sessions = runCatching { WalletKit.getListOfActiveSessions().filter { wcSession -> wcSession.metaData != null } }
-            .getOrNull() ?: return
-
-        for (session in sessions) {
+        for (session in activeSessions()) {
             WalletKit.pingSession(Wallet.Params.Ping(session.topic), null)
         }
     }
 
+    private fun activeSessions(): List<Wallet.Model.Session> =
+        runCatching { WalletKit.getListOfActiveSessions().filter { it.metaData != null } }
+            .getOrDefault(emptyList())
+
     suspend fun disconnect(id: String, onSuccess: () -> Unit = {}, onError: (String) -> Unit = {}) {
         val connection = getConnections().firstOrNull()?.firstOrNull { it.session.id == id } ?: return
-        val activeSession = runCatching {
-            WalletKit.getListOfActiveSessions()
-                .firstOrNull { wcSession -> connection.session.sessionId == wcSession.pairingTopic }
-        }.getOrNull()
+        val activeSession = activeSessions().firstOrNull { it.topic == connection.session.sessionId }
         if (activeSession != null) {
             WalletKit.disconnectSession(
                 params = Wallet.Params.SessionDisconnect(activeSession.topic),
@@ -239,10 +227,7 @@ class BridgesRepository(
         WalletKit.approveSession(
             params = approveProposal,
             onError = { error -> onError(error.throwable.message ?: "Unknown error") },
-            onSuccess = {
-                scope.launch(Dispatchers.IO) { addConnection(wallet, proposal) }
-                onSuccess()
-            }
+            onSuccess = { onSuccess() },
         )
     }
 
@@ -272,7 +257,6 @@ class BridgesRepository(
     }
 
     fun approveAuthentication(
-        wallet: com.wallet.core.primitives.Wallet,
         request: Wallet.Model.SessionAuthenticate,
         auths: List<Wallet.Model.Cacao>,
         onSuccess: () -> Unit,
@@ -283,10 +267,7 @@ class BridgesRepository(
                 id = request.id,
                 auths = auths,
             ),
-            onSuccess = {
-                scope.launch(Dispatchers.IO) { addConnection(wallet, request) }
-                onSuccess()
-            },
+            onSuccess = { onSuccess() },
             onError = { error ->
                 onError(error.throwable.message ?: "Authentication failed")
             },
@@ -317,61 +298,36 @@ class BridgesRepository(
         return WalletKit.getSessionProposals().firstOrNull { it.proposerPublicKey == proposalPublicKey }
     }
 
-    private suspend fun addConnection(wallet: com.wallet.core.primitives.Wallet, proposal: Wallet.Model.SessionProposal) {
-        addConnection(
-            wallet = wallet,
-            sessionId = proposal.pairingTopic,
-            metadata = sessionProposalMetadata(proposal),
-            redirect = proposal.redirect,
-        )
-    }
-
-    private suspend fun addConnection(wallet: com.wallet.core.primitives.Wallet, request: Wallet.Model.SessionAuthenticate) {
-        val metadata = request.participant.metadata
-        addConnection(
-            wallet = wallet,
-            sessionId = request.pairingTopic,
-            metadata = metadata.toConnectionMetadata(),
-            redirect = metadata?.redirect,
-        )
-    }
-
-    private suspend fun addConnection(
-        wallet: com.wallet.core.primitives.Wallet,
-        sessionId: String,
-        metadata: WalletConnectionSessionAppMetadata,
-        redirect: String?,
-    ) {
+    private suspend fun addConnection(session: Wallet.Model.Session) {
+        val wallet = resolveWallet(session) ?: return
         connectionsDao.insert(
             DbConnection(
-                id = UUID.randomUUID().toString(),
+                id = session.topic,
                 walletId = wallet.id.id,
-                sessionId = sessionId,
+                sessionId = session.topic,
                 state = WalletConnectionState.Active,
                 createdAt = System.currentTimeMillis(),
-                expireAt = System.currentTimeMillis() + (30L * 24 * 60 * 60 * 1000),
-                appName = metadata.name,
-                appDescription = metadata.description,
-                appUrl = metadata.url,
-                appIcon = metadata.icon,
-                redirectNative = redirect,
-                redirectUniversal = redirect,
-            )
-        )
-    }
-
-    private suspend fun updateSession(session: Wallet.Model.Session) {
-        val room = connectionsDao.getBySessionId(session.pairingTopic) ?: return
-        connectionsDao.update(
-            room.copy(
                 expireAt = System.currentTimeMillis() + session.expiry,
                 appName = walletConnectAppName(session.metaData?.name, session.metaData?.url),
                 appDescription = session.metaData?.description ?: "",
                 appUrl = session.metaData?.url ?: "",
                 appIcon = session.metaData?.icons.walletConnectIcon(),
                 redirectNative = session.redirect,
+                redirectUniversal = session.redirect,
             )
         )
+    }
+
+    private suspend fun resolveWallet(session: Wallet.Model.Session): com.wallet.core.primitives.Wallet? {
+        val addresses = session.namespaces.values
+            .flatMap { it.accounts }
+            .mapNotNull { it.split(":").getOrNull(2) }
+            .toSet()
+        if (addresses.isEmpty()) return null
+        val wallets = walletsRepository.getAll().firstOrNull() ?: return null
+        return wallets.firstOrNull { wallet ->
+            wallet.type.canSign && wallet.accounts.any { it.address in addresses }
+        }
     }
 
     private fun getSupportedNamespaces(wallet: com.wallet.core.primitives.Wallet): Map<String, Wallet.Model.Namespace.Session> {
@@ -400,13 +356,4 @@ class BridgesRepository(
         icon = this?.icons.walletConnectIcon(),
     )
 
-    private fun sessionProposalMetadata(proposal: Wallet.Model.SessionProposal): WalletConnectionSessionAppMetadata {
-        val icons = proposal.icons.map { it.toString() }
-        return WalletConnectionSessionAppMetadata(
-            name = walletConnectAppName(proposal.name, proposal.url),
-            description = proposal.description,
-            url = proposal.url,
-            icon = icons.walletConnectIcon(),
-        )
-    }
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/BridgesRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/BridgesRepository.kt
@@ -307,7 +307,7 @@ class BridgesRepository(
                 sessionId = session.topic,
                 state = WalletConnectionState.Active,
                 createdAt = System.currentTimeMillis(),
-                expireAt = System.currentTimeMillis() + session.expiry,
+                expireAt = session.expiry * 1000L,
                 appName = walletConnectAppName(session.metaData?.name, session.metaData?.url),
                 appDescription = session.metaData?.description ?: "",
                 appUrl = session.metaData?.url ?: "",

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/ConnectionViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/ConnectionViewModel.kt
@@ -7,8 +7,6 @@ import com.gemwallet.android.data.repositories.bridge.BridgesRepository
 import com.gemwallet.android.ui.models.navigation.RouteArgument
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -22,7 +20,7 @@ class ConnectionViewModel @Inject constructor(
 
     private val connectionId = savedState.requireString(RouteArgument.ConnectionId)
 
-    val connection = flow { emitAll(bridgesRepository.getConnections(connectionId)) }
+    val connection = bridgesRepository.getConnection(connectionId)
         .stateIn(viewModelScope, SharingStarted.Companion.Eagerly, null)
 
     fun disconnect(onSuccess: () -> Unit) {

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCAuthViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCAuthViewModel.kt
@@ -182,7 +182,6 @@ class WCAuthViewModel @Inject constructor(
                     ),
                 )
                 bridgesRepository.approveAuthentication(
-                    wallet = approval.wallet,
                     request = request,
                     auths = listOf(authObject),
                     onSuccess = {


### PR DESCRIPTION
## Summary
WalletKit deprecated `Session.pairingTopic`, and our Android bridge was storing it as the connection's session id — architecturally wrong, since pairing topic and session topic are different concepts in WalletConnect v2. This PR switches storage and lookups to `session.topic`.

Local connections are now persisted only after the session is actually established (on `SettledSessionResponse`), instead of right after user approval based on the pairing topic. The owning wallet is resolved from the session's account addresses, ignoring watch-only wallets.

## Notes
- No DB migration. After upgrade, existing entries will be cleaned up by sync on first launch — users will need to re-pair their dApps once.
- Follow-up: persist chains locally — [#392](https://github.com/gemwalletcom/wallet/issues/392).

Closes #34