### PR TITLE
Match swap "You Receive" search order with iOS

### DIFF
--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
@@ -308,7 +308,7 @@ interface AssetsDao {
             AND assetRank > 0
             AND (symbol LIKE '%' || :query || '%'
             OR name LIKE '%' || :query || '%' COLLATE NOCASE)
-            ORDER BY balanceFiatTotalAmount DESC, assetRank DESC
+            ORDER BY assetRank DESC
         """)
     fun swapSearch(walletId: String, query: String, byChains: List<Chain>, byAssets: List<String>): Flow<List<DbAssetInfo>>
 
@@ -320,7 +320,7 @@ interface AssetsDao {
             (chain IN (:byChains) OR id IN (:byAssets) )
             AND assetRank > 0
             AND assets_priority.`query` = :query
-            ORDER BY balanceFiatTotalAmount DESC, assets_priority.priority ASC, assetRank DESC
+            ORDER BY assets_priority.priority ASC, assetRank DESC
         """)
     fun swapSearchWithPriority(walletId: String, query: String, byChains: List<Chain>, byAssets: List<String>): Flow<List<DbAssetInfo>>
 


### PR DESCRIPTION
When searching for a token to receive in Swap, Android ordered the results
by your balance while iOS ordered them by relevance. This aligns Android
with iOS so the same search returns results in the same order on both apps.

Closes #398
Search
<img width="640" alt="Screenshot 2026-05-29 at 5 03 44 PM" src="https://github.com/user-attachments/assets/b0d05b47-9a39-4856-987d-d10f9e425772" />
Receive
<img width="640" alt="Screenshot 2026-05-29 at 5 03 18 PM" src="https://github.com/user-attachments/assets/956f1a69-d99a-4126-aa03-a52c28a9b395" />
