### PR TITLE
Show pending unstaking with network icon

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stake/StakeRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stake/StakeRepository.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.data.repositories.stake
 import com.gemwallet.android.blockchain.services.StakeService
 import com.gemwallet.android.cases.stake.SyncStakeDelegations
 import com.gemwallet.android.data.service.store.database.StakeDao
+import com.gemwallet.android.domains.asset.SYSTEM_VALIDATOR_ID
 import com.gemwallet.android.data.service.store.database.entities.toDTO
 import com.gemwallet.android.data.service.store.database.entities.toModel
 import com.gemwallet.android.data.service.store.database.entities.toRecord
@@ -30,14 +31,8 @@ class StakeRepository(
     private val recommendedValidators = Config().getValidators()
 
     override suspend fun sync(walletId: WalletId, assetId: AssetId, address: String, apr: Double) = withContext(Dispatchers.IO) {
-        val validators = stakeDao.getValidators(assetId.toIdentifier(), StakeProviderType.Stake).first()
-        if (validators.isEmpty()) {
-            syncValidators(assetId, apr)
-            syncDelegations(walletId, assetId, address)
-        } else {
-            syncDelegations(walletId, assetId, address)
-            syncValidators(assetId, apr)
-        }
+        syncValidators(assetId, apr)
+        syncDelegations(walletId, assetId, address)
     }
 
     fun getRecommendValidators(assetId: AssetId): List<String> {
@@ -98,8 +93,12 @@ class StakeRepository(
         if (deleteIds.isNotEmpty()) {
             stakeDao.deleteDelegations(walletId.id, deleteIds)
         }
-        if (incoming.isNotEmpty()) {
-            stakeDao.upsertDelegations(incoming)
+        val validatorIds = stakeDao.getValidators(assetId.toIdentifier(), StakeProviderType.Stake).first()
+            .map { it.id }
+            .toSet()
+        val upsertable = incoming.filter { validatorIds.contains(it.validatorId) }
+        if (upsertable.isNotEmpty()) {
+            stakeDao.upsertDelegations(upsertable)
         }
     }
 }
@@ -116,6 +115,6 @@ internal fun pickRecommendedValidator(
 
 internal fun selectableValidators(validators: List<DelegationValidator>): List<DelegationValidator> {
     return validators
-        .filter { it.isActive && it.name.isNotEmpty() }
+        .filter { it.isActive && it.name.isNotEmpty() && it.id != SYSTEM_VALIDATOR_ID }
         .sortedByDescending { it.apr }
 }

--- a/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/models/DelegationInfo.kt
+++ b/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/models/DelegationInfo.kt
@@ -1,12 +1,12 @@
 package com.gemwallet.android.features.earn.delegation.models
 
 import androidx.compose.runtime.Stable
+import com.gemwallet.android.domains.asset.getIconUrl
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.ui.models.CryptoFormattedUIModel
 import com.gemwallet.android.ui.models.FiatFormattedUIModel
 import com.wallet.core.primitives.Asset
-import com.gemwallet.android.Constants
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.Delegation
 
@@ -22,7 +22,7 @@ class HeadDelegationInfo(
 ) : DelegationInfoUIModel, CryptoFormattedUIModel, FiatFormattedUIModel {
 
     override val iconUrl: String
-        get() = "${Constants.ASSETS_URL}/blockchains/${delegation.validator.chain.string}/validators/${delegation.validator.id}/logo.png"
+        get() = delegation.validator.getIconUrl()
 
     override val cryptoAmount: Double by lazy {
         Crypto(delegation.base.balance).value(asset.decimals).toDouble()

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/asset/IconUrlGeneration.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/asset/IconUrlGeneration.kt
@@ -10,6 +10,7 @@ import com.wallet.core.primitives.AssetSubtype
 import com.wallet.core.primitives.AssetType
 import com.gemwallet.android.Constants
 import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.DelegationValidator
 import com.wallet.core.primitives.FiatProvider
 import com.wallet.core.primitives.FiatProviderName
 import com.wallet.core.primitives.NFTAsset
@@ -76,6 +77,14 @@ fun Asset.getIconUrl(): String {
 }
 
 fun Asset.getSupportIconUrl(): String? = id.getSupportIconUrl()
+
+const val SYSTEM_VALIDATOR_ID = "system"
+
+fun DelegationValidator.getIconUrl(): String = if (id == SYSTEM_VALIDATOR_ID) {
+    chain.getIconUrl()
+} else {
+    "${Constants.ASSETS_URL}/blockchains/${chain.string}/validators/${id}/logo.png"
+}
 
 fun FiatProviderName.getFiatProviderIcon(): String = "file:///android_asset/fiat/${string}.svg"
 

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/DelegationItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/DelegationItem.kt
@@ -8,8 +8,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import com.gemwallet.android.domains.asset.getIconUrl
 import com.gemwallet.android.model.AssetInfo
-import com.gemwallet.android.Constants
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.image.IconWithBadge
 import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
@@ -38,7 +38,7 @@ fun DelegationItem(
         listPosition = listPosition,
         leading = {
             IconWithBadge(
-                icon = "${Constants.ASSETS_URL}/blockchains/${delegation.validator.chain.string}/validators/${delegation.validator.id}/logo.png",
+                icon = delegation.validator.getIconUrl(),
                 placeholder = delegation.validator.name.firstOrNull()?.toString() ?: delegation.validator.id.firstOrNull()?.toString() ?: "",
             )
         },

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/ValidatorItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/ValidatorItem.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import com.gemwallet.android.Constants
+import com.gemwallet.android.domains.asset.getIconUrl
 import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
 import com.gemwallet.android.domains.percentage.formatAsPercentage
 import com.gemwallet.android.ui.R
@@ -77,10 +77,6 @@ fun DelegationValidator.formatApr(): String {
 
 private val DelegationValidator.placeholder: String
     get() = name.firstOrNull()?.toString() ?: id.firstOrNull()?.toString() ?: "V"
-
-fun DelegationValidator.getIconUrl(): String {
-    return "${Constants.ASSETS_URL}/blockchains/${chain.string}/validators/${id}/logo.png"
-}
 
 fun availableIn(delegation: Delegation?): String {
     val completionDate = ((delegation?.base?.completionDate ?: return "") - System.currentTimeMillis() / 1000) * 1000

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/PropertyValidatorItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/PropertyValidatorItem.kt
@@ -12,9 +12,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.image.IconWithBadge
+import com.gemwallet.android.domains.asset.getIconUrl
 import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.ui.components.list_item.formatApr
-import com.gemwallet.android.ui.components.list_item.getIconUrl
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.theme.paddingMiddle
 import com.wallet.core.primitives.DelegationValidator

--- a/ios/Features/Stake/Sources/ViewModels/ValidatorViewModel.swift
+++ b/ios/Features/Stake/Sources/ViewModels/ValidatorViewModel.swift
@@ -42,7 +42,9 @@ public struct ValidatorViewModel {
     public var imageUrl: URL? {
         switch validator.providerType {
         case .stake:
-            imageFormatter.getValidatorUrl(chain: validator.chain, id: validator.id)
+            validator.id == DelegationValidator.systemId
+                ? imageFormatter.getURL(for: validator.chain.assetId)
+                : imageFormatter.getValidatorUrl(chain: validator.chain, id: validator.id)
         case .earn:
             nil
         }

--- a/ios/Packages/ChainServices/StakeService/StakeService.swift
+++ b/ios/Packages/ChainServices/StakeService/StakeService.swift
@@ -30,14 +30,8 @@ public struct StakeService: StakeServiceable {
     }
 
     public func update(walletId: WalletId, chain: Chain, address: String) async throws {
-        let validators = try store.getValidators(assetId: chain.assetId, providerType: .stake)
-        if validators.isEmpty {
-            try await updateValidators(chain: chain)
-            try await updateDelegations(walletId: walletId, chain: chain, address: address)
-        } else {
-            try await updateDelegations(walletId: walletId, chain: chain, address: address)
-            try await updateValidators(chain: chain)
-        }
+        try await updateValidators(chain: chain)
+        try await updateDelegations(walletId: walletId, chain: chain, address: address)
     }
 
     public func clearDelegations() throws {


### PR DESCRIPTION
- Show pending unstake as an Unstaking delegation using the network icon
- Centralize the validator icon URL; route the system validator to the chain icon
- Android: fix delegation FK crash — sync validators before delegations and skip delegations without a known validator
- Align iOS staking sync with Android (validators first)