### PR TITLE
Remove transaction context menu

### DIFF
--- a/ios/Packages/PrimitivesComponents/Sources/Components/TransactionView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/TransactionView.swift
@@ -22,7 +22,6 @@ public struct TransactionView: View {
             subtitleExtra: model.subtitleExtraTextValue,
             imageStyle: .asset(assetImage: model.assetImage),
         )
-        .explorerContext(model.explorerContext)
     }
 }
 

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
@@ -312,24 +312,6 @@ public struct TransactionViewModel: Sendable {
         }
     }
 
-    public var transactionLink: BlockExplorerLink {
-        explorerService.transactionLink(
-            chain: assetId.chain,
-            provider: transaction.transaction.swapProvider,
-            hash: transaction.transaction.id.hash,
-            recipient: transaction.transaction.to,
-            memo: transaction.transaction.memo,
-        )
-    }
-
-    public var transactionHashCopyValue: CopyValue {
-        .plain(transaction.transaction.id.hash)
-    }
-
-    public var explorerContext: ExplorerContextData {
-        ExplorerContextData(copyValue: transactionHashCopyValue, explorerLink: transactionLink)
-    }
-
     private var addressLink: BlockExplorerLink {
         explorerService.addressUrl(chain: assetId.chain, address: participant)
     }


### PR DESCRIPTION
Removes the long-press copy/explorer context menu from transaction rows.

iOS: drop the `.explorerContext` modifier from `TransactionView` and the now-unused view model properties backing it (`transactionLink`, `transactionHashCopyValue`, `explorerContext`). The shared `explorerContext` modifier stays — still used by Stake/NFT/MarketInsight/Transfer.

Android: no transaction-row context menu exists, so no change needed.

Closes #328