### PR TITLE
Fix network fee values in fee rate selector

### DIFF
--- a/android/features/confirm/viewmodels/src/test/kotlin/com/gemwallet/android/features/confirm/models/FeeRateUIModelTest.kt
+++ b/android/features/confirm/viewmodels/src/test/kotlin/com/gemwallet/android/features/confirm/models/FeeRateUIModelTest.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.domains.confirm
 import com.gemwallet.android.testkit.mockAssetEthereum
 import com.gemwallet.android.testkit.mockAssetInfo
 import com.gemwallet.android.testkit.mockAssetPriceInfo
+import com.gemwallet.android.testkit.mockAssetSolana
 import com.wallet.core.primitives.FeePriority
 import com.wallet.core.primitives.FeeUnitType
 import org.junit.Assert.assertEquals
@@ -37,26 +38,23 @@ class FeeRateUIModelTest {
     }
 
     @Test
-    fun nativeFeeChainShowsCryptoAmountAndFiat() {
-        val assetInfo = mockAssetInfo(asset = mockAssetEthereum())
-            .copy(price = mockAssetPriceInfo(price = 1.0))
+    fun nativeFeeChainScalesCryptoFromSelectedLoadedFee() {
+        val assetInfo = mockAssetInfo(asset = mockAssetSolana())
         val selectedRate = GemFeeRate(
             priority = FeePriority.Normal.string,
-            gasPriceType = GemGasPriceType.Regular(gasPrice = "1"),
+            gasPriceType = GemGasPriceType.Regular(gasPrice = "110"),
         )
-        val model = FeeRateUIModel(
-            feeRate = GemFeeRate(
-                priority = FeePriority.Normal.string,
-                gasPriceType = GemGasPriceType.Regular(gasPrice = "1"),
-            ),
+        fun model(priority: FeePriority, gasPrice: String) = FeeRateUIModel(
+            feeRate = GemFeeRate(priority = priority.string, gasPriceType = GemGasPriceType.Regular(gasPrice = gasPrice)),
             feeAsset = assetInfo,
             feeUnitType = FeeUnitType.Native,
             selectedRate = selectedRate,
-            selectedFeeAmount = BigInteger("1000000000000000000"),
+            selectedFeeAmount = BigInteger("110000"),
         )
 
-        assertEquals("0.000000000000000001 ETH", model.price)
-        assertEquals("$1.00", model.fiatValue)
+        assertEquals("0.0001 SOL", model(FeePriority.Slow, "100").price)
+        assertEquals("0.00011 SOL", model(FeePriority.Normal, "110").price)
+        assertEquals("0.0002 SOL", model(FeePriority.Fast, "200").price)
     }
 
     @Test

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeRateUIModel.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeRateUIModel.kt
@@ -64,7 +64,9 @@ data class FeeRateUIModel(
             .string(feeRate.gasPriceType.totalFee(), decimals, symbol)
     }
 
-    private fun nativeAmountText(): String =
-        ValueFormatter(style = ValueFormatter.Style.Auto)
-            .string(feeRate.gasPriceType.totalFee(), feeAsset.asset.decimals, feeAsset.asset.symbol)
+    private fun nativeAmountText(): String {
+        val amount = feeAmount ?: feeRate.gasPriceType.totalFee()
+        return ValueFormatter(style = ValueFormatter.Style.Auto)
+            .string(amount, feeAsset.asset.decimals, feeAsset.asset.symbol)
+    }
 }

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeSceneViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeSceneViewModel.swift
@@ -68,14 +68,14 @@ public final class NetworkFeeSceneViewModel {
     }
 
     public func valueForRate(_ rate: FeeRateViewModel) -> String {
-        rate.valueText
+        switch chain.feeUnitType {
+        case .native: feeAmount(for: rate.feeRate).map { display(for: $0).amount.text } ?? rate.valueText
+        case .gwei, .satVb: rate.valueText
+        }
     }
 
     public func fiatValueForRate(_ rate: FeeRateViewModel) -> String? {
-        switch chain.feeUnitType {
-        case .native: display(for: rate.feeRate.gasPriceType.totalFee).fiat?.text
-        case .gwei, .satVb: feeAmount(for: rate.feeRate).flatMap { display(for: $0).fiat?.text }
-        }
+        feeAmount(for: rate.feeRate).flatMap { display(for: $0).fiat?.text }
     }
 
     func feeAmount(for rate: FeeRate) -> BigInt? {

--- a/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ViewModels/NetworkFeeSceneViewModelTests.swift
+++ b/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ViewModels/NetworkFeeSceneViewModelTests.swift
@@ -55,6 +55,7 @@ struct NetworkFeeSceneViewModelTests {
         let price = Price(price: 150.0, priceChangePercentage24h: 0, updatedAt: Date())
 
         model.update(rates: [rate], feeAssetPrice: price)
+        model.update(feeAmount: BigInt(5000))
 
         let feeRateVM = try #require(model.feeRatesViewModels.first)
 
@@ -80,6 +81,7 @@ struct NetworkFeeSceneViewModelTests {
         let rate = FeeRate(priority: .normal, gasPriceType: .solana(gasPrice: 5000, priorityFee: 0, unitPrice: 0))
 
         model.update(rates: [rate], feeAssetPrice: nil)
+        model.update(feeAmount: BigInt(5000))
 
         let feeRateVM = try #require(model.feeRatesViewModels.first)
 
@@ -100,6 +102,50 @@ struct NetworkFeeSceneViewModelTests {
         #expect(model.feeAmount(for: rates[0]) == BigInt(500))
         #expect(model.feeAmount(for: rates[1]) == BigInt(1000))
         #expect(model.feeAmount(for: rates[2]) == BigInt(2000))
+    }
+
+    @Test
+    func valueForRateUsesScaledLoadedFeeForNativeChain() throws {
+        let feeAsset = Asset.mockSUI()
+        let model = NetworkFeeSceneViewModel.mock(chain: .sui, feeAsset: feeAsset)
+        model.update(
+            rates: [
+                FeeRate(priority: .slow, gasPriceType: .regular(gasPrice: 100)),
+                FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 110)),
+                FeeRate(priority: .fast, gasPriceType: .regular(gasPrice: 200)),
+            ],
+            feeAssetPrice: nil,
+        )
+        model.update(feeAmount: BigInt(110_000))
+
+        let slowRate = try #require(model.feeRatesViewModels.first { $0.feeRate.priority == .slow })
+        let normalRate = try #require(model.feeRatesViewModels.first { $0.feeRate.priority == .normal })
+        let fastRate = try #require(model.feeRatesViewModels.first { $0.feeRate.priority == .fast })
+
+        #expect(model.valueForRate(slowRate) == feeAsset.feeText(100_000))
+        #expect(model.valueForRate(normalRate) == feeAsset.feeText(110_000))
+        #expect(model.valueForRate(fastRate) == feeAsset.feeText(200_000))
+        #expect(model.valueForRate(normalRate) == model.value)
+        #expect(model.valueForRate(slowRate) != slowRate.valueText)
+    }
+
+    @Test
+    func valueForRateUsesGasPriceRateForNonNativeChains() throws {
+        let ethModel = NetworkFeeSceneViewModel.mock(chain: .ethereum)
+        ethModel.update(rates: [FeeRate(priority: .normal, gasPriceType: .eip1559(gasPrice: 1_000_000_000, priorityFee: 0))], feeAssetPrice: nil)
+        ethModel.update(feeAmount: BigInt(21_000_000_000_000))
+        let ethVM = try #require(ethModel.feeRatesViewModels.first)
+
+        #expect(ethModel.valueForRate(ethVM) == ethVM.valueText)
+        #expect(ethModel.valueForRate(ethVM) != ethModel.value)
+
+        let bitcoinModel = NetworkFeeSceneViewModel.mock(chain: .bitcoin)
+        bitcoinModel.update(rates: [.defaultRate()], feeAssetPrice: nil)
+        bitcoinModel.update(feeAmount: BigInt(10_000))
+        let bitcoinVM = try #require(bitcoinModel.feeRatesViewModels.first)
+
+        #expect(bitcoinModel.valueForRate(bitcoinVM) == bitcoinVM.valueText)
+        #expect(bitcoinModel.valueForRate(bitcoinVM) != bitcoinModel.value)
     }
 
     @Test
@@ -140,22 +186,13 @@ struct NetworkFeeSceneViewModelTests {
             feeAmount: feeAmount,
         )
 
-        let expected = AmountDisplay.numeric(
-            asset: feeAsset,
-            price: nil,
-            value: feeAmount,
-            currency: Currency.usd.rawValue,
-            formatter: .auto,
-        ).amount.text
-        let wrong = AmountDisplay.numeric(
-            asset: .mockHypercore(),
-            price: nil,
-            value: feeAmount,
-            currency: Currency.usd.rawValue,
-            formatter: .auto,
-        ).amount.text
+        #expect(model.value == feeAsset.feeText(feeAmount))
+        #expect(model.value != Asset.mockHypercore().feeText(feeAmount))
+    }
+}
 
-        #expect(model.value == expected)
-        #expect(model.value != wrong)
+private extension Asset {
+    func feeText(_ value: BigInt) -> String {
+        AmountDisplay.numeric(asset: self, price: nil, value: value, currency: Currency.usd.rawValue, formatter: .auto).amount.text
     }
 }


### PR DESCRIPTION
Closes #329

The network fee selector showed a tiny, incorrect value for the Slow/Normal/Fast options on some chains (Sui, Aptos, NEAR) — it displayed the gas price unit instead of the actual fee. Now each option shows the real fee in the native token, matching the total shown at the bottom. Other chains (Solana, Bitcoin, Ethereum) are unaffected. Fixed on both iOS and Android.

<img width="640" alt="Screenshot 2026-06-01 at 2 28 22 PM" src="https://github.com/user-attachments/assets/dbb030a5-63bc-4580-8693-2d5c5e43c618" />
<img width="640" alt="Screenshot 2026-06-01 at 2 29 44 PM" src="https://github.com/user-attachments/assets/e4d36a2d-dfc9-4ba5-b08a-082b0bcc6b42" />
