### PR TITLE
Fix stale fiat prices on Android

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamEventHandler.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamEventHandler.kt
@@ -72,9 +72,7 @@ class StreamEventHandler(
     private suspend fun updateRates(newRates: List<FiatRate>, currency: Currency) {
         pricesDao.setRates(newRates.toRecord())
         newRates.firstOrNull { it.symbol == currency.string }?.let { rate ->
-            pricesDao.getAll().firstOrNull()?.map {
-                it.copy(value = (it.usdValue ?: 0.0) * rate.rate)
-            }?.let { pricesDao.insert(it) }
+            pricesDao.updateValues(currency.string, rate.rate)
         }
     }
 

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/PricesDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/PricesDao.kt
@@ -21,6 +21,9 @@ interface PricesDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun setRates(rates: List<DbFiatRate>)
 
+    @Query("UPDATE prices SET value = usd_value * :rate WHERE currency = :currency")
+    suspend fun updateValues(currency: String, rate: Double)
+
     @Query("SELECT * FROM prices")
     fun getAll(): Flow<List<DbPrice>>
 


### PR DESCRIPTION
**Problem**
On the wallet overview, fiat prices sometimes got stuck on old values — even though opening a coin's details page showed the correct, up-to-date price. Because the wrong price was used, swap price impact was off too.

**Why it happened**
Prices arrive constantly and in parallel from the live price stream. Every time the currency rate updated, the app reloaded the whole saved price table, recalculated every value, and wrote it all back. If two price updates ran at the same time, one could overwrite the freshly received prices with older data — so the list stayed stuck on stale values.

**What was done**
Instead of reloading and rewriting all prices at once, the app now updates the stored values directly in a single database step. Parallel updates can no longer overwrite each other, so prices on the overview stay correct.