### PR TITLE
Consolidate missing output token on swap screen

### DIFF
--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/components/SwapItem.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/components/SwapItem.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -23,7 +22,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
@@ -32,7 +30,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import com.gemwallet.android.domains.asset.availableBalance
-import com.gemwallet.android.domains.asset.availableBalanceFormatted
+import com.gemwallet.android.domains.asset.availableBalanceAmount
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.clickable
@@ -59,38 +57,43 @@ internal fun SwapItem(
     state: TextFieldState = rememberTextFieldState(),
     onAssetSelect: () -> Unit,
 ) {
-    Column(
+    Row(
         modifier = Modifier
             .listItem(ListPosition.Single)
             .padding(horizontal = paddingDefault, vertical = paddingMiddle)
-            .fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(space2)
+            .fillMaxWidth()
+            .heightIn(min = listItemIconSize),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(paddingSmall),
     ) {
-        Row(
-            modifier = Modifier
-                .heightIn(min = listItemIconSize)
-                .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(space2),
         ) {
             SwapItemInput(
                 calculating = calculating,
                 interaction = interaction,
                 state = state,
+                assetSelected = item != null,
             )
+            SwapEquivalent(calculating = calculating, equivalent = equivalent)
+        }
+        Column(
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.spacedBy(space2),
+        ) {
             SwapItemLotInfo(
                 asset = item?.asset,
                 enabled = interaction.isAssetSelectable,
                 onClick = onAssetSelect,
             )
-        }
-        SwapValues(
-            calculating = calculating,
-            equivalent = equivalent,
-            balance = item?.availableBalanceFormatted,
-            interaction = interaction,
-        ) {
-            state.clearText()
-            state.setTextAndPlaceCursorAtEnd(item?.availableBalance.orEmpty())
+            SwapBalance(
+                balance = item?.availableBalanceAmount,
+                interaction = interaction,
+            ) {
+                state.clearText()
+                state.setTextAndPlaceCursorAtEnd(item?.availableBalance.orEmpty())
+            }
         }
     }
 }
@@ -120,7 +123,7 @@ private fun SelectAssetInfo(enabled: Boolean, onClick: () -> Unit) {
     ) {
         Text(
             text = stringResource(R.string.assets_select_asset),
-            style = MaterialTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.titleMedium,
         )
         AssetPickerChevron()
     }
@@ -158,47 +161,45 @@ private fun AssetPickerChevron() {
 }
 
 @Composable
-private fun SwapValues(
-    calculating: Boolean,
-    equivalent: String,
+private fun SwapEquivalent(calculating: Boolean, equivalent: String) {
+    Text(
+        modifier = Modifier.smallPadding(),
+        text = if (calculating) "" else equivalent,
+        minLines = 1,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        style = MaterialTheme.typography.bodySmall,
+    )
+}
+
+@Composable
+private fun SwapBalance(
     balance: String?,
     interaction: SwapItemInteraction,
     onBalanceClick: () -> Unit,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(paddingSmall)
-    ) {
-        Text(
-            modifier = Modifier.fillMaxWidth(0.5f),
-            text = if (calculating) "" else equivalent,
-            style = MaterialTheme.typography.bodySmall,
-        )
-        Box(modifier = Modifier.fillMaxWidth(1f)) {
-            Text(
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .clickable(
-                        enabled = interaction.isBalanceActionEnabled,
-                        shape = MaterialTheme.shapes.small,
-                        onClick = onBalanceClick,
-                    )
-                    .smallPadding(),
-                text = balance?.let { stringResource(id = R.string.transfer_balance, it) } ?: "",
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                textAlign = TextAlign.End,
-                style = MaterialTheme.typography.bodySmall,
+    if (balance == null) return
+    Text(
+        modifier = Modifier
+            .clickable(
+                enabled = interaction.isBalanceActionEnabled,
+                shape = MaterialTheme.shapes.small,
+                onClick = onBalanceClick,
             )
-        }
-    }
+            .smallPadding(),
+        text = stringResource(id = R.string.transfer_balance, balance),
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.End,
+        style = MaterialTheme.typography.bodySmall,
+    )
 }
 
 @Composable
-private fun RowScope.SwapItemInput(
+private fun SwapItemInput(
     calculating: Boolean,
     interaction: SwapItemInteraction,
+    assetSelected: Boolean,
     state: TextFieldState = rememberTextFieldState(),
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -207,15 +208,17 @@ private fun RowScope.SwapItemInput(
         color = MaterialTheme.colorScheme.onSurface
     )
 
-    LaunchedEffect(Unit) {
-        if (interaction.isAmountEditable) {
+    LaunchedEffect(assetSelected) {
+        if (interaction.isAmountEditable && assetSelected) {
             focusRequester.requestFocus()
         }
     }
     Box(
         modifier = Modifier
-            .weight(1f)
             .fillMaxWidth()
+            .smallPadding()
+            .heightIn(min = listItemIconSize),
+        contentAlignment = Alignment.CenterStart,
     ) {
         if (calculating) {
             CircularProgressIndicator16()
@@ -231,7 +234,7 @@ private fun RowScope.SwapItemInput(
                     keyboardType = KeyboardType.Decimal
                 ),
                 decorator = { innerTextField ->
-                    if (state.text.isEmpty()) {
+                    if (assetSelected && state.text.isEmpty()) {
                         Text(
                             text = "0",
                             style = amountTextStyle,

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/asset/AssetInfoExt.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/asset/AssetInfoExt.kt
@@ -40,6 +40,10 @@ val AssetInfo.availableBalanceFormatted: String // TODO: Out to BalanceExt
     get() = ValueFormatter(style = ValueFormatter.Style.Auto)
         .string(balance.balance.available.toBigInteger(), balance.asset)
 
+val AssetInfo.availableBalanceAmount: String
+    get() = ValueFormatter(style = ValueFormatter.Style.Auto)
+        .string(balance.balance.available.toBigInteger(), decimals = asset.decimals)
+
 
 fun AssetInfo.calculateFiat(rawInput: String): BigDecimal {
     val value = Crypto(rawInput.toBigIntegerOrNull() ?: BigInteger.ZERO)

--- a/ios/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
+++ b/ios/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
@@ -170,7 +170,7 @@ public final class SwapSceneViewModel {
         }
         guard let assetData: AssetData = type == .pay ? fromAsset : toAsset else {
             return SwapTokenViewModel(
-                type: .placeholder(currencyCode: preferences.currency),
+                type: .placeholder,
                 interaction: interaction,
             )
         }

--- a/ios/Features/Swap/Sources/ViewModels/SwapTokenViewModel.swift
+++ b/ios/Features/Swap/Sources/ViewModels/SwapTokenViewModel.swift
@@ -9,7 +9,7 @@ import PrimitivesComponents
 
 enum SwapTokenViewType {
     case selected(AssetDataViewModel)
-    case placeholder(currencyCode: String)
+    case placeholder
 }
 
 struct SwapTokenInteraction {
@@ -68,19 +68,27 @@ struct SwapTokenViewModel {
         }
     }
 
-    func fiatBalance(amount: String) -> String {
+    var amountPlaceholder: String {
+        switch type {
+        case .selected: .zero
+        case .placeholder: .empty
+        }
+    }
+
+    func fiatBalance(amount: String) -> String? {
         switch type {
         case let .selected(model):
             guard
                 let value = try? formatter.inputNumber(from: amount, decimals: model.asset.decimals.asInt),
                 let amount = try? formatter.double(from: value, decimals: model.asset.decimals.asInt),
+                amount > 0,
                 let price = model.priceViewModel.price
             else {
-                return .empty
+                return nil
             }
             return model.priceViewModel.fiatAmountText(amount: price.price * amount)
-        case let .placeholder(currencyCode):
-            return CurrencyFormatter(currencyCode: currencyCode).string(.zero)
+        case .placeholder:
+            return nil
         }
     }
 }

--- a/ios/Features/Swap/Sources/Views/SwapTokenView.swift
+++ b/ios/Features/Swap/Sources/Views/SwapTokenView.swift
@@ -31,7 +31,7 @@ struct SwapTokenView: View {
             if showLoading {
                 LoadingView()
             }
-            TextField(showLoading ? "" : String.zero, text: $text)
+            TextField(showLoading ? "" : model.amountPlaceholder, text: $text)
                 .keyboardType(.decimalPad)
                 .foregroundStyle(Colors.black)
                 .font(.app.title1)
@@ -41,8 +41,8 @@ struct SwapTokenView: View {
     }
 
     private var fiatBalanceView: some View {
-        Text(model.fiatBalance(amount: text))
-            .lineLimit(1)
+        Text(model.fiatBalance(amount: text) ?? "")
+            .lineLimit(1, reservesSpace: true)
             .font(.app.callout)
             .foregroundStyle(Colors.secondaryText)
     }


### PR DESCRIPTION
Closes #455

Fixes the missing output token state on the swap screen:
- selector aligned and cards equal height
- no fiat / ticker when there is nothing to show
- consistent "Select Asset" style across iOS and Android

<img width="640" alt="Screenshot 2026-06-05 at 11 47 18 AM" src="https://github.com/user-attachments/assets/9ea9b9f3-0f56-4441-a66c-077f1a134313" />
<img width="640" alt="Screenshot 2026-06-05 at 11 48 07 AM" src="https://github.com/user-attachments/assets/3101ec2b-2dbd-46f8-8ff2-91b5c2268833" />
<img width="640" alt="Screenshot 2026-06-05 at 11 49 14 AM" src="https://github.com/user-attachments/assets/f10eb95a-6042-436e-9dfc-ddd1e7f6b670" />

