### PR TITLE
Add Android reproducible build tooling

### DIFF
--- a/.github/workflows/android-reproducible.yml
+++ b/.github/workflows/android-reproducible.yml
@@ -1,0 +1,75 @@
+name: Android Reproducible Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      variant:
+        description: Release APK variant to verify
+        required: true
+        default: universal
+        type: choice
+        options:
+          - fdroid
+          - universal
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "android/app/build.gradle.kts"
+      - "android/app/proguard-rules.pro"
+      - "android/fdroid-build/**"
+      - "android/reproducible/**"
+      - "android/gradle/**"
+      - "shell.nix"
+      - ".github/workflows/android-reproducible.yml"
+  push:
+    paths:
+      - "android/app/build.gradle.kts"
+      - "android/app/proguard-rules.pro"
+      - "android/fdroid-build/**"
+      - "android/reproducible/**"
+      - "android/gradle/**"
+      - "shell.nix"
+      - ".github/workflows/android-reproducible.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  verify:
+    name: Verify ${{ github.event.inputs.variant || 'universal' }} APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      GPR_USERNAME: ${{ github.actor }}
+      GPR_TOKEN: ${{ github.token }}
+      REPRO_VARIANT: ${{ github.event.inputs.variant || 'universal' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Verify reproducible APK
+        run: |
+          nix-shell shell.nix --run \
+            "android/reproducible/verify.sh --source . --variant $REPRO_VARIANT --work-dir $RUNNER_TEMP/gem-repro --keep"
+
+      - name: Upload verifier artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-reproducible-${{ env.REPRO_VARIANT }}
+          path: |
+            ${{ runner.temp }}/gem-repro/build-one/*.apk
+            ${{ runner.temp }}/gem-repro/build-two/*.apk
+            ${{ runner.temp }}/gem-repro/build-one/build.log
+            ${{ runner.temp }}/gem-repro/build-two/build.log
+            ${{ runner.temp }}/gem-repro/build-one/*mapping*.txt
+            ${{ runner.temp }}/gem-repro/build-two/*mapping*.txt
+            ${{ runner.temp }}/gem-repro/build-one/*configuration*.txt
+            ${{ runner.temp }}/gem-repro/build-two/*configuration*.txt
+            ${{ runner.temp }}/gem-repro/*.html

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ core/.env
 core/.vscode/
 core/gemstone/src/.build/
 *.code-workspace
+.gradle-reproducible/
+.cargo-reproducible/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Gem Wallet is an open-source mobile wallet for iOS and Android. This repository 
 
 🤖 [Android on Google Play](https://play.google.com/store/apps/details?id=com.gemwallet.android&utm_campaign=github&utm_source=referral&utm_medium=github)
 
+🔁 [Android reproducible builds](docs/android-reproducible-builds.md)
+
 ## Features
 
 - Open source, self-custodial wallet with multi-chain support

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,10 @@ plugins {
     id("kotlinx-serialization")
     id("com.google.devtools.ksp")
     id("androidx.room")
-    id("com.google.gms.google-services")
+}
+
+if (System.getenv("FDROID_BUILD") != "true") {
+    apply(plugin = "com.google.gms.google-services")
 }
 
 repositories {
@@ -57,6 +60,10 @@ android {
 
         create("fdroid") {
             dimension = channelDimension
+            ndk {
+                abiFilters.add("armeabi-v7a")
+                abiFilters.add("arm64-v8a")
+            }
             buildConfigField("String", "UPDATE_URL", "\"\"")
         }
         create("huawei") {
@@ -138,7 +145,17 @@ android {
         }
 
         getByName("release") {
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            val reproducibleBuild = System.getenv("ANDROID_REPRODUCIBLE_BUILD") == "true"
+            val releaseProguardFiles = mutableListOf<Any>(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+            if (reproducibleBuild) {
+                releaseProguardFiles.add("proguard-reproducible-rules.pro")
+            } else if (System.getenv("FDROID_BUILD") != "true") {
+                releaseProguardFiles.add("proguard-stacktrace-rules.pro")
+            }
+            proguardFiles(*releaseProguardFiles.toTypedArray())
             isMinifyEnabled = true
             isShrinkResources = true
             isDebuggable = false

--- a/android/app/proguard-reproducible-rules.pro
+++ b/android/app/proguard-reproducible-rules.pro
@@ -1,0 +1,1 @@
+-dontoptimize

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -12,8 +12,9 @@
 #   public *;
 #}
 
-# Preserve stack traces and fix R8 non-deterministic map-id for reproducible builds.
--keepattributes SourceFile,LineNumberTable
+# Keep SourceFile stable for stack traces and avoid R8 path-derived SourceFile names.
+# Store releases add LineNumberTable in proguard-stacktrace-rules.pro.
+-keepattributes SourceFile
 -renamesourcefileattribute SourceFile
 
 -verbose

--- a/android/app/proguard-stacktrace-rules.pro
+++ b/android/app/proguard-stacktrace-rules.pro
@@ -1,0 +1,6 @@
+# Preserve source line numbers for store releases.
+#
+# Reproducible/F-Droid builds intentionally skip LineNumberTable because R8 9.2.14
+# produced non-deterministic outline and residual-signature position metadata across
+# two clean Linux builds.
+-keepattributes LineNumberTable

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -3,7 +3,9 @@ buildscript {
         gradlePluginPortal()
         google()
         mavenCentral()
-        mavenLocal()
+        if (System.getenv("FDROID_BUILD") != "true") {
+            mavenLocal()
+        }
     }
     dependencies {
         classpath(libs.gradle)
@@ -33,7 +35,9 @@ allprojects {
         }
         google()
         mavenCentral()
-        mavenLocal()
+        if (System.getenv("FDROID_BUILD") != "true") {
+            mavenLocal()
+        }
         maven { url = uri("https://jitpack.io") }
     }
 

--- a/android/fdroid-build/cargo-config.toml.template
+++ b/android/fdroid-build/cargo-config.toml.template
@@ -1,0 +1,7 @@
+[target.aarch64-linux-android]
+ar = "{NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
+linker = "{NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang"
+
+[target.armv7-linux-androideabi]
+ar = "{NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
+linker = "{NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi28-clang"

--- a/android/fdroid-build/env.sh
+++ b/android/fdroid-build/env.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$HOME/.cargo/env"
+
+export FDROID_BUILD=true
+export ANDROID_REPRODUCIBLE_BUILD=true
+export SKIP_SIGN=true
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+export NDK_TOOLCHAIN_DIR="$NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin"
+
+export AR_aarch64_linux_android="$NDK_TOOLCHAIN_DIR/llvm-ar"
+export AR_armv7_linux_androideabi="$NDK_TOOLCHAIN_DIR/llvm-ar"
+
+export CC_aarch64_linux_android="$NDK_TOOLCHAIN_DIR/aarch64-linux-android28-clang"
+export CC_armv7_linux_androideabi="$NDK_TOOLCHAIN_DIR/armv7a-linux-androideabi28-clang"
+
+export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$CC_aarch64_linux_android"
+export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$CC_armv7_linux_androideabi"
+export GEMSTONE_ANDROID_ABIS="arm64-v8a,armeabi-v7a"
+
+export RUSTFLAGS="${RUSTFLAGS:-} --remap-path-prefix=$repo_root=. --remap-path-prefix=$HOME=FDROID_HOME"

--- a/android/fdroid-build/init.sh
+++ b/android/fdroid-build/init.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+curl -sfL https://sh.rustup.rs -o /tmp/rustup.sh
+chmod +x /tmp/rustup.sh
+/tmp/rustup.sh -y --profile minimal --default-toolchain 1.91.0
+
+# shellcheck source=/dev/null
+source "$HOME/.cargo/env"
+rustup target add \
+  aarch64-linux-android \
+  armv7-linux-androideabi
+
+cargo install --locked cargo-ndk@4.1.2
+mkdir -p "$HOME/.cargo"
+sed -e "s|{NDK_PATH}|$NDK_PATH|g" "$script_dir/cargo-config.toml.template" > "$HOME/.cargo/config.toml"

--- a/android/fdroid-build/metadata/com.gemwallet.android.yml
+++ b/android/fdroid-build/metadata/com.gemwallet.android.yml
@@ -1,0 +1,32 @@
+Categories:
+  - Money
+License: GPL-3.0-only
+WebSite: https://gemwallet.com
+SourceCode: https://github.com/gemwalletcom/wallet
+IssueTracker: https://github.com/gemwalletcom/wallet/issues
+
+AutoName: Gem Wallet
+
+RepoType: git
+Repo: https://github.com/gemwalletcom/wallet.git
+
+Builds:
+  - versionName: '2.80'
+    versionCode: 779
+    commit: '2.80'
+    timeout: 10800
+    subdir: android
+    submodules: true
+    init: NDK_PATH="$$NDK$$" fdroid-build/init.sh
+    output: app/build/outputs/apk/fdroid/release/app-fdroid-release-unsigned.apk
+    build:
+      - NDK_PATH="$$NDK$$" source fdroid-build/env.sh
+      - touch local.properties
+      - ./gradlew --no-daemon --console plain --no-configuration-cache :app:assembleFdroidRelease
+    ndk: 28.1.13356709
+    binary: https://github.com/gemwalletcom/wallet/releases/download/%v/gem_wallet_fdroid_%v.apk
+
+AutoUpdateMode: Version
+UpdateCheckMode: Tags ^[0-9]+\.[0-9]+$
+CurrentVersion: '2.80'
+CurrentVersionCode: 779

--- a/android/gemstone/build.gradle.kts
+++ b/android/gemstone/build.gradle.kts
@@ -10,6 +10,16 @@ val rustSrcDir = gemstoneRoot.resolve("src")
 val cratesDir = rootProject.projectDir.resolve("../core/crates")
 val jniLibsDir = gemstoneSrc.resolve("main/jniLibs")
 val generatedKotlinDir = gemstoneSrc.resolve("main/java")
+val defaultCargoNdkAbis = if (System.getenv("UNIT_TESTS") == "true") {
+    "x86_64"
+} else {
+    "arm64-v8a,armeabi-v7a"
+}
+val cargoNdkTargets = (System.getenv("GEMSTONE_ANDROID_ABIS") ?: defaultCargoNdkAbis)
+    .split(",")
+    .map { it.trim() }
+    .filter { it.isNotEmpty() }
+    .joinToString(" ") { "-t $it" }
 
 android {
     namespace = "com.gemwallet.gemstone"
@@ -76,7 +86,7 @@ val buildCargoNdk = tasks.register<Exec>("buildCargoNdk") {
     inputs.dir(cratesDir)
     inputs.file(gemstoneRoot.resolve("Cargo.toml"))
     outputs.dir(jniLibsDir)
-    commandLine("/bin/sh", "-l", "-c", "cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -o ${jniLibsDir.absolutePath} build --lib")
+    commandLine("/bin/sh", "-l", "-c", "cargo ndk $cargoNdkTargets -o ${jniLibsDir.absolutePath} build --lib")
 }
 
 tasks.configureEach {

--- a/android/reproducible/README.md
+++ b/android/reproducible/README.md
@@ -1,3 +1,36 @@
 # Reproducible Builds
 
-The previous Docker-based reproducible build tooling has been removed. A [Nix](https://nixos.org/)-based replacement build environment is being evaluated; this directory is a placeholder until that work lands.
+Gem Wallet Android reproducible builds use the root `shell.nix` and Linux
+x86_64 as the canonical environment.
+
+Run the default direct APK reproducibility check:
+
+```bash
+nix-shell shell.nix --run "android/reproducible/verify.sh --source ."
+```
+
+Run the F-Droid reproducibility check:
+
+```bash
+nix-shell shell.nix --run "android/reproducible/verify.sh --source . --variant fdroid"
+```
+
+On macOS, use Nix for smoke/debug builds:
+
+```bash
+nix-shell shell.nix --run "android/reproducible/build-apk.sh --output /tmp/gem-universal.apk"
+nix-shell shell.nix --run "android/reproducible/build-apk.sh --variant fdroid --output /tmp/gem-fdroid.apk"
+```
+
+The two-build byte comparison is Linux-only release evidence. A macOS two-build
+run can still be useful for debugging, but it is not expected to be the
+authoritative reproducibility result.
+
+Run the direct APK check explicitly:
+
+```bash
+nix-shell shell.nix --run "android/reproducible/verify.sh --source . --variant universal"
+```
+
+See [`docs/android-reproducible-builds.md`](../../docs/android-reproducible-builds.md)
+for the full design, R8 policy, Linux signing flow, and F-Droid setup.

--- a/android/reproducible/build-apk.sh
+++ b/android/reproducible/build-apk.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: android/reproducible/build-apk.sh --variant <fdroid|universal> [--output <apk>]
+
+Builds an unsigned release APK in the current checkout. Run from the repository
+root inside shell.nix.
+USAGE
+}
+
+variant="universal"
+output=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --variant)
+      variant="${2:?Missing value for --variant}"
+      shift 2
+      ;;
+    --output)
+      output="${2:?Missing value for --output}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$variant" in
+  fdroid)
+    task=":app:assembleFdroidRelease"
+    apk_dir="android/app/build/outputs/apk/fdroid/release"
+    export FDROID_BUILD=true
+    ;;
+  universal)
+    task=":app:assembleUniversalRelease"
+    apk_dir="android/app/build/outputs/apk/universal/release"
+    ;;
+  *)
+    echo "Unsupported variant: $variant" >&2
+    exit 2
+    ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+repo_root_physical="$(cd "$repo_root" && pwd -P)"
+cd "$repo_root"
+
+export SKIP_SIGN=true
+export ANDROID_REPRODUCIBLE_BUILD=true
+export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log -1 --pretty=%ct 2>/dev/null || echo 0)}"
+export GRADLE_USER_HOME="${GRADLE_USER_HOME:-$repo_root/.gradle-reproducible}"
+export CARGO_HOME="${GEM_REPRO_CARGO_HOME:-$repo_root/.cargo-reproducible}"
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+export GEMSTONE_ANDROID_ABIS="${GEMSTONE_ANDROID_ABIS:-arm64-v8a,armeabi-v7a}"
+mkdir -p "$GRADLE_USER_HOME" "$CARGO_HOME"
+unset RUSTC_WRAPPER
+unset RUSTC_WORKSPACE_WRAPPER
+unset CARGO_BUILD_RUSTC_WRAPPER
+
+append_rustflag() {
+  case " ${RUSTFLAGS:-} " in
+    *" $1 "*) ;;
+    *) export RUSTFLAGS="${RUSTFLAGS:-} $1" ;;
+  esac
+}
+
+append_path_remap() {
+  local from="$1"
+  local to="$2"
+  [ -n "$from" ] || return 0
+
+  append_rustflag "--remap-path-prefix=$from=$to"
+  if [ -e "$from" ]; then
+    local physical
+    physical="$(cd "$from" && pwd -P)"
+    if [ "$physical" != "$from" ]; then
+      append_rustflag "--remap-path-prefix=$physical=$to"
+    fi
+  fi
+}
+
+append_path_remap "$repo_root" "."
+append_path_remap "$repo_root_physical" "."
+append_path_remap "$CARGO_HOME" "CARGO_HOME"
+append_path_remap "${ANDROID_HOME:-}" "ANDROID_HOME"
+append_path_remap "${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-}}" "ANDROID_NDK_HOME"
+
+touch android/local.properties
+
+(
+  cd android
+  gradle_arguments=(
+    clean "$task"
+    --no-configuration-cache
+    --no-daemon
+    --console plain
+  )
+  if [ -n "${JAVA_HOME:-}" ]; then
+    gradle_arguments=(
+      "-Dorg.gradle.java.home=$JAVA_HOME"
+      "-Dorg.gradle.java.installations.paths=$JAVA_HOME"
+      "-Dorg.gradle.java.installations.auto-detect=false"
+      "-Dorg.gradle.java.installations.auto-download=false"
+      "${gradle_arguments[@]}"
+    )
+  fi
+  ./gradlew "${gradle_arguments[@]}"
+)
+
+apk_path="$(find "$apk_dir" -maxdepth 1 -type f -name '*.apk' | sort | head -n 1)"
+if [ -z "$apk_path" ]; then
+  echo "No APK produced in $apk_dir" >&2
+  exit 1
+fi
+
+if unzip -p "$apk_path" 'classes*.dex' 2>/dev/null | strings | grep -Fq 'r8-map-id-'; then
+  echo "R8 map id leaked into DEX SourceFile attributes: $apk_path" >&2
+  exit 1
+fi
+
+if [ -n "$output" ]; then
+  mkdir -p "$(dirname "$output")"
+  cp "$apk_path" "$output"
+  apk_path="$output"
+fi
+
+echo "$apk_path"

--- a/android/reproducible/sign-apk.sh
+++ b/android/reproducible/sign-apk.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  android/reproducible/sign-apk.sh --unsigned <apk> --out <apk> --ks <keystore> --ks-key-alias <alias>
+
+Signs an already-built unsigned APK. Run inside shell.nix so zipalign and
+apksigner come from the pinned Android build-tools.
+USAGE
+}
+
+unsigned_apk=""
+output_apk=""
+keystore=""
+alias=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --unsigned)
+      unsigned_apk="${2:?Missing value for --unsigned}"
+      shift 2
+      ;;
+    --out)
+      output_apk="${2:?Missing value for --out}"
+      shift 2
+      ;;
+    --ks)
+      keystore="${2:?Missing value for --ks}"
+      shift 2
+      ;;
+    --ks-key-alias)
+      alias="${2:?Missing value for --ks-key-alias}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[ -n "$unsigned_apk" ] || { usage >&2; exit 2; }
+[ -n "$output_apk" ] || { usage >&2; exit 2; }
+[ -n "$keystore" ] || { usage >&2; exit 2; }
+[ -n "$alias" ] || { usage >&2; exit 2; }
+[ -n "${ANDROID_KEYSTORE_PASSWORD:-}" ] || { echo "ANDROID_KEYSTORE_PASSWORD is required" >&2; exit 1; }
+
+build_tools="${GEM_ANDROID_SIGNING_BUILD_TOOLS:-${ANDROID_HOME:-}/build-tools/34.0.0}"
+zipalign="$build_tools/zipalign"
+apksigner="$build_tools/apksigner"
+
+[ -x "$zipalign" ] || { echo "zipalign not found: $zipalign" >&2; exit 1; }
+[ -x "$apksigner" ] || { echo "apksigner not found: $apksigner" >&2; exit 1; }
+
+aligned_apk="$(mktemp "${TMPDIR:-/tmp}/gem-aligned.XXXXXX.apk")"
+trap 'rm -f "$aligned_apk"' EXIT
+
+"$zipalign" -p -f 4 "$unsigned_apk" "$aligned_apk"
+"$apksigner" sign \
+  --ks "$keystore" \
+  --ks-key-alias "$alias" \
+  --ks-pass env:ANDROID_KEYSTORE_PASSWORD \
+  --key-pass env:ANDROID_KEYSTORE_PASSWORD \
+  --v1-signing-enabled true \
+  --v2-signing-enabled true \
+  --v3-signing-enabled false \
+  --v4-signing-enabled false \
+  --out "$output_apk" \
+  "$aligned_apk"
+"$apksigner" verify --verbose "$output_apk"

--- a/android/reproducible/verify.sh
+++ b/android/reproducible/verify.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  android/reproducible/verify.sh --source <checkout> --variant <fdroid|universal> [--official <signed.apk>] [--work-dir <dir>] [--keep] [--allow-non-linux]
+
+Builds the selected unsigned release APK twice from two independent source
+copies on Linux, verifies that no R8 r8-map-id SourceFile value is present in
+the DEX files, and compares the unsigned APK hashes. If --official is provided,
+the official APK signature is copied onto the rebuilt APK with apksigcopier and
+the signed bytes are compared too.
+USAGE
+}
+
+source_dir=""
+variant="universal"
+official_apk=""
+work_dir=""
+keep=0
+allow_non_linux=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --source)
+      source_dir="${2:?Missing value for --source}"
+      shift 2
+      ;;
+    --variant)
+      variant="${2:?Missing value for --variant}"
+      shift 2
+      ;;
+    --official)
+      official_apk="${2:?Missing value for --official}"
+      shift 2
+      ;;
+    --work-dir)
+      work_dir="${2:?Missing value for --work-dir}"
+      shift 2
+      ;;
+    --keep)
+      keep=1
+      shift
+      ;;
+    --allow-non-linux)
+      allow_non_linux=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$source_dir" ]; then
+  source_dir="$(pwd)"
+fi
+
+if [ "$(uname -s)" != "Linux" ] && [ "${ALLOW_NON_LINUX_REPRO:-}" != "true" ] && [ "$allow_non_linux" -ne 1 ]; then
+  echo "Canonical reproducible verification must run on Linux. Set ALLOW_NON_LINUX_REPRO=true only for local smoke tests." >&2
+  exit 1
+fi
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "Non-Linux verification is a smoke/debug check only; Linux x86_64 CI is authoritative." >&2
+fi
+
+source_dir="$(cd "$source_dir" && pwd)"
+if [ ! -f "$source_dir/shell.nix" ] || [ ! -f "$source_dir/android/reproducible/build-apk.sh" ]; then
+  echo "Source directory does not look like the Gem Wallet repo: $source_dir" >&2
+  exit 1
+fi
+
+command -v rsync >/dev/null || { echo "rsync is required" >&2; exit 1; }
+command -v unzip >/dev/null || { echo "unzip is required" >&2; exit 1; }
+command -v strings >/dev/null || { echo "strings is required" >&2; exit 1; }
+
+if [ -n "$official_apk" ]; then
+  official_apk="$(cd "$(dirname "$official_apk")" && pwd)/$(basename "$official_apk")"
+  command -v apksigcopier >/dev/null || { echo "apksigcopier is required for --official" >&2; exit 1; }
+fi
+
+sha256_file() {
+  if command -v sha256sum >/dev/null; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+print_r8_markers() {
+  local label="$1"
+  local apk="$2"
+  echo "R8 markers in $label:" >&2
+  unzip -p "$apk" 'classes*.dex' 2>/dev/null \
+    | strings \
+    | grep -F '~~R8{' \
+    | sort -u \
+    | sed 's/^/    /' >&2 || true
+}
+
+print_apk_entry_diff() {
+  local first="$1"
+  local second="$2"
+  python3 - "$first" "$second" <<'PY' >&2 || true
+import hashlib
+import sys
+from zipfile import ZipFile
+
+first, second = sys.argv[1:3]
+
+def entries(path):
+    with ZipFile(path) as archive:
+        result = {}
+        for info in archive.infolist():
+            data = archive.read(info.filename)
+            result[info.filename] = (
+                hashlib.sha256(data).hexdigest(),
+                len(data),
+                info.compress_size,
+                info.CRC,
+            )
+        return result
+
+left = entries(first)
+right = entries(second)
+names = sorted(set(left) | set(right))
+missing = [name for name in names if name not in left or name not in right]
+changed = [name for name in names if name in left and name in right and left[name] != right[name]]
+
+print("Changed APK entries:")
+for name in missing[:50]:
+    print(f"    missing {name}: first={name in left} second={name in right}")
+for name in changed[:100]:
+    left_hash, left_size, left_compressed, left_crc = left[name]
+    right_hash, right_size, right_compressed, right_crc = right[name]
+    print(
+        "    "
+        f"{name}: "
+        f"{left_hash[:16]} size={left_size} compressed={left_compressed} crc={left_crc:08x} -> "
+        f"{right_hash[:16]} size={right_size} compressed={right_compressed} crc={right_crc:08x}"
+    )
+if len(missing) > 50 or len(changed) > 100:
+    print(f"    ... truncated: missing={len(missing)} changed={len(changed)}")
+PY
+}
+
+run_diffoscope() {
+  local left="$1"
+  local right="$2"
+  local output="$3"
+  if command -v diffoscope >/dev/null && diffoscope --version >/dev/null 2>&1; then
+    diffoscope "$left" "$right" --html "$output" || true
+    echo "Diffoscope report: $output" >&2
+  fi
+}
+
+if [ -z "$work_dir" ]; then
+  work_dir="$(mktemp -d)"
+else
+  mkdir -p "$work_dir"
+  work_dir="$(cd "$work_dir" && pwd)"
+fi
+
+if [ "$keep" -eq 0 ]; then
+  trap 'rm -rf "$work_dir"' EXIT
+else
+  echo "Keeping work directory: $work_dir"
+fi
+
+source_epoch="$(cd "$source_dir" && git log -1 --pretty=%ct 2>/dev/null || echo 0)"
+export SOURCE_DATE_EPOCH="$source_epoch"
+export GEM_REPRO_CARGO_HOME="$work_dir/cargo-home"
+mkdir -p "$GEM_REPRO_CARGO_HOME"
+
+copy_source() {
+  local destination="$1"
+  mkdir -p "$destination"
+  rsync -a --delete --delete-excluded \
+    --exclude '.git' \
+    --exclude '.jj' \
+    --exclude '.gradle' \
+    --exclude '.gradle-reproducible' \
+    --exclude '.cargo-reproducible' \
+    --exclude '.kotlin' \
+    --exclude 'result' \
+    --exclude 'android/local.properties' \
+    --exclude 'android/.gradle' \
+    --exclude 'android/.kotlin' \
+    --exclude 'android/app/build' \
+    --exclude 'android/app/release.keystore' \
+    --exclude 'android/build' \
+    --exclude 'core/target' \
+    --exclude 'ios/build' \
+    --exclude 'artifacts' \
+    "$source_dir/" "$destination/"
+}
+
+build_once() {
+  local name="$1"
+  local checkout="$work_dir/$name/source"
+  local apk="$work_dir/$name/$variant.apk"
+  local log="$work_dir/$name/build.log"
+  copy_source "$checkout"
+  if ! (
+    cd "$checkout"
+    android/reproducible/build-apk.sh --variant "$variant" --output "$apk"
+  ) 2>&1 | tee "$log" >&2; then
+    echo "Build failed. Log: $log" >&2
+    return 1
+  fi
+  find "$checkout/android/app/build/outputs/mapping" \
+    -maxdepth 3 \
+    -type f \
+    \( -name 'mapping.txt' -o -name 'configuration.txt' -o -name 'seeds.txt' -o -name 'usage.txt' \) \
+    -exec sh -c 'for file do cp "$file" "$0/$(basename "$(dirname "$file")")-$(basename "$file")"; done' "$work_dir/$name" {} + \
+    2>/dev/null || true
+  printf '%s\n' "$apk"
+}
+
+echo "==> Building first $variant APK"
+apk_one="$(build_once build-one)" || exit 1
+hash_one="$(sha256_file "$apk_one")"
+echo "    $hash_one  $apk_one"
+
+echo "==> Building second $variant APK"
+apk_two="$(build_once build-two)" || exit 1
+hash_two="$(sha256_file "$apk_two")"
+echo "    $hash_two  $apk_two"
+
+if [ "$hash_one" != "$hash_two" ]; then
+  echo "Unsigned APK mismatch" >&2
+  print_apk_entry_diff "$apk_one" "$apk_two"
+  print_r8_markers "first APK" "$apk_one"
+  print_r8_markers "second APK" "$apk_two"
+  run_diffoscope "$apk_one" "$apk_two" "$work_dir/unsigned-diff.html"
+  exit 1
+fi
+
+echo "Unsigned APKs match."
+
+if [ -n "$official_apk" ]; then
+  rebuilt_signed="$work_dir/rebuilt-signed.apk"
+  echo "==> Copying official signature"
+  apksigcopier copy "$official_apk" "$apk_one" "$rebuilt_signed"
+
+  official_hash="$(sha256_file "$official_apk")"
+  rebuilt_hash="$(sha256_file "$rebuilt_signed")"
+  echo "    $official_hash  $official_apk"
+  echo "    $rebuilt_hash  $rebuilt_signed"
+
+  if [ "$official_hash" != "$rebuilt_hash" ]; then
+    echo "Official signed APK mismatch" >&2
+    run_diffoscope "$official_apk" "$rebuilt_signed" "$work_dir/signed-diff.html"
+    exit 1
+  fi
+
+  echo "Official signed APK matches after signature copy."
+fi

--- a/docs/android-reproducible-builds.md
+++ b/docs/android-reproducible-builds.md
@@ -1,0 +1,249 @@
+# Android Reproducible Builds
+
+This document is the target design for Gem Wallet Android reproducible releases.
+The canonical build is Linux x86_64 under Nix. macOS can enter the same Nix
+shell for development smoke tests, but a macOS result is not a reproducibility
+proof because the Android NDK host toolchain and native linkers differ by OS.
+Docker is not part of the release design.
+
+## Goals
+
+1. Build the release APK from source in a pinned Linux toolchain.
+2. Rebuild the same source in a second clean checkout and get identical unsigned
+   APK bytes.
+3. Sign the exact unsigned APK as a final step, preferably on Linux with the same
+   pinned Android build-tools.
+4. Allow F-Droid to rebuild the `fdroidRelease` flavor and verify our published
+   developer-signed APK with signature copying.
+5. Fail the build if R8 emits a path-sensitive or map-id-derived `SourceFile`
+   value into DEX.
+
+## Canonical Toolchain
+
+The pinned environment lives in `shell.nix`.
+
+| Component | Version | Source of truth |
+| --- | --- | --- |
+| Nixpkgs | `c7f47036d3df2add644c46d712d14262b7d86c0c` | `shell.nix` |
+| Android SDK package set | `tadfisher/android-nixpkgs@77f1c65db15624af98a6b670e386f4cb57b2d62b` | `shell.nix` |
+| Rust overlay | `02061303f7c4c964f7b4584dabd9e985b4cd442b` | `shell.nix` |
+| Rust | `1.91.0` | `shell.nix` |
+| Gradle | `9.4.1` | `android/gradle/wrapper/gradle-wrapper.properties` |
+| Android Gradle Plugin | `9.2.1` | `android/gradle/libs.versions.toml` |
+| Kotlin | `2.3.21` | `android/gradle/libs.versions.toml` |
+| JDK | Temurin 21 for Gradle; Java 17 bytecode target | `shell.nix`, `android/gradle/gradle-daemon-jvm.properties`, and Android Gradle config |
+| Android platform | `37` | `android/app/build.gradle.kts` and `shell.nix` |
+| Build tools for build/aapt2 | `36.0.0` | `shell.nix`, matching AGP 9.2 default |
+| Build tools for APK signing | `34.0.0` | `shell.nix`, for apksigcopier-compatible signatures |
+| NDK | `28.1.13356709` | `android/app/build.gradle.kts` and `shell.nix` |
+| Min SDK | `28` | `android/app/build.gradle.kts` and NDK linker names |
+| cargo-ndk | Nixpkgs-pinned package | `shell.nix` |
+
+AGP 9.2 requires Gradle 9.4.1, and Android API 37 requires AGP 9.1.1 or newer.
+The current branch already satisfies both constraints. See Android's AGP
+compatibility tables for the Gradle and API-level requirements:
+https://developer.android.com/build/releases/about-agp
+
+## Build Outputs
+
+The reproducible scripts build unsigned APKs first:
+
+```bash
+nix-shell shell.nix --run "android/reproducible/build-apk.sh"
+nix-shell shell.nix --run "android/reproducible/build-apk.sh --variant fdroid"
+```
+
+The expected output paths are:
+
+```text
+android/app/build/outputs/apk/fdroid/release/app-fdroid-release-unsigned.apk
+android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
+```
+
+The `fdroid` flavor is the F-Droid target. It uses `pushes-stub` instead of FCM
+and `review-stub` instead of Play Review. During `FDROID_BUILD=true`, the app
+does not apply the Google Services Gradle plugin and the root build excludes
+`mavenLocal()`. JitPack remains enabled because current Reown/WalletConnect
+dependencies resolve several transitive artifacts from JitPack. The F-Droid APK
+is ARM-only (`armeabi-v7a` and `arm64-v8a`) to match Gem's existing release ABI
+surface.
+
+The `universal` flavor is the direct APK distribution target. It still includes
+the normal Gem direct-distribution behavior and is not the F-Droid recipe.
+
+## Verification Flow
+
+Run the local two-build verifier on Linux:
+
+```bash
+nix-shell shell.nix --run "android/reproducible/verify.sh --source ."
+nix-shell shell.nix --run "android/reproducible/verify.sh --source . --variant fdroid"
+```
+
+On macOS, use the same Nix shell for smoke/debug builds:
+
+```bash
+nix-shell shell.nix --run "android/reproducible/build-apk.sh --output /tmp/gem-universal.apk"
+nix-shell shell.nix --run "android/reproducible/build-apk.sh --variant fdroid --output /tmp/gem-fdroid.apk"
+```
+
+You can run `verify.sh --allow-non-linux` on macOS as an exploratory diagnostic,
+but it is not release evidence. The macOS NDK host tools and linker are
+different from Linux x86_64, and DEX/R8 differences found there must be
+confirmed in Linux CI before treating them as release blockers.
+
+The verifier does this:
+
+1. Copies the source tree to two independent temporary directories with build
+   outputs and VCS metadata removed.
+2. Builds the selected release variant in both copies with `SKIP_SIGN=true`.
+3. Sets `SOURCE_DATE_EPOCH` from the source commit time.
+4. Adds Rust `--remap-path-prefix` flags for the checkout, Cargo home, Android
+   SDK, and Android NDK paths.
+5. Scans every `classes*.dex` for `r8-map-id-`.
+6. Compares the unsigned APK SHA-256 values. This catches broader R8/DEX
+   instability, including changes to R8 marker metadata such as `pg-map-id`.
+7. Prints changed APK entries and R8 marker strings from both APKs if the
+   unsigned bytes differ.
+8. Optionally copies the official APK signature onto the rebuilt unsigned APK
+   and compares the signed bytes:
+
+```bash
+nix-shell shell.nix --run \
+  "android/reproducible/verify.sh --source . --variant fdroid --official gem_wallet_fdroid_2.80.apk"
+```
+
+If the unsigned APKs differ, the script writes a `diffoscope` HTML report when
+`diffoscope` is installed in the surrounding environment.
+
+## R8 SourceFile / Map-Id Policy
+
+R8 can emit synthetic `SourceFile` values like `r8-map-id-...` when retracing
+metadata is required. Those values couple DEX output to the generated mapping
+state. Gem avoids post-processing DEX or patching APK contents after the build.
+Instead, the app ProGuard rules force a stable `SourceFile` value:
+
+```proguard
+-keepattributes SourceFile
+-renamesourcefileattribute SourceFile
+```
+
+Store release builds also include `android/app/proguard-stacktrace-rules.pro`,
+which keeps `LineNumberTable` for crash line-number retracing. F-Droid and
+`ANDROID_REPRODUCIBLE_BUILD=true` builds intentionally omit that file. Linux CI
+proved R8 9.2.14 can otherwise make different line-position, `outlineCallsite`,
+and `residualsignature` mapping metadata across two clean builds of the same
+source. Those differences changed `classes.dex`, `classes2.dex`, and
+`assets/dexopt/baseline.prof`.
+
+Reproducible builds also include `android/app/proguard-reproducible-rules.pro`,
+which applies `-dontoptimize`. AGP 9 no longer allows
+`getDefaultProguardFile("proguard-android.txt")`, so the supported form is the
+normal optimized default ProGuard file plus this reproducible-only rule file.
+This keeps shrinking and obfuscation enabled while removing the R8 optimization
+phase that produced different `pg-map-id` values between clean builds.
+
+The verifier treats any `r8-map-id-` string in DEX as a release blocker. This is
+the direct test for the historical `SourceFile` issue. R8 also writes marker
+metadata such as `~~R8{...,"pg-map-id":"..."}` into DEX. That marker is allowed
+to exist, but it must be stable as part of the full unsigned APK byte comparison
+on Linux.
+
+## Signing
+
+Signing is not macOS-specific. Android APK signing is Java/Android build-tools
+work and can run on Linux. The release design is:
+
+1. Build unsigned APKs on Linux in Nix.
+2. Compare unsigned outputs before signing.
+3. Sign the exact unsigned artifact on Linux with pinned build-tools 34:
+
+```bash
+ANDROID_KEYSTORE_PASSWORD=... nix-shell shell.nix --run \
+  "android/reproducible/sign-apk.sh \
+    --unsigned app-fdroid-release-unsigned.apk \
+    --out gem_wallet_fdroid_2.80.apk \
+    --ks release.keystore \
+    --ks-key-alias \"$ANDROID_KEYSTORE_ALIAS\""
+```
+
+Build-tools 34 is intentionally used for signing because F-Droid documents that
+signatures from newer `apksigner` versions can fail `apksigcopier` verification:
+https://f-droid.org/docs/Reproducible_Builds/
+
+The release keystore should never be present during the reproducible unsigned
+comparison step. Keep it in the final signing job only.
+
+## F-Droid Setup
+
+The F-Droid recipe template is in:
+
+```text
+android/fdroid-build/metadata/com.gemwallet.android.yml
+```
+
+The recipe builds `:app:assembleFdroidRelease`, sets `FDROID_BUILD=true`, uses
+NDK `28.1.13356709`, installs Rust `1.91.0`, installs Android Rust targets, and
+writes Cargo linker configuration for the F-Droid Linux build server.
+
+For a real fdroiddata merge request, update these fields for every release:
+
+```yaml
+versionName: '2.80'
+versionCode: 779
+commit: '2.80'
+binary: https://github.com/gemwalletcom/wallet/releases/download/%v/gem_wallet_fdroid_%v.apk
+CurrentVersion: '2.80'
+CurrentVersionCode: 779
+```
+
+After the first developer-signed F-Droid APK is published, extract signatures in
+fdroiddata:
+
+```bash
+fdroid signatures https://github.com/gemwalletcom/wallet/releases/download/2.80/gem_wallet_fdroid_2.80.apk
+```
+
+F-Droid's reproducible build model copies signatures from the developer APK to
+the rebuilt unsigned APK and verifies the result, so the unsigned APK bytes must
+match exactly apart from the signature block. F-Droid's metadata fields and
+`binary:` verification are documented here:
+https://f-droid.org/en/docs/Build_Metadata_Reference/
+
+## Known Non-Determinism Sources And Controls
+
+| Source | Control |
+| --- | --- |
+| R8 `SourceFile` map ids | `-renamesourcefileattribute SourceFile` and DEX scan |
+| R8 line-position / `pg-map-id` instability | omit `LineNumberTable` and add `-dontoptimize` for reproducible builds; two-build unsigned APK comparison on Linux; verifier prints R8 markers on mismatch |
+| Absolute Rust paths | `--remap-path-prefix` in reproducible scripts |
+| Host NDK differences | canonical Linux x86_64 build only |
+| Extra native ABIs | reproducible/F-Droid scripts build only `arm64-v8a,armeabi-v7a` |
+| Signing block bytes | sign after unsigned comparison with build-tools 34 |
+| Gradle daemon/caches | `--no-daemon`, clean source copies, isolated `GRADLE_USER_HOME` |
+| Google/Firebase resources in F-Droid | `FDROID_BUILD=true` disables Google Services plugin |
+| Local repositories | `FDROID_BUILD=true` disables `mavenLocal()` |
+| JitPack transitive dependencies | currently required by Reown/WalletConnect; replace or vendor before an F-Droid review if policy requires it |
+| Prebuilt native wallet-core | no tracked wallet-core `.so`, `.aar`, or `.jar` artifacts |
+
+## CI Design
+
+`.github/workflows/android-reproducible.yml` runs the Linux Nix verifier. The
+default workflow variant is `universal`, matching direct APK releases. Use
+manual dispatch with `fdroid` when validating the F-Droid flavor.
+Do not use local Docker as a substitute on Apple Silicon; that produces an
+`aarch64-linux` environment, while the Android NDK Linux host used for
+reproducible releases is x86_64 Linux. Android's NDK host tag table documents
+Linux as `linux-x86_64`, while macOS keeps the historical `darwin-x86_64` tag
+for fat binaries that include Apple Silicon support:
+https://developer.android.com/ndk/guides/other_build_systems
+
+The release repo should eventually split Android from the current macOS
+self-hosted runner:
+
+1. Linux Nix job builds `fdroidRelease` and `universalRelease` unsigned APKs.
+2. Linux Nix verifier compares two clean builds.
+3. Linux signing job downloads the verified unsigned artifact and signs it.
+4. Upload jobs publish the signed APKs to GitHub Releases, R2, F-Droid binary
+   URL, and store-specific pipelines.
+5. macOS self-hosted runners remain only for iOS/Xcode release jobs.

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,130 @@
+# Reproducible Android build environment.
+#
+# Canonical verification is Linux x86_64:
+#   nix-shell shell.nix --run "android/reproducible/verify.sh --source ."
+let
+  nixpkgs = fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/c7f47036d3df2add644c46d712d14262b7d86c0c.tar.gz";
+    sha256 = "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=";
+  };
+
+  rustOverlay = fetchTarball {
+    url = "https://github.com/oxalica/rust-overlay/archive/02061303f7c4c964f7b4584dabd9e985b4cd442b.tar.gz";
+    sha256 = "sha256-k9G98qzn+7npROUaks8VqCFm7cFtEG8ulQLBBo5lItg=";
+  };
+
+  androidNixpkgs = fetchTarball {
+    url = "https://github.com/tadfisher/android-nixpkgs/archive/77f1c65db15624af98a6b670e386f4cb57b2d62b.tar.gz";
+    sha256 = "sha256-Sa+pki/B361TigSv2Ipkj0qSoJw8P44c4rUjqhmiUQs=";
+  };
+
+  pkgs = import nixpkgs {
+    overlays = [ (import rustOverlay) ];
+    config = {
+      allowUnfree = true;
+      android_sdk.accept_license = true;
+    };
+  };
+
+  jdkMajorVersion = "21";
+  jdk = pkgs.temurin-bin-21;
+  jdkHome =
+    if pkgs.stdenv.isDarwin then
+      "${jdk}/Library/Java/JavaVirtualMachines/temurin-${jdkMajorVersion}.jdk/Contents/Home"
+    else
+      "${jdk}";
+  jdkTrustStore = "${jdkHome}/lib/security/cacerts";
+  compileSdkVersion = "37";
+  buildToolsVersion = "36.0.0";
+  signingBuildToolsVersion = "34.0.0";
+  ndkVersion = "28.1.13356709";
+  minSdkVersion = "28";
+
+  androidSdk =
+    (import androidNixpkgs {
+      pkgs = pkgs // {
+        openjdk = jdk;
+      };
+    }).sdk
+      (
+        sdkPkgs: with sdkPkgs; [
+          platforms-android-37-0
+          build-tools-36-0-0
+          build-tools-34-0-0
+          ndk-28-1-13356709
+          cmdline-tools-latest
+          platform-tools
+        ]
+      );
+  androidSdkRoot = "${androidSdk}/share/android-sdk";
+
+  rustToolchain = pkgs.rust-bin.stable."1.91.0".default.override {
+    targets = [
+      "aarch64-linux-android"
+      "armv7-linux-androideabi"
+    ];
+  };
+
+  ndkHost =
+    if pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64 then
+      "linux-x86_64"
+    else if pkgs.stdenv.isDarwin then
+      "darwin-x86_64"
+    else
+      throw "Unsupported Android NDK host platform: ${pkgs.stdenv.hostPlatform.system}";
+
+  ndkToolchainDir = "${androidSdkRoot}/ndk/${ndkVersion}/toolchains/llvm/prebuilt/${ndkHost}/bin";
+in
+pkgs.mkShell {
+  packages = [
+    jdk
+    androidSdk
+    rustToolchain
+    pkgs.cargo-ndk
+    pkgs.coreutils
+    pkgs.git
+    pkgs.gnugrep
+    pkgs.gnutar
+    pkgs.gzip
+    pkgs.just
+    pkgs.openssl
+    pkgs.pkg-config
+    pkgs.protobuf
+    pkgs.apksigcopier
+    pkgs.cacert
+    pkgs.rsync
+    pkgs.unzip
+    pkgs.which
+    pkgs.zip
+  ];
+
+  JAVA_HOME = jdkHome;
+  ANDROID_HOME = androidSdkRoot;
+  ANDROID_SDK_ROOT = androidSdkRoot;
+  ANDROID_NDK_HOME = "${androidSdkRoot}/ndk/${ndkVersion}";
+  ANDROID_NDK_ROOT = "${androidSdkRoot}/ndk/${ndkVersion}";
+  NDK_HOME = "${androidSdkRoot}/ndk/${ndkVersion}";
+  NDK_TOOLCHAIN_DIR = ndkToolchainDir;
+  NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+  SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+  GEM_ANDROID_BUILD_TOOLS = "${androidSdkRoot}/build-tools/${buildToolsVersion}";
+  GEM_ANDROID_SIGNING_BUILD_TOOLS = "${androidSdkRoot}/build-tools/${signingBuildToolsVersion}";
+  GRADLE_OPTS = "-Dorg.gradle.java.home=${jdkHome} -Dorg.gradle.java.installations.paths=${jdkHome} -Dorg.gradle.java.installations.auto-detect=false -Dorg.gradle.java.installations.auto-download=false -Dorg.gradle.project.android.aapt2FromMavenOverride=${androidSdkRoot}/build-tools/${buildToolsVersion}/aapt2";
+  JAVA_TOOL_OPTIONS = "-Djavax.net.ssl.trustStore=${jdkTrustStore} -Djavax.net.ssl.trustStorePassword=changeit -Djavax.net.ssl.trustStoreType=JKS";
+
+  AR_aarch64_linux_android = "${ndkToolchainDir}/llvm-ar";
+  AR_armv7_linux_androideabi = "${ndkToolchainDir}/llvm-ar";
+  CC_aarch64_linux_android = "${ndkToolchainDir}/aarch64-linux-android${minSdkVersion}-clang";
+  CC_armv7_linux_androideabi = "${ndkToolchainDir}/armv7a-linux-androideabi${minSdkVersion}-clang";
+  CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER = "${ndkToolchainDir}/aarch64-linux-android${minSdkVersion}-clang";
+  CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER = "${ndkToolchainDir}/armv7a-linux-androideabi${minSdkVersion}-clang";
+
+  shellHook = ''
+    echo "Gem Wallet Android reproducible build environment"
+    echo "  Android platform:    ${compileSdkVersion}"
+    echo "  Android build-tools: ${buildToolsVersion}"
+    echo "  Signing build-tools: ${signingBuildToolsVersion}"
+    echo "  NDK:                 ${ndkVersion}"
+    echo "  Rust:                1.91.0"
+  '';
+}


### PR DESCRIPTION
Draft PR for isolated Linux verification of Android reproducible build tooling.

Scope:
- Nix Android/Rust toolchain for reproducible APK builds
- F-Droid build scaffold
- Linux verifier that builds twice, scans DEX for r8-map-id, and compares unsigned APK bytes
- Linux signing helper using pinned Android build-tools 34

This PR is intended to be closed after verification.