### PR TITLE
Single origin check for WalletConnect

### DIFF
--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
@@ -52,7 +52,7 @@ fun RequestScene(
     DisposableEffect(request.topic, request.request.id) {
         viewModel.onRequest(request, verifyContext) { error ->
             when (error) {
-                BridgeRequestError.ScamSession -> Toast.makeText(
+                BridgeRequestError.MaliciousSession -> Toast.makeText(
                     context,
                     R.string.errors_connections_malicious_origin,
                     Toast.LENGTH_LONG

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/ProposalSceneViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/ProposalSceneViewModel.kt
@@ -7,7 +7,7 @@ import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.ext.walletConnectAppName
 import com.gemwallet.android.ext.walletConnectIcon
-import com.gemwallet.android.features.bridge.viewmodels.model.map
+import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectOriginVerifier
 import com.gemwallet.android.features.bridge.viewmodels.model.toSessionUI
 import com.reown.walletkit.client.Wallet
 import com.wallet.core.primitives.WalletConnectionSessionAppMetadata
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import uniffi.gemstone.WalletConnect
 import uniffi.gemstone.WalletConnectionVerificationStatus
 import javax.inject.Inject
 
@@ -36,6 +35,7 @@ class ProposalSceneViewModel @Inject constructor(
     sessionRepository: SessionRepository,
     private val bridgesRepository: BridgesRepository,
     private val walletsRepository: WalletsRepository,
+    private val originVerifier: WalletConnectOriginVerifier,
 ) : ViewModel() {
 
     val state = MutableStateFlow<ProposalSceneState>(ProposalSceneState.Init(WalletConnectionVerificationStatus.UNKNOWN))
@@ -78,18 +78,13 @@ class ProposalSceneViewModel @Inject constructor(
         proposal: Wallet.Model.SessionProposal,
         verifyContext: Wallet.Model.VerifyContext
     ) {
-        val validation = WalletConnect().validateOrigin(proposal.url, verifyContext.origin, verifyContext.map())
-        when (validation) {
-            WalletConnectionVerificationStatus.UNKNOWN,
-            WalletConnectionVerificationStatus.VERIFIED -> {
-                state.update { ProposalSceneState.Init(validation) }
-                _proposal.update { proposal }
-            }
-            WalletConnectionVerificationStatus.INVALID,
-            WalletConnectionVerificationStatus.MALICIOUS -> {
-                onReject(proposal, ProposalSceneState.ScamCanceled)
-            }
+        val verification = originVerifier.verify(proposal.url, verifyContext)
+        if (verification.isScam) {
+            onReject(proposal, ProposalSceneState.ScamCanceled)
+            return
         }
+        state.update { ProposalSceneState.Init(verification.status) }
+        _proposal.update { proposal }
     }
 
     fun onApprove() {

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCAuthViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCAuthViewModel.kt
@@ -15,10 +15,9 @@ import com.gemwallet.android.ext.toChainType
 import com.gemwallet.android.ext.walletConnectAppName
 import com.gemwallet.android.ext.walletConnectIcon
 import com.gemwallet.android.features.bridge.viewmodels.model.SessionUI
-import com.gemwallet.android.features.bridge.viewmodels.model.map
+import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectOriginVerifier
 import com.gemwallet.android.features.bridge.viewmodels.model.toSessionUI
 import com.gemwallet.android.ui.models.PayloadField
-import com.reown.android.Core
 import com.reown.walletkit.client.Wallet
 import com.reown.walletkit.client.WalletKit
 import com.wallet.core.primitives.Account
@@ -38,8 +37,6 @@ import kotlinx.coroutines.launch
 import uniffi.gemstone.MessageSigner
 import uniffi.gemstone.SignDigestType
 import uniffi.gemstone.SignMessage
-import uniffi.gemstone.WalletConnect
-import uniffi.gemstone.WalletConnectionVerificationStatus
 import java.util.Arrays
 import javax.inject.Inject
 
@@ -50,9 +47,9 @@ class WCAuthViewModel @Inject constructor(
     private val walletsRepository: WalletsRepository,
     private val passwordStore: PasswordStore,
     private val loadPrivateKeyOperator: LoadPrivateKeyOperator,
+    private val originVerifier: WalletConnectOriginVerifier,
 ) : ViewModel() {
 
-    private val walletConnect = WalletConnect()
     private var authRequest: Wallet.Model.SessionAuthenticate? = null
     private var hasResponded = false
 
@@ -68,18 +65,13 @@ class WCAuthViewModel @Inject constructor(
         _state.update { AuthSceneState.Loading }
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                val validation = validateSession(request.participant.metadata, verifyContext)
+                val verification = originVerifier.verify(request.participant.metadata?.url, verifyContext)
                 if (!isActiveRequest(request)) {
                     return@launch
                 }
-                when (validation) {
-                    WalletConnectionVerificationStatus.INVALID,
-                    WalletConnectionVerificationStatus.MALICIOUS -> {
-                        rejectRequest(request, AuthSceneState.ScamCanceled)
-                        return@launch
-                    }
-                    WalletConnectionVerificationStatus.UNKNOWN,
-                    WalletConnectionVerificationStatus.VERIFIED -> Unit
+                if (verification.isScam) {
+                    rejectRequest(request, AuthSceneState.ScamCanceled)
+                    return@launch
                 }
 
                 val availableWallets = (walletsRepository.getAll().firstOrNull() ?: emptyList())
@@ -232,17 +224,6 @@ class WCAuthViewModel @Inject constructor(
 
     private fun isActiveRequest(request: Wallet.Model.SessionAuthenticate): Boolean {
         return authRequest?.id == request.id && !hasResponded
-    }
-
-    private fun validateSession(
-        metadata: Core.Model.AppMetaData?,
-        verifyContext: Wallet.Model.VerifyContext,
-    ): WalletConnectionVerificationStatus {
-        return walletConnect.validateOrigin(
-            metadataUrl = metadata?.url ?: "",
-            origin = verifyContext.origin,
-            validation = verifyContext.map(),
-        )
     }
 
     private fun buildApproval(

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
@@ -11,7 +11,7 @@ import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.ext.getAccount
 import com.gemwallet.android.features.bridge.viewmodels.model.BridgeRequestError
 import com.gemwallet.android.features.bridge.viewmodels.model.WCRequest
-import com.gemwallet.android.features.bridge.viewmodels.model.map
+import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectOriginVerifier
 import com.reown.walletkit.client.Wallet
 import com.reown.walletkit.client.WalletKit
 import com.wallet.core.primitives.Account
@@ -33,7 +33,6 @@ import kotlinx.coroutines.launch
 import com.wallet.core.primitives.SimulationResult
 import uniffi.gemstone.WalletConnect
 import uniffi.gemstone.WalletConnectAction
-import uniffi.gemstone.WalletConnectionVerificationStatus
 import java.util.Arrays
 import javax.inject.Inject
 
@@ -45,6 +44,7 @@ class WCRequestViewModel @Inject constructor(
     private val loadPrivateKeyOperator: LoadPrivateKeyOperator,
     private val simulationService: com.gemwallet.android.blockchain.services.WalletConnectSimulationService,
     private val getCurrentBlockExplorer: GetCurrentBlockExplorer,
+    private val originVerifier: WalletConnectOriginVerifier,
 ) : ViewModel() {
 
     private val walletConnect = WalletConnect()
@@ -68,7 +68,9 @@ class WCRequestViewModel @Inject constructor(
                 }
 
                 val appMetadata = connection.session.metadata
-                validateSession(appMetadata.url, verifyContext)
+                if (originVerifier.verify(appMetadata.url, verifyContext).isScam) {
+                    throw BridgeRequestError.ScamSession
+                }
                 val chainId = sessionRequest.chainId ?: throw BridgeRequestError.UnresolvedChainId
                 val sessionDomain = appMetadata.url
                 val action = walletConnect.parseRequest(
@@ -219,27 +221,6 @@ class WCRequestViewModel @Inject constructor(
                 Arrays.fill(privateKey, 0)
             }
             response(request.sessionRequest.topic, request.sessionRequest.request.id, sign)
-        }
-    }
-
-    private fun validateSession(
-        metadataUrl: String,
-        verifyContext: Wallet.Model.VerifyContext
-    ) {
-        val validation = walletConnect.validateOrigin(
-            metadataUrl,
-            verifyContext.origin,
-            verifyContext.map()
-        )
-        when (validation) {
-            WalletConnectionVerificationStatus.UNKNOWN,
-            WalletConnectionVerificationStatus.VERIFIED -> {
-                return
-            }
-            WalletConnectionVerificationStatus.INVALID,
-            WalletConnectionVerificationStatus.MALICIOUS -> {
-                throw BridgeRequestError.ScamSession
-            }
         }
     }
 

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
@@ -69,7 +69,7 @@ class WCRequestViewModel @Inject constructor(
 
                 val appMetadata = connection.session.metadata
                 if (originVerifier.verify(appMetadata.url, verifyContext).isScam) {
-                    throw BridgeRequestError.ScamSession
+                    throw BridgeRequestError.MaliciousSession
                 }
                 val chainId = sessionRequest.chainId ?: throw BridgeRequestError.UnresolvedChainId
                 val sessionDomain = appMetadata.url
@@ -264,7 +264,7 @@ class WCRequestViewModel @Inject constructor(
         error: BridgeRequestError,
         onNotify: (BridgeRequestError) -> Unit
     ) {
-        if (error is BridgeRequestError.ScamSession) {
+        if (error is BridgeRequestError.MaliciousSession) {
             onNotify(error)
         }
         rejectRequest(sessionRequest)

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/BridgeRequestError.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/BridgeRequestError.kt
@@ -1,7 +1,7 @@
 package com.gemwallet.android.features.bridge.viewmodels.model
 
 sealed class BridgeRequestError(message: String) : Exception(message) {
-    object ScamSession : BridgeRequestError("Scam session")
+    object MaliciousSession : BridgeRequestError("Malicious session")
     object ChainUnsupported : BridgeRequestError("chain not supported")
     object MethodUnsupported : BridgeRequestError("method not supported")
     object UnresolvedChainId : BridgeRequestError("Unresolved chain id")

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WalletConnectOriginVerifier.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WalletConnectOriginVerifier.kt
@@ -1,0 +1,35 @@
+package com.gemwallet.android.features.bridge.viewmodels.model
+
+import com.reown.walletkit.client.Wallet
+import uniffi.gemstone.WalletConnect
+import uniffi.gemstone.WalletConnectionVerificationStatus
+import javax.inject.Inject
+
+class WalletConnectOriginVerifier @Inject constructor() {
+
+    private val walletConnect = WalletConnect()
+
+    fun verify(
+        metadataUrl: String?,
+        verifyContext: Wallet.Model.VerifyContext,
+    ): OriginVerification {
+        val status = walletConnect.validateOrigin(
+            metadataUrl = metadataUrl ?: "",
+            origin = verifyContext.origin,
+            validation = verifyContext.map(),
+        )
+        return OriginVerification(status)
+    }
+}
+
+data class OriginVerification(
+    val status: WalletConnectionVerificationStatus,
+) {
+    val isScam: Boolean
+        get() = when (status) {
+            WalletConnectionVerificationStatus.INVALID,
+            WalletConnectionVerificationStatus.MALICIOUS -> true
+            WalletConnectionVerificationStatus.UNKNOWN,
+            WalletConnectionVerificationStatus.VERIFIED -> false
+        }
+}

--- a/android/features/bridge/viewmodels/src/test/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WalletConnectOriginVerifierTest.kt
+++ b/android/features/bridge/viewmodels/src/test/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WalletConnectOriginVerifierTest.kt
@@ -1,0 +1,16 @@
+package com.gemwallet.android.features.bridge.viewmodels.model
+
+import uniffi.gemstone.WalletConnectionVerificationStatus
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WalletConnectOriginVerifierTest {
+
+    @Test
+    fun scamRejectsInvalidAndMalicious() {
+        assertEquals(false, OriginVerification(WalletConnectionVerificationStatus.UNKNOWN).isScam)
+        assertEquals(false, OriginVerification(WalletConnectionVerificationStatus.VERIFIED).isScam)
+        assertEquals(true, OriginVerification(WalletConnectionVerificationStatus.INVALID).isScam)
+        assertEquals(true, OriginVerification(WalletConnectionVerificationStatus.MALICIOUS).isScam)
+    }
+}


### PR DESCRIPTION
The same check for whether a WalletConnect session is trustworthy or a scam was written in three different screens. Now it lives in one place, so the rule can't drift between screens and a scam site can't slip through one of them.

The verification badge on the connection screen still works as before.

Closes #469