### PR TITLE
Perp sheets improvements

### DIFF
--- a/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/ProviderExtras.kt
+++ b/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/ProviderExtras.kt
@@ -116,6 +116,7 @@ private fun PerpetualLeverageSection(provider: AmountPerpetualProvider) {
     SelectLeverageDialog(
         isVisible = showLeverageSelect,
         leverages = state.options,
+        selected = state.current,
         onDismiss = { showLeverageSelect = false },
         onSelect = provider::setLeverage,
     )

--- a/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/dialogs/SelectLeverageDialog.kt
+++ b/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/dialogs/SelectLeverageDialog.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.transfer_amount.presents.dialogs
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -8,7 +9,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.gemwallet.android.domains.perpetual.formatLeverage
 import com.gemwallet.android.ui.R
-import com.gemwallet.android.ui.components.list_item.property.PropertyItem
+import com.gemwallet.android.ui.components.list_item.ListItem
+import com.gemwallet.android.ui.components.list_item.ListItemDefaults
+import com.gemwallet.android.ui.components.list_item.ListItemTitleText
+import com.gemwallet.android.ui.components.list_item.SelectionCheckmark
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet
 
@@ -17,6 +21,7 @@ import com.gemwallet.android.ui.components.screen.ModalBottomSheet
 fun SelectLeverageDialog(
     isVisible: Boolean,
     leverages: List<Int>,
+    selected: Int,
     onDismiss: () -> Unit,
     onSelect: (Int) -> Unit,
 ) {
@@ -29,13 +34,20 @@ fun SelectLeverageDialog(
             modifier = Modifier.fillMaxWidth()
         ) {
             itemsPositioned(leverages) { position, item ->
-                PropertyItem(
-                    action = item.formatLeverage(),
+                ListItem(
+                    modifier = Modifier.clickable {
+                        onSelect(item)
+                        onDismiss()
+                    },
+                    minHeight = ListItemDefaults.plainMinHeight,
+                    title = { ListItemTitleText(item.formatLeverage()) },
                     listPosition = position,
-                ) {
-                    onSelect(item)
-                    onDismiss()
-                }
+                    trailing = if (item == selected) {
+                        @Composable { SelectionCheckmark() }
+                    } else {
+                        null
+                    },
+                )
             }
         }
     }

--- a/ios/Packages/PrimitivesComponents/Sources/Components/ToolbarDismissItem.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/ToolbarDismissItem.swift
@@ -12,13 +12,14 @@ public struct ToolbarDismissItem: ToolbarContent {
         case cancel
         case done
         case close
+        case confirm
         case custom(String)
 
         var localized: String {
             switch self {
             case .cancel: Localized.Common.cancel
             case .done: Localized.Common.done
-            case .close: ""
+            case .close, .confirm: ""
             case let .custom(title): title
             }
         }
@@ -40,6 +41,8 @@ public struct ToolbarDismissItem: ToolbarContent {
             switch type {
             case .close:
                 Button("", systemImage: SystemImage.xmark, action: { dismiss() })
+            case .confirm:
+                Button("", systemImage: SystemImage.checkmark, action: { dismiss() })
             case .cancel, .done, .custom:
                 Button(type.localized, action: { dismiss() })
                     .bold()

--- a/ios/Packages/PrimitivesComponents/Sources/Scenes/WheelPickerSheet.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Scenes/WheelPickerSheet.swift
@@ -24,6 +24,10 @@ public struct WheelPickerSheet<T: WheelPickerDisplayable>: View {
                         type: .close,
                         placement: .topBarLeading,
                     )
+                    ToolbarDismissItem(
+                        type: .confirm,
+                        placement: .topBarTrailing,
+                    )
                 }
         }
         .presentationDetents([.height(300)])


### PR DESCRIPTION
closes #475 

images:

<table>
  <tr>
    <td align="center"><b>Android</b><br><sub>checkmark on selected row</sub></td>
    <td align="center"><b>iOS</b><br><sub>Leverage sheet</sub></td>
    <td align="center"><b>iOS</b><br><sub>confirm&nbsp;✓ in toolbar</sub></td>
  </tr>
  <tr>
    <td><img width="270" src="https://github.com/user-attachments/assets/ab70360d-5621-4178-b9b1-3fd0c12e3e62"></td>
    <td><img width="270" src="https://github.com/user-attachments/assets/a4019216-f915-4ff7-9939-3e19d351b4a7"></td>
    <td><img width="270" src="https://github.com/user-attachments/assets/dd06ee08-d5bd-45d8-923b-5d9a84b54ea4"></td>
  </tr>
</table>
