### PR TITLE
Refactor AssetsRepository

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/App.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/App.kt
@@ -12,6 +12,7 @@ import coil3.memory.MemoryCache
 import coil3.svg.SvgDecoder
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetualPositions
 import com.gemwallet.android.application.transactions.coordinators.GetTransactions
+import com.gemwallet.android.data.repositories.assets.TransactionPostProcessingService
 import com.gemwallet.android.data.repositories.stream.StreamObserverService
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
@@ -25,6 +26,8 @@ class App : Application(), SingletonImageLoader.Factory, Application.ActivityLif
     lateinit var syncPerpetualPositions: SyncPerpetualPositions
     @Inject
     lateinit var getTransactions: GetTransactions
+    @Inject
+    lateinit var transactionPostProcessingService: TransactionPostProcessingService
 
     override fun onCreate() {
         super.onCreate()

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsAvailabilityService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsAvailabilityService.kt
@@ -1,0 +1,63 @@
+package com.gemwallet.android.data.repositories.assets
+
+import com.gemwallet.android.data.service.store.database.AssetsDao
+import com.gemwallet.android.domains.asset.calculateAvailabilityChanges
+import com.gemwallet.android.ext.asset
+import com.gemwallet.android.ext.swapSupport
+import com.gemwallet.android.ext.toIdentifier
+import com.wallet.core.primitives.Chain
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AssetsAvailabilityService @Inject constructor(
+    private val assetsDao: AssetsDao,
+) {
+
+    suspend fun updateBuyAvailable(assets: List<String>) {
+        syncAvailability(
+            currentEnabledAssetIds = assetsDao.getBuyAvailableAssetIds(),
+            targetEnabledAssetIds = assets,
+            setAvailability = assetsDao::setBuyAvailable,
+        )
+    }
+
+    suspend fun updateSellAvailable(assets: List<String>) {
+        syncAvailability(
+            currentEnabledAssetIds = assetsDao.getSellAvailableAssetIds(),
+            targetEnabledAssetIds = assets,
+            setAvailability = assetsDao::setSellAvailable,
+        )
+    }
+
+    suspend fun syncSwapSupportChains() {
+        val nativeAssetIds = Chain.entries.map { it.asset().id.toIdentifier() }
+        syncAvailability(
+            currentEnabledAssetIds = assetsDao.getSwapAvailableAssetIds(nativeAssetIds),
+            targetEnabledAssetIds = Chain.swapSupport()
+                .map { it.asset().id.toIdentifier() },
+            trackedAssetIds = nativeAssetIds,
+            setAvailability = assetsDao::setSwapAvailable,
+        )
+    }
+
+    private suspend fun syncAvailability(
+        currentEnabledAssetIds: List<String>,
+        targetEnabledAssetIds: List<String>,
+        setAvailability: suspend (List<String>, Boolean) -> Unit,
+        trackedAssetIds: List<String> = (currentEnabledAssetIds + targetEnabledAssetIds).distinct(),
+    ) {
+        val changes = calculateAvailabilityChanges(
+            currentEnabledAssetIds = currentEnabledAssetIds,
+            targetEnabledAssetIds = targetEnabledAssetIds,
+            trackedAssetIds = trackedAssetIds,
+        )
+
+        if (changes.idsToDisable.isNotEmpty()) {
+            setAvailability(changes.idsToDisable, false)
+        }
+        if (changes.idsToEnable.isNotEmpty()) {
+            setAvailability(changes.idsToEnable, true)
+        }
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
@@ -1,22 +1,16 @@
 package com.gemwallet.android.data.repositories.assets
 
 import android.util.Log
-import com.gemwallet.android.application.transactions.coordinators.GetChangedTransactions
 import com.gemwallet.android.blockchain.operators.GetAsset
 import com.gemwallet.android.blockchain.services.BalancesService
-import com.gemwallet.android.cases.nft.SyncNfts
-import com.gemwallet.android.cases.stake.SyncStakeDelegations
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.stream.StreamSubscriptionService
-import com.gemwallet.android.data.repositories.tokens.toPriorityQuery
 import com.gemwallet.android.data.service.store.database.AssetsDao
-import com.gemwallet.android.data.service.store.database.AssetsPriorityDao
 import com.gemwallet.android.data.service.store.database.BalancesDao
 import com.gemwallet.android.data.service.store.database.PricesDao
 import com.gemwallet.android.data.service.store.database.entities.DbAsset
 import com.gemwallet.android.data.service.store.database.entities.DbAssetBasicUpdate
-import com.gemwallet.android.data.service.store.database.entities.DbRecentActivity
 import com.gemwallet.android.data.service.store.database.entities.toAssetInfoModel
 import com.gemwallet.android.data.service.store.database.entities.toAssetLinkRecord
 import com.gemwallet.android.data.service.store.database.entities.toAssetLinksModel
@@ -25,24 +19,17 @@ import com.gemwallet.android.data.service.store.database.entities.toDTO
 import com.gemwallet.android.data.service.store.database.entities.toPriceRecord
 import com.gemwallet.android.data.service.store.database.entities.toRecord
 import com.gemwallet.android.data.service.store.database.entities.toUpdateRecord
-import com.gemwallet.android.domains.asset.calculateAvailabilityChanges
 import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.asset.defaultBasic
 import com.gemwallet.android.ext.asset
 import com.gemwallet.android.ext.available
-import com.gemwallet.android.ext.getAssociatedAssetIds
-import com.gemwallet.android.ext.isCompleted
-import com.gemwallet.android.ext.swapSupport
 import com.gemwallet.android.ext.toAssetId
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.model.AssetBalance
 import com.gemwallet.android.model.AssetInfo
-import com.gemwallet.android.model.AssetPriceInfo
 import com.gemwallet.android.model.RecentAsset
 import com.gemwallet.android.model.RecentAssetsRequest
 import com.gemwallet.android.model.RecentType
-import com.wallet.core.primitives.Transaction
-import com.gemwallet.android.model.TransactionExtended
 import com.wallet.core.primitives.Account
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.AssetBasic
@@ -50,12 +37,10 @@ import com.wallet.core.primitives.AssetFull
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.AssetLink
 import com.wallet.core.primitives.AssetMarket
-import com.wallet.core.primitives.AssetPrice
 import com.wallet.core.primitives.AssetTag
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.FiatRate
-import com.wallet.core.primitives.TransactionType
 import com.wallet.core.primitives.Wallet
 import com.wallet.core.primitives.WalletId
 import com.wallet.core.primitives.WalletType
@@ -68,9 +53,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -88,16 +70,16 @@ private const val TAG = "AssetsRepository"
 @Singleton
 class AssetsRepository @Inject constructor(
     private val assetsDao: AssetsDao,
-    private val assetsPriorityDao: AssetsPriorityDao,
     private val balancesDao: BalancesDao,
     private val pricesDao: PricesDao,
     private val sessionRepository: SessionRepository,
     private val balancesService: BalancesService,
-    getChangedTransactions: GetChangedTransactions,
-    private val syncStakeDelegations: SyncStakeDelegations,
-    private val syncNfts: SyncNfts,
     private val searchTokensCase: SearchTokensCase,
     private val streamSubscriptionService: StreamSubscriptionService,
+    private val availabilityService: AssetsAvailabilityService,
+    private val currencyRatesService: CurrencyRatesService,
+    private val searchService: AssetsSearchService,
+    private val recentAssetsService: RecentAssetsService,
     private val updateBalances: UpdateBalances = UpdateBalances(balancesDao, balancesService),
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
 ) : GetAsset {
@@ -105,34 +87,26 @@ class AssetsRepository @Inject constructor(
 
     init {
         scope.launch(Dispatchers.IO) {
-            getChangedTransactions.getChangedTransactions().collect {
-                onTransactions(it)
-            }
-        }
-        scope.launch(Dispatchers.IO) {
             sessionRepository.session().collectLatest {
-                changeCurrency(it?.currency ?: return@collectLatest)
+                currencyRatesService.changeCurrency(it?.currency ?: return@collectLatest)
             }
         }
         scope.launch(Dispatchers.IO) {
-            syncSwapSupportChains()
+            availabilityService.syncSwapSupportChains()
         }
     }
 
-    private fun currentWalletId(): Flow<String> = sessionRepository.session()
-        .filterNotNull()
-        .map { it.wallet.id.id }
-        .distinctUntilChanged()
+    private fun currentWalletId(): Flow<String> = sessionRepository.currentWalletId()
 
     suspend fun sync() {
-        getAssetsInfo().firstOrNull()?.updateBalances()?.awaitAll()
+        getAssetsInfo().firstOrNull()?.refreshBalances()?.awaitAll()
     }
 
     suspend fun saveAssetMetadata(assetFull: AssetFull) = withContext(Dispatchers.IO) {
         val assetId = assetFull.asset.id
         val assetIdIdentifier = assetId.toIdentifier()
         val currency = sessionRepository.getCurrentCurrency()
-        val rate = getCurrencyRate(currency).firstOrNull() ?: when (currency) {
+        val rate = currencyRatesService.getCurrencyRate(currency).firstOrNull() ?: when (currency) {
             Currency.USD -> FiatRate(Currency.USD.string, 1.0)
             else -> null
         }
@@ -152,7 +126,7 @@ class AssetsRepository @Inject constructor(
     }
 
     suspend fun updateAssetMarket(assetId: AssetId, market: AssetMarket, currency: Currency) = withContext(Dispatchers.IO) {
-        val rate = getCurrencyRate(currency).firstOrNull()?.rate ?: return@withContext
+        val rate = currencyRatesService.getCurrencyRate(currency).firstOrNull()?.rate ?: return@withContext
         assetsDao.setMarket(market.toRecord(assetId, rate))
     }
 
@@ -262,40 +236,11 @@ class AssetsRepository @Inject constructor(
         return searchTokensCase.search(assetId, currency)
     }
 
-    fun search(query: String, tags: List<AssetTag>, byAllWallets: Boolean): Flow<List<AssetInfo>> {
-        val query = tags.toPriorityQuery(query)
-        return currentWalletId().flatMapLatest { walletId ->
-            assetsPriorityDao.hasPriorities(query).map { it > 0 }.flatMapLatest { hasPriority ->
-                when {
-                    byAllWallets && hasPriority -> assetsDao.searchByAllWalletsWithPriority(walletId, query)
-                    byAllWallets -> assetsDao.searchByAllWallets(walletId, query)
-                    hasPriority -> assetsDao.searchWithPriority(walletId, query)
-                    else -> assetsDao.search(walletId, query)
-                }
-            }
-        }
-        .toAssetInfoModel()
-    }
+    fun search(query: String, tags: List<AssetTag>, byAllWallets: Boolean): Flow<List<AssetInfo>> =
+        searchService.search(query, tags, byAllWallets)
 
-    fun swapSearch(wallet: Wallet, query: String, byChains: List<Chain>, byAssets: List<AssetId>, tags: List<AssetTag>): Flow<List<AssetInfo>> {
-        val query = tags.toPriorityQuery(query)
-        val walletChains = wallet.accounts.map { it.chain }
-        val includeChains = byChains.filter { walletChains.contains(it) }
-        val includeAssetIds = byAssets.filter { walletChains.contains(it.chain) }
-        return assetsPriorityDao.hasPriorities(query).map { it > 0 }.flatMapLatest { hasPriority ->
-                if (hasPriority) {
-                    assetsDao.swapSearchWithPriority(wallet.id.id, query, includeChains, includeAssetIds.map { it.toIdentifier() })
-                } else {
-                    assetsDao.swapSearch(wallet.id.id, query, includeChains, includeAssetIds.map { it.toIdentifier() })
-                }
-            }
-            .toAssetInfoModel()
-            .map { assets ->
-                assets.filter { asset ->
-                    asset.metadata?.isEnabled == true
-                }
-            }
-    }
+    fun swapSearch(wallet: Wallet, query: String, byChains: List<Chain>, byAssets: List<AssetId>, tags: List<AssetTag>): Flow<List<AssetInfo>> =
+        searchService.swapSearch(wallet, query, byChains, byAssets, tags)
 
     /**
      * Check and add new coins and active tokens
@@ -348,7 +293,11 @@ class AssetsRepository @Inject constructor(
     }
 
     suspend fun updateBalances(vararg tokens: AssetId) {
-        getAssetsInfo(tokens.toList()).firstOrNull()?.updateBalances()?.awaitAll()
+        getAssetsInfo(tokens.toList()).firstOrNull()?.refreshBalances()?.awaitAll()
+    }
+
+    suspend fun updateBalances(assetInfos: List<AssetInfo>) {
+        assetInfos.refreshBalances().awaitAll()
     }
 
     suspend fun add(walletId: String, asset: Asset, visible: Boolean) {
@@ -425,62 +374,9 @@ class AssetsRepository @Inject constructor(
         assetsDao.setWalletAssetVisibility(walletId, assetIdIdentifier, visible)
     }
 
-    suspend fun updateBuyAvailable(assets: List<String>) {
-        syncAvailability(
-            currentEnabledAssetIds = assetsDao.getBuyAvailableAssetIds(),
-            targetEnabledAssetIds = assets,
-            setAvailability = assetsDao::setBuyAvailable,
-        )
-    }
+    suspend fun updateBuyAvailable(assets: List<String>) = availabilityService.updateBuyAvailable(assets)
 
-    suspend fun updateSellAvailable(assets: List<String>) {
-        syncAvailability(
-            currentEnabledAssetIds = assetsDao.getSellAvailableAssetIds(),
-            targetEnabledAssetIds = assets,
-            setAvailability = assetsDao::setSellAvailable,
-        )
-    }
-
-    private fun onTransactions(transactions: List<TransactionExtended>) = scope.launch {
-        processTransactions(transactions)
-    }
-
-    internal suspend fun processTransactions(transactions: List<TransactionExtended>) = withContext(Dispatchers.IO) {
-        transactions.map { transactionExtended ->
-            async {
-                val transaction = transactionExtended.transaction
-                val assetInfos = getAssetsInfo(transaction.getAssociatedAssetIds()).firstOrNull().orEmpty()
-                assetInfos.updateBalances()
-                val walletId = assetInfos.firstNotNullOfOrNull { it.walletId } ?: return@async
-                if (transaction.state.isCompleted()) {
-                    processCompleteTransaction(walletId, transaction, assetInfos)
-                }
-            }
-        }.awaitAll()
-    }
-
-    private suspend fun processCompleteTransaction(
-        walletId: WalletId,
-        transaction: Transaction,
-        assetInfos: List<AssetInfo>,
-    ) {
-        when (transaction.type) {
-            TransactionType.StakeDelegate,
-            TransactionType.StakeUndelegate,
-            TransactionType.StakeRewards,
-            TransactionType.StakeRedelegate,
-            TransactionType.StakeWithdraw,
-            TransactionType.StakeFreeze,
-            TransactionType.StakeUnfreeze -> syncStakeDelegations.sync(
-                walletId = walletId,
-                assetId = transaction.assetId,
-                address = transaction.from,
-                apr = assetInfos.firstOrNull { it.id() == transaction.assetId }?.stakeApr ?: 0.0,
-            )
-            TransactionType.TransferNFT -> syncNfts.sync(walletId)
-            else -> Unit
-        }
-    }
+    suspend fun updateSellAvailable(assets: List<String>) = availabilityService.updateSellAvailable(assets)
 
     fun getAssetLinks(id: AssetId): Flow<List<AssetLink>> {
         return assetsDao.getAssetLinks(id.toIdentifier())
@@ -498,38 +394,7 @@ class AssetsRepository @Inject constructor(
         return visibleByDefault.contains(chain) || type != WalletType.Multicoin
     }
 
-    private suspend fun syncSwapSupportChains() {
-        val nativeAssetIds = Chain.entries.map { it.asset().id.toIdentifier() }
-        syncAvailability(
-            currentEnabledAssetIds = assetsDao.getSwapAvailableAssetIds(nativeAssetIds),
-            targetEnabledAssetIds = Chain.swapSupport()
-                .map { it.asset().id.toIdentifier() },
-            trackedAssetIds = nativeAssetIds,
-            setAvailability = assetsDao::setSwapAvailable,
-        )
-    }
-
-    private suspend fun syncAvailability(
-        currentEnabledAssetIds: List<String>,
-        targetEnabledAssetIds: List<String>,
-        setAvailability: suspend (List<String>, Boolean) -> Unit,
-        trackedAssetIds: List<String> = (currentEnabledAssetIds + targetEnabledAssetIds).distinct(),
-    ) {
-        val changes = calculateAvailabilityChanges(
-            currentEnabledAssetIds = currentEnabledAssetIds,
-            targetEnabledAssetIds = targetEnabledAssetIds,
-            trackedAssetIds = trackedAssetIds,
-        )
-
-        if (changes.idsToDisable.isNotEmpty()) {
-            setAvailability(changes.idsToDisable, false)
-        }
-        if (changes.idsToEnable.isNotEmpty()) {
-            setAvailability(changes.idsToEnable, true)
-        }
-    }
-
-    private suspend fun List<AssetInfo>.updateBalances(): List<Deferred<List<AssetBalance>>> = withContext(Dispatchers.IO) {
+    private suspend fun List<AssetInfo>.refreshBalances(): List<Deferred<List<AssetBalance>>> = withContext(Dispatchers.IO) {
         groupBy { it.walletId }
             .mapValues { wallet ->
                 val walletId = wallet.key ?: return@mapValues null
@@ -550,48 +415,19 @@ class AssetsRepository @Inject constructor(
             .flatten()
     }
 
-    private suspend fun changeCurrency(currency: Currency) {
-        val rate = pricesDao.getRates(currency).map { it?.toDTO() }.firstOrNull() ?: return
-        pricesDao.getAll().firstOrNull()?.map {
-            it.copy(value = (it.usdValue ?: 0.0) * rate.rate, currency = currency.string)
-        }?.let { pricesDao.insert(it) }
-    }
-
-    fun getCurrencyRate(currency: Currency): Flow<FiatRate?> {
-        return pricesDao.getRates(currency).map { it?.toDTO() }
-    }
+    fun getCurrencyRate(currency: Currency): Flow<FiatRate?> = currencyRatesService.getCurrencyRate(currency)
 
     suspend fun addRecentActivity(
         assetId: AssetId,
         walletId: String,
         type: RecentType,
         toAssetId: AssetId? = null,
-    ) {
-        return assetsDao.addRecentActivity(
-            DbRecentActivity(
-                assetId = assetId.toIdentifier(),
-                walletId = walletId,
-                toAssetId = toAssetId?.toIdentifier(),
-                type = type,
-                addedAt = System.currentTimeMillis(),
-            )
-        )
-    }
+    ) = recentAssetsService.addRecentActivity(assetId, walletId, type, toAssetId)
 
-    fun getRecentAssets(request: RecentAssetsRequest): Flow<List<RecentAsset>> {
-        return currentWalletId()
-            .flatMapLatest { walletId -> assetsDao.getRecentAssets(walletId, request.types, request.filters, request.limit) }
-            .map { items ->
-                items.mapNotNull { row ->
-                    val asset = row.asset.toDTO() ?: return@mapNotNull null
-                    RecentAsset(asset = asset, addedAt = row.addedAt)
-                }
-            }
-    }
+    fun getRecentAssets(request: RecentAssetsRequest): Flow<List<RecentAsset>> = recentAssetsService.getRecentAssets(request)
 
-    suspend fun clearRecentAssets(walletId: WalletId, types: List<RecentType>) {
-        assetsDao.clearRecentAssets(walletId.id, types)
-    }
+    suspend fun clearRecentAssets(walletId: WalletId, types: List<RecentType>) =
+        recentAssetsService.clearRecentAssets(walletId, types)
 }
 
 private fun DbAsset.toBasicUpdateRecord() = DbAssetBasicUpdate(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsSearchService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsSearchService.kt
@@ -1,0 +1,63 @@
+package com.gemwallet.android.data.repositories.assets
+
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.data.repositories.tokens.toPriorityQuery
+import com.gemwallet.android.data.service.store.database.AssetsDao
+import com.gemwallet.android.data.service.store.database.AssetsPriorityDao
+import com.gemwallet.android.data.service.store.database.entities.toAssetInfoModel
+import com.gemwallet.android.ext.toIdentifier
+import com.gemwallet.android.model.AssetInfo
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.AssetTag
+import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.Wallet
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Singleton
+class AssetsSearchService @Inject constructor(
+    private val assetsDao: AssetsDao,
+    private val assetsPriorityDao: AssetsPriorityDao,
+    private val sessionRepository: SessionRepository,
+) {
+
+    fun search(query: String, tags: List<AssetTag>, byAllWallets: Boolean): Flow<List<AssetInfo>> {
+        val query = tags.toPriorityQuery(query)
+        return sessionRepository.currentWalletId().flatMapLatest { walletId ->
+            assetsPriorityDao.hasPriorities(query).map { it > 0 }.flatMapLatest { hasPriority ->
+                when {
+                    byAllWallets && hasPriority -> assetsDao.searchByAllWalletsWithPriority(walletId, query)
+                    byAllWallets -> assetsDao.searchByAllWallets(walletId, query)
+                    hasPriority -> assetsDao.searchWithPriority(walletId, query)
+                    else -> assetsDao.search(walletId, query)
+                }
+            }
+        }
+        .toAssetInfoModel()
+    }
+
+    fun swapSearch(wallet: Wallet, query: String, byChains: List<Chain>, byAssets: List<AssetId>, tags: List<AssetTag>): Flow<List<AssetInfo>> {
+        val query = tags.toPriorityQuery(query)
+        val walletChains = wallet.accounts.map { it.chain }
+        val includeChains = byChains.filter { walletChains.contains(it) }
+        val includeAssetIds = byAssets.filter { walletChains.contains(it.chain) }
+        return assetsPriorityDao.hasPriorities(query).map { it > 0 }.flatMapLatest { hasPriority ->
+                if (hasPriority) {
+                    assetsDao.swapSearchWithPriority(wallet.id.id, query, includeChains, includeAssetIds.map { it.toIdentifier() })
+                } else {
+                    assetsDao.swapSearch(wallet.id.id, query, includeChains, includeAssetIds.map { it.toIdentifier() })
+                }
+            }
+            .toAssetInfoModel()
+            .map { assets ->
+                assets.filter { asset ->
+                    asset.metadata?.isEnabled == true
+                }
+            }
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/CurrencyRatesService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/CurrencyRatesService.kt
@@ -1,0 +1,28 @@
+package com.gemwallet.android.data.repositories.assets
+
+import com.gemwallet.android.data.service.store.database.PricesDao
+import com.gemwallet.android.data.service.store.database.entities.toDTO
+import com.wallet.core.primitives.Currency
+import com.wallet.core.primitives.FiatRate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CurrencyRatesService @Inject constructor(
+    private val pricesDao: PricesDao,
+) {
+
+    suspend fun changeCurrency(currency: Currency) {
+        val rate = pricesDao.getRates(currency).map { it?.toDTO() }.firstOrNull() ?: return
+        pricesDao.getAll().firstOrNull()?.map {
+            it.copy(value = (it.usdValue ?: 0.0) * rate.rate, currency = currency.string)
+        }?.let { pricesDao.insert(it) }
+    }
+
+    fun getCurrencyRate(currency: Currency): Flow<FiatRate?> {
+        return pricesDao.getRates(currency).map { it?.toDTO() }
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/CurrentWalletId.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/CurrentWalletId.kt
@@ -1,0 +1,12 @@
+package com.gemwallet.android.data.repositories.assets
+
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
+
+internal fun SessionRepository.currentWalletId(): Flow<String> = session()
+    .filterNotNull()
+    .map { it.wallet.id.id }
+    .distinctUntilChanged()

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/RecentAssetsService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/RecentAssetsService.kt
@@ -1,0 +1,58 @@
+package com.gemwallet.android.data.repositories.assets
+
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.data.service.store.database.AssetsDao
+import com.gemwallet.android.data.service.store.database.entities.DbRecentActivity
+import com.gemwallet.android.data.service.store.database.entities.toDTO
+import com.gemwallet.android.ext.toIdentifier
+import com.gemwallet.android.model.RecentAsset
+import com.gemwallet.android.model.RecentAssetsRequest
+import com.gemwallet.android.model.RecentType
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.WalletId
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Singleton
+class RecentAssetsService @Inject constructor(
+    private val assetsDao: AssetsDao,
+    private val sessionRepository: SessionRepository,
+) {
+
+    suspend fun addRecentActivity(
+        assetId: AssetId,
+        walletId: String,
+        type: RecentType,
+        toAssetId: AssetId? = null,
+    ) {
+        return assetsDao.addRecentActivity(
+            DbRecentActivity(
+                assetId = assetId.toIdentifier(),
+                walletId = walletId,
+                toAssetId = toAssetId?.toIdentifier(),
+                type = type,
+                addedAt = System.currentTimeMillis(),
+            )
+        )
+    }
+
+    fun getRecentAssets(request: RecentAssetsRequest): Flow<List<RecentAsset>> {
+        return sessionRepository.currentWalletId()
+            .flatMapLatest { walletId -> assetsDao.getRecentAssets(walletId, request.types, request.filters, request.limit) }
+            .map { items ->
+                items.mapNotNull { row ->
+                    val asset = row.asset.toDTO() ?: return@mapNotNull null
+                    RecentAsset(asset = asset, addedAt = row.addedAt)
+                }
+            }
+    }
+
+    suspend fun clearRecentAssets(walletId: WalletId, types: List<RecentType>) {
+        assetsDao.clearRecentAssets(walletId.id, types)
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/TransactionPostProcessingService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/TransactionPostProcessingService.kt
@@ -1,0 +1,84 @@
+package com.gemwallet.android.data.repositories.assets
+
+import com.gemwallet.android.application.transactions.coordinators.GetChangedTransactions
+import com.gemwallet.android.cases.nft.SyncNfts
+import com.gemwallet.android.cases.stake.SyncStakeDelegations
+import com.gemwallet.android.ext.getAssociatedAssetIds
+import com.gemwallet.android.ext.isCompleted
+import com.gemwallet.android.model.AssetInfo
+import com.gemwallet.android.model.TransactionExtended
+import com.wallet.core.primitives.Transaction
+import com.wallet.core.primitives.TransactionType
+import com.wallet.core.primitives.WalletId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TransactionPostProcessingService(
+    getChangedTransactions: GetChangedTransactions,
+    private val assetsRepository: AssetsRepository,
+    private val syncStakeDelegations: SyncStakeDelegations,
+    private val syncNfts: SyncNfts,
+    private val scope: CoroutineScope,
+) {
+
+    @Inject
+    constructor(
+        getChangedTransactions: GetChangedTransactions,
+        assetsRepository: AssetsRepository,
+        syncStakeDelegations: SyncStakeDelegations,
+        syncNfts: SyncNfts,
+    ) : this(getChangedTransactions, assetsRepository, syncStakeDelegations, syncNfts, CoroutineScope(Dispatchers.IO))
+
+    init {
+        scope.launch(Dispatchers.IO) {
+            getChangedTransactions.getChangedTransactions().collect {
+                processTransactions(it)
+            }
+        }
+    }
+
+    internal suspend fun processTransactions(transactions: List<TransactionExtended>) = withContext(Dispatchers.IO) {
+        transactions.map { transactionExtended ->
+            async {
+                val transaction = transactionExtended.transaction
+                val assetInfos = assetsRepository.getAssetsInfo(transaction.getAssociatedAssetIds()).firstOrNull().orEmpty()
+                assetsRepository.updateBalances(assetInfos)
+                val walletId = assetInfos.firstNotNullOfOrNull { it.walletId } ?: return@async
+                if (transaction.state.isCompleted()) {
+                    processCompleteTransaction(walletId, transaction, assetInfos)
+                }
+            }
+        }.awaitAll()
+    }
+
+    private suspend fun processCompleteTransaction(
+        walletId: WalletId,
+        transaction: Transaction,
+        assetInfos: List<AssetInfo>,
+    ) {
+        when (transaction.type) {
+            TransactionType.StakeDelegate,
+            TransactionType.StakeUndelegate,
+            TransactionType.StakeRewards,
+            TransactionType.StakeRedelegate,
+            TransactionType.StakeWithdraw,
+            TransactionType.StakeFreeze,
+            TransactionType.StakeUnfreeze -> syncStakeDelegations.sync(
+                walletId = walletId,
+                assetId = transaction.assetId,
+                address = transaction.from,
+                apr = assetInfos.firstOrNull { it.id() == transaction.assetId }?.stakeApr ?: 0.0,
+            )
+            TransactionType.TransferNFT -> syncNfts.sync(walletId)
+            else -> Unit
+        }
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
@@ -4,14 +4,16 @@ import com.gemwallet.android.application.assets.coordinators.SyncAssets
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
 import com.gemwallet.android.application.fiat.coordinators.SyncFiatTransactions
 import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAlerts
-import com.gemwallet.android.application.transactions.coordinators.GetChangedTransactions
 import com.gemwallet.android.blockchain.services.BalancesService
 import com.gemwallet.android.blockchain.services.PerpetualService
 import com.gemwallet.android.cases.nft.SyncNfts
-import com.gemwallet.android.cases.stake.SyncStakeDelegations
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
+import com.gemwallet.android.data.repositories.assets.AssetsAvailabilityService
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsSearchService
+import com.gemwallet.android.data.repositories.assets.CurrencyRatesService
+import com.gemwallet.android.data.repositories.assets.RecentAssetsService
 import com.gemwallet.android.data.repositories.assets.UpdateBalances
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.stream.ExponentialReconnection
@@ -20,7 +22,6 @@ import com.gemwallet.android.data.repositories.stream.StreamObserverService
 import com.gemwallet.android.data.repositories.stream.StreamSubscriptionService
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.data.service.store.database.AssetsDao
-import com.gemwallet.android.data.service.store.database.AssetsPriorityDao
 import com.gemwallet.android.data.service.store.database.BalancesDao
 import com.gemwallet.android.data.service.store.database.InAppNotificationsDao
 import com.gemwallet.android.data.service.store.database.PriceAlertsDao
@@ -40,28 +41,28 @@ object AssetsModule {
     @Singleton
     fun provideAssetsRepository(
         assetsDao: AssetsDao,
-        assetsPriorityDao: AssetsPriorityDao,
         balancesDao: BalancesDao,
         pricesDao: PricesDao,
         sessionRepository: SessionRepository,
         balancesService: BalancesService,
-        getChangedTransactions: GetChangedTransactions,
-        syncStakeDelegations: SyncStakeDelegations,
-        syncNfts: SyncNfts,
         searchTokensCase: SearchTokensCase,
         streamSubscriptionService: StreamSubscriptionService,
+        availabilityService: AssetsAvailabilityService,
+        currencyRatesService: CurrencyRatesService,
+        searchService: AssetsSearchService,
+        recentAssetsService: RecentAssetsService,
     ): AssetsRepository = AssetsRepository(
         assetsDao = assetsDao,
-        assetsPriorityDao = assetsPriorityDao,
         balancesDao = balancesDao,
         pricesDao = pricesDao,
         sessionRepository = sessionRepository,
-        getChangedTransactions = getChangedTransactions,
         balancesService = balancesService,
-        syncStakeDelegations = syncStakeDelegations,
-        syncNfts = syncNfts,
         searchTokensCase = searchTokensCase,
         streamSubscriptionService = streamSubscriptionService,
+        availabilityService = availabilityService,
+        currencyRatesService = currencyRatesService,
+        searchService = searchService,
+        recentAssetsService = recentAssetsService,
     )
 
     @Provides

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
@@ -1,9 +1,6 @@
 package com.gemwallet.android.data.repositories.assets
 
-import com.gemwallet.android.application.transactions.coordinators.GetChangedTransactions
 import com.gemwallet.android.blockchain.services.BalancesService
-import com.gemwallet.android.cases.nft.SyncNfts
-import com.gemwallet.android.cases.stake.SyncStakeDelegations
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.stream.StreamSubscriptionService
 import com.gemwallet.android.cases.tokens.SearchTokensCase
@@ -22,7 +19,6 @@ import com.gemwallet.android.data.service.store.database.entities.mockDbAssetInf
 import com.gemwallet.android.domains.asset.defaultBasic
 import com.gemwallet.android.ext.asset
 import com.gemwallet.android.ext.available
-import com.gemwallet.android.ext.getAssociatedAssetIds
 import com.gemwallet.android.ext.isStakeSupported
 import com.gemwallet.android.ext.isSwapSupport
 import com.gemwallet.android.ext.toIdentifier
@@ -35,9 +31,7 @@ import com.gemwallet.android.testkit.mockWalletId
 import com.gemwallet.android.testkit.mockAssetProperties
 import com.gemwallet.android.testkit.mockAssetSolana
 import com.gemwallet.android.testkit.mockAssetSolanaUSDC
-import com.gemwallet.android.testkit.mockTransaction
 import com.gemwallet.android.testkit.mockSession
-import com.gemwallet.android.testkit.mockTransactionExtended
 import com.gemwallet.android.testkit.mockWallet
 import com.gemwallet.android.testkit.mockWalletId
 import com.gemwallet.android.testkit.mockChartValuePercentage
@@ -47,8 +41,6 @@ import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.AssetScore
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.Currency
-import com.wallet.core.primitives.TransactionState
-import com.wallet.core.primitives.TransactionType
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -56,12 +48,10 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
-import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -78,9 +68,6 @@ class AssetsRepositoryTest {
     private val pricesDao = mockk<PricesDao>(relaxed = true)
     private val sessionRepository = mockk<SessionRepository>()
     private val balancesService = mockk<BalancesService>(relaxed = true)
-    private val getChangedTransactions = mockk<GetChangedTransactions>()
-    private val syncStakeDelegations = mockk<SyncStakeDelegations>(relaxed = true)
-    private val syncNfts = mockk<SyncNfts>(relaxed = true)
     private val searchTokensCase = mockk<SearchTokensCase>(relaxed = true)
     private val streamSubscriptionService = mockk<StreamSubscriptionService>(relaxed = true)
     private val updateBalances = mockk<UpdateBalances>(relaxed = true)
@@ -89,16 +76,16 @@ class AssetsRepositoryTest {
 
     private fun createSubject() = AssetsRepository(
         assetsDao = assetsDao,
-        assetsPriorityDao = assetsPriorityDao,
         balancesDao = balancesDao,
         pricesDao = pricesDao,
         sessionRepository = sessionRepository,
         balancesService = balancesService,
-        getChangedTransactions = getChangedTransactions,
-        syncStakeDelegations = syncStakeDelegations,
-        syncNfts = syncNfts,
         searchTokensCase = searchTokensCase,
         streamSubscriptionService = streamSubscriptionService,
+        availabilityService = AssetsAvailabilityService(assetsDao),
+        currencyRatesService = CurrencyRatesService(pricesDao),
+        searchService = AssetsSearchService(assetsDao, assetsPriorityDao, sessionRepository),
+        recentAssetsService = RecentAssetsService(assetsDao, sessionRepository),
         updateBalances = updateBalances,
         scope = scope,
     )
@@ -110,71 +97,7 @@ class AssetsRepositoryTest {
     }
 
     @Test
-    fun completeStakeTransaction_syncsDelegations() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
-        sessionFlow.value = mockSession(wallet = mockWallet(id = "wallet-1"))
-        every { sessionRepository.session() } returns sessionFlow
-        val asset = mockAssetSolana()
-        every { assetsDao.getAssetsInfo("wallet-1", listOf(asset.id.toIdentifier())) } returns flowOf(
-            listOf(
-                mockDbAssetInfo(
-                    chain = asset.id.chain,
-                    id = asset.id.toIdentifier(),
-                    name = asset.name,
-                    symbol = asset.symbol,
-                    decimals = asset.decimals,
-                    type = asset.type,
-                    address = "solana-sender",
-                    stakingApr = 7.5,
-                )
-            )
-        )
-
-        val subject = createSubject()
-        subject.processTransactions(
-            listOf(TransactionState.Confirmed, TransactionState.Failed, TransactionState.Reverted).map { state ->
-                mockTransactionExtended(
-                    transaction = mockTransaction(
-                        assetId = asset.id,
-                        from = "solana-sender",
-                        type = TransactionType.StakeDelegate,
-                        state = state,
-                    ),
-                    asset = asset,
-                )
-            }
-        )
-
-        coVerify(exactly = 3) {
-            syncStakeDelegations.sync(mockWalletId("wallet-1"), asset.id, "solana-sender", apr = 7.5)
-        }
-        coVerify(exactly = 0) { syncNfts.sync(any()) }
-    }
-
-    @Test
-    fun completeNftTransfer_syncsWalletNfts() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
-        sessionFlow.value = mockSession(wallet = mockWallet(id = "wallet-1"))
-        every { sessionRepository.session() } returns sessionFlow
-        val transaction = mockTransaction(type = TransactionType.TransferNFT)
-        every { assetsDao.getAssetsInfo("wallet-1", transaction.getAssociatedAssetIds().map { it.toIdentifier() }) } returns flowOf(
-            listOf(mockDbAssetInfo(chain = transaction.assetId.chain, id = transaction.assetId.toIdentifier()))
-        )
-
-        val subject = createSubject()
-        subject.processTransactions(
-            listOf(TransactionState.Confirmed, TransactionState.Failed, TransactionState.Reverted).map { state ->
-                mockTransactionExtended(transaction = transaction.copy(state = state))
-            }
-        )
-
-        coVerify(exactly = 3) { syncNfts.sync(mockWalletId()) }
-        coVerify(exactly = 0) { syncStakeDelegations.sync(any(), any(), any(), any()) }
-    }
-
-    @Test
     fun saveAssetMetadata_storesLinksPriceAndMarketFromAssetResponse() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
 
         val asset = mockAssetSolana()
@@ -238,7 +161,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun saveAssetMetadata_persistsUnknownAssetAndMarketInOneAtomicCall() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
 
         val asset = mockAssetSolanaUSDC()
@@ -263,7 +185,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun updateBuyAvailable_appliesAvailabilityDiffWithoutResettingAllRows() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
         coEvery { assetsDao.getSwapAvailableAssetIds(any()) } returns emptyList()
         coEvery { assetsDao.getBuyAvailableAssetIds() } returns listOf("bitcoin", "ethereum")
@@ -277,7 +198,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun updateSellAvailable_appliesAvailabilityDiffWithoutResettingAllRows() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
         coEvery { assetsDao.getSwapAvailableAssetIds(any()) } returns emptyList()
         coEvery { assetsDao.getSellAvailableAssetIds() } returns listOf("bitcoin", "ethereum")
@@ -291,7 +211,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun addApiAsset_insertsApiRank() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
         val asset = mockAssetSolana()
         val assetBasic = AssetBasic(
@@ -335,7 +254,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun addApiAssets_updatesExistingRowsWithApiRank() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
 
         val asset = mockAssetSolanaUSDC()
@@ -356,7 +274,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun linkAssetToWallet_visibleAssetSubscribesToPriceStream() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
 
         val asset = mockAssetSolanaUSDC()
@@ -376,7 +293,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun linkAssetToWallet_hiddenAssetDoesNotSubscribeToPriceStream() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
 
         val asset = mockAssetSolanaUSDC()
@@ -396,7 +312,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun addLocalAsset_insertsDefaultTokenRank() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
 
         val asset = mockAssetSolanaUSDC()
@@ -428,7 +343,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun updateNativeAssetRanks_repairsLegacyNativeRanks() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
         mockkStatic("com.gemwallet.android.ext.ChainKt")
         mockkStatic("uniffi.gemstone.GemstoneKt")
@@ -451,7 +365,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun switchVisibility_hideUnlinkedAsset_doesNotCreateWalletAsset() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         sessionFlow.value = mockSession(wallet = mockWallet(id = "wallet-1"))
         every { sessionRepository.session() } returns sessionFlow
         every { assetsDao.getAssetInfo("wallet-1", "solana", Chain.Solana) } returns flowOf(null)
@@ -464,7 +377,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun switchVisibility_showUnlinkedAsset_linksOnce() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         sessionFlow.value = mockSession(wallet = mockWallet(id = "wallet-1"))
         every { sessionRepository.session() } returns sessionFlow
         every { assetsDao.getAssetInfo("wallet-1", "solana", Chain.Solana) } returns flowOf(null)
@@ -484,7 +396,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun swapSearch_includesEnabledHiddenAndUnlinkedAssets() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
         every { assetsPriorityDao.hasPriorities("") } returns flowOf(0)
 
@@ -551,7 +462,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun swapSearch_usesPriorityDaoAndPreservesOrderWhenPrioritiesExist() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
         every { assetsPriorityDao.hasPriorities("usd") } returns flowOf(2)
 
@@ -590,7 +500,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun getAssetsInfo_returnsStoreRowsWithoutRepositoryDedupe() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         sessionFlow.value = mockSession(wallet = mockWallet(id = "wallet-1"))
         every { sessionRepository.session() } returns sessionFlow
 
@@ -610,7 +519,6 @@ class AssetsRepositoryTest {
 
     @Test
     fun getNativeAssets_returnsNativeWalletAssetsFromDao() = runBlocking {
-        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
         every { sessionRepository.session() } returns sessionFlow
 
         val wallet = mockWallet(id = "wallet-1")

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/TransactionPostProcessingServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/TransactionPostProcessingServiceTest.kt
@@ -1,0 +1,95 @@
+package com.gemwallet.android.data.repositories.assets
+
+import com.gemwallet.android.application.transactions.coordinators.GetChangedTransactions
+import com.gemwallet.android.cases.nft.SyncNfts
+import com.gemwallet.android.cases.stake.SyncStakeDelegations
+import com.gemwallet.android.model.AssetInfo
+import com.gemwallet.android.testkit.mockAssetInfo
+import com.gemwallet.android.testkit.mockAssetSolana
+import com.gemwallet.android.testkit.mockTransaction
+import com.gemwallet.android.testkit.mockTransactionExtended
+import com.gemwallet.android.testkit.mockWalletId
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.TransactionState
+import com.wallet.core.primitives.TransactionType
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Test
+
+class TransactionPostProcessingServiceTest {
+
+    private val getChangedTransactions = mockk<GetChangedTransactions>()
+    private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
+    private val syncStakeDelegations = mockk<SyncStakeDelegations>(relaxed = true)
+    private val syncNfts = mockk<SyncNfts>(relaxed = true)
+    private val scope = CoroutineScope(Job())
+
+    private fun createSubject() = TransactionPostProcessingService(
+        getChangedTransactions = getChangedTransactions,
+        assetsRepository = assetsRepository,
+        syncStakeDelegations = syncStakeDelegations,
+        syncNfts = syncNfts,
+        scope = scope,
+    )
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+        unmockkAll()
+    }
+
+    @Test
+    fun completeStakeTransaction_syncsDelegations() = runBlocking {
+        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
+        val asset = mockAssetSolana()
+        val assetInfo = mockAssetInfo(asset = asset, walletId = mockWalletId("wallet-1")).copy(stakeApr = 7.5)
+        every { assetsRepository.getAssetsInfo(any<List<AssetId>>()) } returns flowOf(listOf(assetInfo))
+
+        val subject = createSubject()
+        subject.processTransactions(
+            listOf(TransactionState.Confirmed, TransactionState.Failed, TransactionState.Reverted).map { state ->
+                mockTransactionExtended(
+                    transaction = mockTransaction(
+                        assetId = asset.id,
+                        from = "solana-sender",
+                        type = TransactionType.StakeDelegate,
+                        state = state,
+                    ),
+                    asset = asset,
+                )
+            }
+        )
+
+        coVerify(exactly = 3) {
+            syncStakeDelegations.sync(mockWalletId("wallet-1"), asset.id, "solana-sender", apr = 7.5)
+        }
+        coVerify(exactly = 0) { syncNfts.sync(any()) }
+    }
+
+    @Test
+    fun completeNftTransfer_syncsWalletNfts() = runBlocking {
+        every { getChangedTransactions.getChangedTransactions() } returns emptyFlow()
+        val transaction = mockTransaction(type = TransactionType.TransferNFT)
+        val assetInfo: AssetInfo = mockAssetInfo(walletId = mockWalletId())
+        every { assetsRepository.getAssetsInfo(any<List<AssetId>>()) } returns flowOf(listOf(assetInfo))
+
+        val subject = createSubject()
+        subject.processTransactions(
+            listOf(TransactionState.Confirmed, TransactionState.Failed, TransactionState.Reverted).map { state ->
+                mockTransactionExtended(transaction = transaction.copy(state = state))
+            }
+        )
+
+        coVerify(exactly = 3) { syncNfts.sync(mockWalletId()) }
+        coVerify(exactly = 0) { syncStakeDelegations.sync(any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
Splits AssetsRepository into small single-purpose services so it's easier to read and safer to change. No behavior change.

Closes #470