### PR TITLE
Format NFT date attributes as short date

### DIFF
--- a/ios/Features/NFT/Sources/ViewModels/NFTAttributeViewModel.swift
+++ b/ios/Features/NFT/Sources/ViewModels/NFTAttributeViewModel.swift
@@ -8,7 +8,7 @@ struct NFTAttributeViewModel: Identifiable {
     let name: String
     let value: String
 
-    init(attribute: NFTAttribute, relativeDateFormatter: RelativeDateFormatter = RelativeDateFormatter()) {
+    init(attribute: NFTAttribute, relativeDateFormatter: RelativeDateFormatter = RelativeDateFormatter(type: .date)) {
         id = attribute.id
         name = attribute.name
         value = switch attribute.valueType ?? .string {

--- a/ios/Features/NFT/Tests/NFTTests/CollectibleViewModelTests.swift
+++ b/ios/Features/NFT/Tests/NFTTests/CollectibleViewModelTests.swift
@@ -67,6 +67,7 @@ struct CollectibleViewModelTests {
     @Test
     func attributeValueFormatting() throws {
         let formatter = try RelativeDateFormatter(
+            type: .date,
             locale: Locale(identifier: "en_US_POSIX"),
             timeZone: #require(TimeZone(secondsFromGMT: 0)),
         )
@@ -80,7 +81,7 @@ struct CollectibleViewModelTests {
             relativeDateFormatter: formatter,
         )
 
-        #expect(date.value == formatter.string(fromTimestampValue: "1662714817"))
+        #expect(date.value == "Sep 9, 2022")
         #expect(string.value == "9")
     }
 

--- a/ios/Packages/Formatters/Sources/RelativeDateFormatter.swift
+++ b/ios/Packages/Formatters/Sources/RelativeDateFormatter.swift
@@ -2,46 +2,39 @@
 
 import Foundation
 
+public enum RelativeDateFormatterType: Sendable {
+    case dateTime
+    case date
+}
+
 public struct RelativeDateFormatter: Sendable {
+    private let type: RelativeDateFormatterType
     public let calendar: Calendar
 
-    private let relativeDateFormatter: DateFormatter
-    private let timeFormatter: DateFormatter
-    private let dateTimeFormatter: DateFormatter
-
-    public init(locale: Locale = .current, timeZone: TimeZone = .current) {
+    public init(
+        type: RelativeDateFormatterType = .dateTime,
+        locale: Locale = .current,
+        timeZone: TimeZone = .current,
+    ) {
+        self.type = type
         var calendar = Calendar.current
         calendar.locale = locale
         calendar.timeZone = timeZone
         self.calendar = calendar
-
-        relativeDateFormatter = Self.makeDateFormatter(
-            locale: locale,
-            timeZone: timeZone,
-            dateStyle: .medium,
-            timeStyle: .none,
-            relative: true,
-        )
-        timeFormatter = Self.makeDateFormatter(
-            locale: locale,
-            timeZone: timeZone,
-            dateStyle: .none,
-            timeStyle: .short,
-        )
-        dateTimeFormatter = Self.makeDateFormatter(
-            locale: locale,
-            timeZone: timeZone,
-            dateStyle: .long,
-            timeStyle: .short,
-        )
     }
 
     public func string(from date: Date) -> String {
-        guard calendar.isDateInToday(date) || calendar.isDateInYesterday(date) else {
-            return dateTimeFormatter.string(from: date)
+        switch type {
+        case .dateTime:
+            guard calendar.isDateInToday(date) || calendar.isDateInYesterday(date) else {
+                return formatter(dateStyle: .long, timeStyle: .short).string(from: date)
+            }
+            let relative = formatter(dateStyle: .medium, timeStyle: .none, relative: true).string(from: date)
+            let time = formatter(dateStyle: .none, timeStyle: .short).string(from: date)
+            return "\(relative), \(time)"
+        case .date:
+            return formatter(dateStyle: .medium, timeStyle: .none).string(from: date)
         }
-
-        return "\(relativeDateFormatter.string(from: date)), \(timeFormatter.string(from: date))"
     }
 
     public func string(fromTimestampValue value: String) -> String {
@@ -67,16 +60,10 @@ private extension RelativeDateFormatter {
         .time(includingFractionalSeconds: false)
         .timeZone(separator: .omitted)
 
-    static func makeDateFormatter(
-        locale: Locale,
-        timeZone: TimeZone,
-        dateStyle: DateFormatter.Style,
-        timeStyle: DateFormatter.Style,
-        relative: Bool = false,
-    ) -> DateFormatter {
+    func formatter(dateStyle: DateFormatter.Style, timeStyle: DateFormatter.Style, relative: Bool = false) -> DateFormatter {
         let formatter = DateFormatter()
-        formatter.locale = locale
-        formatter.timeZone = timeZone
+        formatter.locale = calendar.locale
+        formatter.timeZone = calendar.timeZone
         formatter.dateStyle = dateStyle
         formatter.timeStyle = timeStyle
         formatter.doesRelativeDateFormatting = relative

--- a/ios/Packages/Formatters/Tests/FormattersTests/RelativeDateFormatterTests.swift
+++ b/ios/Packages/Formatters/Tests/FormattersTests/RelativeDateFormatterTests.swift
@@ -8,10 +8,12 @@ struct RelativeDateFormatterTests {
     private let locale = Locale.US
     private let timeZone = TimeZone.NewYork!
     private let formatter: RelativeDateFormatter
+    private let dateFormatter: RelativeDateFormatter
     private let calendar: Calendar
 
     init() {
         formatter = RelativeDateFormatter(locale: locale, timeZone: timeZone)
+        dateFormatter = RelativeDateFormatter(type: .date, locale: locale, timeZone: timeZone)
         calendar = formatter.calendar
     }
 
@@ -42,5 +44,10 @@ struct RelativeDateFormatterTests {
         let date = try #require(calendar.date(from: components))
 
         #expect(formatter.string(from: date) == "February 2, 2025 at 10:25 AM")
+    }
+
+    @Test
+    func dateTypeFromTimestampValue() {
+        #expect(dateFormatter.string(fromTimestampValue: "1662714817") == "Sep 9, 2022")
     }
 }


### PR DESCRIPTION
NFT property dates like Created Date and Namewrapper Expiry Date were
shown in a long format with time, which didn't fit and got cut off in
the attribute row. Now they show as a compact date, consistent with
Android.
<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-06-11 at 12 49 48" src="https://github.com/user-attachments/assets/639cd613-4871-475b-97d5-73ca831d577d" />

