### PR TITLE
Checksum destination address from core

### DIFF
--- a/core/gemstone/src/models/gateway.rs
+++ b/core/gemstone/src/models/gateway.rs
@@ -1,3 +1,4 @@
+use crate::address::checksum_address;
 use crate::models::GemTransactionInputType;
 use primitives::{BroadcastOptions, FeeRate, GasPriceType, TransactionInputType, TransactionPreloadInput, UTXO};
 
@@ -81,7 +82,7 @@ impl From<TransactionPreloadInput> for GemTransactionPreloadInput {
 impl From<GemTransactionPreloadInput> for TransactionPreloadInput {
     fn from(input: GemTransactionPreloadInput) -> Self {
         let input_type: TransactionInputType = input.input_type.into();
-        let destination_address = crate::address::checksum_address(&input.destination_address, input_type.get_asset().chain);
+        let destination_address = checksum_address(&input.destination_address, input_type.get_asset().chain);
         Self {
             input_type,
             sender_address: input.sender_address,

--- a/core/gemstone/src/models/gateway.rs
+++ b/core/gemstone/src/models/gateway.rs
@@ -1,5 +1,5 @@
 use crate::models::GemTransactionInputType;
-use primitives::{BroadcastOptions, FeeRate, GasPriceType, TransactionPreloadInput, UTXO};
+use primitives::{BroadcastOptions, FeeRate, GasPriceType, TransactionInputType, TransactionPreloadInput, UTXO};
 
 pub type GemUTXO = UTXO;
 
@@ -80,10 +80,12 @@ impl From<TransactionPreloadInput> for GemTransactionPreloadInput {
 
 impl From<GemTransactionPreloadInput> for TransactionPreloadInput {
     fn from(input: GemTransactionPreloadInput) -> Self {
+        let input_type: TransactionInputType = input.input_type.into();
+        let destination_address = crate::address::checksum_address(&input.destination_address, input_type.get_asset().chain);
         Self {
-            input_type: input.input_type.into(),
+            input_type,
             sender_address: input.sender_address,
-            destination_address: input.destination_address,
+            destination_address,
         }
     }
 }

--- a/core/gemstone/src/models/transaction.rs
+++ b/core/gemstone/src/models/transaction.rs
@@ -1,3 +1,4 @@
+use crate::address::checksum_address;
 use crate::models::*;
 use chrono::{DateTime, Utc};
 use num_bigint::BigInt;
@@ -523,7 +524,7 @@ impl From<GemTransactionStateRequest> for TransactionStateRequest {
 impl From<GemTransactionLoadInput> for TransactionLoadInput {
     fn from(value: GemTransactionLoadInput) -> Self {
         let input_type: TransactionInputType = value.input_type.into();
-        let destination_address = crate::address::checksum_address(&value.destination_address, input_type.get_asset().chain);
+        let destination_address = checksum_address(&value.destination_address, input_type.get_asset().chain);
         TransactionLoadInput {
             input_type,
             sender_address: value.sender_address,

--- a/core/gemstone/src/models/transaction.rs
+++ b/core/gemstone/src/models/transaction.rs
@@ -522,10 +522,12 @@ impl From<GemTransactionStateRequest> for TransactionStateRequest {
 
 impl From<GemTransactionLoadInput> for TransactionLoadInput {
     fn from(value: GemTransactionLoadInput) -> Self {
+        let input_type: TransactionInputType = value.input_type.into();
+        let destination_address = crate::address::checksum_address(&value.destination_address, input_type.get_asset().chain);
         TransactionLoadInput {
-            input_type: value.input_type.into(),
+            input_type,
             sender_address: value.sender_address,
-            destination_address: value.destination_address,
+            destination_address,
             value: value.value,
             gas_price: value.gas_price.into(),
             memo: value.memo,

--- a/core/gemstone/src/signer/chain.rs
+++ b/core/gemstone/src/signer/chain.rs
@@ -213,6 +213,16 @@ mod tests {
     };
 
     #[test]
+    fn test_sign_input_checksums_destination() {
+        let mut gem: GemSignerInput = SignerInput::mock_evm(TransactionInputType::Transfer(Asset::mock()), "0", 21000).into();
+        gem.input.destination_address = "0x5615e8ab93b9d695b6d4d6545f7792aa59e1069a".to_string();
+
+        let signer_input: SignerInput = gem.into();
+
+        assert_eq!(signer_input.input.destination_address, "0x5615E8AB93b9d695b6d4d6545f7792aA59e1069a");
+    }
+
+    #[test]
     fn test_sign_input_routing() {
         let signer = GemChainSigner::new(Chain::Ethereum);
         let key = TEST_PRIVATE_KEY.to_vec();


### PR DESCRIPTION
Core now always returns the recipient address in checksum format, so the address sent to the network is canonical.

Closes #202