### PR TITLE
Remove name from ChatwootContactUpdate

### DIFF
--- a/core/crates/support/src/model.rs
+++ b/core/crates/support/src/model.rs
@@ -236,7 +236,6 @@ pub(crate) struct ChatwootMessagesResponse {
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct ChatwootContactUpdate {
     pub(crate) identifier: String,
-    pub(crate) name: String,
     pub(crate) custom_attributes: HashMap<String, String>,
 }
 
@@ -244,7 +243,6 @@ impl ChatwootContactUpdate {
     pub(crate) fn new(device: &Device) -> Self {
         Self {
             identifier: device.id.clone(),
-            name: device.model.clone(),
             custom_attributes: HashMap::from([
                 ("device_id".to_string(), device.id.clone()),
                 ("platform".to_string(), format!("{}: {}", device.platform_store.as_ref(), device.os)),


### PR DESCRIPTION
Drop the `name` field from ChatwootContactUpdate and stop populating it in ChatwootContactUpdate::new. The struct now only contains `identifier` and `custom_attributes`, and the constructor no longer assigns `device.model` to a removed field. This keeps the serialized contact update aligned with current usage.