### PR TITLE
Show required fee with fiat in insufficient network fee sheet

### DIFF
--- a/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
+++ b/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
@@ -19,7 +19,6 @@ import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.ConfirmParams
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.SignerParams
-import com.gemwallet.android.model.ValueFormatter
 import com.gemwallet.android.ui.models.navigation.RouteArgument
 import com.gemwallet.android.ui.models.perpetual.PerpetualConfirmDetailsUIModelFactory
 import com.gemwallet.android.ui.models.swap.SwapDetailsUIModelFactory
@@ -217,15 +216,6 @@ class ConfirmViewModel @Inject constructor(
     }
     .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    val feeValue = combine(preloadData, feeAssetInfo) { signerParams, feeAssetInfo ->
-        val amount = signerParams?.fee()?.amount
-        if (amount == null || feeAssetInfo == null) {
-            return@combine ""
-        }
-        ValueFormatter(style = ValueFormatter.Style.Auto).string(amount, feeAssetInfo.asset)
-    }
-    .stateIn(viewModelScope, SharingStarted.Eagerly, "")
-
     val feeUIModel = combine(preloadData, feeAssetInfo, state) { signerParams, feeAssetInfo, state ->
         val amount = signerParams?.fee()?.amount
         val result = if (state is ConfirmState.Prepare) {
@@ -258,6 +248,9 @@ class ConfirmViewModel @Inject constructor(
         result
     }
     .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val feeValue = feeUIModel.map { (it as? FeeUIModel.FeeInfo)?.cryptoAmountWithFiat.orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, "")
 
     val feeRates = preloadData.map { it?.feeRates.orEmpty() }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeUIModel.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeUIModel.kt
@@ -28,5 +28,9 @@ sealed interface FeeUIModel {
             else CurrencyFormatter(currency = currency)
                 .string(CryptoFiatConverter.toFiat(Crypto(amount), feeAsset.decimals, price).atomicValue)
         }
+
+        val cryptoAmountWithFiat: String by lazy {
+            if (fiatAmount.isEmpty()) cryptoAmount else "$cryptoAmount (~$fiatAmount)"
+        }
     }
 }

--- a/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/confirm/FeeUIModelTest.kt
+++ b/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/confirm/FeeUIModelTest.kt
@@ -35,5 +35,7 @@ class FeeUIModelTest {
         assertEquals("1 SOL", feeInfo(price = null).cryptoAmount)
         assertEquals("", feeInfo(price = null).fiatAmount)
         assertEquals("$200.00", feeInfo(price = 200.0).fiatAmount)
+        assertEquals("1 SOL", feeInfo(price = null).cryptoAmountWithFiat)
+        assertEquals("1 SOL (~$200.00)", feeInfo(price = 200.0).cryptoAmountWithFiat)
     }
 }

--- a/ios/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
+++ b/ios/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
@@ -27,20 +27,21 @@ public enum InfoSheetModelFactory {
                 description: Localized.Info.InsufficientBalance.description(asset.symbol.boldMarkdown()),
                 image: .assetImage(image),
             )
-        case let .insufficientNetworkFee(asset, image, required, action):
-            let formatter = ValueFormatter(style: .auto)
-            let value = if let required {
-                formatter.string(required, decimals: asset.chain.asset.decimals.asInt, currency: asset.chain.asset.symbol)
+        case let .insufficientNetworkFee(asset, image, required, price, currency, action):
+            let feeAsset = asset.chain.asset
+            let value: String
+            if let required {
+                value = Self.requiredFeeText(required, feeAsset: feeAsset, price: price, currency: currency)
             } else {
-                asset.chain.asset.symbol
+                value = feeAsset.symbol
             }
             let description = Localized.Info.InsufficientNetworkFeeBalance.description(
                 value.boldMarkdown(),
-                asset.chain.asset.name.boldMarkdown(),
-                asset.chain.asset.symbol.boldMarkdown(),
+                feeAsset.name.boldMarkdown(),
+                feeAsset.symbol.boldMarkdown(),
             )
             return InfoSheetModel(
-                title: Localized.Info.InsufficientNetworkFeeBalance.title(asset.chain.asset.symbol),
+                title: Localized.Info.InsufficientNetworkFeeBalance.title(feeAsset.symbol),
                 description: description,
                 image: .assetImage(image),
                 button: .action(title: Localized.Asset.buyAsset(asset.feeAsset.symbol), action: action),
@@ -214,5 +215,17 @@ public enum InfoSheetModelFactory {
                 image: .image(Images.Logo.logo),
             )
         }
+    }
+
+    private static func requiredFeeText(_ required: BigInt, feeAsset: Asset, price: Price?, currency: String) -> String {
+        let feeDisplay = NumericViewModel(
+            data: AssetValuePrice(asset: feeAsset, value: required, price: price?.price == 0 ? nil : price),
+            style: AmountDisplayStyle(currencyCode: currency),
+        )
+        let feeText = feeDisplay.amount.text
+        guard let fiatText = feeDisplay.fiat?.text else {
+            return feeText
+        }
+        return "\(feeText) (~\(fiatText))"
     }
 }

--- a/ios/Features/InfoSheet/Sources/Types/InfoSheetType.swift
+++ b/ios/Features/InfoSheet/Sources/Types/InfoSheetType.swift
@@ -13,7 +13,7 @@ import SwiftUI
 public enum InfoSheetType: Identifiable, Sendable, Equatable {
     case networkFee(Chain)
     case insufficientBalance(Asset, image: AssetImage)
-    case insufficientNetworkFee(Asset, image: AssetImage, required: BigInt?, action: InfoSheetAction)
+    case insufficientNetworkFee(Asset, image: AssetImage, required: BigInt?, price: Price?, currency: String, action: InfoSheetAction)
     case transactionState(imageURL: URL?, placeholder: Image?, state: TransactionState)
     case watchWallet
     case stakeLockTime(Image?)

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmNetworkFeeViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmNetworkFeeViewModel.swift
@@ -36,7 +36,6 @@ extension ConfirmNetworkFeeViewModel {
             .init(
                 title: title,
                 subtitle: networkFeeValue,
-                subtitleExtra: networkFeeFiatValue,
                 placeholders: [.subtitle],
                 infoAction: infoAction,
             ),
@@ -48,23 +47,8 @@ extension ConfirmNetworkFeeViewModel {
 // MARK: - Private
 
 extension ConfirmNetworkFeeViewModel {
-    private var isCalculatorError: Bool {
-        switch state.value?.transferAmount {
-        case .success, .none: false
-        case .failure: true
-        }
-    }
-
     private var networkFeeValue: String? {
         if state.isError { return "-" }
-        if isCalculatorError { return value }
         return fiatValue ?? value
-    }
-
-    private var networkFeeFiatValue: String? {
-        if isCalculatorError {
-            return fiatValue
-        }
-        return nil
     }
 }

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
@@ -273,7 +273,7 @@ extension ConfirmTransferSceneViewModel {
             case let .insufficientBalance(asset):
                 isPresentingSheet = .info(.insufficientBalance(asset, image: AssetViewModel(asset: asset).assetImage))
             case let .insufficientNetworkFee(asset, required):
-                isPresentingSheet = .info(.insufficientNetworkFee(asset, image: AssetViewModel(asset: asset).assetImage, required: required, action: onSelectBuy))
+                isPresentingSheet = .info(.insufficientNetworkFee(asset, image: AssetViewModel(asset: asset).assetImage, required: required, price: metadata?.feePrice, currency: Preferences.standard.currency, action: onSelectBuy))
             case let .minimumAccountBalanceTooLow(asset, required):
                 isPresentingSheet = .info(.accountMinimalBalance(asset, required: required))
             }
@@ -372,13 +372,8 @@ extension ConfirmTransferSceneViewModel {
 
         do {
             let metadata = try confirmService.getMetadata(wallet: wallet, data: transferData)
-            try TransferAmountCalculator().validateNetworkFee(metadata.feeAvailable, feeAssetId: metadata.feeAssetId)
 
-            let transferTransactionData = try await confirmService.loadTransferTransactionData(
-                wallet: wallet, data: transferData,
-                priority: feeModel.priority,
-                available: metadata.available,
-            )
+            let transferTransactionData = try await preloadTransferTransactionData(metadata: metadata)
             let transferAmount = calculateTransferAmount(
                 assetBalance: metadata.assetBalance,
                 assetFeeBalance: metadata.assetFeeBalance,
@@ -402,6 +397,20 @@ extension ConfirmTransferSceneViewModel {
             simulationState = await nextSimulationState
             state.setError(error)
             debugLog("preload transaction error: \(error)")
+        }
+    }
+
+    private func preloadTransferTransactionData(metadata: TransferDataMetadata) async throws -> TransferTransactionData {
+        do {
+            return try await confirmService.loadTransferTransactionData(
+                wallet: wallet,
+                data: transferData,
+                priority: feeModel.priority,
+                available: metadata.available,
+            )
+        } catch {
+            try TransferAmountCalculator().validateNetworkFee(metadata.feeAvailable, feeAssetId: metadata.feeAssetId)
+            throw error
         }
     }
 

--- a/ios/Features/Transfer/Tests/ViewModels/ConfirmNetworkFeeViewModelTests.swift
+++ b/ios/Features/Transfer/Tests/ViewModels/ConfirmNetworkFeeViewModelTests.swift
@@ -79,8 +79,8 @@ struct ConfirmNetworkFeeViewModelTests {
         )
 
         guard case let .networkFee(item, selectable) = model.itemModel else { return }
-        #expect(item.subtitle == value)
-        #expect(item.subtitleExtra == fiatValue)
+        #expect(item.subtitle == fiatValue)
+        #expect(item.subtitleExtra == nil)
         #expect(selectable == true)
     }
 }

--- a/ios/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
+++ b/ios/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
@@ -13,6 +13,8 @@ import Components
 import EventPresenterService
 import EventPresenterServiceTestKit
 import FiatServiceTestKit
+import Foundation
+import InfoSheet
 import KeystoreTestKit
 import Localization
 import NodeService
@@ -27,6 +29,7 @@ import Testing
 import TransactionStateServiceTestKit
 @testable import Transfer
 import TransferTestKit
+import Validators
 
 @MainActor
 struct ConfirmTransferSceneViewModelTests {
@@ -425,6 +428,48 @@ struct ConfirmTransferSceneViewModelTests {
             return
         }
         #expect(symbol == "BTC")
+    }
+
+    @Test
+    func insufficientNetworkFeeErrorShowsRequiredAmount() {
+        let model = ConfirmTransferSceneViewModel.mock()
+        let required = BigInt(21_000_000_000_000)
+        model.onSelectListError(error: TransferAmountCalculatorError.insufficientNetworkFee(.mockEthereum(), required: required))
+
+        guard case let .info(.insufficientNetworkFee(_, _, sheetRequired, _, _, _)) = model.isPresentingSheet else {
+            Issue.record("Expected insufficientNetworkFee sheet")
+            return
+        }
+        #expect(sheetRequired == required)
+    }
+
+    @Test
+    func insufficientNetworkFeeSheetShowsRequiredFeeWithFiat() {
+        let asset = Asset.mockEthereum()
+        let feeAsset = asset.chain.asset
+        let image = AssetViewModel(asset: asset).assetImage
+        let required = BigInt(2_000_000_000_000_000)
+
+        let withPrice = InfoSheetModelFactory.create(from: .insufficientNetworkFee(
+            asset, image: image, required: required,
+            price: Price(price: 2000, priceChangePercentage24h: 0, updatedAt: Date()),
+            currency: "USD", action: {},
+        ))
+        let withoutPrice = InfoSheetModelFactory.create(from: .insufficientNetworkFee(
+            asset, image: image, required: required,
+            price: nil, currency: "USD", action: {},
+        ))
+
+        #expect(withPrice.description == Localized.Info.InsufficientNetworkFeeBalance.description(
+            "0.002 ETH (~$4.00)".boldMarkdown(),
+            feeAsset.name.boldMarkdown(),
+            feeAsset.symbol.boldMarkdown(),
+        ))
+        #expect(withoutPrice.description == Localized.Info.InsufficientNetworkFeeBalance.description(
+            "0.002 ETH".boldMarkdown(),
+            feeAsset.name.boldMarkdown(),
+            feeAsset.symbol.boldMarkdown(),
+        ))
     }
 
     private func verifyNonEmpty(_ model: any ItemModelProvidable<ConfirmTransferItemModel>) {


### PR DESCRIPTION
Show how much is needed to cover the network fee, with its fiat value, in the insufficient fee sheet on iOS and Android.

Closes #499

<img width="320" alt="Screenshot_1781545875" src="https://github.com/user-attachments/assets/155cb223-e581-442f-9f3d-ab0925a75f7e" />

<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-06-15 at 17 01 12" src="https://github.com/user-attachments/assets/01086e8b-1573-4535-a77f-87d8566a0960" />
