### PR TITLE
Fix silent token import and search by contract address

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/tokens/TokensRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/tokens/TokensRepository.kt
@@ -20,6 +20,7 @@ import com.wallet.core.primitives.AssetTag
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.Currency
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
 
@@ -35,6 +36,7 @@ class TokensRepository (
         if (query.isEmpty() && tags.isEmpty()) {
             return@withContext false
         }
+        val nodeAssets = async { tokenService.search(query) }
         val tokens = try {
             searchAssets.search(
                 query = query,
@@ -42,18 +44,16 @@ class TokensRepository (
                 tags = tags,
             )
         } catch (_: Throwable) {
+            nodeAssets.cancel()
             return@withContext false
         }
-        val assets = if (tokens.isEmpty()) {
-            val assets = tokenService.search(query)
-            runCatching { assetsDao.insert(assets.map { it.toRecord() }) }
-            assets
-        } else {
-            updateAssets(tokens, currency)
-            assetsPriorityDao.put(tokens.toRecordPriority(tags.toPriorityQuery(query)))
-            tokens
+        val assets = (tokens + nodeAssets.await()).distinctBy { it.asset.id }
+        if (assets.isEmpty()) {
+            return@withContext false
         }
-        assets.isNotEmpty()
+        updateAssets(assets, currency)
+        assetsPriorityDao.put(assets.toRecordPriority(tags.toPriorityQuery(query)))
+        true
     }
 
     override suspend fun search(assetIds: List<AssetId>, currency: Currency): Boolean {

--- a/android/features/add_asset/presents/src/main/kotlin/com/gemwallet/android/features/add_asset/views/AddAssetScene.kt
+++ b/android/features/add_asset/presents/src/main/kotlin/com/gemwallet/android/features/add_asset/views/AddAssetScene.kt
@@ -60,6 +60,7 @@ fun AddAssetScene(
     network: Asset,
     token: Asset?,
     explorerLink: BlockExplorerLink?,
+    isLoading: Boolean,
     onScan: () -> Unit,
     onAddAsset: () -> Unit,
     onChainSelect: (() -> Unit)?,
@@ -79,6 +80,7 @@ fun AddAssetScene(
             MainActionButton(
                 title = stringResource(id = R.string.wallet_import_action),
                 enabled = searchState is TokenSearchState.Idle && token != null,
+                loading = isLoading,
                 onClick = onAddAsset,
             )
         },

--- a/android/features/add_asset/presents/src/main/kotlin/com/gemwallet/android/features/add_asset/views/AddAssetScreen.kt
+++ b/android/features/add_asset/presents/src/main/kotlin/com/gemwallet/android/features/add_asset/views/AddAssetScreen.kt
@@ -53,6 +53,7 @@ fun AddAssetScree(
                 network = network.asset(),
                 token = token,
                 explorerLink = explorerLink,
+                isLoading = uiState.isLoading,
                 onCancel = onCancel,
                 onScan = viewModel::onQrScan,
                 onAddAsset = { viewModel.addAsset(onFinish) },

--- a/android/features/add_asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/add_asset/viewmodels/AddAssetViewModel.kt
+++ b/android/features/add_asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/add_asset/viewmodels/AddAssetViewModel.kt
@@ -17,10 +17,12 @@ import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.BlockExplorerLink
 import com.wallet.core.primitives.Chain
 import uniffi.gemstone.Explorer
+import uniffi.gemstone.checksumAddress
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -32,7 +34,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -75,7 +76,7 @@ class AddAssetViewModel @Inject constructor(
     val addressQuery = snapshotFlow { addressState.value }
 
     val searchState = addressQuery.combine(selectedChain) { address, chain ->
-        Pair(address, chain)
+        Pair(normalizedAddress(chain, address), chain)
     }.flatMapLatest {
         val (address, chain) = it
         flow {
@@ -92,7 +93,7 @@ class AddAssetViewModel @Inject constructor(
     .stateIn(viewModelScope, SharingStarted.Eagerly, TokenSearchState.Idle)
 
     val token = combine(addressQuery, selectedChain) { address, chain ->
-        Pair(address.trim(), chain)
+        Pair(normalizedAddress(chain, address), chain)
     }
     .flatMapLatest {
         val (address, chain) = it
@@ -143,15 +144,20 @@ class AddAssetViewModel @Inject constructor(
     }
 
     fun addAsset(onFinish: () -> Unit) = viewModelScope.launch {
+        val assetId = token.value?.id ?: return@launch
+        state.update { it.copy(isImporting = true) }
+        runCatching {
+            withContext(Dispatchers.IO) {
+                addCustomToken(selectedChain.value, assetId)
+            }
+        }
         onFinish()
-        async(Dispatchers.IO) {
-            addCustomToken(selectedChain.value, token.value?.id ?: return@async)
-        }.await()
     }
 
     private data class State(
         val isQrScan: Boolean = false,
         val isSelectChain: Boolean = false,
+        val isImporting: Boolean = false,
     ) {
         fun toUIState(): AddAssetUIState {
             return AddAssetUIState(
@@ -160,10 +166,14 @@ class AddAssetViewModel @Inject constructor(
                     isSelectChain -> AddAssetUIState.Scene.SelectChain
                     else -> AddAssetUIState.Scene.Form
                 },
+                isLoading = isImporting,
             )
         }
     }
 }
+
+private fun normalizedAddress(chain: Chain, address: String): String =
+    checksumAddress(address = address.trim(), chain = chain.string)
 
 suspend fun searchToken(
     searchCustomToken: SearchCustomToken,

--- a/android/features/add_asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/add_asset/viewmodels/models/AddAssetUIState.kt
+++ b/android/features/add_asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/add_asset/viewmodels/models/AddAssetUIState.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.features.add_asset.viewmodels.models
 
 class AddAssetUIState(
     val scene: Scene = Scene.Form,
+    val isLoading: Boolean = false,
 ) {
     enum class Scene {
         QrScanner,

--- a/ios/GemTests/unit_frameworks.xctestplan
+++ b/ios/GemTests/unit_frameworks.xctestplan
@@ -234,6 +234,13 @@
     {
       "target" : {
         "containerPath" : "container:Packages\/FeatureServices",
+        "identifier" : "AssetsServiceTests",
+        "name" : "AssetsServiceTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/FeatureServices",
         "identifier" : "PriceAlertServiceTests",
         "name" : "PriceAlertServiceTests"
       }

--- a/ios/Packages/FeatureServices/AssetsService/AssetsService.swift
+++ b/ios/Packages/FeatureServices/AssetsService/AssetsService.swift
@@ -145,42 +145,24 @@ public final class AssetsService: Sendable {
     // search
 
     public func searchAssets(query: String, chains: [Chain], tags: [AssetTag]) async throws -> [AssetBasic] {
-        try await withThrowingTaskGroup(of: [AssetBasic]?.self) { group in
-            var assets = [AssetBasic]()
-
-            group.addTask {
-                try await self.searchAPIAssets(query: query, chains: chains, tags: tags)
-            }
-            group.addTask {
-                try await self.searchNetworkAsset(tokenId: query, chains: chains.isEmpty ? Chain.allCases : chains)
-            }
-
-            for try await result in group {
-                if let result, result.count > 0 {
-                    assets.append(contentsOf: result)
-                }
-            }
-            return assets
-        }
+        async let apiAssets = assetsProvider.getSearchAssets(query: query, chains: chains, tags: tags)
+        async let networkAssets = searchNetworkAsset(tokenId: query, chains: chains.isEmpty ? Chain.allCases : chains)
+        return try await apiAssets + networkAssets
     }
 
-    func searchAPIAssets(query: String, chains: [Chain], tags: [AssetTag]) async throws -> [AssetBasic] {
-        try await assetsProvider.getSearchAssets(query: query, chains: chains, tags: tags)
-    }
-
-    func searchNetworkAsset(tokenId: String, chains: [Chain]) async throws -> [AssetBasic] {
-        try await withThrowingTaskGroup(of: AssetBasic?.self) { group in
+    func searchNetworkAsset(tokenId: String, chains: [Chain]) async -> [AssetBasic] {
+        await withTaskGroup(of: AssetBasic?.self) { group in
             for chain in chains {
                 group.addTask {
                     let service = self.chainServiceFactory.service(for: chain)
-                    guard try await service.getIsTokenAddress(tokenId: tokenId),
+                    guard (try? await service.getIsTokenAddress(tokenId: tokenId)) == true,
                           let asset = try? await service.getTokenData(tokenId: tokenId)
                     else { return nil }
 
                     return asset.defaultBasic
                 }
             }
-            return try await group.reduce(into: [AssetBasic]()) { if let asset = $1 { $0.append(asset) } }
+            return await group.reduce(into: [AssetBasic]()) { if let asset = $1 { $0.append(asset) } }
         }
     }
 

--- a/ios/Packages/FeatureServices/AssetsService/Tests/AssetsServiceTests.swift
+++ b/ios/Packages/FeatureServices/AssetsService/Tests/AssetsServiceTests.swift
@@ -1,0 +1,43 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import AssetsService
+import AssetsServiceTestKit
+import BlockchainTestKit
+import ChainServiceTestKit
+import GemAPITestKit
+import Primitives
+import PrimitivesTestKit
+import Testing
+
+struct AssetsServiceTests {
+    private let tokenId = "0x227D920e20eBAc8A40E7D6431B7d724Bb64D7245"
+
+    @Test
+    func searchMergesBackendAndNodeResults() async throws {
+        let apiAsset = AssetBasic.mock(asset: .mock(id: AssetId(chain: .ethereum, tokenId: "0xapi")))
+        let nodeAsset = Asset.mock(id: AssetId(chain: .smartChain, tokenId: tokenId))
+
+        let result = try await search(apiAssets: [apiAsset], nodeAsset: nodeAsset, chains: [.smartChain])
+
+        #expect(result.map(\.asset.id) == [apiAsset.asset.id, nodeAsset.id])
+    }
+
+    @Test
+    func searchResolvesViaNodeWhenBackendEmpty() async throws {
+        let nodeAsset = Asset.mock(id: AssetId(chain: .ethereum, tokenId: tokenId))
+
+        let result = try await search(apiAssets: [], nodeAsset: nodeAsset, chains: [.ethereum])
+
+        #expect(result.map(\.asset.id) == [nodeAsset.id])
+    }
+
+    private func search(apiAssets: [AssetBasic], nodeAsset: Asset, chains: [Chain]) async throws -> [AssetBasic] {
+        let chainService = ChainServiceMock()
+        chainService.tokenData[tokenId] = nodeAsset
+        let service = AssetsService.mock(
+            chainServiceFactory: ChainServiceFactoryMock(chainService: chainService),
+            assetsProvider: GemAPIAssetsServiceMock(searchAssetsResult: apiAssets),
+        )
+        return try await service.searchAssets(query: tokenId, chains: chains, tags: [])
+    }
+}

--- a/ios/Packages/FeatureServices/AssetsService/WalletSearchService.swift
+++ b/ios/Packages/FeatureServices/AssetsService/WalletSearchService.swift
@@ -31,12 +31,39 @@ public struct WalletSearchService: Sendable {
     }
 
     public func search(wallet: Wallet, query: String, tag: AssetTag? = nil) async throws {
-        let response = try await searchProvider.search(
-            query: query,
-            chains: WalletSearchScope.chains(for: wallet),
-            tags: [tag].compactMap(\.self),
-        )
-        let prices: [AssetPrice] = response.assets.compactMap { asset in
+        let scopeChains = WalletSearchScope.chains(for: wallet)
+        let chains = tag == nil ? (scopeChains.isEmpty ? Chain.allCases : scopeChains) : []
+
+        async let networkAssets = assetsService.searchNetworkAsset(tokenId: query, chains: chains)
+        async let response = searchProvider.search(query: query, chains: scopeChains, tags: [tag].compactMap(\.self))
+        let assets = try await response.assets + networkAssets
+
+        let searchKey = searchHistoryKey(query: query, tag: tag)
+        try store(assets: assets, wallet: wallet, searchKey: searchKey)
+        if tag == nil {
+            try await store(perpetuals: response.perpetuals, searchKey: searchKey)
+        }
+    }
+}
+
+// MARK: - Private
+
+private extension WalletSearchService {
+    func store(assets: [AssetBasic], wallet: Wallet, searchKey: String) throws {
+        try assetsService.addAssets(assets: assets)
+        try priceStore.updatePrices(prices: prices(from: assets), currency: preferences.currency)
+        try assetsService.addBalancesIfMissing(walletId: wallet.id, assetIds: assets.map(\.asset.id))
+        try searchStore.add(type: .asset, query: searchKey, ids: assets.map(\.asset.id.identifier))
+    }
+
+    func store(perpetuals: [PerpetualSearchData], searchKey: String) throws {
+        try assetsService.addAssets(assets: perpetuals.map(\.assetBasic))
+        try perpetualStore.upsertPerpetuals(perpetuals.map(\.perpetual))
+        try searchStore.add(type: .perpetual, query: searchKey, ids: perpetuals.map(\.perpetual.id.identifier))
+    }
+
+    func prices(from assets: [AssetBasic]) -> [AssetPrice] {
+        assets.compactMap { asset in
             guard let price = asset.price else { return nil }
             return AssetPrice(
                 assetId: asset.asset.id,
@@ -45,22 +72,9 @@ public struct WalletSearchService: Sendable {
                 updatedAt: price.updatedAt,
             )
         }
+    }
 
-        try assetsService.addAssets(assets: response.assets)
-        try priceStore.updatePrices(prices: prices, currency: preferences.currency)
-        if tag == nil {
-            try assetsService.addAssets(assets: response.perpetuals.map(\.assetBasic))
-            try perpetualStore.upsertPerpetuals(response.perpetuals.map(\.perpetual))
-        }
-        try assetsService.addBalancesIfMissing(
-            walletId: wallet.id,
-            assetIds: response.assets.map(\.asset.id),
-        )
-
-        let searchKey = tag.map { query.isEmpty ? "tag:\($0.rawValue)" : query } ?? query
-        try searchStore.add(type: .asset, query: searchKey, ids: response.assets.map(\.asset.id.identifier))
-        if tag == nil {
-            try searchStore.add(type: .perpetual, query: searchKey, ids: response.perpetuals.map(\.perpetual.id.identifier))
-        }
+    func searchHistoryKey(query: String, tag: AssetTag?) -> String {
+        tag.map { query.isEmpty ? "tag:\($0.rawValue)" : query } ?? query
     }
 }

--- a/ios/Packages/FeatureServices/Package.swift
+++ b/ios/Packages/FeatureServices/Package.swift
@@ -370,7 +370,7 @@ let package = Package(
                 "GemstonePrimitives",
             ],
             path: "AssetsService",
-            exclude: ["TestKit"],
+            exclude: ["TestKit", "Tests"],
         ),
         .target(
             name: "AssetsServiceTestKit",
@@ -668,6 +668,18 @@ let package = Package(
                 .product(name: "StoreTestKit", package: "Store"),
             ],
             path: "FiatService/TestKit",
+        ),
+        .testTarget(
+            name: "AssetsServiceTests",
+            dependencies: [
+                "AssetsService",
+                "AssetsServiceTestKit",
+                .product(name: "GemAPITestKit", package: "GemAPI"),
+                .product(name: "ChainServiceTestKit", package: "ChainServices"),
+                .product(name: "BlockchainTestKit", package: "Blockchain"),
+                .product(name: "PrimitivesTestKit", package: "Primitives"),
+            ],
+            path: "AssetsService/Tests",
         ),
         .testTarget(
             name: "TransactionStateServiceTests",


### PR DESCRIPTION
Pressing Import now adds the token (with a loader) instead of silently exiting to the main screen.

Search also finds tokens by contract address even when they aren't in the catalog, and importing a lowercase address now works.

Closes #503
