### PR TITLE
Fix Activity tab crash when transaction asset prefetch is partial

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/EnsureWalletAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/EnsureWalletAssetsImpl.kt
@@ -19,9 +19,15 @@ class EnsureWalletAssetsImpl(
         }
 
         val linked = assetsRepository.hasWalletAssets(wallet.id.id, requestedAssetIds)
-        val missing = requestedAssetIds
+        val unlinked = requestedAssetIds
             .filterNot(linked::contains)
             .filter { wallet.getAccount(it.chain) != null }
+        if (unlinked.isEmpty()) {
+            return
+        }
+
+        val existing = assetsRepository.hasAssets(unlinked)
+        val missing = unlinked.filter(existing::contains)
 
         if (missing.isEmpty()) {
             return

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/EnsureWalletAssetsImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/EnsureWalletAssetsImplTest.kt
@@ -37,6 +37,9 @@ class EnsureWalletAssetsImplTest {
         coEvery {
             assetsRepository.hasWalletAssets("wallet-1", listOf(bitcoin.id, ethereum.id))
         } returns setOf(bitcoin.id)
+        coEvery {
+            assetsRepository.hasAssets(listOf(ethereum.id))
+        } returns setOf(ethereum.id)
 
         subject.ensureWalletAssets(wallet, listOf(bitcoin.id, ethereum.id, ethereum.id))
 
@@ -72,9 +75,37 @@ class EnsureWalletAssetsImplTest {
         coEvery {
             assetsRepository.hasWalletAssets("wallet-1", listOf(bitcoin.id, ethereum.id))
         } returns emptySet()
+        coEvery {
+            assetsRepository.hasAssets(listOf(bitcoin.id))
+        } returns setOf(bitcoin.id)
 
         subject.ensureWalletAssets(wallet, listOf(bitcoin.id, ethereum.id))
 
         coVerify(exactly = 1) { enableAsset(mockWalletId(), listOf(bitcoin.id)) }
+    }
+
+    @Test
+    fun ensureWalletAssets_skipsAssetsMissingLocally() = runTest {
+        val bitcoin = mockAsset()
+        val ethereum = mockAssetEthereum()
+        val wallet = mockWallet(
+            id = "wallet-1",
+            accounts = listOf(
+                mockAccount(chain = Chain.Bitcoin),
+                mockAccount(chain = Chain.Ethereum),
+            ),
+        )
+
+        coEvery {
+            assetsRepository.hasWalletAssets("wallet-1", listOf(bitcoin.id, ethereum.id))
+        } returns emptySet()
+        coEvery {
+            assetsRepository.hasAssets(listOf(bitcoin.id, ethereum.id))
+        } returns setOf(bitcoin.id)
+
+        subject.ensureWalletAssets(wallet, listOf(bitcoin.id, ethereum.id))
+
+        coVerify(exactly = 1) { enableAsset(mockWalletId(), listOf(bitcoin.id)) }
+        coVerify(exactly = 0) { enableAsset(mockWalletId(), listOf(ethereum.id)) }
     }
 }


### PR DESCRIPTION
Production bug: opening Activity after a transaction can crash if transaction sync tries to link an associated asset that was not materialized locally after prefetch. The balances insert then violates the asset FK.

Fix: only enable wallet assets that exist in the local asset table. Transactions can still be saved; missing asset metadata can be fetched later.

Verification:
- ./gradlew :data:coordinators:testDebugUnitTest --tests com.gemwallet.android.data.coordinators.asset.EnsureWalletAssetsImplTest
- ./gradlew :data:coordinators:assembleDebug
- ./gradlew :data:coordinators:lintDebug