### PR TITLE
Clear clipboard after pasting secret during import

### DIFF
--- a/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/components/ImportInput.kt
+++ b/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/components/ImportInput.kt
@@ -41,6 +41,7 @@ import com.gemwallet.android.blockchain.operators.gemstone.GemValidatePhraseOper
 import com.gemwallet.android.model.ImportType
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.FieldBottomAction
+import com.gemwallet.android.ui.components.clipboard.clear
 import com.gemwallet.android.ui.components.clipboard.getPlainText
 import com.gemwallet.android.ui.components.list_item.SelectionCheckmark
 import com.gemwallet.android.ui.components.progress.CircularProgressIndicator16
@@ -56,6 +57,15 @@ internal fun supportsPhraseSuggestions(walletType: WalletType): Boolean {
         WalletType.Multicoin,
         WalletType.Single -> true
         WalletType.PrivateKey,
+        WalletType.View -> false
+    }
+}
+
+internal fun shouldProtectInput(walletType: WalletType): Boolean {
+    return when (walletType) {
+        WalletType.Multicoin,
+        WalletType.Single,
+        WalletType.PrivateKey -> true
         WalletType.View -> false
     }
 }
@@ -181,6 +191,9 @@ internal fun ImportInput(
                         selection = TextRange(pastedText.length),
                     )
                 )
+                if (shouldProtectInput(importType.walletType)) {
+                    clipboardManager.clear()
+                }
             }
         }
     }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/clipboard/ClipboardExt.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/clipboard/ClipboardExt.kt
@@ -38,3 +38,7 @@ fun NativeClipboard.setPlainText(context: Context, data: String, isSensitive: Bo
 fun NativeClipboard.getPlainText(): String? {
     return primaryClip?.getItemAt(0)?.text?.toString()
 }
+
+fun NativeClipboard.clear() {
+    clearPrimaryClip()
+}


### PR DESCRIPTION
Clears the clipboard after pasting a secret phrase or private key during wallet import, so it can't be pasted again on later screens. Matches existing iOS behavior.

Closes #520