### PR TITLE
Fix transaction row layout breaking on long amounts

### DIFF
--- a/ios/Packages/Components/Sources/Lists/ListItemView.swift
+++ b/ios/Packages/Components/Sources/Lists/ListItemView.swift
@@ -165,26 +165,52 @@ extension ListItemView {
         let titleTagType: TitleTagType
 
         var body: some View {
-            HStack(spacing: .tiny) {
-                Text(titleTag.text)
-                    .textStyle(titleTag.style)
-                    .lineLimit(titleTag.lineLimit)
-                    .minimumScaleFactor(0.8)
-
-                switch titleTagType {
-                case .none:
-                    EmptyView()
-                case let .progressView(scale):
-                    LoadingView(size: .small, tint: titleTag.style.color)
-                        .scaleEffect(scale)
-                case let .image(image):
-                    image
+            switch titleTagType {
+            case .none:
+                tag {
+                    text
+                        .lineLimit(titleTag.lineLimit)
+                        .minimumScaleFactor(0.8)
+                }
+            case .progressView, .image:
+                ViewThatFits(in: .horizontal) {
+                    tag {
+                        HStack(spacing: .tiny) {
+                            text
+                                .lineLimit(1)
+                                .fixedSize()
+                            accessory
+                        }
+                    }
+                    accessory
                 }
             }
-            .padding(.horizontal, .tiny)
-            .padding(.vertical, .extraSmall)
-            .background(titleTag.style.background)
-            .cornerRadius(6)
+        }
+
+        private var text: some View {
+            Text(titleTag.text)
+                .textStyle(titleTag.style)
+        }
+
+        @ViewBuilder
+        private var accessory: some View {
+            switch titleTagType {
+            case .none:
+                EmptyView()
+            case let .progressView(scale):
+                LoadingView(size: .small, tint: titleTag.style.color)
+                    .scaleEffect(scale)
+            case let .image(image):
+                image
+            }
+        }
+
+        private func tag(@ViewBuilder content: () -> some View) -> some View {
+            content()
+                .padding(.horizontal, .tiny)
+                .padding(.vertical, .extraSmall)
+                .background(titleTag.style.background)
+                .cornerRadius(6)
         }
     }
 }


### PR DESCRIPTION
When a pending transaction had a long amount, the "Pending" badge wrapped onto two lines and broke the row layout. Now the badge shows its label when it fits and falls back to just the spinner when there isn't enough space.

| Before | After |

<img width="329" alt="Simulator Screenshot - iPhone Air - 2026-06-17 at 14 37 31" src="https://github.com/user-attachments/assets/71fb3b65-18f5-48e9-af3f-7cdbec14c45b" />
<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-06-17 at 15 22 40" src="https://github.com/user-attachments/assets/2d03db55-7ef7-4403-a3e5-e570b9ef72bb" />
