### PR TITLE
Align transaction sync asset prefetch

### DIFF
--- a/android/app/src/test/kotlin/com/gemwallet/android/NotificationNavigationTest.kt
+++ b/android/app/src/test/kotlin/com/gemwallet/android/NotificationNavigationTest.kt
@@ -64,7 +64,7 @@ class NotificationNavigationTest {
             session.value = mockSession(wallet = invocation.args.first() as Wallet)
         }
         coJustRun { saveTransactions.saveTransactions(any(), any()) }
-        coJustRun { prefetchAssets.prefetchAssets(any()) }
+        coEvery { prefetchAssets.prefetchAssets(any()) } returns emptyList()
         coJustRun { ensureWalletAssets.ensureWalletAssets(any(), any()) }
         every { getAssetById(any()) } returns flowOf(null)
     }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/EnsureWalletAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/EnsureWalletAssetsImpl.kt
@@ -27,12 +27,12 @@ class EnsureWalletAssetsImpl(
         }
 
         val existing = assetsRepository.hasAssets(unlinked)
-        val missing = unlinked.filter(existing::contains)
+        val toEnable = unlinked.filter(existing::contains)
 
-        if (missing.isEmpty()) {
+        if (toEnable.isEmpty()) {
             return
         }
 
-        enableAsset(wallet.id, missing)
+        enableAsset(wallet.id, toEnable)
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/PrefetchAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/PrefetchAssetsImpl.kt
@@ -11,16 +11,18 @@ class PrefetchAssetsImpl(
     private val assetsRepository: AssetsRepository,
 ) : PrefetchAssets {
 
-    override suspend fun prefetchAssets(assetIds: List<AssetId>) {
+    override suspend fun prefetchAssets(assetIds: List<AssetId>): List<AssetId> {
         val requestedAssetIds = assetIds.distinct()
         val existingAssetIds = assetsRepository.hasAssets(requestedAssetIds)
         val missingAssetIds = requestedAssetIds.filterNot(existingAssetIds::contains)
 
         if (missingAssetIds.isEmpty()) {
-            return
+            return emptyList()
         }
 
-        assetsRepository.add(loadAssets(missingAssetIds))
+        val loadedAssets = loadAssets(missingAssetIds)
+        assetsRepository.add(loadedAssets)
+        return loadedAssets.map { it.asset.id }
     }
 
     private suspend fun loadAssets(assetIds: List<AssetId>): List<AssetBasic> {

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/SyncTransactionsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/SyncTransactionsImpl.kt
@@ -1,11 +1,11 @@
 package com.gemwallet.android.data.coordinators.transaction
 
-import com.gemwallet.android.application.assets.coordinators.EnsureWalletAssets
 import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
 import com.gemwallet.android.application.transactions.coordinators.SyncAssetTransactions
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
 import com.gemwallet.android.cases.addresses.SaveAddressNames
 import com.gemwallet.android.cases.transactions.SaveTransactions
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.service.store.WalletPreferencesFactory
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
@@ -25,7 +25,7 @@ class SyncTransactionsImpl @Inject constructor(
     private val saveTransactions: SaveTransactions,
     private val saveAddressNames: SaveAddressNames,
     private val prefetchAssets: PrefetchAssets,
-    private val ensureWalletAssets: EnsureWalletAssets,
+    private val assetsRepository: AssetsRepository,
     private val sessionRepository: SessionRepository,
 ) : SyncTransactions, SyncAssetTransactions {
 
@@ -63,8 +63,8 @@ class SyncTransactionsImpl @Inject constructor(
         val assetIds = response.transactions
             .flatMap { it.getAssociatedAssetIds() }
             .distinct()
-        prefetchAssets.prefetchAssets(assetIds)
-        ensureWalletAssets.ensureWalletAssets(wallet, assetIds)
+        val newAssetIds = prefetchAssets.prefetchAssets(assetIds)
+        assetsRepository.addBalancesIfMissing(wallet.id, newAssetIds)
 
         saveTransactions.saveTransactions(walletId = wallet.id, response.transactions)
         saveAddressNames.saveAddressNames(response.addressNames)

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/PrefetchAssetsImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/PrefetchAssetsImplTest.kt
@@ -10,6 +10,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class PrefetchAssetsImplTest {
@@ -32,10 +33,11 @@ class PrefetchAssetsImplTest {
         coEvery { assetsRepository.hasAssets(assetIds) } returns setOf(bitcoin.id)
         coEvery { gemApiClient.getAssets(listOf(ethereum.id)) } returns listOf(ethereumBasic)
 
-        subject.prefetchAssets(listOf(bitcoin.id, ethereum.id, ethereum.id))
+        val result = subject.prefetchAssets(listOf(bitcoin.id, ethereum.id, ethereum.id))
 
         coVerify { gemApiClient.getAssets(listOf(ethereum.id)) }
         coVerify { assetsRepository.add(listOf(ethereumBasic)) }
+        assertEquals(listOf(ethereum.id), result)
     }
 
     @Test
@@ -44,9 +46,10 @@ class PrefetchAssetsImplTest {
 
         coEvery { assetsRepository.hasAssets(listOf(bitcoin.id)) } returns setOf(bitcoin.id)
 
-        subject.prefetchAssets(listOf(bitcoin.id))
+        val result = subject.prefetchAssets(listOf(bitcoin.id))
 
         coVerify(exactly = 0) { gemApiClient.getAssets(any()) }
         coVerify(exactly = 0) { assetsRepository.add(any<List<AssetBasic>>()) }
+        assertEquals(emptyList<com.wallet.core.primitives.AssetId>(), result)
     }
 }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/transaction/SyncTransactionsImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/transaction/SyncTransactionsImplTest.kt
@@ -1,0 +1,75 @@
+package com.gemwallet.android.data.coordinators.transaction
+
+import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
+import com.gemwallet.android.cases.addresses.SaveAddressNames
+import com.gemwallet.android.cases.transactions.SaveTransactions
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.data.service.store.WalletPreferences
+import com.gemwallet.android.data.service.store.WalletPreferencesFactory
+import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
+import com.gemwallet.android.testkit.mockAssetEthereum
+import com.gemwallet.android.testkit.mockAssetSolana
+import com.gemwallet.android.testkit.mockTransaction
+import com.gemwallet.android.testkit.mockWallet
+import com.wallet.core.primitives.TransactionsResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class SyncTransactionsImplTest {
+
+    private val walletPreferences = mockk<WalletPreferences>(relaxed = true) {
+        every { transactionsTimestamp } returns 42L
+    }
+    private val walletPreferencesFactory = mockk<WalletPreferencesFactory> {
+        every { create(any()) } returns walletPreferences
+    }
+    private val gemDeviceApiClient = mockk<GemDeviceApiClient>()
+    private val saveTransactions = mockk<SaveTransactions>(relaxed = true)
+    private val saveAddressNames = mockk<SaveAddressNames>(relaxed = true)
+    private val prefetchAssets = mockk<PrefetchAssets>(relaxed = true)
+    private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
+    private val sessionRepository = mockk<SessionRepository>(relaxed = true)
+
+    private val subject = SyncTransactionsImpl(
+        walletPreferencesFactory = walletPreferencesFactory,
+        gemDeviceApiClient = gemDeviceApiClient,
+        saveTransactions = saveTransactions,
+        saveAddressNames = saveAddressNames,
+        prefetchAssets = prefetchAssets,
+        assetsRepository = assetsRepository,
+        sessionRepository = sessionRepository,
+    )
+
+    @Test
+    fun syncTransactions_prefetchesAssetsAndSavesTransactions() = runTest {
+        val wallet = mockWallet(id = "wallet-1")
+        val solana = mockAssetSolana()
+        val ethereum = mockAssetEthereum()
+        val transaction = mockTransaction(
+            assetId = solana.id,
+            feeAssetId = ethereum.id,
+        )
+
+        coEvery {
+            gemDeviceApiClient.getTransactions(wallet.id, 42L)
+        } returns TransactionsResponse(
+            transactions = listOf(transaction),
+            addressNames = emptyList(),
+        )
+        coEvery { prefetchAssets.prefetchAssets(listOf(solana.id, ethereum.id)) } returns listOf(solana.id)
+
+        subject.syncTransactions(wallet)
+
+        coVerify { prefetchAssets.prefetchAssets(listOf(solana.id, ethereum.id)) }
+        coVerify { assetsRepository.addBalancesIfMissing(wallet.id, listOf(solana.id)) }
+        coVerify { saveTransactions.saveTransactions(wallet.id, listOf(transaction)) }
+        coVerify { saveAddressNames.saveAddressNames(emptyList()) }
+        verify { walletPreferences.transactionsTimestamp = any() }
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
@@ -11,6 +11,7 @@ import com.gemwallet.android.data.service.store.database.BalancesDao
 import com.gemwallet.android.data.service.store.database.PricesDao
 import com.gemwallet.android.data.service.store.database.entities.DbAsset
 import com.gemwallet.android.data.service.store.database.entities.DbAssetBasicUpdate
+import com.gemwallet.android.data.service.store.database.entities.DbBalance
 import com.gemwallet.android.data.service.store.database.entities.toAssetInfoModel
 import com.gemwallet.android.data.service.store.database.entities.toAssetLinkRecord
 import com.gemwallet.android.data.service.store.database.entities.toAssetLinksModel
@@ -339,6 +340,23 @@ class AssetsRepository @Inject constructor(
         assetsDao.setWalletAssetVisibility(walletId, assetId.toIdentifier(), visible)
         if (visible) {
             streamSubscriptionService.addAssetIds(listOf(assetId))
+        }
+    }
+
+    suspend fun addBalancesIfMissing(walletId: WalletId, assetIds: List<AssetId>) = withContext(Dispatchers.IO) {
+        if (assetIds.isEmpty()) {
+            return@withContext
+        }
+        val existing = assetsDao.getAssetIds(assetIds.map { it.toIdentifier() }).toSet()
+        for (assetIdentifier in existing) {
+            assetsDao.insertBalance(
+                DbBalance(
+                    assetId = assetIdentifier,
+                    walletId = walletId.id,
+                    isVisible = false,
+                    updatedAt = null,
+                )
+            )
         }
     }
 

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
@@ -13,6 +13,7 @@ import com.gemwallet.android.data.service.store.database.entities.DbAssetBasicUp
 import com.gemwallet.android.data.service.store.database.entities.DbFiatRate
 import com.gemwallet.android.data.service.store.database.entities.DbAssetLink
 import com.gemwallet.android.data.service.store.database.entities.DbAssetMarket
+import com.gemwallet.android.data.service.store.database.entities.DbBalance
 import com.gemwallet.android.data.service.store.database.entities.DbPrice
 import com.gemwallet.android.data.service.store.database.entities.mockDbAsset
 import com.gemwallet.android.data.service.store.database.entities.mockDbAssetInfo
@@ -157,6 +158,28 @@ class AssetsRepositoryTest {
         assertEquals(100.0, marketSlot.captured.totalVolume ?: 0.0, 0.0)
         assertEquals(150.0, marketSlot.captured.allTimeHigh ?: 0.0, 0.0)
         assertEquals(25.0, marketSlot.captured.allTimeLow ?: 0.0, 0.0)
+    }
+
+    @Test
+    fun addBalancesIfMissing_insertsHiddenBalanceOnlyForExistingAssets() = runBlocking {
+        every { sessionRepository.session() } returns sessionFlow
+
+        val present = mockAssetSolana()
+        val absent = mockAssetEthereum()
+        val walletId = mockWalletId()
+
+        coEvery {
+            assetsDao.getAssetIds(listOf(present.id.toIdentifier(), absent.id.toIdentifier()))
+        } returns listOf(present.id.toIdentifier())
+
+        val subject = createSubject()
+        subject.addBalancesIfMissing(walletId, listOf(present.id, absent.id))
+
+        val balanceSlot = slot<DbBalance>()
+        coVerify(exactly = 1) { assetsDao.insertBalance(capture(balanceSlot)) }
+        assertEquals(present.id.toIdentifier(), balanceSlot.captured.assetId)
+        assertEquals(walletId.id, balanceSlot.captured.walletId)
+        assertEquals(false, balanceSlot.captured.isVisible)
     }
 
     @Test

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/PrefetchAssets.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/PrefetchAssets.kt
@@ -3,5 +3,5 @@ package com.gemwallet.android.application.assets.coordinators
 import com.wallet.core.primitives.AssetId
 
 interface PrefetchAssets {
-    suspend fun prefetchAssets(assetIds: List<AssetId>)
+    suspend fun prefetchAssets(assetIds: List<AssetId>): List<AssetId>
 }


### PR DESCRIPTION
## Problem

Opening Activity after a transaction could crash with `SQLITE_CONSTRAINT_FOREIGNKEY` on the `balances -> asset` foreign key. Android transaction sync called `ensureWalletAssets` → `enableAsset` → `linkAssetToWallet(visible = true)`, inserting a balance row for every transaction-associated asset. When `prefetchAssets` was partial (the assets API returned fewer/no assets, e.g. on failure), the asset row was never materialized, so the balance insert violated the FK.

This also diverged from iOS behaviorally: enabling with `visible = true` auto-showed transaction tokens in the wallet list, whereas iOS only stores them hidden.

## Fix

Mirror iOS `TransactionsService.prefetchAssets` → `AssetsService.addBalancesIfMissing(newAssets)` instead of ensuring/enabling wallet assets:

- `PrefetchAssets.prefetchAssets` now returns the asset ids it newly persisted.
- Transaction sync inserts a hidden (`isVisible = false`) balance row only for those newly prefetched assets, via `AssetsRepository.addBalancesIfMissing`.
- The insert is FK-safe: `addBalancesIfMissing` filters to assets that exist locally — `INSERT OR IGNORE` resolves a primary-key conflict but does not suppress the `balances -> asset` foreign-key violation.

Net result: transaction-associated assets are tracked but stay hidden until the user enables them, matching iOS, and the crash path (enabling unmaterialized assets) is removed.

## Verification

- `./gradlew :data:coordinators:testDebugUnitTest --tests "*SyncTransactionsImplTest" --tests "*PrefetchAssetsImplTest" --tests "*EnsureWalletAssetsImplTest"`
- `./gradlew :data:repositories:testDebugUnitTest --tests "*AssetsRepositoryTest.addBalancesIfMissing_insertsHiddenBalanceOnlyForExistingAssets"`
- `./gradlew :app:testFdroidDebugUnitTest --tests "*NotificationNavigationTest"`
- `./gradlew :data:coordinators:lintDebug :data:repositories:lintDebug`
