### PR TITLE
Extract AssetDetailsViewModel.toUIState into a mapper

### DIFF
--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/models/AssetInfoUIModelFactory.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/models/AssetInfoUIModelFactory.kt
@@ -1,0 +1,101 @@
+package com.gemwallet.android.features.asset.viewmodels.details.models
+
+import com.gemwallet.android.domains.asset.chain
+import com.gemwallet.android.domains.asset.getIconUrl
+import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
+import com.gemwallet.android.domains.percentage.formatAsPercentage
+import com.gemwallet.android.domains.price.toValueDirection
+import com.gemwallet.android.ext.asset
+import com.gemwallet.android.ext.isStaked
+import com.gemwallet.android.ext.type
+import com.gemwallet.android.model.AssetInfo
+import com.gemwallet.android.model.ChainAssetInfo
+import com.gemwallet.android.model.CurrencyFormatter
+import com.gemwallet.android.model.ValueFormatter
+import com.gemwallet.android.model.getStackedAmount
+import com.gemwallet.android.model.getTotalAmount
+import com.wallet.core.primitives.Asset
+import com.wallet.core.primitives.AssetSubtype
+import com.wallet.core.primitives.AssetType
+import com.wallet.core.primitives.Currency
+import com.wallet.core.primitives.StakeChain
+import uniffi.gemstone.Explorer
+
+object AssetInfoUIModelFactory {
+
+    fun create(chainAssetInfo: ChainAssetInfo, explorerName: String): AssetInfoUIModel {
+        val assetInfo = chainAssetInfo.assetInfo
+        val feeAssetInfo = chainAssetInfo.feeAssetInfo
+        val asset = assetInfo.asset
+        val balances = assetInfo.balance
+        val price = assetInfo.price?.price?.price ?: 0.0
+        val currency = assetInfo.price?.currency ?: Currency.USD
+        val currencyFormatter = CurrencyFormatter(currency = currency)
+        val valueFormatter = ValueFormatter(style = ValueFormatter.Style.Auto)
+        val fiatTotal = if (balances.fiatTotalAmount == 0.0) "" else currencyFormatter.string(balances.fiatTotalAmount)
+
+        return AssetInfoUIModel(
+            assetInfo = assetInfo,
+            name = assetName(asset),
+            iconUrl = asset.id.getIconUrl(),
+            priceValue = if (price == 0.0) "" else currencyFormatter.string(price),
+            priceDayChanges = assetInfo.price?.price?.priceChangePercentage24h.formatAsPercentage(),
+            priceChangedType = assetInfo.price?.price?.priceChangePercentage24h.toValueDirection(),
+            tokenType = asset.type,
+            isBuyEnabled = assetInfo.metadata?.isBuyEnabled == true,
+            isSwapEnabled = assetInfo.metadata?.isSwapEnabled == true,
+            explorerName = explorerName,
+            explorerAddressUrl = assetInfo.owner?.address?.let {
+                Explorer(asset.chain.string).getAddressUrl(explorerName, it)
+            },
+            explorerTokenUrl = asset.id.tokenId?.let {
+                Explorer(asset.chain.string).getTokenUrl(explorerName, it)
+            },
+            accountInfoUIModel = AssetInfoUIModel.AccountInfoUIModel(
+                walletType = assetInfo.walletType,
+                totalBalance = valueFormatter.string(balances.balance.getTotalAmount(), balances.asset),
+                totalFiat = fiatTotal,
+                owner = assetInfo.owner?.address ?: "",
+                balanceMetadata = feeAssetInfo.balance.metadata,
+                hasBalanceDetails = StakeChain.isStaked(asset.id.chain) || balances.balanceAmount.reserved != 0.0,
+                available = formatAvailable(assetInfo, valueFormatter),
+                stake = formatStake(assetInfo, valueFormatter),
+                reserved = formatReserved(assetInfo, valueFormatter),
+            ),
+        )
+    }
+
+    private fun assetName(asset: Asset): String =
+        if (asset.type == AssetType.NATIVE) asset.id.chain.asset().name else asset.name
+
+    private fun formatAvailable(assetInfo: AssetInfo, formatter: ValueFormatter): String {
+        val balances = assetInfo.balance
+        return if (balances.balanceAmount.available != balances.totalAmount) {
+            formatter.string(balances.balance.available.toBigInteger(), balances.asset)
+        } else {
+            ""
+        }
+    }
+
+    private fun formatStake(assetInfo: AssetInfo, formatter: ValueFormatter): String {
+        val asset = assetInfo.asset
+        if (asset.id.type() != AssetSubtype.NATIVE || !StakeChain.isStaked(asset.id.chain)) {
+            return ""
+        }
+        val balances = assetInfo.balance
+        return if (balances.balanceAmount.getStackedAmount() == 0.0) {
+            "APR ${(assetInfo.stakeApr ?: 0.0).formatAsPercentage(style = PercentageFormatterStyle.PercentSignLess)}"
+        } else {
+            formatter.string(balances.balance.getStackedAmount(), balances.asset)
+        }
+    }
+
+    private fun formatReserved(assetInfo: AssetInfo, formatter: ValueFormatter): String {
+        val balances = assetInfo.balance
+        return if (balances.balanceAmount.reserved != 0.0) {
+            formatter.string(balances.balance.reserved.toBigInteger(), balances.asset)
+        } else {
+            ""
+        }
+    }
+}

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
@@ -18,27 +18,12 @@ import com.gemwallet.android.application.transactions.coordinators.TransactionsR
 import com.gemwallet.android.cases.banners.HasMultiSign
 import com.gemwallet.android.cases.nodes.GetCurrentBlockExplorer
 import com.gemwallet.android.domains.asset.chain
-import com.gemwallet.android.domains.asset.getIconUrl
-import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
-import com.gemwallet.android.domains.percentage.formatAsPercentage
-import com.gemwallet.android.domains.price.toValueDirection
 import com.gemwallet.android.domains.pricealerts.values.PriceAlertsStateEvent
-import com.gemwallet.android.ext.asset
 import com.gemwallet.android.ext.getAccount
-import com.gemwallet.android.ext.isStaked
-import com.gemwallet.android.ext.type
 import com.gemwallet.android.model.ChainAssetInfo
-import com.gemwallet.android.model.ValueFormatter
-import com.gemwallet.android.model.CurrencyFormatter
-import com.gemwallet.android.model.getStackedAmount
-import com.gemwallet.android.model.getTotalAmount
-import com.gemwallet.android.features.asset.viewmodels.details.models.AssetInfoUIModel
+import com.gemwallet.android.features.asset.viewmodels.details.models.AssetInfoUIModelFactory
 import com.gemwallet.android.ui.models.navigation.requireAssetId
 import com.wallet.core.primitives.AssetId
-import com.wallet.core.primitives.AssetSubtype
-import com.wallet.core.primitives.AssetType
-import com.wallet.core.primitives.Currency
-import com.wallet.core.primitives.StakeChain
 import com.wallet.core.primitives.Wallet
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
@@ -122,7 +107,9 @@ class AssetDetailsViewModel @Inject constructor(
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    val uiModel = model.map { it?.toUIState() }
+    val uiModel = model.map { current ->
+        current?.let { AssetInfoUIModelFactory.create(it.chainAssetInfo, it.explorerName) }
+    }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     fun refresh() {
@@ -210,69 +197,5 @@ class AssetDetailsViewModel @Inject constructor(
         val chainAssetInfo: ChainAssetInfo,
         val updatedAt: Long,
         val explorerName: String,
-    ) {
-        fun toUIState(): AssetInfoUIModel {
-            val assetInfo = chainAssetInfo.assetInfo
-            val feeAssetInfo = chainAssetInfo.feeAssetInfo
-            val price = assetInfo.price?.price?.price ?: 0.0
-            val currency = assetInfo.price?.currency ?: Currency.USD
-            val asset = assetInfo.asset
-            val balances = assetInfo.balance
-            val total = balances.totalAmount
-            val currencyFormatter = CurrencyFormatter(currency = currency)
-            val fiatTotal = if (balances.fiatTotalAmount == 0.0) "" else currencyFormatter.string(balances.fiatTotalAmount)
-            val stakeBalance = balances.balanceAmount.getStackedAmount()
-            val formatter = ValueFormatter(style = ValueFormatter.Style.Auto)
-
-            return AssetInfoUIModel(
-                assetInfo = assetInfo,
-                name = if (asset.type == AssetType.NATIVE) { // TODO: ????
-                    asset.id.chain.asset().name
-                } else {
-                    asset.name
-                },
-                iconUrl = asset.id.getIconUrl(),
-                priceValue = if (price == 0.0) "" else currencyFormatter.string(price),
-                priceDayChanges = assetInfo.price?.price?.priceChangePercentage24h.formatAsPercentage(),
-                priceChangedType = assetInfo.price?.price?.priceChangePercentage24h.toValueDirection(),
-                tokenType = asset.type,
-                isBuyEnabled = assetInfo.metadata?.isBuyEnabled == true,
-                isSwapEnabled = assetInfo.metadata?.isSwapEnabled == true,
-                explorerName = explorerName, //  TODO: Out to separate state and model
-                explorerAddressUrl = assetInfo.owner?.address?.let {//  TODO: Out to separate state
-                    Explorer(asset.chain.string).getAddressUrl(explorerName,  it)
-                },
-                explorerTokenUrl = asset.id.tokenId?.let {
-                    Explorer(asset.chain.string).getTokenUrl(explorerName, it)
-                },
-                accountInfoUIModel = AssetInfoUIModel.AccountInfoUIModel(
-                    walletType = assetInfo.walletType,
-                    totalBalance = formatter.string(balances.balance.getTotalAmount(), balances.asset),
-                    totalFiat = fiatTotal,
-                    owner = assetInfo.owner?.address ?: "",
-                    balanceMetadata = feeAssetInfo.balance.metadata,
-                    hasBalanceDetails = StakeChain.isStaked(asset.id.chain) || balances.balanceAmount.reserved != 0.0,
-                    available = if (balances.balanceAmount.available != total) {
-                        formatter.string(balances.balance.available.toBigInteger(), balances.asset)
-                    } else {
-                        ""
-                    },
-                    stake = if (asset.id.type() == AssetSubtype.NATIVE && StakeChain.isStaked(asset.id.chain)) {
-                        if (stakeBalance == 0.0) {
-                            "APR ${(assetInfo.stakeApr ?: 0.0).formatAsPercentage(style = PercentageFormatterStyle.PercentSignLess)}"
-                        } else {
-                            formatter.string(balances.balance.getStackedAmount(), balances.asset)
-                        }
-                    } else {
-                        ""
-                    },
-                    reserved = if (balances.balanceAmount.reserved != 0.0) {
-                        formatter.string(balances.balance.reserved.toBigInteger(), balances.asset)
-                    } else {
-                        ""
-                    },
-                ),
-            )
-        }
-    }
+    )
 }

--- a/android/features/asset/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset/viewmodels/details/models/AssetInfoUIModelFactoryTest.kt
+++ b/android/features/asset/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset/viewmodels/details/models/AssetInfoUIModelFactoryTest.kt
@@ -1,0 +1,85 @@
+package com.gemwallet.android.features.asset.viewmodels.details.models
+
+import com.gemwallet.android.ext.asset
+import com.gemwallet.android.model.AssetBalance
+import com.gemwallet.android.model.ChainAssetInfo
+import com.gemwallet.android.testkit.mockAsset
+import com.gemwallet.android.testkit.mockAssetInfo
+import com.wallet.core.primitives.Asset
+import com.wallet.core.primitives.AssetType
+import com.wallet.core.primitives.Chain
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AssetInfoUIModelFactoryTest {
+
+    @Before
+    fun setUp() {
+        mockkStatic("com.gemwallet.android.ext.ChainKt")
+        every { Chain.Cosmos.asset() } returns mockAsset(chain = Chain.Cosmos, name = "Cosmos")
+        every { Chain.Bitcoin.asset() } returns mockAsset(chain = Chain.Bitcoin, name = "Bitcoin")
+    }
+
+    @After
+    fun tearDown() = unmockkStatic("com.gemwallet.android.ext.ChainKt")
+
+    @Test
+    fun `name uses chain asset for native and own name for token`() {
+        val native = model(mockAsset(chain = Chain.Cosmos, name = "Renamed Cosmos"))
+        val token = model(mockAsset(chain = Chain.Cosmos, name = "Token", type = AssetType.TOKEN))
+
+        assertEquals("Cosmos", native.name)
+        assertEquals("Token", token.name)
+    }
+
+    @Test
+    fun `available is hidden when equal to total and shown otherwise`() {
+        val whole = model(mockAsset(chain = Chain.Cosmos), available = "3000000")
+        val partial = model(mockAsset(chain = Chain.Cosmos), available = "1000000", staked = "2000000")
+
+        assertEquals("", whole.accountInfoUIModel.available)
+        assertTrue(partial.accountInfoUIModel.available.isNotEmpty())
+    }
+
+    @Test
+    fun `stake formats balance, falls back to apr, and is empty off staking chains`() {
+        val withStake = model(mockAsset(chain = Chain.Cosmos), available = "1000000", staked = "2000000")
+        val withoutStake = model(mockAsset(chain = Chain.Cosmos), available = "1000000")
+        val nonStaking = model(mockAsset(chain = Chain.Bitcoin), available = "100000000")
+
+        assertTrue(withStake.accountInfoUIModel.stake.isNotEmpty())
+        assertFalse(withStake.accountInfoUIModel.stake.startsWith("APR"))
+        assertTrue(withoutStake.accountInfoUIModel.stake.startsWith("APR"))
+        assertEquals("", nonStaking.accountInfoUIModel.stake)
+    }
+
+    @Test
+    fun `reserved is shown only when non zero`() {
+        val reserved = model(mockAsset(chain = Chain.Bitcoin), available = "100000000", reserved = "500000")
+        val noReserved = model(mockAsset(chain = Chain.Bitcoin), available = "100000000")
+
+        assertTrue(reserved.accountInfoUIModel.reserved.isNotEmpty())
+        assertEquals("", noReserved.accountInfoUIModel.reserved)
+    }
+
+    private fun model(
+        asset: Asset,
+        available: String = "0",
+        staked: String = "0",
+        reserved: String = "0",
+    ): AssetInfoUIModel {
+        val balance = AssetBalance.create(asset, available = available, staked = staked, reserved = reserved)
+        val assetInfo = mockAssetInfo(asset = asset, owner = null, balance = balance)
+        return AssetInfoUIModelFactory.create(
+            ChainAssetInfo(assetInfo = assetInfo, feeAssetInfo = assetInfo),
+            explorerName = "Explorer",
+        )
+    }
+}


### PR DESCRIPTION
Moves the asset details screen's UI mapping out of the view model into its own factory, with the balance formatting split into clearly named pieces. Adds a unit test for it. No behaviour change.

Closes #527