### PR TITLE
Fix Tron dynamic-energy penalty double-count and surface failed simulations

### DIFF
--- a/core/crates/gem_tron/Cargo.toml
+++ b/core/crates/gem_tron/Cargo.toml
@@ -55,5 +55,5 @@ chain_integration_tests = ["rpc", "reqwest", "primitives/testkit", "settings/tes
 tokio = { workspace = true, features = ["macros", "rt"] }
 reqwest = { workspace = true }
 primitives = { path = "../primitives", features = ["testkit"] }
-gem_client = { path = "../gem_client", features = ["reqwest"] }
+gem_client = { path = "../gem_client", features = ["reqwest", "testkit"] }
 settings = { path = "../settings", features = ["testkit"] }

--- a/core/crates/gem_tron/src/models/mod.rs
+++ b/core/crates/gem_tron/src/models/mod.rs
@@ -149,8 +149,7 @@ pub struct TriggerConstantContractResponse {
     #[serde(default)]
     pub constant_result: Vec<String>,
     pub result: Option<TriggerContractResult>,
-    pub energy_used: u64,
-    #[serde(default)]
+    pub energy_used: Option<u64>,
     pub energy_penalty: Option<u64>,
 }
 
@@ -160,7 +159,10 @@ impl TriggerConstantContractResponse {
         if let Some(error) = self.result.as_ref().and_then(|r| r.check_error()) {
             return Err(error);
         }
-        Ok(self.energy_used)
+        self.energy_used.ok_or_else(|| TronRpcError {
+            code: None,
+            message: Some("Tron triggerconstantcontract response missing energy_used".to_string()),
+        })
     }
 }
 

--- a/core/crates/gem_tron/src/models/mod.rs
+++ b/core/crates/gem_tron/src/models/mod.rs
@@ -155,11 +155,12 @@ pub struct TriggerConstantContractResponse {
 }
 
 impl TriggerConstantContractResponse {
+    /// Returns `energy_used` (the total, which already includes `energy_penalty` — don't add it) and surfaces failed simulations as errors.
     pub fn get_energy(&self) -> Result<u64, TronRpcError> {
         if let Some(error) = self.result.as_ref().and_then(|r| r.check_error()) {
             return Err(error);
         }
-        Ok(self.energy_used + self.energy_penalty.unwrap_or_default())
+        Ok(self.energy_used)
     }
 }
 

--- a/core/crates/gem_tron/src/rpc/client.rs
+++ b/core/crates/gem_tron/src/rpc/client.rs
@@ -275,10 +275,12 @@ mod tests {
 
         let mock = MockClient::new().with_post(|_, _| Ok(include_str!("../../testdata/trigger_constant_contract_failed.json").as_bytes().to_vec()));
         let client = TronClient::new(mock.clone(), TronGridClient::new(mock, String::new()));
-        let result = client
+        let error = client
             .estimate_trc20_transfer_gas("Tsender".to_string(), "Tusdt".to_string(), "0".repeat(64), "1000000".to_string())
-            .await;
-        assert!(result.is_err());
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("CONTRACT_VALIDATE_ERROR"), "expected structured Tron RPC error, got: {error}");
     }
 
     #[test]

--- a/core/crates/gem_tron/src/rpc/client.rs
+++ b/core/crates/gem_tron/src/rpc/client.rs
@@ -238,7 +238,7 @@ impl<C: Client> TronClient<C> {
             visible: true,
         };
 
-        Ok(self.trigger_constant_contract_request(&request).await?.energy_used)
+        Ok(self.trigger_constant_contract_request(&request).await?.get_energy()?)
     }
 }
 
@@ -261,6 +261,25 @@ impl<C: Client + Clone> chain_traits::ChainProvider for TronClient<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gem_client::testkit::MockClient;
+
+    #[tokio::test]
+    async fn test_estimate_trc20_transfer_gas_uses_total_energy_and_surfaces_errors() {
+        let mock = MockClient::new().with_post(|_, _| Ok(include_str!("../../testdata/trigger_constant_contract_with_penalty.json").as_bytes().to_vec()));
+        let client = TronClient::new(mock.clone(), TronGridClient::new(mock, String::new()));
+        let energy = client
+            .estimate_trc20_transfer_gas("Tsender".to_string(), "Tusdt".to_string(), "0".repeat(64), "1000000".to_string())
+            .await
+            .unwrap();
+        assert_eq!(energy, 64285);
+
+        let mock = MockClient::new().with_post(|_, _| Ok(include_str!("../../testdata/trigger_constant_contract_failed.json").as_bytes().to_vec()));
+        let client = TronClient::new(mock.clone(), TronGridClient::new(mock, String::new()));
+        let result = client
+            .estimate_trc20_transfer_gas("Tsender".to_string(), "Tusdt".to_string(), "0".repeat(64), "1000000".to_string())
+            .await;
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_value_encoding_for_trc20_transfer() {

--- a/core/crates/gem_tron/testdata/trigger_constant_contract_failed.json
+++ b/core/crates/gem_tron/testdata/trigger_constant_contract_failed.json
@@ -1,7 +1,6 @@
 {
   "result": {
-    "result": false,
-    "code": "CONTRACT_VALIDATE_ERROR"
-  },
-  "energy_used": 0
+    "code": "CONTRACT_VALIDATE_ERROR",
+    "message": "Smart contract is not exist."
+  }
 }

--- a/core/crates/gem_tron/testdata/trigger_constant_contract_failed.json
+++ b/core/crates/gem_tron/testdata/trigger_constant_contract_failed.json
@@ -1,0 +1,7 @@
+{
+  "result": {
+    "result": false,
+    "code": "CONTRACT_VALIDATE_ERROR"
+  },
+  "energy_used": 0
+}

--- a/core/crates/gem_tron/testdata/trigger_constant_contract_with_penalty.json
+++ b/core/crates/gem_tron/testdata/trigger_constant_contract_with_penalty.json
@@ -1,0 +1,8 @@
+{
+  "result": {
+    "result": true
+  },
+  "energy_used": 64285,
+  "energy_penalty": 20000,
+  "constant_result": []
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in Tron energy estimation (`gem_tron`).

**1. `get_energy()` double-counted the dynamic-energy penalty.** Per the [TRON docs](https://developers.tron.network/reference/triggerconstantcontract) and [TIP-491](https://github.com/tronprotocol/tips/blob/master/tip-491.md), `triggerconstantcontract`'s `energy_used` is the **total** energy and **already includes** `energy_penalty` (basic energy = `energy_used − energy_penalty`). `get_energy()` returned `energy_used + energy_penalty`, so for contracts under a high dynamic-energy penalty (e.g. USDT) the estimate was up to ~2× actual. This affected the existing `get_energy()` callers — swaps and generic contract calls. `get_energy()` now returns `energy_used`.

**2. The TRC-20 / USDT send path ignored failed simulations.** `estimate_trc20_transfer_gas` read the raw `energy_used` field, so a `result: false` simulation was used as-is instead of erroring. It now routes through `get_energy()?`. The energy *amount* is unchanged from the original (raw `energy_used`); only failed-simulation error handling is added.

## Net effect

- USDT/TRC-20 and swap fee estimates: back to actual + the existing 20% `FEE_LIMIT_BUFFER_PERCENT` (previously up to ~2× during high-penalty periods).
- Failed simulations surface as explicit errors instead of a bad estimate.

## Not the cause: "first-time recipient"

A support report proposed a Solana-style static `token_activation_fee` for first-time USDT recipients. That's not it — Tron energy is simulated against live chain state with the real recipient, so the new-account `0 → non-zero` SSTORE cost is already in `energy_used`. No static fee needed.

## Testing

- `test_estimate_trc20_transfer_gas_uses_total_energy_and_surfaces_errors`: asserts the estimate equals `energy_used` (not `energy_used + energy_penalty`) and that a failed simulation errors.
- `cargo test -p gem_tron` → 68 passed; `cargo clippy -p gem_tron --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- Locally confirmed the over-estimate: USDT → fresh address showed ~$8 estimated vs ~$4 on-chain before this fix.

## Sources

- TRON docs — TriggerConstantContract: *"basic energy consumption: `energy_used` − `energy_penalty`"*
- TIP-491 Dynamic Energy Model

> Heads-up for reviewers: an earlier revision of this branch *added* the penalty (wrong direction). That was corrected after local testing showed the 2× over-estimate; the net diff stops the double-count and keeps only the error-surfacing improvement.
