### PR TITLE
Fix v3 keystore migration for legacy empty scrypt salt

### DIFF
--- a/android/app/src/androidTest/assets/v3_empty_salt_mnemonic.json
+++ b/android/app/src/androidTest/assets/v3_empty_salt_mnemonic.json
@@ -1,0 +1,30 @@
+{
+  "activeAccounts": [
+    {
+      "address": "0x5a8f70b44aFa00Cb70615D9c9CCb9A24933ED2D3",
+      "coin": 60,
+      "derivationPath": "m/44'/60'/0'/0/0",
+      "publicKey": "0411111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+    }
+  ],
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": {
+      "iv": "02020202020202020202020202020202"
+    },
+    "ciphertext": "694794c24b4ef152f91130aa2959ee2c238cb328439a83b6a53c46ba89b8689ef0228bab10cb9921fd5e9a737a77512435bf1f2b143a3710ce2cce9aa97a6bbbdf557529294be4a6054001e62c2c3e669fa7f42741b07051788e7ba6827718df4df14a94ae248880526e151ae796d70c9948a088db7f767fd0f499b1d67e5476239496a0c6ebeda1299f0195c73d8f91c796436c22651b2037041084c9e7132414",
+    "kdf": "scrypt",
+    "kdfparams": {
+      "dklen": 32,
+      "n": 16,
+      "p": 1,
+      "r": 1,
+      "salt": ""
+    },
+    "mac": "939249695743756d274bc400f5bafacd1bff085c0252bfffd3a877d1a0f0ba16"
+  },
+  "id": "4b8fc216-dc74-481e-8011-bd4d1bc968ab",
+  "name": "Ethereum Wallet #4",
+  "type": "mnemonic",
+  "version": 3
+}

--- a/android/app/src/androidTest/kotlin/com/gemwallet/android/services/MigrateV3KeystoreServiceTest.kt
+++ b/android/app/src/androidTest/kotlin/com/gemwallet/android/services/MigrateV3KeystoreServiceTest.kt
@@ -86,6 +86,21 @@ class MigrateV3KeystoreServiceTest {
         coVerify(exactly = 0) { walletsRepository.updateWallet(any()) }
     }
 
+    @Test
+    fun migrateV3WithEmptyScryptSalt_createsV4AndRecoversKey() = runBlocking {
+        val walletId = WalletId("multicoin_$KEYSTORE_TEST_ETH_ADDRESS")
+        val current = mockWallet(id = walletId.id, type = WalletType.Multicoin, source = WalletSource.Import)
+        every { walletsRepository.getAll() } answers { flowOf(listOf(current)) }
+        prepareV3File(walletId, "v3_empty_salt_mnemonic.json")
+
+        service()
+
+        val keystoreId = uniffi.gemstone.keystoreIdForWallet(walletId.id)
+        assertTrue("v4 file must exist after migrating an empty-salt v3 file", File(baseDir, "$keystoreId.json").exists())
+        assertFalse("v3 file must be deleted after a verified migration", File(baseDir, walletId.id).exists())
+        assertEquals(EXPECTED_PRIVATE_KEY, loadKey(current, Chain.Ethereum, KEYSTORE_TEST_PASSWORD).hex)
+    }
+
     private fun prepareV3File(walletId: WalletId, assetName: String) {
         val fixture = InstrumentationRegistry.getInstrumentation().context.assets
             .open(assetName).bufferedReader().use { it.readText() }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/wallet/GetWalletSecretDataImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/wallet/GetWalletSecretDataImpl.kt
@@ -7,6 +7,7 @@ import com.gemwallet.android.blockchain.operators.LoadPrivateDataOperator
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.domains.wallet.values.WalletSecretDataValue
 import com.wallet.core.primitives.WalletId
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapLatest
@@ -20,22 +21,26 @@ class GetWalletSecretDataImpl(
 
     override fun getSecretData(walletId: WalletId): Flow<WalletSecretDataValue> {
         return walletsRepository.getWallet(walletId).mapLatest { wallet ->
-            val data = try {
-                wallet?.let {
-                    val password = passwordStore.getPassword(wallet.id.id)
-                    val phrase = loadPrivateDataOperator(wallet, password)
-                    phrase
-                }
+            wallet ?: return@mapLatest WalletSecretDataValueImpl(emptyList())
+            try {
+                val password = passwordStore.getPassword(wallet.id.id)
+                val phrase = loadPrivateDataOperator(wallet, password)
+                WalletSecretDataValueImpl(phrase.split(" "))
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Throwable) {
-                null
-            }?.split(" ") ?: emptyList()
-            WalletSecretDataValueImpl(data)
+                // Surface keystore read failures as an error, not a blank phrase.
+                WalletSecretDataValueImpl(emptyList(), isError = true)
+            }
         }
     }
 }
 
 @Stable
-class WalletSecretDataValueImpl(override val data: List<String>) : WalletSecretDataValue {
+class WalletSecretDataValueImpl(
+    override val data: List<String>,
+    override val isError: Boolean = false,
+) : WalletSecretDataValue {
     override fun phrase(): List<String> {
         return data.takeIf { data.size >= 12 } ?: emptyList()
     }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/wallet/GetWalletSecretDataImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/wallet/GetWalletSecretDataImplTest.kt
@@ -1,0 +1,69 @@
+package com.gemwallet.android.data.coordinators.wallet
+
+import com.gemwallet.android.application.PasswordStore
+import com.gemwallet.android.blockchain.operators.LoadPrivateDataOperator
+import com.gemwallet.android.data.repositories.wallets.WalletsRepository
+import com.gemwallet.android.testkit.TEST_PHRASE
+import com.gemwallet.android.testkit.mockWallet
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GetWalletSecretDataImplTest {
+
+    private val walletsRepository = mockk<WalletsRepository>()
+    private val passwordStore = mockk<PasswordStore>()
+    private val loadPrivateDataOperator = mockk<LoadPrivateDataOperator>()
+
+    private val subject = GetWalletSecretDataImpl(
+        walletsRepository = walletsRepository,
+        passwordStore = passwordStore,
+        loadPrivateDataOperator = loadPrivateDataOperator,
+    )
+
+    @Test
+    fun success_returnsPhrase_notError() = runTest {
+        val wallet = mockWallet()
+        every { walletsRepository.getWallet(wallet.id) } returns flowOf(wallet)
+        every { passwordStore.getPassword(wallet.id.id) } returns "0xdeadbeef"
+        coEvery { loadPrivateDataOperator(wallet, "0xdeadbeef") } returns TEST_PHRASE
+
+        val value = subject.getSecretData(wallet.id).first()
+
+        assertFalse(value.isError)
+        assertEquals(12, value.phrase().size)
+    }
+
+    @Test
+    fun keystoreFailure_surfacesError_notBlankPhrase() = runTest {
+        val wallet = mockWallet()
+        every { walletsRepository.getWallet(wallet.id) } returns flowOf(wallet)
+        every { passwordStore.getPassword(wallet.id.id) } throws IllegalStateException("Password not found")
+
+        val value = subject.getSecretData(wallet.id).first()
+
+        assertTrue(value.isError)
+        assertTrue(value.phrase().isEmpty())
+    }
+
+    @Test
+    fun cancellation_isNotMappedToError() = runTest {
+        val wallet = mockWallet()
+        every { walletsRepository.getWallet(wallet.id) } returns flowOf(wallet)
+        every { passwordStore.getPassword(wallet.id.id) } throws CancellationException("cancelled")
+
+        val value = subject.getSecretData(wallet.id).firstOrNull()
+
+        // Cancellation is rethrown (structured concurrency), never converted into a false isError emission.
+        assertFalse("cancellation must not surface as isError", value?.isError == true)
+    }
+}

--- a/android/features/wallet-details/presents/src/main/kotlin/com/gemwallet/android/features/wallet/presents/WalletSecretDataNavScreen.kt
+++ b/android/features/wallet-details/presents/src/main/kotlin/com/gemwallet/android/features/wallet/presents/WalletSecretDataNavScreen.kt
@@ -79,6 +79,32 @@ fun WalletSecretDataNavScreen(
         return
     }
 
+    if (value?.isError == true) {
+        Scene(
+            title = stringResource(id = content.titleRes),
+            padding = sceneContentPaddingValues(),
+            onClose = onCancel,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingDefault),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "Couldn't access this wallet's keys on this device. " +
+                        "If you have your recovery phrase, remove this wallet and import it again to restore access.",
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+        return
+    }
+
     Scene(
         title = stringResource(id = content.titleRes),
         padding = sceneContentPaddingValues(),

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/wallet/values/WalletSecretDataValue.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/wallet/values/WalletSecretDataValue.kt
@@ -3,6 +3,8 @@ package com.gemwallet.android.domains.wallet.values
 interface WalletSecretDataValue {
     val data: List<String>
 
+    val isError: Boolean
+
     fun phrase(): List<String>
 
     fun privateKey(): String?

--- a/core/crates/gem_keystore/src/v3/constants.rs
+++ b/core/crates/gem_keystore/src/v3/constants.rs
@@ -6,7 +6,6 @@ pub(super) const AES_128_KEY_LEN: usize = 16;
 pub(super) const AES_128_CTR_IV_LEN: usize = 16;
 pub(super) const DERIVED_KEY_LEN: usize = 32;
 pub(super) const MAC_LEN: usize = 32;
-pub(super) const MIN_SALT_LEN: usize = 16;
 pub(super) const MAX_SALT_LEN: usize = 64;
 pub(super) const MAX_SCRYPT_N: u64 = 16_384;
 pub(super) const MAX_SCRYPT_R: u32 = 8;

--- a/core/crates/gem_keystore/src/v3/deserialize.rs
+++ b/core/crates/gem_keystore/src/v3/deserialize.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use super::constants::{AES_128_CTR_IV_LEN, CIPHERTEXT_CAP, MAC_LEN, MAX_SALT_LEN, MIN_SALT_LEN};
+use super::constants::{AES_128_CTR_IV_LEN, CIPHERTEXT_CAP, MAC_LEN, MAX_SALT_LEN};
 use crate::KeystoreError;
 
 const ERROR_HEX: &str = "invalid v3 hex";
@@ -25,7 +25,7 @@ pub(super) fn deserialize_salt<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Er
 where
     D: serde::Deserializer<'de>,
 {
-    deserialize_hex_in_range(deserializer, MIN_SALT_LEN, MAX_SALT_LEN, ERROR_HEX_LENGTH)
+    deserialize_hex_in_range(deserializer, 0, MAX_SALT_LEN, ERROR_HEX_LENGTH)
 }
 
 pub(super) fn deserialize_ciphertext<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>

--- a/core/crates/gem_keystore/src/v3/tests.rs
+++ b/core/crates/gem_keystore/src/v3/tests.rs
@@ -4,7 +4,7 @@ use sha3::{Digest, Keccak256};
 use zeroize::Zeroizing;
 
 use super::{
-    constants::{AES_128_KEY_LEN, DERIVED_KEY_LEN},
+    constants::{AES_128_KEY_LEN, DERIVED_KEY_LEN, MAX_SALT_LEN},
     crypto::{Aes128Ctr, derive_scrypt_key},
     types::{KdfParamsV3, KeystoreV3, KindV3, ReaderV3, SecretV3},
 };
@@ -17,7 +17,10 @@ use crate::{
 const V3_MINIMAL_TEMPLATE: &str = include_str!("../../testdata/v3_minimal_template.json");
 
 fn mock_v3_json(kind: &str, plaintext: &[u8], password: &[u8]) -> String {
-    let salt = [1u8; 16];
+    mock_v3_json_with_salt(kind, plaintext, password, &[1u8; 16])
+}
+
+fn mock_v3_json_with_salt(kind: &str, plaintext: &[u8], password: &[u8], salt: &[u8]) -> String {
     let iv = [2u8; 16];
     let kdfparams = KdfParamsV3 {
         dklen: DERIVED_KEY_LEN as u32,
@@ -74,6 +77,25 @@ fn test_v3_accepts_extra_legacy_metadata_fields() {
     let json = serde_json::to_string(&value).unwrap();
 
     assert_eq!(ReaderV3::decrypt_json(&json, password).unwrap(), SecretV3::Mnemonic(ABANDON_PHRASE.to_string()));
+}
+
+#[test]
+fn test_v3_accepts_empty_and_short_scrypt_salt() {
+    let password = b"v3-password";
+
+    for salt in [Vec::new(), vec![7u8; 8]] {
+        let json = mock_v3_json_with_salt("mnemonic", ABANDON_PHRASE.as_bytes(), password, &salt);
+        let parsed = KeystoreV3::parse(json.as_bytes()).unwrap();
+        assert_eq!(parsed.crypto.kdfparams.salt.len(), salt.len());
+        assert_eq!(ReaderV3::decrypt_json(&json, password).unwrap(), SecretV3::Mnemonic(ABANDON_PHRASE.to_string()));
+        assert_eq!(ReaderV3::decrypt_json(&json, b"wrong").unwrap_err(), KeystoreError::AuthenticationFailed);
+    }
+
+    let valid = mock_v3_json_with_salt("mnemonic", ABANDON_PHRASE.as_bytes(), password, &[1u8; 16]);
+    let mut value: Value = serde_json::from_str(&valid).unwrap();
+    value["crypto"]["kdfparams"]["salt"] = Value::String(hex::encode(vec![1u8; MAX_SALT_LEN + 1]));
+    let oversized = serde_json::to_string(&value).unwrap();
+    assert_eq!(KeystoreV3::parse(oversized.as_bytes()).unwrap_err(), KeystoreError::corrupt_file("invalid v3 hex length"));
 }
 
 #[test]

--- a/core/crates/gem_keystore/src/v3/types.rs
+++ b/core/crates/gem_keystore/src/v3/types.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use serde::Deserialize;
 use zeroize::{Zeroize, Zeroizing};
 
-use super::constants::{DERIVED_KEY_LEN, MAX_SALT_LEN, MAX_SCRYPT_N, MAX_SCRYPT_P, MAX_SCRYPT_R, MIN_SALT_LEN, V3_CIPHER, V3_KDF, WHOLE_FILE_CAP};
+use super::constants::{DERIVED_KEY_LEN, MAX_SALT_LEN, MAX_SCRYPT_N, MAX_SCRYPT_P, MAX_SCRYPT_R, V3_CIPHER, V3_KDF, WHOLE_FILE_CAP};
 use super::deserialize::{deserialize_ciphertext, deserialize_iv, deserialize_mac, deserialize_salt, map_json_error};
 use crate::KeystoreError;
 
@@ -119,7 +119,8 @@ impl KdfParamsV3 {
         if self.p == 0 || self.p > MAX_SCRYPT_P {
             return Err(KeystoreError::corrupt_file("invalid v3 scrypt p"));
         }
-        if self.salt.len() < MIN_SALT_LEN || self.salt.len() > MAX_SALT_LEN {
+        // Legacy WalletCore wrote some keystores with an empty scrypt salt; accept short salts (the MAC still authenticates) and only cap the max.
+        if self.salt.len() > MAX_SALT_LEN {
             return Err(KeystoreError::corrupt_file("invalid v3 hex length"));
         }
         Ok(())

--- a/core/crates/gem_keystore/testdata/v3_empty_salt_mnemonic.json
+++ b/core/crates/gem_keystore/testdata/v3_empty_salt_mnemonic.json
@@ -1,0 +1,30 @@
+{
+  "activeAccounts": [
+    {
+      "address": "0x5a8f70b44aFa00Cb70615D9c9CCb9A24933ED2D3",
+      "coin": 60,
+      "derivationPath": "m/44'/60'/0'/0/0",
+      "publicKey": "0411111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+    }
+  ],
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": {
+      "iv": "02020202020202020202020202020202"
+    },
+    "ciphertext": "65de17d03103be68f7810354440f6a808884e2ae8f2a27a184bdcc3366b0d4fdff15f8eb2f3aef937fa5e9b1eb2740adb88b819d2ebd1e55fd4f7690a73bcfc01512e1279dc868a2176702d6eeedc00a5fa9d1e04a1e79061485ea843fd496fef8d14ebb67940abf8e34c52599fbc23e3ef7afe12f6d2a4aae24cc5eb8497311dd195c1d23d2bb0d8f8692efab92ef54e44e3d3515cc233d0ecf7950875a29bfa4",
+    "kdf": "scrypt",
+    "kdfparams": {
+      "dklen": 32,
+      "n": 16,
+      "p": 1,
+      "r": 1,
+      "salt": ""
+    },
+    "mac": "a23ff12e61581bd8f5fb726e618ba6841da1b3d5918186af955de7672d2b9daa"
+  },
+  "id": "4b8fc216-dc74-481e-8011-bd4d1bc968ab",
+  "name": "Ethereum Wallet #4",
+  "type": "mnemonic",
+  "version": 3
+}

--- a/core/gemstone/src/keystore/keystore.rs
+++ b/core/gemstone/src/keystore/keystore.rs
@@ -244,6 +244,7 @@ mod migration_tests {
 
     const V3_MNEMONIC: &str = include_str!("../../../crates/gem_keystore/testdata/v3_ios_mnemonic.json");
     const V3_PRIVATE_KEY: &str = include_str!("../../../crates/gem_keystore/testdata/v3_ios_private_key.json");
+    const V3_EMPTY_SALT_MNEMONIC: &str = include_str!("../../../crates/gem_keystore/testdata/v3_empty_salt_mnemonic.json");
     const V3_PASSWORD: &[u8] = b"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
     const NEW_PASSWORD: &[u8] = b"raw-v4-password-bytes";
     const EXPECTED_PHRASE: &str =
@@ -291,6 +292,28 @@ mod migration_tests {
         let again = keystore.migrate_v3(v3_path, V3_PASSWORD.to_vec(), NEW_PASSWORD.to_vec(), wallet_id).unwrap();
         assert_eq!(again.keystore_id, keystore_id);
         assert_eq!(keystore.export_recovery_phrase(keystore_id, NEW_PASSWORD.to_vec()).unwrap().join(" "), EXPECTED_PHRASE);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn migrate_v3_empty_salt_mnemonic_round_trip() {
+        let (base, v3_path) = prepare("empty_salt", V3_EMPTY_SALT_MNEMONIC);
+        let keystore = GemKeystore::new(base.to_string_lossy().into_owned()).unwrap();
+        let wallet_id = MNEMONIC_WALLET_ID.to_string();
+        let keystore_id = keystore_id_for_wallet(wallet_id.clone());
+
+        let migration = keystore
+            .migrate_v3(v3_path.clone(), V3_PASSWORD.to_vec(), NEW_PASSWORD.to_vec(), wallet_id.clone())
+            .unwrap();
+        assert_eq!(migration.keystore_id, keystore_id);
+        assert!(!Path::new(&v3_path).exists(), "v3 file must be removed after a verified migration");
+        assert_eq!(
+            keystore.export_recovery_phrase(keystore_id.clone(), NEW_PASSWORD.to_vec()).unwrap().join(" "),
+            EXPECTED_PHRASE
+        );
+        let accounts = keystore.add_accounts(keystore_id, NEW_PASSWORD.to_vec(), vec![Chain::Ethereum]).unwrap();
+        assert_eq!(accounts[0].address, EXPECTED_ETHEREUM_ADDRESS);
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/ios/Packages/Keystore/Sources/LocalKeystore.swift
+++ b/ios/Packages/Keystore/Sources/LocalKeystore.swift
@@ -311,7 +311,7 @@ func withV4Password<T>(
     _ operation: (Data) throws -> T,
 ) throws -> T {
     guard password.isNotEmpty else {
-        throw AnyError("keystore password is missing")
+        throw AnyError("Couldn't access this wallet's keys on this device. If you have your recovery phrase, remove this wallet and import it again to restore access.")
     }
     var passwordBytes = try password.v4KeystorePasswordBytes()
     defer { passwordBytes.zeroize() }

--- a/ios/Packages/Keystore/Tests/MigrateV3KeystoreTests.swift
+++ b/ios/Packages/Keystore/Tests/MigrateV3KeystoreTests.swift
@@ -36,6 +36,16 @@ struct MigrateV3KeystoreTests {
     }
 
     @Test
+    func migrateV3WithEmptyScryptSalt() async throws {
+        let legacy = Wallet.mock(
+            id: .privateKey(chain: .ethereum, address: Self.ethereumAddress),
+            type: .privateKey,
+            source: .import,
+        )
+        try await assertMigratesAndIsIdempotent(legacy, fixture: "v3_empty_salt_private_key")
+    }
+
+    @Test
     func migrationWithoutV3FileDoesNotReadThePassword() async throws {
         let directory = "migrate-test-\(UUID().uuidString)"
         let baseDir = try FileManager.default
@@ -116,7 +126,7 @@ struct MigrateV3KeystoreTests {
     }
 
     @discardableResult
-    private func assertMigratesAndIsIdempotent(_ legacy: Wallet) async throws -> String {
+    private func assertMigratesAndIsIdempotent(_ legacy: Wallet, fixture: String = "v3_ios_private_key") async throws -> String {
         let directory = "migrate-test-\(UUID().uuidString)"
         let baseDir = try FileManager.default
             .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
@@ -129,7 +139,7 @@ struct MigrateV3KeystoreTests {
             keystorePassword: mockPassword,
         )
 
-        let fixtureURL = try #require(Bundle.module.url(forResource: "v3_ios_private_key", withExtension: "json"))
+        let fixtureURL = try #require(Bundle.module.url(forResource: fixture, withExtension: "json"))
         let v3URL = baseDir.appending(path: legacy.legacyV3Id, directoryHint: .notDirectory)
         try FileManager.default.copyItem(at: fixtureURL, to: v3URL)
 

--- a/ios/Packages/Keystore/Tests/Resources/v3_empty_salt_private_key.json
+++ b/ios/Packages/Keystore/Tests/Resources/v3_empty_salt_private_key.json
@@ -1,0 +1,30 @@
+{
+  "activeAccounts": [
+    {
+      "address": "0x5a8f70b44aFa00Cb70615D9c9CCb9A24933ED2D3",
+      "coin": 60,
+      "derivationPath": "m/44'/60'/0'/0/0",
+      "publicKey": "0411111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+    }
+  ],
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": {
+      "iv": "02020202020202020202020202020202"
+    },
+    "ciphertext": "af30e446116e76077e3f80d0e2240ca9ac0d9a00f6df0dd20d59e0fa54ae282c",
+    "kdf": "scrypt",
+    "kdfparams": {
+      "dklen": 32,
+      "n": 16,
+      "p": 1,
+      "r": 1,
+      "salt": ""
+    },
+    "mac": "4e2a486e891ff51492dd0bbad98795a737ab0fef673254bd03e7562358b2f2be"
+  },
+  "id": "4b8fc216-dc74-481e-8011-bd4d1bc968ab",
+  "name": "Ethereum Wallet #4",
+  "type": "private-key",
+  "version": 3
+}


### PR DESCRIPTION
## Problem

The oldest wallets (created by WalletCore ~2024-11) have an **empty scrypt salt** (`"salt": ""`) in their v3 keystore file. The v4 migrator's v3 reader rejected any salt shorter than `MIN_SALT_LEN` (16) during JSON deserialization — *before any decryption* — with `CorruptFile("invalid v3 hex length")`. Migration runs on every launch and fails identically every time, so the v4 file is never written and the wallet's secret phrase becomes unviewable (e.g. "Not Found" on iOS).

The **seed is intact** — scrypt accepts an empty salt and the original app read these files fine. This is over-strict validation, not data loss or password loss. Confirmed against a real affected file (structurally intact: 16-byte iv, 32-byte mac, only the salt zeroed).

## Fix (core)

Relax the v3 **reader** to accept any salt length up to `MAX_SALT_LEN` (lower bound → 0), keeping the upper bound. Correctness is still gated by:
- the existing Keccak256 **MAC** (wrong password / tampering → `AuthenticationFailed`, before any plaintext is returned), and
- `migrate_v3`'s **binding verification** (the decrypted secret must derive the wallet id, else the staged v4 file is deleted and the v3 file preserved).

v4 always writes a fresh 16-byte Argon2id salt on a separate path, so going-forward security is unchanged. A scoped audit confirmed the salt floor is the **only** over-rejection for the Gem population (n/r/p/dklen/kdf/cipher/version all match production exactly).

**Recovery:** shipping this is the recovery — the installed app re-runs migration on launch (holding the keychain password) and completes it. Conditional only on the keychain password still being present (strong evidence it is: the failure is at salt parsing, not decryption).

## Also included (cause-agnostic safety nets — help any keystore-read failure)

- **Android:** the reveal screen surfaces a keystore failure as an explicit error instead of a silent blank phrase (`WalletSecretDataValue.isError`); cancellation is rethrown (no false `isError` on coroutine cancellation).
- **iOS:** inaccessible-keys errors show actionable guidance instead of "keystore password is missing". `getOrCreatePassword` keeps its existing fail-closed behavior (thrown keychain errors propagate; never wipes the password).

## Tests

- **Core unit:** empty/short-salt v3 round-trip; wrong password still fails closed; oversized salt still rejected.
- **End-to-end migration** of an empty-salt keystore through the full path (parse → decrypt → binding-verify → v4 write → key recovered):
  - Rust: `gemstone migrate_v3_empty_salt_mnemonic_round_trip`
  - iOS: `MigrateV3KeystoreTests.migrateV3WithEmptyScryptSalt`
  - Android (instrumented): `MigrateV3KeystoreServiceTest.migrateV3WithEmptyScryptSalt_createsV4AndRecoversKey`
- Android unit: `GetWalletSecretDataImplTest` (error surfacing + cancellation).

Verified: `cargo test -p gem_keystore --features v3` (27), `cargo test -p gemstone migrate_v3` (6), `clippy -D warnings` clean; iOS KeystoreTests + MigrateV3KeystoreTests; Android unit + instrumented (emulator). The same empty-salt issue affects both platforms (shared WalletCore origin + shared core reader) and the fix covers both.
