### PR TITLE
Improve large-amount number formatting

### DIFF
--- a/android/blockchain/src/androidTest/kotlin/com/gemwallet/android/blockchain/TestFormatter.kt
+++ b/android/blockchain/src/androidTest/kotlin/com/gemwallet/android/blockchain/TestFormatter.kt
@@ -1,26 +1,35 @@
 package com.gemwallet.android.blockchain
 
 import com.gemwallet.android.model.CurrencyFormatter
+import com.gemwallet.android.model.ValueFormatter
 import com.wallet.core.primitives.Currency
 import junit.framework.TestCase.assertEquals
 import org.junit.Test
+import java.math.BigInteger
 import java.util.Locale
 
 class TestFormatter {
     @Test
     fun testCompactFormat_Italy() {
         val formatter = CurrencyFormatter(type = CurrencyFormatter.Type.Abbreviated, currency = Currency.EUR, locale = Locale.ITALY)
-        assertEquals("5,00 Mio €", formatter.string(5_000_000.0))
-        assertEquals("7,89 Mrd €", formatter.string(7_890_000_000.0))
-        assertEquals("1,20 Bln €", formatter.string(1_200_000_000_000.0))
+        assertEquals("5 Mio €", formatter.string(5_000_000.0))
+        assertEquals("7,9 Mrd €", formatter.string(7_890_000_000.0))
+        assertEquals("1,2 Bln €", formatter.string(1_200_000_000_000.0))
     }
 
     @Test
     fun testCompactFormat_Usd() {
         val formatter = CurrencyFormatter(type = CurrencyFormatter.Type.Abbreviated, currency = Currency.USD, locale = Locale.US)
-        assertEquals("\$5.00M", formatter.string(5_000_000.0))
-        assertEquals("\$7.89B", formatter.string(7_890_000_000.0))
-        assertEquals("\$1.20T", formatter.string(1_200_000_000_000.0))
-        assertEquals("\$19.88M", formatter.string(1.9876725E7))
+        assertEquals("\$5M", formatter.string(5_000_000.0))
+        assertEquals("\$7.9B", formatter.string(7_890_000_000.0))
+        assertEquals("\$1.2T", formatter.string(1_200_000_000_000.0))
+        assertEquals("\$20M", formatter.string(1.9876725E7))
+    }
+
+    @Test
+    fun testCompactBalance_Usd() {
+        val formatter = ValueFormatter(style = ValueFormatter.Style.Short, locale = Locale.US)
+        assertEquals("120K USDC", formatter.string(BigInteger.valueOf(123_456_789_100L), decimals = 6, currency = "USDC"))
+        assertEquals("1.5M USDC", formatter.string(BigInteger.valueOf(1_500_000_000_000L), decimals = 6, currency = "USDC"))
     }
 }

--- a/android/data/coordinators/src/androidTest/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualsImplTest.kt
+++ b/android/data/coordinators/src/androidTest/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualsImplTest.kt
@@ -59,6 +59,6 @@ class GetPerpetualsImplTest {
         assertEquals("\$95,420.50", item.price.valueFormatted)
         assertEquals("+2.50%", item.price.changePercentageFormatted)
         assertEquals(ValueDirection.Up, item.price.state)
-        assertEquals("\$15.00B", item.volume)
+        assertEquals("\$15B", item.volume)
     }
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/CurrencyFormatter.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/CurrencyFormatter.kt
@@ -25,7 +25,7 @@ class CurrencyFormatter(
     private val abbreviatedFormatter: CompactDecimalFormat by lazy {
         CompactDecimalFormat.getInstance(locale, CompactDecimalFormat.CompactStyle.SHORT).apply {
             currency = android.icu.util.Currency.getInstance(this@CurrencyFormatter.currency.string)
-            maximumFractionDigits = 2
+            maximumSignificantDigits = 2
         }
     }
 

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/Precision.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/Precision.kt
@@ -35,7 +35,7 @@ internal fun adaptivePrecision(magnitude: BigDecimal): Precision =
         Precision.fourSignificant
     }
 
-internal val ABBREVIATION_THRESHOLD: BigDecimal = BigDecimal(10_000)
+internal val ABBREVIATION_THRESHOLD: BigDecimal = BigDecimal(100_000)
 
 private val SMALL_VALUE_THRESHOLD: BigDecimal = BigDecimal("0.99")
 private val DUST_THRESHOLD: BigDecimal = BigDecimal("0.0000000001")

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/ValueFormatter.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/ValueFormatter.kt
@@ -51,7 +51,7 @@ class ValueFormatter(
 
     private fun abbreviated(decimal: BigDecimal): String {
         val formatter = CompactDecimalFormat.getInstance(locale, CompactDecimalFormat.CompactStyle.SHORT)
-        formatter.maximumFractionDigits = 2
+        formatter.maximumSignificantDigits = 2
         return formatter.format(decimal)
     }
 
@@ -69,6 +69,6 @@ class ValueFormatter(
     companion object {
         private val SMALL_AMOUNT_THRESHOLD: BigDecimal = BigDecimal("0.1")
         private val DUST_THRESHOLD: BigDecimal = BigDecimal("0.0001")
-        val ABBREVIATION_THRESHOLD: BigDecimal = BigDecimal(10_000)
+        val ABBREVIATION_THRESHOLD: BigDecimal = BigDecimal(100_000)
     }
 }

--- a/ios/Features/Perpetuals/Tests/CandleTooltipViewModelTests.swift
+++ b/ios/Features/Perpetuals/Tests/CandleTooltipViewModelTests.swift
@@ -29,7 +29,7 @@ struct CandleTooltipViewModelTests {
         #expect(model.changeField.value.text == "+0.55%")
 
         #expect(model.volumeField.title.text == Localized.Perpetual.volume)
-        #expect(model.volumeField.value.text == "$34.04M")
+        #expect(model.volumeField.value.text == "$34M")
     }
 
     @Test

--- a/ios/Features/Perpetuals/Tests/PerpetualViewModelTests.swift
+++ b/ios/Features/Perpetuals/Tests/PerpetualViewModelTests.swift
@@ -19,7 +19,7 @@ struct PerpetualViewModelTests {
 
     @Test
     func openInterestField() {
-        #expect(PerpetualViewModel(perpetual: .mock(openInterest: 5_250_000)).openInterestField.value.text == "$5.25M")
+        #expect(PerpetualViewModel(perpetual: .mock(openInterest: 5_250_000)).openInterestField.value.text == "$5.2M")
     }
 
     @Test

--- a/ios/Packages/Formatters/Sources/AbbreviatedFormatter.swift
+++ b/ios/Packages/Formatters/Sources/AbbreviatedFormatter.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public let defaultAbbreviationThreshold: Decimal = 10000.0
+public let defaultAbbreviationThreshold: Decimal = 100000.0
 
 public struct AbbreviatedFormatter {
     private let locale: Locale
@@ -33,7 +33,7 @@ public struct AbbreviatedFormatter {
             .number
                 .notation(.compactName)
                 .locale(locale)
-                .precision(.fractionLength(0 ... 2)),
+                .precision(.significantDigits(1 ... 2)),
         )
     }
 
@@ -46,7 +46,7 @@ public struct AbbreviatedFormatter {
             .currency(code: currency)
                 .notation(.compactName)
                 .locale(locale)
-                .precision(.fractionLength(0 ... 2)),
+                .precision(.significantDigits(1 ... 2)),
         )
     }
 }

--- a/ios/Packages/Formatters/Tests/FormattersTests/AbbreviatedFormatterTests.swift
+++ b/ios/Packages/Formatters/Tests/FormattersTests/AbbreviatedFormatterTests.swift
@@ -9,12 +9,13 @@ struct AbbreviatedFormatterTests {
 
     @Test
     func abbreviatedFormatter() {
-        #expect(formatter.string(from: 9999.0) == nil)
-        #expect(formatter.string(from: 10000.0) == "10K")
+        #expect(formatter.string(from: 99999.0) == nil)
+        #expect(formatter.string(from: 100000.0) == "100K")
+        #expect(formatter.string(from: 123456.0) == "120K")
         #expect(formatter.string(from: 1_500_000.0) == "1.5M")
         #expect(formatter.string(from: 2_300_000_000.0) == "2.3B")
         #expect(formatter.string(from: 1_200_000_000_000.0) == "1.2T")
-        #expect(formatter.string(from: 10000.0, currency: "USD") == "$10K")
+        #expect(formatter.string(from: 100000.0, currency: "USD") == "$100K")
         #expect(formatter.string(from: 2_000_000.0, currency: "EUR") == "€2M")
         #expect(formatter.string(from: 2_500_000.0, currency: "USD") == "$2.5M")
     }

--- a/ios/Packages/Formatters/Tests/FormattersTests/CurrencyFormatterTests.swift
+++ b/ios/Packages/Formatters/Tests/FormattersTests/CurrencyFormatterTests.swift
@@ -54,14 +54,14 @@ final class CurrencyFormatterTests {
         #expect(abbreviatedFormatterUS.string(0) == "$0.00")
         #expect(abbreviatedFormatterUS.string(12) == "$12.00")
         #expect(abbreviatedFormatterUS.string(1234) == "$1,234.00")
-        #expect(abbreviatedFormatterUS.string(10000) == "$10K")
+        #expect(abbreviatedFormatterUS.string(10000) == "$10,000.00")
         #expect(abbreviatedFormatterUS.string(-1234) == "-$1,234.00")
-        #expect(abbreviatedFormatterUS.string(-10000) == "-$10K")
+        #expect(abbreviatedFormatterUS.string(-10000) == "-$10,000.00")
         #expect(abbreviatedFormatterUS.string(-5_600_000) == "-$5.6M")
 
-        #expect(abbreviatedFormatterUK.string(123_456) == "£123.46k")
+        #expect(abbreviatedFormatterUK.string(123_456) == "£120k")
         #expect(abbreviatedFormatterUK.string(5_000_000) == "£5m")
-        #expect(abbreviatedFormatterUK.string(7_890_000_000) == "£7.89bn")
+        #expect(abbreviatedFormatterUK.string(7_890_000_000) == "£7.9bn")
         #expect(abbreviatedFormatterUK.string(1_200_000_000_000) == "£1.2tn")
         #expect(abbreviatedFormatterUK.string(-9_999_999_999) == "-£10bn")
     }

--- a/ios/Packages/Formatters/Tests/FormattersTests/ValueFormatterTests.swift
+++ b/ios/Packages/Formatters/Tests/FormattersTests/ValueFormatterTests.swift
@@ -29,7 +29,7 @@ final class ValueFormatterTests {
         #expect(formatter.string(1, decimals: 4) == "0.0001")
         #expect(formatter.string(1, decimals: 5) == "<0.0001")
         #expect(formatter.string(1, decimals: 6) == "<0.0001")
-        #expect(formatter.string(12_345_678_910, decimals: 6) == "12.35K")
+        #expect(formatter.string(12_345_678_910, decimals: 6) == "12,345.67")
 
         #expect(formatter.string(7_758_980_129_936_940, decimals: 18, currency: "BNB") == "0.0077 BNB")
         #expect(formatter.string(2_737_071, decimals: 8, currency: "BTC") == "0.0273 BTC")


### PR DESCRIPTION
Large amounts were shown as hard-to-read hybrids like `45,18K`.

Now amounts below 100,000 display in full (`45,180`), and larger amounts use clean rounded compact values (`120K`, `1.5M`) instead of mixing a rounding marker with decimals. Applies to balances and fiat amounts on both iOS and Android.
