### PR TITLE
Inject WalletSessionService into WalletService

### DIFF
--- a/ios/Gem/Services/ServicesFactory.swift
+++ b/ios/Gem/Services/ServicesFactory.swift
@@ -106,11 +106,16 @@ struct ServicesFactory {
             chainFactory: chainServiceFactory,
         )
 
+        let walletSessionService = WalletSessionService(
+            walletStore: storeManager.walletStore,
+            preferences: storages.observablePreferences,
+        )
         let walletService = Self.makeWalletService(
             preferences: storages.observablePreferences,
             keystore: storages.keystore,
             walletStore: storeManager.walletStore,
             avatarService: avatarService,
+            walletSessionService: walletSessionService,
         )
         let balanceService = Self.makeBalanceService(
             balanceStore: storeManager.balanceStore,
@@ -215,10 +220,6 @@ struct ServicesFactory {
         let explorerService = ExplorerService.standard
         let swapService = SwapService(nodeProvider: nodeProvider, requestInterceptor: nodeAuthProvider)
 
-        let walletSessionService = WalletSessionService(
-            walletStore: storeManager.walletStore,
-            preferences: storages.observablePreferences,
-        )
         let presenter = WalletConnectorPresenter()
         let walletConnectorManager = WalletConnectorManager(presenter: presenter)
         let connectionsService = Self.makeConnectionsService(
@@ -445,12 +446,14 @@ extension ServicesFactory {
         keystore: any Keystore,
         walletStore: WalletStore,
         avatarService: AvatarService,
+        walletSessionService: any WalletSessionManageable,
     ) -> WalletService {
         WalletService(
             keystore: keystore,
             walletStore: walletStore,
             preferences: preferences,
             avatarService: avatarService,
+            walletSessionService: walletSessionService,
         )
     }
 

--- a/ios/Packages/FeatureServices/Package.swift
+++ b/ios/Packages/FeatureServices/Package.swift
@@ -428,6 +428,8 @@ let package = Package(
                 .product(name: "StoreTestKit", package: "Store"),
                 "BalanceServiceTestKit",
                 "WalletService",
+                "WalletSessionService",
+                "WalletSessionServiceTestKit",
             ],
             path: "WalletService/TestKit",
         ),

--- a/ios/Packages/FeatureServices/WalletService/TestKit/WalletServiceTestKit.swift
+++ b/ios/Packages/FeatureServices/WalletService/TestKit/WalletServiceTestKit.swift
@@ -9,6 +9,8 @@ import PreferencesTestKit
 import Store
 import StoreTestKit
 import WalletService
+import WalletSessionService
+import WalletSessionServiceTestKit
 
 public extension WalletService {
     static func mock(
@@ -21,6 +23,7 @@ public extension WalletService {
             walletStore: walletStore,
             preferences: preferences,
             avatarService: AvatarService(store: walletStore),
+            walletSessionService: WalletSessionService.mock(store: walletStore, preferences: preferences),
         )
     }
 

--- a/ios/Packages/FeatureServices/WalletService/WalletService.swift
+++ b/ios/Packages/FeatureServices/WalletService/WalletService.swift
@@ -20,11 +20,12 @@ public struct WalletService: Sendable {
         walletStore: WalletStore,
         preferences: ObservablePreferences,
         avatarService: AvatarService,
+        walletSessionService: any WalletSessionManageable,
     ) {
         self.keystore = keystore
         self.walletStore = walletStore
         self.avatarService = avatarService
-        walletSessionService = WalletSessionService(walletStore: walletStore, preferences: preferences)
+        self.walletSessionService = walletSessionService
         self.preferences = preferences
     }
 


### PR DESCRIPTION
Inject a single WalletSessionService into WalletService instead of letting it build its own (the app factory already creates one). Removes a redundant instance and makes the session injectable in tests. No behavior change — the session is a stateless wrapper over the shared preferences and wallet store.