### PR TITLE
Register device before opening the events stream

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -1,7 +1,6 @@
 package com.gemwallet.android.data.repositories.device
 
 import android.content.Context
-import android.net.http.HttpException
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
@@ -9,6 +8,7 @@ import com.gemwallet.android.application.device.coordinators.GetDeviceId
 import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
 import com.gemwallet.android.cases.device.GetPushEnabled
 import com.gemwallet.android.cases.device.GetPushToken
+import com.gemwallet.android.cases.device.IsDeviceRegistered
 import com.gemwallet.android.cases.device.RequestPushToken
 import com.gemwallet.android.cases.device.SetPushToken
 import com.gemwallet.android.cases.device.SwitchPushEnabled
@@ -57,7 +57,8 @@ class DeviceRepository(
     GetPushEnabled,
     GetPushToken,
     SetPushToken,
-    SyncSubscription
+    SyncSubscription,
+    IsDeviceRegistered
 {
     private val Context.dataStore by preferencesDataStore(name = "device_config")
 
@@ -145,14 +146,12 @@ class DeviceRepository(
         return walletsRepository.getAll().firstOrNull() ?: emptyList()
     }
 
-    @Throws(HttpException::class)
-    private suspend fun isDeviceRegistered(): Boolean {
-        val local = context.dataStore.data.map { it[Key.DeviceRegistered] }.firstOrNull() == true
-        return local || gemDeviceApiClient.isDeviceRegistered()
+    override suspend fun isDeviceRegistered(): Boolean {
+        return context.dataStore.data.map { it[Key.DeviceRegistered] }.firstOrNull() == true
     }
 
     private suspend fun getOrCreateDevice(device: Device): Device {
-        if (isDeviceRegistered()) {
+        if (isDeviceRegistered() || gemDeviceApiClient.isDeviceRegistered()) {
             gemDeviceApiClient.getDevice()?.let { remoteDevice ->
                 setDeviceRegistered(true)
                 return remoteDevice

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
@@ -7,6 +7,8 @@ import com.gemwallet.android.application.fiat.coordinators.SyncFiatTransactions
 import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAlerts
 import com.gemwallet.android.blockchain.services.BalancesService
 import com.gemwallet.android.blockchain.services.PerpetualService
+import com.gemwallet.android.cases.device.IsDeviceRegistered
+import com.gemwallet.android.cases.device.SyncDeviceInfo
 import com.gemwallet.android.cases.nft.SyncNfts
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
@@ -148,6 +150,8 @@ object AssetsModule {
         deviceRequestSigner: DeviceRequestSigner,
         streamSubscriptionService: StreamSubscriptionService,
         eventHandler: StreamEventHandler,
+        syncDeviceInfo: SyncDeviceInfo,
+        isDeviceRegistered: IsDeviceRegistered,
     ): StreamObserverService = StreamObserverService(
         sessionRepository = sessionRepository,
         userConfig = userConfig,
@@ -164,6 +168,8 @@ object AssetsModule {
             },
             reconnection = ExponentialReconnection(maxDelay = 30.0),
         ),
+        syncDeviceInfo = syncDeviceInfo,
+        isDeviceRegistered = isDeviceRegistered,
     )
 
     @Provides

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
@@ -5,6 +5,7 @@ import com.gemwallet.android.application.device.coordinators.GetDeviceId
 import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
 import com.gemwallet.android.cases.device.GetPushEnabled
 import com.gemwallet.android.cases.device.GetPushToken
+import com.gemwallet.android.cases.device.IsDeviceRegistered
 import com.gemwallet.android.cases.device.SetPushToken
 import com.gemwallet.android.cases.device.SwitchPushEnabled
 import com.gemwallet.android.cases.device.SyncDeviceInfo
@@ -69,4 +70,7 @@ object DeviceModule {
 
     @Provides
     fun provideSyncSubscriptionCase(repository: DeviceRepository): SyncSubscription = repository
+
+    @Provides
+    fun provideIsDeviceRegisteredCase(repository: DeviceRepository): IsDeviceRegistered = repository
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
@@ -3,6 +3,8 @@ package com.gemwallet.android.data.repositories.stream
 import android.util.Log
 import com.gemwallet.android.application.assets.coordinators.SyncAssets
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetuals
+import com.gemwallet.android.cases.device.IsDeviceRegistered
+import com.gemwallet.android.cases.device.SyncDeviceInfo
 import com.gemwallet.android.data.repositories.config.UserConfig
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.ext.hasPerpetualsSupport
@@ -28,6 +30,8 @@ class StreamObserverService(
     private val subscriptionService: StreamSubscriptionService,
     private val eventHandler: StreamEventHandler,
     private val connection: WebSocketConnectable,
+    private val syncDeviceInfo: SyncDeviceInfo,
+    private val isDeviceRegistered: IsDeviceRegistered,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
 ) {
     private var connectionJob: Job? = null
@@ -56,6 +60,9 @@ class StreamObserverService(
         if (sessionRepository.session().value?.wallet == null) return
 
         connectionJob = scope.launch {
+            if (!isDeviceRegistered.isDeviceRegistered()) {
+                registerDevice()
+            }
             launch {
                 for (message in subscriptionService.messages) {
                     connection.send(jsonEncoder.encodeToString<StreamMessage>(message))
@@ -69,6 +76,11 @@ class StreamObserverService(
                 }
             }
         }
+    }
+
+    private suspend fun registerDevice() {
+        runCatching { syncDeviceInfo.syncDeviceInfo() }
+            .onFailure { Log.e(TAG, "Device registration error", it) }
     }
 
     fun stop() {

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/IsDeviceRegistered.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/IsDeviceRegistered.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.cases.device
+
+interface IsDeviceRegistered {
+    suspend fun isDeviceRegistered(): Boolean
+}

--- a/ios/Packages/FeatureServices/AppService/AppLifecycleService.swift
+++ b/ios/Packages/FeatureServices/AppService/AppLifecycleService.swift
@@ -107,7 +107,18 @@ extension AppLifecycleService {
 
     private func connectStreamObserver() async {
         guard currentWallet != nil else { return }
+        if preferences.isDeviceRegistered == false {
+            await registerDevice()
+        }
         await streamObserverService.connect()
+    }
+
+    private func registerDevice() async {
+        do {
+            try await deviceObserverService.synchronizeIfNeeded()
+        } catch {
+            debugLog("AppLifecycleService registerDevice error: \(error)")
+        }
     }
 
     private func connectPerpetual() async {

--- a/ios/Packages/FeatureServices/DeviceService/DeviceObserverService.swift
+++ b/ios/Packages/FeatureServices/DeviceService/DeviceObserverService.swift
@@ -26,6 +26,10 @@ public actor DeviceObserverService {
         }
     }
 
+    public func synchronizeIfNeeded() async throws {
+        try await deviceService.synchronizeIfNeeded()
+    }
+
     public func startNodeAuthTokenUpdates() {
         guard nodeAuthTokenUpdateTask == nil else { return }
 


### PR DESCRIPTION
Connect to the device events stream only after the device is registered, so it no longer fails with a 404 on a fresh install. Applies to iOS and Android.

Closes #501