### PR TITLE
Fix TRON address transaction history 500 on missing receipt

### DIFF
--- a/core/crates/gem_tron/src/provider/testkit.rs
+++ b/core/crates/gem_tron/src/provider/testkit.rs
@@ -1,9 +1,13 @@
 #[cfg(test)]
 use crate::models::account::{TronAccount, TronAccountOwnerPermission, TronAccountPermission, TronAccountPermissionKey, TronFrozen, TronVote};
-#[cfg(all(test, feature = "chain_integration_tests"))]
+#[cfg(test)]
 use crate::rpc::client::TronClient;
+#[cfg(test)]
+use crate::rpc::trongrid::client::TronGridClient;
 #[cfg(all(test, feature = "chain_integration_tests"))]
 use gem_client::ReqwestClient;
+#[cfg(test)]
+use gem_client::{ClientError, testkit::MockClient};
 #[cfg(all(test, feature = "chain_integration_tests"))]
 use primitives::asset_constants::TRON_USDT_TOKEN_ID;
 #[cfg(all(test, feature = "chain_integration_tests"))]
@@ -58,9 +62,14 @@ impl TronAccount {
     }
 }
 
+#[cfg(test)]
+pub fn mock_tron_client(get_handler: impl Fn(&str) -> Result<Vec<u8>, ClientError> + Send + Sync + 'static) -> TronClient<MockClient> {
+    let mock = MockClient::new().with_get(get_handler);
+    TronClient::new(mock.clone(), TronGridClient::new(mock, String::new()))
+}
+
 #[cfg(all(test, feature = "chain_integration_tests"))]
 pub fn create_test_client() -> TronClient<ReqwestClient> {
-    use crate::rpc::trongrid::client::TronGridClient;
     let settings = get_test_settings();
     let reqwest_client = ReqwestClient::new(settings.chains.tron.url, reqwest::Client::new());
     let trongrid_client = TronGridClient::new(reqwest_client.clone(), settings.trongrid.key.secret);

--- a/core/crates/gem_tron/src/provider/transaction_state.rs
+++ b/core/crates/gem_tron/src/provider/transaction_state.rs
@@ -11,6 +11,6 @@ use crate::{provider::transaction_state_mapper::map_transaction_status, rpc::cli
 impl<C: Client + Clone> ChainTransactionState for TronClient<C> {
     async fn get_transaction_status(&self, request: TransactionStateRequest) -> Result<TransactionUpdate, Box<dyn Error + Sync + Send>> {
         let receipt = self.get_transaction_reciept(request.id).await?;
-        Ok(map_transaction_status(&receipt))
+        Ok(map_transaction_status(receipt.as_ref()))
     }
 }

--- a/core/crates/gem_tron/src/provider/transaction_state_mapper.rs
+++ b/core/crates/gem_tron/src/provider/transaction_state_mapper.rs
@@ -4,7 +4,11 @@ use primitives::{TransactionChange, TransactionState, TransactionUpdate};
 use crate::models::TransactionReceiptData;
 use crate::rpc::constants::{RECEIPT_FAILED, RECEIPT_OUT_OF_ENERGY};
 
-pub fn map_transaction_status(receipt: &TransactionReceiptData) -> TransactionUpdate {
+pub fn map_transaction_status(receipt: Option<&TransactionReceiptData>) -> TransactionUpdate {
+    let Some(receipt) = receipt else {
+        return TransactionUpdate::new_state(TransactionState::Pending);
+    };
+
     if let Some(receipt_result) = &receipt.receipt.result
         && (receipt_result == RECEIPT_OUT_OF_ENERGY || receipt_result == RECEIPT_FAILED)
     {
@@ -44,7 +48,7 @@ mod tests {
     fn test_map_transaction_status_confirmed() {
         let receipt = create_receipt(None, 10, Some(100));
 
-        let result = map_transaction_status(&receipt);
+        let result = map_transaction_status(Some(&receipt));
         assert_eq!(result.state, TransactionState::Confirmed);
         assert!(!result.changes.is_empty());
     }
@@ -53,7 +57,7 @@ mod tests {
     fn test_map_transaction_status_reverted_out_of_energy() {
         let receipt = create_receipt(Some(RECEIPT_OUT_OF_ENERGY), 10, Some(100));
 
-        let result = map_transaction_status(&receipt);
+        let result = map_transaction_status(Some(&receipt));
         assert_eq!(result.state, TransactionState::Reverted);
     }
 
@@ -61,7 +65,7 @@ mod tests {
     fn test_map_transaction_status_reverted_failed() {
         let receipt = create_receipt(Some(RECEIPT_FAILED), 10, Some(100));
 
-        let result = map_transaction_status(&receipt);
+        let result = map_transaction_status(Some(&receipt));
         assert_eq!(result.state, TransactionState::Reverted);
     }
 
@@ -69,7 +73,9 @@ mod tests {
     fn test_map_transaction_status_pending() {
         let receipt = create_receipt(None, 0, None);
 
-        let result = map_transaction_status(&receipt);
+        let result = map_transaction_status(Some(&receipt));
         assert_eq!(result.state, TransactionState::Pending);
+
+        assert_eq!(map_transaction_status(None).state, TransactionState::Pending);
     }
 }

--- a/core/crates/gem_tron/src/provider/transactions.rs
+++ b/core/crates/gem_tron/src/provider/transactions.rs
@@ -21,11 +21,10 @@ impl<C: Client + Clone> ChainTransactions for TronClient<C> {
     }
 
     async fn get_transaction_by_hash(&self, hash: String) -> Result<Option<Transaction>, Box<dyn Error + Sync + Send>> {
-        Ok(map_transaction(
-            self.get_chain(),
-            self.get_transaction(hash.clone()).await?,
-            self.get_transaction_reciept(hash).await?,
-        ))
+        let Some(receipt) = self.get_transaction_reciept(hash.clone()).await? else {
+            return Ok(None);
+        };
+        Ok(map_transaction(self.get_chain(), self.get_transaction(hash).await?, receipt))
     }
 
     async fn get_transactions_by_address(&self, request: TransactionsRequest) -> Result<Vec<Transaction>, Box<dyn Error + Sync + Send>> {
@@ -39,8 +38,77 @@ impl<C: Client + Clone> ChainTransactions for TronClient<C> {
 
         let futures = transactions.iter().map(|transaction| self.get_transaction_reciept(transaction.transaction_id.clone()));
         let receipts = futures::future::try_join_all(futures).await?;
+        let (transactions, receipts) = transactions
+            .into_iter()
+            .zip(receipts)
+            .filter_map(|(transaction, receipt)| receipt.map(|receipt| (transaction, receipt)))
+            .unzip();
 
         Ok(map_transactions_by_address(transactions, receipts))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::testkit::mock_tron_client;
+    use gem_client::ClientError;
+
+    const TRANSACTIONS_RESPONSE: &str = include_str!("../../testdata/transactions_by_address.json");
+    const RECEIPTS_RESPONSE: &str = include_str!("../../testdata/transactions_by_address_receipts.json");
+    const ADDRESS: &str = "TBKwjUtXVsX1r724C1V52nocBgtioDjx9u";
+    const LAGGING_TRANSACTION_ID: &str = "e5c5dc535b267134024e887c00b1522426661b1b5ae6efb76606f4d83bca1a81";
+    const INCOMING_TRANSACTION_ID: &str = "7b633cd06802d7117a7202650c7580516c742ce1e20d43ba736ab8da1a02cd8f";
+
+    async fn mock_fetch(receipt_handler: impl Fn(&str) -> Result<Vec<u8>, ClientError> + Send + Sync + 'static) -> Result<Vec<Transaction>, Box<dyn Error + Sync + Send>> {
+        let client = mock_tron_client(move |path| {
+            if path.contains("/transactions?") {
+                Ok(TRANSACTIONS_RESPONSE.as_bytes().to_vec())
+            } else {
+                receipt_handler(path)
+            }
+        });
+        client.get_transactions_by_address(TransactionsRequest::new(ADDRESS.to_string()).with_limit(4)).await
+    }
+
+    #[tokio::test]
+    async fn test_get_transactions_by_address() {
+        let receipts: Vec<serde_json::Value> = serde_json::from_str(RECEIPTS_RESPONSE).unwrap();
+
+        let valid_receipts = receipts.clone();
+        let transactions = mock_fetch(move |path| {
+            if path.contains(LAGGING_TRANSACTION_ID) {
+                Ok(b"{}".to_vec())
+            } else {
+                let receipt = valid_receipts.iter().find(|receipt| path.contains(receipt["id"].as_str().unwrap())).unwrap();
+                Ok(serde_json::to_vec(receipt).unwrap())
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(transactions.len(), 3);
+        assert!(!transactions.iter().any(|transaction| transaction.hash == LAGGING_TRANSACTION_ID));
+        assert!(transactions.iter().any(|transaction| transaction.hash == INCOMING_TRANSACTION_ID));
+
+        let outage = mock_fetch(|path| {
+            if path.contains(LAGGING_TRANSACTION_ID) {
+                Err(ClientError::Http { status: 503, body: vec![] })
+            } else {
+                Ok(b"{}".to_vec())
+            }
+        })
+        .await;
+        assert!(outage.is_err());
+
+        let malformed = mock_fetch(|path| {
+            if path.contains(LAGGING_TRANSACTION_ID) {
+                Ok(br#"{"unexpected":"shape"}"#.to_vec())
+            } else {
+                Ok(b"{}".to_vec())
+            }
+        })
+        .await;
+        assert!(malformed.is_err());
     }
 }
 
@@ -70,7 +138,7 @@ mod chain_integration_tests {
     async fn test_get_transactions_by_address() {
         let tron_client = create_test_client();
         let transactions = tron_client
-            .get_transactions_by_address(TransactionsRequest::new(TEST_ADDRESS.to_string()).with_limit(1))
+            .get_transactions_by_address(TransactionsRequest::new(TEST_ADDRESS.to_string()).with_limit(2))
             .await
             .unwrap();
 

--- a/core/crates/gem_tron/src/rpc/client.rs
+++ b/core/crates/gem_tron/src/rpc/client.rs
@@ -46,8 +46,12 @@ impl<C: Client> TronClient<C> {
         Ok(self.client.get(&format!("/wallet/gettransactionbyid?value={}", id)).await?)
     }
 
-    pub async fn get_transaction_reciept(&self, id: String) -> Result<TransactionReceiptData, Box<dyn Error + Send + Sync>> {
-        Ok(self.client.get(&format!("/wallet/gettransactioninfobyid?value={}", id)).await?)
+    pub async fn get_transaction_reciept(&self, id: String) -> Result<Option<TransactionReceiptData>, Box<dyn Error + Send + Sync>> {
+        let response: serde_json::Value = self.client.get(&format!("/wallet/gettransactioninfobyid?value={}", id)).await?;
+        if response.as_object().is_some_and(|object| object.is_empty()) {
+            return Ok(None);
+        }
+        Ok(Some(serde_json::from_value(response)?))
     }
 
     pub async fn trigger_constant_contract(&self, contract_address: &str, function_selector: &str, parameter: &str) -> Result<String, Box<dyn Error + Send + Sync>> {

--- a/core/crates/gem_tron/testdata/transactions_by_address.json
+++ b/core/crates/gem_tron/testdata/transactions_by_address.json
@@ -1,0 +1,173 @@
+{
+    "data": [
+        {
+            "ret": [
+                {
+                    "contractRet": "SUCCESS",
+                    "fee": 0
+                }
+            ],
+            "signature": [
+                "4df0ca93bd2e3f6285c386d5e2b37fbe0f132aa23a94ad3d700e670993fa542d10a925bf28a163b76a3d2308dd7871117058d049defdc03b425940d4036a57bd00"
+            ],
+            "txID": "e5c5dc535b267134024e887c00b1522426661b1b5ae6efb76606f4d83bca1a81",
+            "net_usage": 267,
+            "raw_data_hex": "0a0217af22085dbdf03e714b635c40a8c19894ef335a67080112630a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412320a15410e5783ea50c6cbc04e779c446ddf97601dbf6d8d1215410ee41d8bf4fada586e04e524c7191d81c3b063a51889ea0470a89f8383ef33",
+            "net_fee": 0,
+            "energy_usage": 0,
+            "blockNumber": 83826609,
+            "block_timestamp": 1782149343000,
+            "energy_fee": 0,
+            "energy_usage_total": 0,
+            "raw_data": {
+                "contract": [
+                    {
+                        "parameter": {
+                            "value": {
+                                "amount": 79113,
+                                "owner_address": "410e5783ea50c6cbc04e779c446ddf97601dbf6d8d",
+                                "to_address": "410ee41d8bf4fada586e04e524c7191d81c3b063a5"
+                            },
+                            "type_url": "type.googleapis.com/protocol.TransferContract"
+                        },
+                        "type": "TransferContract"
+                    }
+                ],
+                "ref_block_bytes": "17af",
+                "ref_block_hash": "5dbdf03e714b635c",
+                "expiration": 1782185337000,
+                "timestamp": 1782149337000
+            },
+            "internal_transactions": []
+        },
+        {
+            "ret": [
+                {
+                    "contractRet": "SUCCESS",
+                    "fee": 0
+                }
+            ],
+            "signature": [
+                "e1ba5edeefa0b89cc4778f724a10bc537587f6e935043fdbbeb003f5d6d530d632015dc1cb88c82553bab5d896099fb1e23506908cb4fade5d509d364d4be9c201"
+            ],
+            "txID": "9d06ad2ed73cb50191728723dead659e3e31cdccd865717061292b9e8c4a93f0",
+            "net_usage": 268,
+            "raw_data_hex": "0a02e44d220865161539f0eb9cfa40d0beac95d8335a68080112640a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412330a15410ee41d8bf4fada586e04e524c7191d81c3b063a51215417538ff928e4b0cc534c5056c26d9ab96099225b718c799c32070d8fe8a95d833",
+            "net_fee": 0,
+            "energy_usage": 0,
+            "blockNumber": 81781857,
+            "block_timestamp": 1776013206000,
+            "energy_fee": 0,
+            "energy_usage_total": 0,
+            "raw_data": {
+                "contract": [
+                    {
+                        "parameter": {
+                            "value": {
+                                "amount": 68209863,
+                                "owner_address": "410ee41d8bf4fada586e04e524c7191d81c3b063a5",
+                                "to_address": "417538ff928e4b0cc534c5056c26d9ab96099225b7"
+                            },
+                            "type_url": "type.googleapis.com/protocol.TransferContract"
+                        },
+                        "type": "TransferContract"
+                    }
+                ],
+                "ref_block_bytes": "e44d",
+                "ref_block_hash": "65161539f0eb9cfa",
+                "expiration": 1776013746000,
+                "timestamp": 1776013197144
+            },
+            "internal_transactions": []
+        },
+        {
+            "ret": [
+                {
+                    "contractRet": "SUCCESS",
+                    "fee": 0
+                }
+            ],
+            "signature": [
+                "a9d69ca47905ddfc9fc680a04e84dd9ae667f4e4cd519dc8477208270241135a58a6f3693edb027b9c50904c7f8afa125a680b0a6c83a9744dec4b62f8978fd81c"
+            ],
+            "txID": "7b633cd06802d7117a7202650c7580516c742ce1e20d43ba736ab8da1a02cd8f",
+            "net_usage": 268,
+            "raw_data_hex": "0a029d0222081ef285586373656740e8e6eafbd7335a68080112640a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412330a1541e78cc21a0dfb6e840d52652224493b60d02ed6281215410ee41d8bf4fada586e04e524c7191d81c3b063a518eeb8a01570c8a3f9fad733",
+            "net_fee": 0,
+            "energy_usage": 0,
+            "blockNumber": 81763589,
+            "block_timestamp": 1775958390000,
+            "energy_fee": 0,
+            "energy_usage_total": 0,
+            "raw_data": {
+                "contract": [
+                    {
+                        "parameter": {
+                            "value": {
+                                "amount": 44571758,
+                                "owner_address": "41e78cc21a0dfb6e840d52652224493b60d02ed628",
+                                "to_address": "410ee41d8bf4fada586e04e524c7191d81c3b063a5"
+                            },
+                            "type_url": "type.googleapis.com/protocol.TransferContract"
+                        },
+                        "type": "TransferContract"
+                    }
+                ],
+                "ref_block_bytes": "9d02",
+                "ref_block_hash": "1ef2855863736567",
+                "expiration": 1775960241000,
+                "timestamp": 1775958381000
+            },
+            "internal_transactions": []
+        },
+        {
+            "ret": [
+                {
+                    "contractRet": "SUCCESS",
+                    "fee": 1100000
+                }
+            ],
+            "signature": [
+                "e870ab4fcb0580dbe378b9775cee1a8416bd03779ee546ac8bf669a9524811b624b93cd53a1c1dcb351ea72b9f55c660516f3c03093522ca50591699704cb73900"
+            ],
+            "txID": "44dbabfe6034497097fe01f13b60f545d3d103a7a6ea8895a2b06ab324008024",
+            "net_usage": 0,
+            "raw_data_hex": "0a02d2172208885d114f307a0a5540c0ccacf5d5335a68080112640a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412330a15410ee41d8bf4fada586e04e524c7191d81c3b063a5121541b2a78396cda4fd07e04f9378d079fafb60d24f0518ca8be303709e928bf5d533",
+            "net_fee": 100000,
+            "energy_usage": 0,
+            "blockNumber": 81580587,
+            "block_timestamp": 1775409228000,
+            "energy_fee": 0,
+            "energy_usage_total": 0,
+            "raw_data": {
+                "contract": [
+                    {
+                        "parameter": {
+                            "value": {
+                                "amount": 7914954,
+                                "owner_address": "410ee41d8bf4fada586e04e524c7191d81c3b063a5",
+                                "to_address": "41b2a78396cda4fd07e04f9378d079fafb60d24f05"
+                            },
+                            "type_url": "type.googleapis.com/protocol.TransferContract"
+                        },
+                        "type": "TransferContract"
+                    }
+                ],
+                "ref_block_bytes": "d217",
+                "ref_block_hash": "885d114f307a0a55",
+                "expiration": 1775409768000,
+                "timestamp": 1775409219870
+            },
+            "internal_transactions": []
+        }
+    ],
+    "success": true,
+    "meta": {
+        "at": 1782169831859,
+        "fingerprint": "2NgPQPX6mkxX1nyEcdNgHL1S2oc6C2YNniHptY2Nbq9Ja5fetDtG2WmdZHJ6LSz5JcuhU5ofSuCDwavxdAmdx4HY3kqMowHJwVn1V9kHL4MLPEgGQSNYpmjSu9z6tWbuTpaLashp8XLgJgxbyK1kTinb6THXLug265TJGCo9LU4VbEDG8kbG9AgpSsQqcSm3AxRhcu56RqnsdVDTTM4gTjJ1uRc",
+        "links": {
+            "next": "https://api.trongrid.io/v1/accounts/TBKwjUtXVsX1r724C1V52nocBgtioDjx9u/transactions?limit=4&fingerprint=2NgPQPX6mkxX1nyEcdNgHL1S2oc6C2YNniHptY2Nbq9Ja5fetDtG2WmdZHJ6LSz5JcuhU5ofSuCDwavxdAmdx4HY3kqMowHJwVn1V9kHL4MLPEgGQSNYpmjSu9z6tWbuTpaLashp8XLgJgxbyK1kTinb6THXLug265TJGCo9LU4VbEDG8kbG9AgpSsQqcSm3AxRhcu56RqnsdVDTTM4gTjJ1uRc"
+        },
+        "page_size": 4
+    }
+}

--- a/core/crates/gem_tron/testdata/transactions_by_address_receipts.json
+++ b/core/crates/gem_tron/testdata/transactions_by_address_receipts.json
@@ -1,0 +1,47 @@
+[
+    {
+        "id": "e5c5dc535b267134024e887c00b1522426661b1b5ae6efb76606f4d83bca1a81",
+        "blockNumber": 83826609,
+        "blockTimeStamp": 1782149343000,
+        "contractResult": [
+            ""
+        ],
+        "receipt": {
+            "net_usage": 267
+        }
+    },
+    {
+        "id": "9d06ad2ed73cb50191728723dead659e3e31cdccd865717061292b9e8c4a93f0",
+        "blockNumber": 81781857,
+        "blockTimeStamp": 1776013206000,
+        "contractResult": [
+            ""
+        ],
+        "receipt": {
+            "net_usage": 268
+        }
+    },
+    {
+        "id": "7b633cd06802d7117a7202650c7580516c742ce1e20d43ba736ab8da1a02cd8f",
+        "blockNumber": 81763589,
+        "blockTimeStamp": 1775958390000,
+        "contractResult": [
+            ""
+        ],
+        "receipt": {
+            "net_usage": 268
+        }
+    },
+    {
+        "id": "44dbabfe6034497097fe01f13b60f545d3d103a7a6ea8895a2b06ab324008024",
+        "fee": 1100000,
+        "blockNumber": 81580587,
+        "blockTimeStamp": 1775409228000,
+        "contractResult": [
+            ""
+        ],
+        "receipt": {
+            "net_fee": 100000
+        }
+    }
+]


### PR DESCRIPTION
## Problem

`GET /v1/chain/address/tron/{address}/transactions` returned **HTTP 500** (`missing field \`id\``) whenever any transaction's receipt was missing. Users saw incoming TRX transfers as missing (outgoing still showed because the app sources sent txs from its local DB).

Root cause: TRON's `gettransactioninfobyid` returns an empty object `{}` (HTTP 200) for a transaction the node has not indexed yet (recent tx / fullnode lag). `{}` fails to deserialize into `TransactionReceiptData`, and `try_join_all` propagated that single failure, tanking the whole address request.

## Fix

`get_transaction_reciept` now returns `Option<TransactionReceiptData>`:
- empty `{}` body → `None` (not indexed yet)
- any other body — malformed JSON or a transport error — still **propagates** (no silent data loss)

Callers handle the typed missing case:
- **`get_transactions_by_address`** keeps `try_join_all` (errors propagate) and drops only the transactions whose receipt is `None`.
- **`get_transaction_by_hash`** returns `Ok(None)` for a missing receipt.
- **`get_transaction_status`** maps a missing receipt to `Pending` (consistent with the existing `block_number == 0` branch).

This fixes the `{}`-induced 500 on all three TRON receipt paths.

## Tests

- Unit test via `mock_tron_client` (new testkit helper): a `{}` receipt is dropped while the rest map; malformed and transport errors fail the whole request rather than silently dropping data. Fixtures (`transactions_by_address.json`, `transactions_by_address_receipts.json`) are real responses captured for `TBKwjUtXVsX1r724C1V52nocBgtioDjx9u`.
- Integration `test_get_transactions_by_address` bumped from limit 1 → 2 so it no longer depends on the single most-recent tx being a mapper-supported type.
- Verified live: `get_transaction_by_hash`, `get_transactions_by_block`, and a by-address fetch for another address all pass.