### PR TITLE
Improve recipient address validation message

### DIFF
--- a/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/components/AddressChainField.kt
+++ b/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/components/AddressChainField.kt
@@ -1,7 +1,6 @@
 package com.gemwallet.android.features.recipient.presents.components
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,6 +26,7 @@ import com.gemwallet.android.ui.components.clipboard.getPlainText
 import com.gemwallet.android.ui.components.fields.TransferTextFieldActions
 import com.gemwallet.android.ui.components.progress.CircularProgressIndicator16
 import com.gemwallet.android.ui.icons.AppIcons
+import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.paddingHalfSmall
 import com.gemwallet.android.ui.theme.paddingSmall
 import com.gemwallet.android.ui.theme.sceneContentPadding
@@ -48,59 +48,56 @@ fun ColumnScope.AddressChainField(
     val keyboardController = LocalSoftwareKeyboardController.current
     val clipboardManager = LocalClipboard.current.nativeClipboard
 
-    Column(
-        modifier = Modifier,
-        verticalArrangement = Arrangement.spacedBy(paddingHalfSmall),
-    ) {
-        GemTextField(
+    GemTextField(
+        modifier = Modifier
+            .fillMaxWidth()
+            .onFocusChanged {
+                if (it.hasFocus) keyboardController?.show() else keyboardController?.hide()
+            },
+        value = value,
+        singleLine = true,
+        readOnly = !editable,
+        label = label,
+        onValueChange = onValueChange,
+        trailing = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(paddingSmall),
+            ) {
+                when (state) {
+                    NameRecordState.Loading -> CircularProgressIndicator16()
+                    NameRecordState.Error -> Icon(
+                        modifier = Modifier.size(smallIconSize),
+                        imageVector = AppIcons.Error,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                    is NameRecordState.Complete -> Icon(
+                        modifier = Modifier.size(smallIconSize),
+                        imageVector = AppIcons.CheckCircle,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.tertiary,
+                    )
+                    NameRecordState.None -> Unit
+                }
+                TransferTextFieldActions(
+                    value = value,
+                    paste = { (onPaste ?: onValueChange)(clipboardManager.getPlainText() ?: "") },
+                    qrScanner = onQrScanner,
+                    onClean = { onValueChange("") },
+                )
+            }
+        }
+    )
+    if (error.isNotEmpty()) {
+        Text(
             modifier = Modifier
                 .fillMaxWidth()
-                .onFocusChanged {
-                    if (it.hasFocus) keyboardController?.show() else keyboardController?.hide()
-                },
-            value = value,
-            singleLine = true,
-            readOnly = !editable,
-            label = label,
-            onValueChange = onValueChange,
-            trailing = {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(paddingSmall),
-                ) {
-                    when (state) {
-                        NameRecordState.Loading -> CircularProgressIndicator16()
-                        NameRecordState.Error -> Icon(
-                            modifier = Modifier.size(smallIconSize),
-                            imageVector = AppIcons.Error,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.error,
-                        )
-                        is NameRecordState.Complete -> Icon(
-                            modifier = Modifier.size(smallIconSize),
-                            imageVector = AppIcons.CheckCircle,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.tertiary,
-                        )
-                        NameRecordState.None -> Unit
-                    }
-                    TransferTextFieldActions(
-                        value = value,
-                        paste = { (onPaste ?: onValueChange)(clipboardManager.getPlainText() ?: "") },
-                        qrScanner = onQrScanner,
-                        onClean = { onValueChange("") },
-                    )
-                }
-            }
+                .padding(start = sceneContentPadding() + paddingDefault, end = sceneContentPadding(), top = paddingHalfSmall),
+            text = error,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodySmall,
         )
-        if (error.isNotEmpty()) {
-            Text(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = sceneContentPadding()),
-                text = error,
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.labelMedium,
-            )
-        }
     }
 }
 

--- a/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/components/RecipientError.kt
+++ b/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/components/RecipientError.kt
@@ -8,5 +8,5 @@ import com.gemwallet.android.ui.R
 @Composable
 fun recipientErrorString(error: RecipientError): String = when (error) {
     RecipientError.None -> ""
-    RecipientError.IncorrectAddress -> stringResource(id = R.string.errors_invalid_address_name)
+    is RecipientError.IncorrectAddress -> stringResource(id = R.string.errors_invalid_asset_address, error.assetName)
 }

--- a/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/RecipientViewModel.kt
+++ b/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/RecipientViewModel.kt
@@ -9,6 +9,7 @@ import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.blockchain.operators.ValidateAddressOperator
 import com.gemwallet.android.cases.contacts.ContactRecipient
 import com.gemwallet.android.cases.contacts.GetContacts
+import com.gemwallet.android.cases.name.ResolveName
 import com.gemwallet.android.cases.nft.GetAssetNft
 import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.ext.asset
@@ -27,8 +28,8 @@ import com.gemwallet.android.ui.models.actions.ConfirmTransactionAction
 import com.gemwallet.android.ui.models.navigation.RouteArgument
 import com.gemwallet.android.ui.models.navigation.optionalNftAssetId
 import com.gemwallet.android.ui.models.navigation.requireAssetId
+import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.AssetId
-import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.NFTAsset
 import com.wallet.core.primitives.NameRecord
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -62,6 +63,7 @@ class RecipientViewModel @Inject constructor(
     private val getAssetInfo: GetAssetInfo,
     private val getAssetNft: GetAssetNft,
     private val validateAddressOperator: ValidateAddressOperator,
+    private val resolveName: ResolveName,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -121,11 +123,11 @@ class RecipientViewModel @Inject constructor(
         val resolvedAddress = record?.address ?: address
         when (state) {
             RecipientState.Loading -> RecipientError.None
-            is RecipientState.Ready -> if (resolvedAddress.isEmpty()) {
-                RecipientError.None
-            } else {
-                validateDestination(
-                    chain = state.type.assetInfo.asset.chain,
+            is RecipientState.Ready -> when {
+                resolvedAddress.isEmpty() -> RecipientError.None
+                resolveName.canResolveName(address) -> RecipientError.None
+                else -> validateDestination(
+                    asset = state.type.assetInfo.asset,
                     destination = DestinationAddress(resolvedAddress, record?.name),
                 )
             }
@@ -174,9 +176,11 @@ class RecipientViewModel @Inject constructor(
         amountAction: AmountTransactionAction,
         confirmAction: ConfirmTransactionAction,
     ) {
-        val validation = validateDestination(type.assetInfo.asset.chain, destination)
+        val validation = validateDestination(type.assetInfo.asset, destination)
         if (validation != RecipientError.None) {
-            addressError.update { validation }
+            if (!resolveName.canResolveName(destination.address)) {
+                addressError.update { validation }
+            }
             return
         }
         when (type) {
@@ -242,10 +246,10 @@ class RecipientViewModel @Inject constructor(
         confirmAction(params)
     }
 
-    private fun validateDestination(chain: Chain, destination: DestinationAddress): RecipientError =
-        if (validateAddressOperator(destination.address, chain).getOrNull() == true) {
+    private fun validateDestination(asset: Asset, destination: DestinationAddress): RecipientError =
+        if (validateAddressOperator(destination.address, asset.chain).getOrNull() == true) {
             RecipientError.None
         } else {
-            RecipientError.IncorrectAddress
+            RecipientError.IncorrectAddress(asset.name)
         }
 }

--- a/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/models/RecipientError.kt
+++ b/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/models/RecipientError.kt
@@ -1,6 +1,6 @@
 package com.gemwallet.android.features.recipient.viewmodel.models
 
-enum class RecipientError {
-    None,
-    IncorrectAddress,
+sealed interface RecipientError {
+    data object None : RecipientError
+    data class IncorrectAddress(val assetName: String) : RecipientError
 }


### PR DESCRIPTION
Improves the recipient "Invalid address" message to match iOS:

- it now names the network, e.g. "Invalid TRON address"
- typing a name (e.g. name.eth) no longer shows the error while it resolves — only the inline status icon
- the message is shown under the field in the standard Android style

Closes #451

<img width="320" alt="Screenshot_1782207652" src="https://github.com/user-attachments/assets/6fe764e4-7018-4839-b0ed-eae17015aa49" />
<img width="320" alt="Screenshot_1782207658" src="https://github.com/user-attachments/assets/db61f56d-e39a-427d-8b0f-025f287fa481" />

