### PR TITLE
Add retry when building aead, check key before rotate device id

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStore.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStore.kt
@@ -84,28 +84,49 @@ internal class TinkAeadProvider(
         }
     }
 
-    // Building the Aead touches the Android Keystore, which can fail transiently (e.g. KeyMint -41); retry briefly.
     private fun buildAead(): Aead {
         AeadConfig.register()
         var lastError: GeneralSecurityException? = null
         repeat(MAX_BUILD_ATTEMPTS) { attempt ->
-            try {
-                val keysetHandle = AndroidKeysetManager.Builder()
-                    .withSharedPref(context, config.keysetName, config.keysetPreferencesFileName)
-                    .withKeyTemplate(AesGcmKeyManager.aes256GcmTemplate())
-                    .withMasterKeyUri("android-keystore://${config.masterKeyAlias}")
-                    .build()
-                    .keysetHandle
-                return keysetHandle.getPrimitive(RegistryConfiguration.get(), Aead::class.java)
+            val keysetExisted = keysetExists()
+            val manager = try {
+                buildKeysetManager()
             } catch (error: GeneralSecurityException) {
                 lastError = error
-                if (attempt < MAX_BUILD_ATTEMPTS - 1) {
-                    Thread.sleep(BUILD_RETRY_DELAY_MS * (attempt + 1))
+                null
+            }
+            if (manager != null) {
+                if (manager.isUsingKeystore) {
+                    return manager.keysetHandle.getPrimitive(RegistryConfiguration.get(), Aead::class.java)
                 }
+                if (keysetExisted) {
+                    throw SecurityException("Refusing cleartext keyset for ${config.namespace}: existing keyset is not Keystore-backed")
+                }
+                if (!clearKeyset()) {
+                    throw SecurityException("Refusing cleartext keyset for ${config.namespace}: failed to remove fallback keyset")
+                }
+                lastError = GeneralSecurityException("Keystore unavailable for ${config.namespace}; removed cleartext fallback keyset")
+            }
+            if (attempt < MAX_BUILD_ATTEMPTS - 1) {
+                Thread.sleep(BUILD_RETRY_DELAY_MS * (attempt + 1))
             }
         }
         throw lastError ?: GeneralSecurityException("Unable to build Aead for ${config.namespace}")
     }
+
+    private fun buildKeysetManager(): AndroidKeysetManager =
+        AndroidKeysetManager.Builder()
+            .withSharedPref(context, config.keysetName, config.keysetPreferencesFileName)
+            .withKeyTemplate(AesGcmKeyManager.aes256GcmTemplate())
+            .withMasterKeyUri("android-keystore://${config.masterKeyAlias}")
+            .build()
+
+    private fun keysetExists(): Boolean = keysetPreferences().contains(config.keysetName)
+
+    private fun clearKeyset(): Boolean = keysetPreferences().edit().remove(config.keysetName).commit()
+
+    private fun keysetPreferences() =
+        context.getSharedPreferences(config.keysetPreferencesFileName, Context.MODE_PRIVATE)
 
     private companion object {
         const val MAX_BUILD_ATTEMPTS = 3

--- a/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStore.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStore.kt
@@ -8,6 +8,7 @@ import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.aead.AesGcmKeyManager
 import com.google.crypto.tink.integration.android.AndroidKeysetManager
 import java.nio.charset.StandardCharsets.UTF_8
+import java.security.GeneralSecurityException
 import java.security.MessageDigest
 import java.util.Base64
 
@@ -83,14 +84,31 @@ internal class TinkAeadProvider(
         }
     }
 
+    // Building the Aead touches the Android Keystore, which can fail transiently (e.g. KeyMint -41); retry briefly.
     private fun buildAead(): Aead {
         AeadConfig.register()
-        val keysetHandle = AndroidKeysetManager.Builder()
-            .withSharedPref(context, config.keysetName, config.keysetPreferencesFileName)
-            .withKeyTemplate(AesGcmKeyManager.aes256GcmTemplate())
-            .withMasterKeyUri("android-keystore://${config.masterKeyAlias}")
-            .build()
-            .keysetHandle
-        return keysetHandle.getPrimitive(RegistryConfiguration.get(), Aead::class.java)
+        var lastError: GeneralSecurityException? = null
+        repeat(MAX_BUILD_ATTEMPTS) { attempt ->
+            try {
+                val keysetHandle = AndroidKeysetManager.Builder()
+                    .withSharedPref(context, config.keysetName, config.keysetPreferencesFileName)
+                    .withKeyTemplate(AesGcmKeyManager.aes256GcmTemplate())
+                    .withMasterKeyUri("android-keystore://${config.masterKeyAlias}")
+                    .build()
+                    .keysetHandle
+                return keysetHandle.getPrimitive(RegistryConfiguration.get(), Aead::class.java)
+            } catch (error: GeneralSecurityException) {
+                lastError = error
+                if (attempt < MAX_BUILD_ATTEMPTS - 1) {
+                    Thread.sleep(BUILD_RETRY_DELAY_MS * (attempt + 1))
+                }
+            }
+        }
+        throw lastError ?: GeneralSecurityException("Unable to build Aead for ${config.namespace}")
+    }
+
+    private companion object {
+        const val MAX_BUILD_ATTEMPTS = 3
+        const val BUILD_RETRY_DELAY_MS = 50L
     }
 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStore.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStore.kt
@@ -89,27 +89,16 @@ internal class TinkAeadProvider(
         var lastError: GeneralSecurityException? = null
         repeat(MAX_BUILD_ATTEMPTS) { attempt ->
             val keysetExisted = keysetExists()
-            val manager = try {
-                buildKeysetManager()
-            } catch (error: GeneralSecurityException) {
-                lastError = error
-                null
-            }
-            if (manager != null) {
+            try {
+                val manager = buildKeysetManager()
                 if (manager.isUsingKeystore) {
                     return manager.keysetHandle.getPrimitive(RegistryConfiguration.get(), Aead::class.java)
                 }
-                if (keysetExisted) {
-                    throw SecurityException("Refusing cleartext keyset for ${config.namespace}: existing keyset is not Keystore-backed")
-                }
-                if (!clearKeyset()) {
-                    throw SecurityException("Refusing cleartext keyset for ${config.namespace}: failed to remove fallback keyset")
-                }
-                lastError = GeneralSecurityException("Keystore unavailable for ${config.namespace}; removed cleartext fallback keyset")
+                lastError = handleCleartextFallback(keysetExisted)
+            } catch (error: GeneralSecurityException) {
+                lastError = error
             }
-            if (attempt < MAX_BUILD_ATTEMPTS - 1) {
-                Thread.sleep(BUILD_RETRY_DELAY_MS * (attempt + 1))
-            }
+            delayBeforeRetry(attempt)
         }
         throw lastError ?: GeneralSecurityException("Unable to build Aead for ${config.namespace}")
     }
@@ -127,6 +116,22 @@ internal class TinkAeadProvider(
 
     private fun keysetPreferences() =
         context.getSharedPreferences(config.keysetPreferencesFileName, Context.MODE_PRIVATE)
+
+    private fun handleCleartextFallback(keysetExisted: Boolean): GeneralSecurityException {
+        if (keysetExisted) {
+            throw SecurityException("Refusing cleartext keyset for ${config.namespace}: existing keyset is not Keystore-backed")
+        }
+        if (!clearKeyset()) {
+            throw SecurityException("Refusing cleartext keyset for ${config.namespace}: failed to remove fallback keyset")
+        }
+        return GeneralSecurityException("Keystore unavailable for ${config.namespace}; removed cleartext fallback keyset")
+    }
+
+    private fun delayBeforeRetry(attempt: Int) {
+        if (attempt < MAX_BUILD_ATTEMPTS - 1) {
+            Thread.sleep(BUILD_RETRY_DELAY_MS * (attempt + 1))
+        }
+    }
 
     private companion object {
         const val MAX_BUILD_ATTEMPTS = 3

--- a/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkSecurityStore.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkSecurityStore.kt
@@ -42,6 +42,11 @@ class TinkSecurityStore(
         aeadProvider = aeadProvider,
     )
 
+    override suspend fun contains(key: Any): Boolean = withContext(Dispatchers.IO) {
+        val keyValue = key.toString()
+        encryptedStore.contains(keyValue) || hasLegacyValue(keyValue)
+    }
+
     override suspend fun getValue(key: Any): String = withContext(Dispatchers.IO) {
         val keyValue = key.toString()
         val currentValue = encryptedStore.getString(keyValue)
@@ -59,6 +64,11 @@ class TinkSecurityStore(
         val keyValue = key.toString()
         encryptedStore.putString(keyValue, value)
         removeLegacyValue(keyValue)
+    }
+
+    private suspend fun hasLegacyValue(key: String): Boolean {
+        return context.dataStore.data.map { preferences -> preferences.contains(stringPreferencesKey(key)) }
+            .firstOrNull() == true
     }
 
     private suspend fun getLegacyValue(key: String): String? {

--- a/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkSecurityStore.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkSecurityStore.kt
@@ -8,7 +8,6 @@ import com.gemwallet.android.application.SecurityStore
 import com.gemwallet.android.math.fromHex
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import java.nio.charset.StandardCharsets.UTF_8
 
@@ -66,17 +65,13 @@ class TinkSecurityStore(
         removeLegacyValue(keyValue)
     }
 
-    private suspend fun hasLegacyValue(key: String): Boolean {
-        return context.dataStore.data.map { preferences -> preferences.contains(stringPreferencesKey(key)) }
-            .firstOrNull() == true
-    }
+    private suspend fun hasLegacyValue(key: String): Boolean =
+        context.dataStore.data.firstOrNull()?.contains(stringPreferencesKey(key)) == true
 
-    private suspend fun getLegacyValue(key: String): String? {
-        return context.dataStore.data.map { preferences -> preferences[stringPreferencesKey(key)] }
-            .firstOrNull()?.let {
-                String(aeadProvider.get().decrypt(it.fromHex(), null), UTF_8)
-            }
-    }
+    private suspend fun getLegacyValue(key: String): String? =
+        context.dataStore.data.firstOrNull()?.get(stringPreferencesKey(key))?.let {
+            String(aeadProvider.get().decrypt(it.fromHex(), null), UTF_8)
+        }
 
     private suspend fun removeLegacyValue(key: String) {
         context.dataStore.edit { preferences ->

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/GetDeviceIdImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/GetDeviceIdImpl.kt
@@ -26,7 +26,6 @@ class GetDeviceIdImpl(
     }
 
     private suspend fun initDeviceKeys(): DeviceKeys {
-        // If keys exist, let read failures propagate rather than overwrite (and rotate) the device identity.
         if (store.contains(Keys.PrivateKey) && store.contains(Keys.PublicKey)) {
             return DeviceKeys(
                 privateKey = store.getValue(Keys.PrivateKey),

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/GetDeviceIdImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/GetDeviceIdImpl.kt
@@ -26,13 +26,17 @@ class GetDeviceIdImpl(
     }
 
     private suspend fun initDeviceKeys(): DeviceKeys {
-        try {
+        // If keys exist, let read failures propagate rather than overwrite (and rotate) the device identity.
+        if (store.contains(Keys.PrivateKey) && store.contains(Keys.PublicKey)) {
             return DeviceKeys(
                 privateKey = store.getValue(Keys.PrivateKey),
                 publicKey = store.getValue(Keys.PublicKey),
             )
-        } catch (_: Throwable) {}
+        }
+        return createDeviceKeys()
+    }
 
+    private suspend fun createDeviceKeys(): DeviceKeys {
         val deviceKey = generateDeviceKeyPair()
         val privateKey = deviceKey.privateKey.hex
         val publicKey = deviceKey.publicKey.hex

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/GetDeviceIdImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/GetDeviceIdImpl.kt
@@ -25,15 +25,16 @@ class GetDeviceIdImpl(
         }
     }
 
-    private suspend fun initDeviceKeys(): DeviceKeys {
-        if (store.contains(Keys.PrivateKey) && store.contains(Keys.PublicKey)) {
-            return DeviceKeys(
-                privateKey = store.getValue(Keys.PrivateKey),
-                publicKey = store.getValue(Keys.PublicKey),
-            )
-        }
-        return createDeviceKeys()
-    }
+    private suspend fun initDeviceKeys(): DeviceKeys =
+        if (hasDeviceKeys()) readDeviceKeys() else createDeviceKeys()
+
+    private suspend fun hasDeviceKeys(): Boolean =
+        store.contains(Keys.PrivateKey) && store.contains(Keys.PublicKey)
+
+    private suspend fun readDeviceKeys(): DeviceKeys = DeviceKeys(
+        privateKey = store.getValue(Keys.PrivateKey),
+        publicKey = store.getValue(Keys.PublicKey),
+    )
 
     private suspend fun createDeviceKeys(): DeviceKeys {
         val deviceKey = generateDeviceKeyPair()

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/device/GetDeviceIdImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/device/GetDeviceIdImplTest.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.data.coordinators.device
 import com.gemwallet.android.application.SecurityStore
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GetDeviceIdImplTest {
@@ -35,20 +36,46 @@ class GetDeviceIdImplTest {
         assertEquals("private", deviceId.getDeviceKey())
 
         assertEquals(2, store.readCount)
+        assertEquals(0, store.writeCount)
+    }
+
+    @Test
+    fun `existing keys are not rotated when read fails`() = runTest {
+        val store = RecordingSecurityStore(
+            values = mapOf(
+                GetDeviceIdImpl.Keys.PrivateKey.toString() to "private",
+                GetDeviceIdImpl.Keys.PublicKey.toString() to "public",
+            ),
+            failReadWith = IllegalStateException("Keystore operation failed"),
+        )
+        val deviceId = GetDeviceIdImpl(store)
+
+        val error = runCatching { deviceId.getDeviceId() }.exceptionOrNull()
+
+        assertTrue(error is IllegalStateException)
+        assertEquals(0, store.writeCount)
     }
 
     private class RecordingSecurityStore(
         private val values: Map<String, String>,
+        private val failReadWith: Throwable? = null,
     ) : SecurityStore<Any> {
 
         var readCount = 0
             private set
+        var writeCount = 0
+            private set
+
+        override suspend fun contains(key: Any): Boolean = values.containsKey(key.toString())
 
         override suspend fun getValue(key: Any): String {
             readCount += 1
+            failReadWith?.let { throw it }
             return values.getValue(key.toString())
         }
 
-        override suspend fun putValue(key: Any, value: String) = Unit
+        override suspend fun putValue(key: Any, value: String) {
+            writeCount += 1
+        }
     }
 }

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptor.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptor.kt
@@ -20,13 +20,13 @@ class SecurityInterceptor internal constructor(
             it.writeTo(buffer)
             buffer.readByteArray()
         }
-        val signature = signer.sign(
-            method = request.method,
-            path = request.url.encodedPath,
-            body = body,
-            walletId = request.tag(WalletId::class.java)?.id.orEmpty(),
-        )
         return try {
+            val signature = signer.sign(
+                method = request.method,
+                path = request.url.encodedPath,
+                body = body,
+                walletId = request.tag(WalletId::class.java)?.id.orEmpty(),
+            )
             val builder = request.newBuilder()
             signature.toHeaders().forEach { (key, value) -> builder.header(key, value) }
             chain.proceed(builder.build())

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptor.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptor.kt
@@ -37,7 +37,7 @@ class SecurityInterceptor internal constructor(
                 .message("HTTP Exception: ${error.message}")
                 .request(request)
                 .protocol(Protocol.HTTP_2)
-                .body(ByteArray(0).toResponseBody(null))
+                .body("".toResponseBody())
                 .build()
         }
     }

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptor.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptor.kt
@@ -5,6 +5,7 @@ import com.wallet.core.primitives.WalletId
 import okhttp3.Interceptor
 import okhttp3.Protocol
 import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.Buffer
 
 class SecurityInterceptor internal constructor(
@@ -36,6 +37,7 @@ class SecurityInterceptor internal constructor(
                 .message("HTTP Exception: ${error.message}")
                 .request(request)
                 .protocol(Protocol.HTTP_2)
+                .body(ByteArray(0).toResponseBody(null))
                 .build()
         }
     }

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptorTest.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptorTest.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.data.services.gemapi.http
 
 import com.gemwallet.android.testkit.mockMulticoinWalletId
 import com.wallet.core.primitives.WalletId
+import java.security.GeneralSecurityException
 import java.util.concurrent.TimeUnit
 import okhttp3.Call
 import okhttp3.Connection
@@ -44,6 +45,22 @@ class SecurityInterceptorTest {
         assertEquals(walletId.id, signedWalletId)
         assertEquals(body, signedBody!!.toString(Charsets.UTF_8))
         assertNull(signedRequest.header("x-wallet-id"))
+    }
+
+    @Test
+    fun interceptReturnsPeekableResponseWhenSigningFails() {
+        val signer = object : DeviceRequestSigner {
+            override fun sign(method: String, path: String, body: ByteArray?, walletId: String): DeviceSignature =
+                throw GeneralSecurityException("Keystore operation failed")
+        }
+        val request = Request.Builder()
+            .url("https://api.gemwallet.com/v2/devices/rewards")
+            .build()
+
+        val response = SecurityInterceptor(signer).intercept(FakeChain(request))
+
+        assertEquals(503, response.code)
+        assertEquals("", response.peekBody(64L * 1024).string())
     }
 }
 

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/SecurityStore.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/SecurityStore.kt
@@ -1,6 +1,8 @@
 package com.gemwallet.android.application
 
 interface SecurityStore<T> {
+    suspend fun contains(key: T): Boolean
+
     suspend fun getValue(key: T): String
 
     suspend fun putValue(key: T, value: String)


### PR DESCRIPTION
## Summary

Hardens Android Keystore-backed Tink storage used for device keys and wallet passwords.

- Do not rotate the device identity when stored keys exist but secure-storage reads fail.
- Retry Tink `Aead` creation and fail closed if Tink falls back to a cleartext keyset.
- Return a retryable `503` when request signing cannot access the device key, with an empty body safe for downstream `peekBody(...)`.

The cleartext-keyset guard is based on `AndroidKeysetManager.isUsingKeystore`; JVM tests cover the reachable coordinator/interceptor behavior.

## Tests

- `./gradlew :data:coordinators:testDebugUnitTest --tests com.gemwallet.android.data.coordinators.device.GetDeviceIdImplTest`
- `./gradlew :data:services:remote-gem:testDebugUnitTest --tests com.gemwallet.android.data.services.gemapi.http.SecurityInterceptorTest`
- `./gradlew :app:testGoogleDebugUnitTest --tests com.gemwallet.android.data.password.TinkPasswordStoreTest`
- `./gradlew :app:lintGoogleDebug`
- `./gradlew :app:assembleGoogleDebug`