### PR TITLE
Deduplicate add-missing-balance logic

### DIFF
--- a/ios/Packages/FeatureServices/AssetsService/AssetsService.swift
+++ b/ios/Packages/FeatureServices/AssetsService/AssetsService.swift
@@ -96,11 +96,7 @@ public final class AssetsService: Sendable {
     }
 
     public func addBalanceIfMissing(walletId: WalletId, assetId: AssetId) throws {
-        let exist = try balanceStore.isBalanceExist(walletId: walletId, assetId: assetId)
-        if !exist {
-            let balance = AddBalance(assetId: assetId, isEnabled: false)
-            try balanceStore.addBalance([balance], for: walletId)
-        }
+        try balanceStore.addBalance(assetIds: [assetId], isEnabled: false, for: walletId)
     }
 
     public func updateEnabled(walletId: WalletId, assetIds: [AssetId], enabled: Bool) throws {

--- a/ios/Packages/FeatureServices/BalanceService/BalanceService.swift
+++ b/ios/Packages/FeatureServices/BalanceService/BalanceService.swift
@@ -86,28 +86,10 @@ extension BalanceService {
     }
 
     public func addAssetsBalancesIfMissing(assetIds: [AssetId], wallet: Wallet, isEnabled: Bool?) throws {
-        let walletId = wallet.id
-        let balancesAssetIds = try balanceStore
-            .getBalances(walletId: walletId, assetIds: assetIds)
-            .map(\.assetId)
-        let missingBalancesAssetIds = assetIds.asSet().subtracting(balancesAssetIds)
-
-        try addBalance(
-            walletId: walletId,
-            balances: missingBalancesAssetIds.map {
-                AddBalance(
-                    assetId: $0,
-                    isEnabled: isEnabled ?? false,
-                )
-            },
-        )
+        try balanceStore.addBalance(assetIds: assetIds, isEnabled: isEnabled ?? false, for: wallet.id)
     }
 
     // MARK: - Private Helpers
-
-    private func addBalance(walletId: WalletId, balances: [AddBalance]) throws {
-        try balanceStore.addBalance(balances, for: walletId)
-    }
 
     @discardableResult
     private func updateCoinBalance(walletId: WalletId, asset: AssetId, address: String) async -> [AssetBalanceChange] {
@@ -227,14 +209,7 @@ extension BalanceService {
     }
 
     private func updateBalances(_ balances: [UpdateBalance], walletId: WalletId) throws {
-        let assetIds = balances.map(\.assetId)
-        let existBalances = try balanceStore.getBalances(walletId: walletId, assetIds: assetIds)
-        let missingBalances = assetIds.asSet().subtracting(existBalances.map(\.assetId))
-        let addBalances: [AddBalance] = missingBalances.map {
-            AddBalance(assetId: $0, isEnabled: false)
-        }
-
-        try balanceStore.addBalance(addBalances, for: walletId)
+        try balanceStore.addBalance(assetIds: balances.map(\.assetId), isEnabled: false, for: walletId)
         try balanceStore.updateBalances(balances, for: walletId)
     }
 }

--- a/ios/Packages/FeatureServices/BalanceService/BalanceService.swift
+++ b/ios/Packages/FeatureServices/BalanceService/BalanceService.swift
@@ -85,8 +85,8 @@ extension BalanceService {
         try balanceStore.getBalance(walletId: walletId, assetId: assetId)
     }
 
-    public func addAssetsBalancesIfMissing(assetIds: [AssetId], wallet: Wallet, isEnabled: Bool?) throws {
-        try balanceStore.addBalance(assetIds: assetIds, isEnabled: isEnabled ?? false, for: wallet.id)
+    public func addAssetsBalancesIfMissing(assetIds: [AssetId], wallet: Wallet, isEnabled: Bool) throws {
+        try balanceStore.addBalance(assetIds: assetIds, isEnabled: isEnabled, for: wallet.id)
     }
 
     // MARK: - Private Helpers

--- a/ios/Packages/Store/Sources/Stores/BalanceStore.swift
+++ b/ios/Packages/Store/Sources/Stores/BalanceStore.swift
@@ -23,6 +23,17 @@ public struct BalanceStore: Sendable {
         }
     }
 
+    public func addBalance(
+        assetIds: [AssetId],
+        isEnabled: Bool,
+        for walletId: WalletId,
+    ) throws {
+        try addBalance(
+            assetIds.map { AddBalance(assetId: $0, isEnabled: isEnabled) },
+            for: walletId,
+        )
+    }
+
     public func updateBalances(
         _ balances: [UpdateBalance],
         for walletId: WalletId,


### PR DESCRIPTION
Unifies three duplicated "add balance row if missing" code paths into a single `BalanceStore.addBalance` overload that relies on the existing insert-or-ignore. No behavior change.