### PR TITLE
Keep WalletConnect connections when active-session fetch fails

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/BridgesRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/BridgesRepository.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.data.repositories.bridge
 
+import android.util.Log
 import androidx.core.net.toUri
 import com.wallet.core.primitives.WalletConnection
 import com.wallet.core.primitives.Wallet as GemWallet
@@ -88,7 +89,7 @@ class BridgesRepository(
     }
 
     private fun handlePendingRequests() {
-        for (session in activeSessions()) {
+        for (session in activeSessions().orEmpty()) {
             val request = walletConnectClient.pendingSessionRequests(session.topic).firstOrNull() ?: continue
             val verifyContext = walletConnectClient.verifyContext(request.request.id) ?: continue
             pendingEvents.tryEmit(WalletConnectEvent.SessionRequest(request, verifyContext))
@@ -96,18 +97,19 @@ class BridgesRepository(
     }
 
     private fun pingActiveSessions() {
-        for (session in activeSessions()) {
+        for (session in activeSessions().orEmpty()) {
             walletConnectClient.pingSession(session.topic)
         }
     }
 
-    private fun activeSessions(): List<WalletConnectSession> =
+    private fun activeSessions(): List<WalletConnectSession>? =
         runCatching { walletConnectClient.activeSessions().filter { it.metadata != null } }
-            .getOrDefault(emptyList())
+            .onFailure { Log.e("BridgesRepository", "Failed to get active sessions", it) }
+            .getOrNull()
 
     suspend fun disconnect(id: String, onSuccess: () -> Unit = {}, onError: (String) -> Unit = {}) {
         val connection = connectionsRepository.disconnect(id) ?: return
-        val activeSession = activeSessions().firstOrNull { it.topic == connection.session.sessionId }
+        val activeSession = activeSessions()?.firstOrNull { it.topic == connection.session.sessionId }
         if (activeSession != null) {
             walletConnectClient.disconnectSession(activeSession.topic, onSuccess = {}, onError = {})
         }
@@ -146,7 +148,7 @@ class BridgesRepository(
             properties = proposal.properties ?: emptyMap(),
             caip2Chains = sessionNamespaces.values.flatMap { it.chains.orEmpty() },
         )
-        val activeBefore = activeSessions().map { it.topic }.toSet()
+        val activeBefore = activeSessions().orEmpty().map { it.topic }.toSet()
 
         walletConnectClient.approveSession(
             proposal = proposal,
@@ -174,7 +176,7 @@ class BridgesRepository(
         onSuccess: () -> Unit,
         onError: (String) -> Unit,
     ) {
-        val activeBefore = activeSessions().map { it.topic }.toSet()
+        val activeBefore = activeSessions().orEmpty().map { it.topic }.toSet()
         walletConnectClient.approveAuthentication(
             request = request,
             auths = auths,
@@ -245,6 +247,6 @@ class BridgesRepository(
         wallet: GemWallet,
         activeBefore: Set<String>,
     ) {
-        connectionsRepository.addNewSessions(wallet, activeSessions(), activeBefore)
+        connectionsRepository.addNewSessions(wallet, activeSessions().orEmpty(), activeBefore)
     }
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/BridgesRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/BridgesRepository.kt
@@ -148,17 +148,15 @@ class BridgesRepository(
             properties = proposal.properties ?: emptyMap(),
             caip2Chains = sessionNamespaces.values.flatMap { it.chains.orEmpty() },
         )
-        val activeBefore = activeSessions().orEmpty().map { it.topic }.toSet()
-
-        walletConnectClient.approveSession(
-            proposal = proposal,
-            namespaces = sessionNamespaces,
-            properties = sessionProperties,
-            onSuccess = {
-                persistNewSessions(wallet, activeBefore, "Connection failed", onSuccess, onError)
-            },
-            onError = onError,
-        )
+        approveAndStoreSession(wallet, "Connection failed", onSuccess, onError) { onApproved, onFailure ->
+            walletConnectClient.approveSession(
+                proposal = proposal,
+                namespaces = sessionNamespaces,
+                properties = sessionProperties,
+                onSuccess = onApproved,
+                onError = onFailure,
+            )
+        }
     }
 
     fun rejectConnection(
@@ -176,15 +174,14 @@ class BridgesRepository(
         onSuccess: () -> Unit,
         onError: (String) -> Unit,
     ) {
-        val activeBefore = activeSessions().orEmpty().map { it.topic }.toSet()
-        walletConnectClient.approveAuthentication(
-            request = request,
-            auths = auths,
-            onSuccess = {
-                persistNewSessions(wallet, activeBefore, "Authentication failed", onSuccess, onError)
-            },
-            onError = onError,
-        )
+        approveAndStoreSession(wallet, "Authentication failed", onSuccess, onError) { onApproved, onFailure ->
+            walletConnectClient.approveAuthentication(
+                request = request,
+                auths = auths,
+                onSuccess = onApproved,
+                onError = onFailure,
+            )
+        }
     }
 
     fun rejectAuthentication(
@@ -223,6 +220,20 @@ class BridgesRepository(
         signature: String,
     ): WalletConnectAuthObject {
         return walletConnectClient.generateAuthObject(payloadParams, issuer, signature)
+    }
+
+    private fun approveAndStoreSession(
+        wallet: GemWallet,
+        failureMessage: String,
+        onSuccess: () -> Unit,
+        onError: (String) -> Unit,
+        approve: (onSuccess: () -> Unit, onError: (String) -> Unit) -> Unit,
+    ) {
+        val activeBefore = activeSessions().orEmpty().map { it.topic }.toSet()
+        approve(
+            { persistNewSessions(wallet, activeBefore, failureMessage, onSuccess, onError) },
+            onError,
+        )
     }
 
     private fun persistNewSessions(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/ConnectionsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/ConnectionsRepository.kt
@@ -48,7 +48,8 @@ class ConnectionsRepository(
         }
     }
 
-    suspend fun sync(sessions: List<WalletConnectSession>) {
+    suspend fun sync(sessions: List<WalletConnectSession>?) {
+        if (sessions == null) return
         val local = getConnections().firstOrNull() ?: emptyList()
         val unknownSessions = local.filter { local -> !sessions.any { local.session.sessionId == it.topic } }
         if (unknownSessions.isNotEmpty()) {

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/bridge/ConnectionsRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/bridge/ConnectionsRepositoryTest.kt
@@ -58,6 +58,26 @@ class ConnectionsRepositoryTest {
         coVerify { connectionsDao.delete("connection-1") }
     }
 
+    @Test
+    fun sync_withNullSessions_doesNotDeleteConnections() = runTest {
+        every { walletsRepository.getAll() } returns flowOf(listOf(mockWallet(id = "wallet-1")))
+        every { connectionsDao.getAll() } returns flowOf(listOf(connection(id = "connection-1", walletId = "wallet-1")))
+
+        repository.sync(null)
+
+        coVerify(exactly = 0) { connectionsDao.deleteAll(any()) }
+    }
+
+    @Test
+    fun sync_withEmptySessions_deletesUnknownConnections() = runTest {
+        every { walletsRepository.getAll() } returns flowOf(listOf(mockWallet(id = "wallet-1")))
+        every { connectionsDao.getAll() } returns flowOf(listOf(connection(id = "connection-1", walletId = "wallet-1")))
+
+        repository.sync(emptyList())
+
+        coVerify { connectionsDao.deleteAll(any()) }
+    }
+
     private fun connection(
         id: String,
         walletId: String,


### PR DESCRIPTION
When the WalletConnect SDK failed to return the active session list, BridgesRepository treated the empty result as "no sessions" and deleted every local connection. It now returns null on failure and skips the reconciliation, so connections are kept. Includes unit tests for the null and empty cases.

Draft.