### PR TITLE
Harden keystore secret handling and durability

### DIFF
--- a/core/crates/gem_keystore/src/mnemonic.rs
+++ b/core/crates/gem_keystore/src/mnemonic.rs
@@ -14,15 +14,15 @@ impl Mnemonic {
         Ok(mnemonic.words().map(|word| word.to_string()).collect())
     }
 
-    pub fn sanitize(phrase: &str) -> Result<Zeroizing<String>, KeystoreError> {
-        let sanitized = Zeroizing::new(phrase.nfkd().collect::<String>());
-        let sanitized = Zeroizing::new(sanitized.split_whitespace().map(|word| word.to_lowercase()).collect::<Vec<_>>().join(" "));
-        let mnemonic = Bip39Mnemonic::parse_in_normalized(Language::English, &sanitized).map_err(|_| KeystoreError::invalid_input("mnemonic"))?;
+    pub fn canonicalize(phrase: &str) -> Result<Zeroizing<String>, KeystoreError> {
+        let canonical = Zeroizing::new(phrase.nfkd().collect::<String>());
+        let canonical = Zeroizing::new(canonical.split_whitespace().map(|word| word.to_lowercase()).collect::<Vec<_>>().join(" "));
+        let mnemonic = Bip39Mnemonic::parse_in_normalized(Language::English, &canonical).map_err(|_| KeystoreError::invalid_input("mnemonic"))?;
         Ok(Zeroizing::new(mnemonic.words().collect::<Vec<_>>().join(" ")))
     }
 
     pub fn is_valid(phrase: &str) -> bool {
-        Self::sanitize(phrase).is_ok()
+        Self::canonicalize(phrase).is_ok()
     }
 
     pub fn is_valid_word(word: &str) -> bool {
@@ -35,14 +35,14 @@ impl Mnemonic {
     }
 
     pub fn seed(phrase: &str) -> Result<Zeroizing<[u8; 64]>, KeystoreError> {
-        let sanitized = Self::sanitize(phrase)?;
-        let mnemonic = Bip39Mnemonic::parse_in_normalized(Language::English, &sanitized).map_err(|_| KeystoreError::invalid_input("mnemonic"))?;
+        let canonical = Self::canonicalize(phrase)?;
+        let mnemonic = Bip39Mnemonic::parse_in_normalized(Language::English, &canonical).map_err(|_| KeystoreError::invalid_input("mnemonic"))?;
         Ok(Zeroizing::new(mnemonic.to_seed_normalized("")))
     }
 
     pub fn entropy(phrase: &str) -> Result<Zeroizing<Vec<u8>>, KeystoreError> {
-        let sanitized = Self::sanitize(phrase)?;
-        let mnemonic = Bip39Mnemonic::parse_in_normalized(Language::English, &sanitized).map_err(|_| KeystoreError::invalid_input("mnemonic"))?;
+        let canonical = Self::canonicalize(phrase)?;
+        let mnemonic = Bip39Mnemonic::parse_in_normalized(Language::English, &canonical).map_err(|_| KeystoreError::invalid_input("mnemonic"))?;
         let (entropy, len) = mnemonic.to_entropy_array();
         Ok(Zeroizing::new(entropy[..len].to_vec()))
     }
@@ -99,10 +99,10 @@ mod tests {
     }
 
     #[test]
-    fn test_sanitize() {
+    fn test_canonicalize() {
         let phrase = format!("  {} ", ABANDON_PHRASE.replacen("abandon abandon", "ABANDON   abandon", 1).replace("about", "ABOUT"));
-        assert_eq!(Mnemonic::sanitize(&phrase).unwrap().as_str(), ABANDON_PHRASE);
-        assert_eq!(Mnemonic::sanitize("abandon abandon").unwrap_err(), KeystoreError::invalid_input("mnemonic"));
+        assert_eq!(Mnemonic::canonicalize(&phrase).unwrap().as_str(), ABANDON_PHRASE);
+        assert_eq!(Mnemonic::canonicalize("abandon abandon").unwrap_err(), KeystoreError::invalid_input("mnemonic"));
     }
 
     #[test]

--- a/core/crates/gem_keystore/src/mnemonic.rs
+++ b/core/crates/gem_keystore/src/mnemonic.rs
@@ -14,11 +14,11 @@ impl Mnemonic {
         Ok(mnemonic.words().map(|word| word.to_string()).collect())
     }
 
-    pub fn sanitize(phrase: &str) -> Result<String, KeystoreError> {
-        let sanitized = phrase.nfkd().collect::<String>();
-        let sanitized = sanitized.split_whitespace().map(|word| word.to_lowercase()).collect::<Vec<_>>().join(" ");
+    pub fn sanitize(phrase: &str) -> Result<Zeroizing<String>, KeystoreError> {
+        let sanitized = Zeroizing::new(phrase.nfkd().collect::<String>());
+        let sanitized = Zeroizing::new(sanitized.split_whitespace().map(|word| word.to_lowercase()).collect::<Vec<_>>().join(" "));
         let mnemonic = Bip39Mnemonic::parse_in_normalized(Language::English, &sanitized).map_err(|_| KeystoreError::invalid_input("mnemonic"))?;
-        Ok(mnemonic.words().collect::<Vec<_>>().join(" "))
+        Ok(Zeroizing::new(mnemonic.words().collect::<Vec<_>>().join(" ")))
     }
 
     pub fn is_valid(phrase: &str) -> bool {
@@ -35,13 +35,13 @@ impl Mnemonic {
     }
 
     pub fn seed(phrase: &str) -> Result<Zeroizing<[u8; 64]>, KeystoreError> {
-        let sanitized = Zeroizing::new(Self::sanitize(phrase)?);
+        let sanitized = Self::sanitize(phrase)?;
         let mnemonic = Bip39Mnemonic::parse_in_normalized(Language::English, &sanitized).map_err(|_| KeystoreError::invalid_input("mnemonic"))?;
         Ok(Zeroizing::new(mnemonic.to_seed_normalized("")))
     }
 
     pub fn entropy(phrase: &str) -> Result<Zeroizing<Vec<u8>>, KeystoreError> {
-        let sanitized = Zeroizing::new(Self::sanitize(phrase)?);
+        let sanitized = Self::sanitize(phrase)?;
         let mnemonic = Bip39Mnemonic::parse_in_normalized(Language::English, &sanitized).map_err(|_| KeystoreError::invalid_input("mnemonic"))?;
         let (entropy, len) = mnemonic.to_entropy_array();
         Ok(Zeroizing::new(entropy[..len].to_vec()))
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn test_sanitize() {
         let phrase = format!("  {} ", ABANDON_PHRASE.replacen("abandon abandon", "ABANDON   abandon", 1).replace("about", "ABOUT"));
-        assert_eq!(Mnemonic::sanitize(&phrase).unwrap(), ABANDON_PHRASE);
+        assert_eq!(Mnemonic::sanitize(&phrase).unwrap().as_str(), ABANDON_PHRASE);
         assert_eq!(Mnemonic::sanitize("abandon abandon").unwrap_err(), KeystoreError::invalid_input("mnemonic"));
     }
 

--- a/core/crates/gem_keystore/src/storage/file_keystore.rs
+++ b/core/crates/gem_keystore/src/storage/file_keystore.rs
@@ -35,7 +35,7 @@ impl FileKeystore {
 
     fn import_mnemonic_unlocked(&self, phrase: &str, password: &[u8], keystore_id: Option<String>) -> Result<StoredSecretMeta, KeystoreError> {
         validate_v4_password(password)?;
-        let phrase = Mnemonic::sanitize(phrase)?;
+        let phrase = Mnemonic::canonicalize(phrase)?;
         let payload = SecretPayload::Mnemonic { phrase: phrase.to_string() };
         self.import_payload_unlocked(SecretKind::Mnemonic, payload, password, keystore_id)
     }

--- a/core/crates/gem_keystore/src/storage/file_keystore.rs
+++ b/core/crates/gem_keystore/src/storage/file_keystore.rs
@@ -36,7 +36,7 @@ impl FileKeystore {
     fn import_mnemonic_unlocked(&self, phrase: &str, password: &[u8], keystore_id: Option<String>) -> Result<StoredSecretMeta, KeystoreError> {
         validate_v4_password(password)?;
         let phrase = Mnemonic::sanitize(phrase)?;
-        let payload = SecretPayload::Mnemonic { phrase };
+        let payload = SecretPayload::Mnemonic { phrase: phrase.to_string() };
         self.import_payload_unlocked(SecretKind::Mnemonic, payload, password, keystore_id)
     }
 
@@ -94,7 +94,10 @@ impl FileKeystore {
         let id = KeystoreId::parse(keystore_id)?;
         let path = self.path_for_id(&id);
         match fs::remove_file(path) {
-            Ok(()) => Ok(true),
+            Ok(()) => {
+                sync_directory(&self.base_dir)?;
+                Ok(true)
+            }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
             Err(error) => Err(error.into()),
         }

--- a/core/crates/gem_keystore/src/storage/queue.rs
+++ b/core/crates/gem_keystore/src/storage/queue.rs
@@ -5,5 +5,5 @@ use crate::KeystoreError;
 static QUEUE: OnceLock<Mutex<()>> = OnceLock::new();
 
 pub(super) fn lock() -> Result<MutexGuard<'static, ()>, KeystoreError> {
-    QUEUE.get_or_init(|| Mutex::new(())).lock().map_err(|_| KeystoreError::io("keystore queue poisoned"))
+    Ok(QUEUE.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(std::sync::PoisonError::into_inner))
 }

--- a/core/crates/gem_keystore/src/v3/reader.rs
+++ b/core/crates/gem_keystore/src/v3/reader.rs
@@ -39,7 +39,7 @@ impl ReaderV3 {
                 let phrase = std::str::from_utf8(&plaintext).map_err(|_| KeystoreError::corrupt_file("invalid v3 mnemonic"))?;
                 let sanitized = Mnemonic::sanitize(phrase).map_err(|_| KeystoreError::corrupt_file("invalid v3 mnemonic"))?;
                 plaintext.zeroize();
-                SecretV3::Mnemonic(sanitized)
+                SecretV3::Mnemonic(sanitized.to_string())
             }
             KindV3::PrivateKey => {
                 if plaintext.len() != 32 {

--- a/core/crates/gem_keystore/src/v3/reader.rs
+++ b/core/crates/gem_keystore/src/v3/reader.rs
@@ -37,9 +37,9 @@ impl ReaderV3 {
                     return Err(KeystoreError::corrupt_file("v3 mnemonic plaintext too large"));
                 }
                 let phrase = std::str::from_utf8(&plaintext).map_err(|_| KeystoreError::corrupt_file("invalid v3 mnemonic"))?;
-                let sanitized = Mnemonic::sanitize(phrase).map_err(|_| KeystoreError::corrupt_file("invalid v3 mnemonic"))?;
+                let canonical = Mnemonic::canonicalize(phrase).map_err(|_| KeystoreError::corrupt_file("invalid v3 mnemonic"))?;
                 plaintext.zeroize();
-                SecretV3::Mnemonic(sanitized.to_string())
+                SecretV3::Mnemonic(canonical.to_string())
             }
             KindV3::PrivateKey => {
                 if plaintext.len() != 32 {

--- a/core/crates/signer/src/decode.rs
+++ b/core/crates/signer/src/decode.rs
@@ -41,9 +41,9 @@ fn scheme_for_chain(chain: &Chain) -> SignatureScheme {
 }
 
 fn decode_base58(value: &str) -> Option<Vec<u8>> {
-    let decoded = bs58::decode(value).into_vec().ok()?;
+    let decoded = Zeroizing::new(bs58::decode(value).into_vec().ok()?);
     match decoded.len() {
-        32 => Some(decoded),
+        32 => Some(decoded.to_vec()),
         64 => Some(decoded[..32].to_vec()),
         _ => None,
     }
@@ -93,7 +93,7 @@ fn decode_base32_stellar(value: &str) -> Option<Vec<u8>> {
     if value.len() != 56 || !value.starts_with('S') {
         return None;
     }
-    let decoded = base32_decode(value.as_bytes())?;
+    let decoded = Zeroizing::new(base32_decode(value.as_bytes())?);
     if decoded.len() != 35 || decoded[0] != 0x90 {
         return None;
     }
@@ -127,14 +127,14 @@ fn validate_key(bytes: &[u8], scheme: SignatureScheme) -> Result<(), SignerError
 fn decode_key(value: &str, encodings: &[KeyEncoding], scheme: SignatureScheme) -> Result<Zeroizing<Vec<u8>>, SignerError> {
     for encoding in encodings {
         let decoded = match encoding {
-            KeyEncoding::Hex => decode_hex(value).ok(),
-            KeyEncoding::Base58 => decode_base58(value),
-            KeyEncoding::Base32 => decode_base32_stellar(value),
+            KeyEncoding::Hex => decode_hex(value).ok().map(Zeroizing::new),
+            KeyEncoding::Base58 => decode_base58(value).map(Zeroizing::new),
+            KeyEncoding::Base32 => decode_base32_stellar(value).map(Zeroizing::new),
         };
         if let Some(bytes) = decoded
             && validate_key(&bytes, scheme).is_ok()
         {
-            return Ok(Zeroizing::new(bytes));
+            return Ok(bytes);
         }
     }
     Err(SignerError::invalid_input("Invalid private key format"))


### PR DESCRIPTION
Zeroize transient private-key decode buffers (the discarded tail of a base58 keypair, the base32 buffer, and failed-validation/hex temporaries) so they are wiped on drop instead of left in freed heap.

Return the sanitized mnemonic as Zeroizing<String> and wipe the normalize/lowercase intermediates, so phrase-validation paths leave no plaintext copy behind.

fsync the keystore directory after deleting a secret file, so a crash cannot resurrect a deleted secret (mirrors the write path).

Recover from a poisoned keystore queue lock (the guarded value is ()) instead of permanently failing all keystore operations after an unrelated panic.