### PR TITLE
Show more than 50 transactions in the list

### DIFF
--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsQueryBuilder.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsQueryBuilder.kt
@@ -4,8 +4,6 @@ import com.gemwallet.android.application.transactions.coordinators.TransactionsR
 import com.gemwallet.android.ext.toIdentifier
 import com.wallet.core.primitives.WalletId
 
-const val DEFAULT_TRANSACTIONS_LIMIT = 50
-
 private fun TransactionsRequestFilter.toSqlClause(): SqlClause = when (this) {
     is TransactionsRequestFilter.Chains -> SqlClause.inList("asset.chain", chains.map { it.string })
     is TransactionsRequestFilter.Types -> SqlClause.inList("tx.type", types.map { it.name })
@@ -20,12 +18,10 @@ private fun TransactionsRequestFilter.toSqlClause(): SqlClause = when (this) {
 fun buildExtendedTransactionsSql(
     walletId: WalletId,
     filters: List<TransactionsRequestFilter>,
-    limit: Int = DEFAULT_TRANSACTIONS_LIMIT,
 ): SqlQuery {
     val source = EXTENDED_SOURCE.replace(":walletId", "?")
     return SqlQueryBuilder(baseSql = "SELECT $EXTENDED_COLUMNS $source", baseArgs = listOf(walletId.id))
         .whereAll(filters.map { it.toSqlClause() })
         .orderBy("tx.createdAt DESC")
-        .limit(limit)
         .build()
 }

--- a/android/data/services/store/src/test/kotlin/com/gemwallet/android/data/service/store/database/TransactionsQueryBuilderTest.kt
+++ b/android/data/services/store/src/test/kotlin/com/gemwallet/android/data/service/store/database/TransactionsQueryBuilderTest.kt
@@ -20,8 +20,8 @@ class TransactionsQueryBuilderTest {
         val query = buildExtendedTransactionsSql(walletId, filters = emptyList())
         assertTrue(query.sql.trimStart().startsWith("SELECT"))
         assertTrue(query.sql.contains("FROM transactions as tx"))
-        assertTrue(query.sql.trimEnd().endsWith("ORDER BY tx.createdAt DESC LIMIT ?"))
-        assertEquals(List(baseArgCount) { walletId.id } + DEFAULT_TRANSACTIONS_LIMIT, query.args)
+        assertTrue(query.sql.trimEnd().endsWith("ORDER BY tx.createdAt DESC"))
+        assertEquals(List(baseArgCount) { walletId.id }, query.args)
     }
 
     @Test
@@ -114,7 +114,6 @@ class TransactionsQueryBuilderTest {
         assertEquals(Chain.Ethereum.string, query.args[baseArgCount])
         assertEquals("Transfer", query.args[baseArgCount + 1])
         assertEquals(15, query.args[baseArgCount + 2])
-        assertEquals(DEFAULT_TRANSACTIONS_LIMIT, query.args[baseArgCount + 3])
     }
 
     @Test

--- a/ios/Features/Perpetuals/Sources/ViewModels/PerpetualSceneViewModel.swift
+++ b/ios/Features/Perpetuals/Sources/ViewModels/PerpetualSceneViewModel.swift
@@ -94,7 +94,6 @@ public final class PerpetualSceneViewModel {
             TransactionsRequest.perpetualScene(
                 walletId: wallet.id,
                 assetId: asset.id,
-                limit: 50,
             ),
             initialValue: [],
         )

--- a/ios/Packages/Store/Sources/Extensions/TransactionsRequest+Store.swift
+++ b/ios/Packages/Store/Sources/Extensions/TransactionsRequest+Store.swift
@@ -4,15 +4,14 @@ import Foundation
 import Primitives
 
 public extension TransactionsRequest {
-    static func assetScene(walletId: WalletId, assetId: AssetId, limit: Int = 25) -> TransactionsRequest {
+    static func assetScene(walletId: WalletId, assetId: AssetId) -> TransactionsRequest {
         TransactionsRequest(
             walletId: walletId,
             type: .asset(assetId: assetId),
-            limit: limit,
         )
     }
 
-    static func perpetualScene(walletId: WalletId, assetId: AssetId, limit: Int = 50) -> TransactionsRequest {
+    static func perpetualScene(walletId: WalletId, assetId: AssetId) -> TransactionsRequest {
         TransactionsRequest(
             walletId: walletId,
             type: .asset(assetId: assetId),
@@ -20,7 +19,6 @@ public extension TransactionsRequest {
                 TransactionType.perpetualOpenPosition.rawValue,
                 TransactionType.perpetualClosePosition.rawValue,
             ])],
-            limit: limit,
         )
     }
 }

--- a/ios/Packages/Store/Sources/Requests/TransactionRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/TransactionRequest.swift
@@ -24,7 +24,6 @@ public struct TransactionRequest: DatabaseQueryable {
             type: .transaction(id: transactionId.identifier),
             filters: filters,
             walletId: walletId,
-            limit: 1,
         ).first ?? .empty
     }
 }

--- a/ios/Packages/Store/Sources/Requests/TransactionsRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/TransactionsRequest.swift
@@ -7,7 +7,6 @@ import Primitives
 public struct TransactionsRequest: DatabaseQueryable {
     private let walletId: WalletId
     private let type: TransactionsRequestType
-    private let limit: Int
 
     public var filters: [TransactionsRequestFilter] = []
 
@@ -15,16 +14,14 @@ public struct TransactionsRequest: DatabaseQueryable {
         walletId: WalletId,
         type: TransactionsRequestType,
         filters: [TransactionsRequestFilter] = [],
-        limit: Int = 50,
     ) {
         self.walletId = walletId
         self.type = type
         self.filters = filters
-        self.limit = limit
     }
 
     public func fetch(_ db: Database) throws -> [TransactionExtended] {
-        try Self.fetch(db, type: type, filters: filters, walletId: walletId, limit: limit)
+        try Self.fetch(db, type: type, filters: filters, walletId: walletId)
     }
 
     public static func fetch(
@@ -32,7 +29,6 @@ public struct TransactionsRequest: DatabaseQueryable {
         type: TransactionsRequestType,
         filters: [TransactionsRequestFilter],
         walletId: WalletId,
-        limit: Int,
     ) throws -> [TransactionExtended] {
         let states = states(type: type)
         let types = types(type: type)
@@ -50,7 +46,6 @@ public struct TransactionsRequest: DatabaseQueryable {
             .including(optional: TransactionRecord.toAddress)
             .order(TransactionRecord.Columns.date.desc)
             .distinct()
-            .limit(limit)
 
         switch type {
         case let .asset(assetId):

--- a/ios/Packages/Store/Tests/StoreTests/Requests/TransactionsRequestTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/Requests/TransactionsRequestTests.swift
@@ -15,7 +15,6 @@ struct TransactionsRequestTests {
                 TransactionsRequest(
                     walletId: walletId,
                     type: .asset(assetId: assetId),
-                    limit: 25,
                 ),
         )
     }
@@ -29,7 +28,6 @@ struct TransactionsRequestTests {
             TransactionsRequest.perpetualScene(
                 walletId: walletId,
                 assetId: assetId,
-                limit: 50,
             ) ==
                 TransactionsRequest(
                     walletId: walletId,
@@ -38,7 +36,6 @@ struct TransactionsRequestTests {
                         TransactionType.perpetualOpenPosition.rawValue,
                         TransactionType.perpetualClosePosition.rawValue,
                     ])],
-                    limit: 50,
                 ),
         )
     }


### PR DESCRIPTION
Remove the 50-transaction cap on the history list (iOS and Android) so it shows the full synced transaction history.

Closes #502