### PR TITLE
Add contact from transaction

### DIFF
--- a/android/ui/src/main/res/values-ar/strings.xml
+++ b/android/ui/src/main/res/values-ar/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">العناوين</string>
   <string name="contacts_state_empty_title">لا توجد جهات اتصال</string>
   <string name="contacts_state_empty_description">احفظ عناوينك التي تستخدمها بشكل متكرر</string>
-  <string name="contacts_create_new_contact">إنشاء جهة اتصال</string>
+  <string name="contacts_create_new_contact">إنشاء جهة اتصال جديدة</string>
   <string name="contacts_add_to_existing_contact">إضافة إلى جهة اتصال</string>
   <string name="simulation_header_unlimited_asset">غير محدود %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">يمنح هذا المُنفِق إمكانية استخدام هذا الرمز المميز حتى تقوم بإلغاء الموافقة أو تنتهي صلاحيته.</string>

--- a/android/ui/src/main/res/values-ar/strings.xml
+++ b/android/ui/src/main/res/values-ar/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">العناوين</string>
   <string name="contacts_state_empty_title">لا توجد جهات اتصال</string>
   <string name="contacts_state_empty_description">احفظ عناوينك التي تستخدمها بشكل متكرر</string>
-  <string name="contacts_add_to_contacts">أضف إلى جهات الاتصال</string>
+  <string name="contacts_create_new_contact">إنشاء جهة اتصال</string>
+  <string name="contacts_add_to_existing_contact">إضافة إلى جهة اتصال</string>
   <string name="simulation_header_unlimited_asset">غير محدود %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">يمنح هذا المُنفِق إمكانية استخدام هذا الرمز المميز حتى تقوم بإلغاء الموافقة أو تنتهي صلاحيته.</string>
   <string name="simulation_warning_externally_owned_spender_description">تسمح هذه الموافقة لعنوان محفظة عادي (EOA) باستخدام أصولك. أكّد فقط إذا كنت تثق بهذا العنوان.</string>

--- a/android/ui/src/main/res/values-bn/strings.xml
+++ b/android/ui/src/main/res/values-bn/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">ঠিকানা</string>
   <string name="contacts_state_empty_title">কোনও পরিচিতি নেই</string>
   <string name="contacts_state_empty_description">আপনার ঘন ঘন ব্যবহৃত ঠিকানাগুলি সংরক্ষণ করুন</string>
-  <string name="contacts_add_to_contacts">পরিচিতিতে যোগ করুন</string>
+  <string name="contacts_create_new_contact">পরিচিতি তৈরি করুন</string>
+  <string name="contacts_add_to_existing_contact">পরিচিতিতে যোগ করুন</string>
   <string name="simulation_header_unlimited_asset">সীমাহীন %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">এটি ব্যয়কারীকে এই টোকেনটি ব্যবহার করার অনুমতি দেয় যতক্ষণ না আপনি অনুমোদন প্রত্যাহার করেন অথবা এটির মেয়াদ শেষ হয়ে যায়।</string>
   <string name="simulation_warning_externally_owned_spender_description">এই অনুমোদন একটি সাধারণ ওয়ালেট ঠিকানাকে (EOA) আপনার সম্পদ ব্যবহার করতে দেয়। আপনি এই ঠিকানাকে বিশ্বাস করলেই নিশ্চিত করুন।</string>

--- a/android/ui/src/main/res/values-bn/strings.xml
+++ b/android/ui/src/main/res/values-bn/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">ঠিকানা</string>
   <string name="contacts_state_empty_title">কোনও পরিচিতি নেই</string>
   <string name="contacts_state_empty_description">আপনার ঘন ঘন ব্যবহৃত ঠিকানাগুলি সংরক্ষণ করুন</string>
-  <string name="contacts_create_new_contact">পরিচিতি তৈরি করুন</string>
+  <string name="contacts_create_new_contact">নতুন পরিচিতি তৈরি করুন</string>
   <string name="contacts_add_to_existing_contact">পরিচিতিতে যোগ করুন</string>
   <string name="simulation_header_unlimited_asset">সীমাহীন %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">এটি ব্যয়কারীকে এই টোকেনটি ব্যবহার করার অনুমতি দেয় যতক্ষণ না আপনি অনুমোদন প্রত্যাহার করেন অথবা এটির মেয়াদ শেষ হয়ে যায়।</string>

--- a/android/ui/src/main/res/values-cs/strings.xml
+++ b/android/ui/src/main/res/values-cs/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Adresy</string>
   <string name="contacts_state_empty_title">Žádné kontakty</string>
   <string name="contacts_state_empty_description">Uložte si často používané adresy</string>
-  <string name="contacts_add_to_contacts">Přidat do kontaktů</string>
+  <string name="contacts_create_new_contact">Vytvořit kontakt</string>
+  <string name="contacts_add_to_existing_contact">Přidat ke kontaktu</string>
   <string name="simulation_header_unlimited_asset">Neomezený %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">To dává utrácející adrese přístup k používání tohoto tokenu, dokud schválení nezrušíte nebo dokud nevyprší jeho platnost.</string>
   <string name="simulation_warning_externally_owned_spender_description">Toto schválení umožní běžné adrese peněženky (EOA) používat vaše aktiva. Potvrďte pouze tehdy, pokud této adrese důvěřujete.</string>

--- a/android/ui/src/main/res/values-cs/strings.xml
+++ b/android/ui/src/main/res/values-cs/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Adresy</string>
   <string name="contacts_state_empty_title">Žádné kontakty</string>
   <string name="contacts_state_empty_description">Uložte si často používané adresy</string>
-  <string name="contacts_create_new_contact">Vytvořit kontakt</string>
+  <string name="contacts_create_new_contact">Vytvořit nový kontakt</string>
   <string name="contacts_add_to_existing_contact">Přidat ke kontaktu</string>
   <string name="simulation_header_unlimited_asset">Neomezený %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">To dává utrácející adrese přístup k používání tohoto tokenu, dokud schválení nezrušíte nebo dokud nevyprší jeho platnost.</string>

--- a/android/ui/src/main/res/values-da/strings.xml
+++ b/android/ui/src/main/res/values-da/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Adresser</string>
   <string name="contacts_state_empty_title">Ingen kontakter</string>
   <string name="contacts_state_empty_description">Gem dine ofte brugte adresser</string>
-  <string name="contacts_add_to_contacts">Føj til Kontakter</string>
+  <string name="contacts_create_new_contact">Opret kontakt</string>
+  <string name="contacts_add_to_existing_contact">Føj til kontakt</string>
   <string name="simulation_header_unlimited_asset">Ubegrænset %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Dette giver brugeren adgang til at bruge denne token, indtil du tilbagekalder godkendelsen, eller den udløber.</string>
   <string name="simulation_warning_externally_owned_spender_description">Denne godkendelse lader en almindelig walletadresse (EOA) bruge dine aktiver. Bekræft kun, hvis du har tillid til denne adresse.</string>

--- a/android/ui/src/main/res/values-da/strings.xml
+++ b/android/ui/src/main/res/values-da/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Adresser</string>
   <string name="contacts_state_empty_title">Ingen kontakter</string>
   <string name="contacts_state_empty_description">Gem dine ofte brugte adresser</string>
-  <string name="contacts_create_new_contact">Opret kontakt</string>
+  <string name="contacts_create_new_contact">Opret ny kontakt</string>
   <string name="contacts_add_to_existing_contact">Føj til kontakt</string>
   <string name="simulation_header_unlimited_asset">Ubegrænset %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Dette giver brugeren adgang til at bruge denne token, indtil du tilbagekalder godkendelsen, eller den udløber.</string>

--- a/android/ui/src/main/res/values-de/strings.xml
+++ b/android/ui/src/main/res/values-de/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Adressen</string>
   <string name="contacts_state_empty_title">Keine Kontakte</string>
   <string name="contacts_state_empty_description">Speichern Sie Ihre häufig verwendeten Adressen</string>
-  <string name="contacts_create_new_contact">Kontakt erstellen</string>
+  <string name="contacts_create_new_contact">Neuen Kontakt erstellen</string>
   <string name="contacts_add_to_existing_contact">Zu Kontakt hinzufügen</string>
   <string name="simulation_header_unlimited_asset">Unbegrenzt %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Dadurch erhält der Ausgeber Zugriff auf dieses Token, bis Sie die Genehmigung widerrufen oder es abläuft.</string>

--- a/android/ui/src/main/res/values-de/strings.xml
+++ b/android/ui/src/main/res/values-de/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Adressen</string>
   <string name="contacts_state_empty_title">Keine Kontakte</string>
   <string name="contacts_state_empty_description">Speichern Sie Ihre häufig verwendeten Adressen</string>
-  <string name="contacts_add_to_contacts">Zu Kontakten hinzufügen</string>
+  <string name="contacts_create_new_contact">Kontakt erstellen</string>
+  <string name="contacts_add_to_existing_contact">Zu Kontakt hinzufügen</string>
   <string name="simulation_header_unlimited_asset">Unbegrenzt %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Dadurch erhält der Ausgeber Zugriff auf dieses Token, bis Sie die Genehmigung widerrufen oder es abläuft.</string>
   <string name="simulation_warning_externally_owned_spender_description">Diese Genehmigung erlaubt einer normalen Wallet-Adresse (EOA), Ihre Assets zu verwenden. Bestätigen Sie nur, wenn Sie dieser Adresse vertrauen.</string>

--- a/android/ui/src/main/res/values-es/strings.xml
+++ b/android/ui/src/main/res/values-es/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Direcciones</string>
   <string name="contacts_state_empty_title">Sin contactos</string>
   <string name="contacts_state_empty_description">Guarde sus direcciones de uso frecuente</string>
-  <string name="contacts_create_new_contact">Crear contacto</string>
+  <string name="contacts_create_new_contact">Crear nuevo contacto</string>
   <string name="contacts_add_to_existing_contact">Añadir a un contacto</string>
   <string name="simulation_header_unlimited_asset">Ilimitado %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Esto le da al gastador acceso para usar este token hasta que revoque la aprobación o expire.</string>

--- a/android/ui/src/main/res/values-es/strings.xml
+++ b/android/ui/src/main/res/values-es/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Direcciones</string>
   <string name="contacts_state_empty_title">Sin contactos</string>
   <string name="contacts_state_empty_description">Guarde sus direcciones de uso frecuente</string>
-  <string name="contacts_add_to_contacts">Añadir a contactos</string>
+  <string name="contacts_create_new_contact">Crear contacto</string>
+  <string name="contacts_add_to_existing_contact">Añadir a un contacto</string>
   <string name="simulation_header_unlimited_asset">Ilimitado %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Esto le da al gastador acceso para usar este token hasta que revoque la aprobación o expire.</string>
   <string name="simulation_warning_externally_owned_spender_description">Esta aprobación permite que una dirección de billetera normal (EOA) use tus activos. Confirma solo si confías en esta dirección.</string>

--- a/android/ui/src/main/res/values-fa/strings.xml
+++ b/android/ui/src/main/res/values-fa/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">آدرس‌ها</string>
   <string name="contacts_state_empty_title">بدون مخاطب</string>
   <string name="contacts_state_empty_description">آدرس‌های پرکاربرد خود را ذخیره کنید</string>
-  <string name="contacts_create_new_contact">ایجاد مخاطب</string>
+  <string name="contacts_create_new_contact">ایجاد مخاطب جدید</string>
   <string name="contacts_add_to_existing_contact">افزودن به مخاطب</string>
   <string name="simulation_header_unlimited_asset">نامحدود %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">این به خرج‌کننده دسترسی می‌دهد تا زمانی که تأییدیه را لغو کنید یا منقضی شود، از این توکن استفاده کند.</string>

--- a/android/ui/src/main/res/values-fa/strings.xml
+++ b/android/ui/src/main/res/values-fa/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">آدرس‌ها</string>
   <string name="contacts_state_empty_title">بدون مخاطب</string>
   <string name="contacts_state_empty_description">آدرس‌های پرکاربرد خود را ذخیره کنید</string>
-  <string name="contacts_add_to_contacts">اضافه کردن به مخاطبین</string>
+  <string name="contacts_create_new_contact">ایجاد مخاطب</string>
+  <string name="contacts_add_to_existing_contact">افزودن به مخاطب</string>
   <string name="simulation_header_unlimited_asset">نامحدود %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">این به خرج‌کننده دسترسی می‌دهد تا زمانی که تأییدیه را لغو کنید یا منقضی شود، از این توکن استفاده کند.</string>
   <string name="simulation_warning_externally_owned_spender_description">این تأییدیه به یک آدرس کیف پول معمولی (EOA) اجازه می‌دهد از دارایی‌های شما استفاده کند. فقط اگر به این آدرس اعتماد دارید تأیید کنید.</string>

--- a/android/ui/src/main/res/values-fil/strings.xml
+++ b/android/ui/src/main/res/values-fil/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Mga Address</string>
   <string name="contacts_state_empty_title">Walang Mga Kontak</string>
   <string name="contacts_state_empty_description">I-save ang iyong mga madalas gamiting address</string>
-  <string name="contacts_add_to_contacts">Idagdag sa Mga Kontak</string>
+  <string name="contacts_create_new_contact">Gumawa ng Contact</string>
+  <string name="contacts_add_to_existing_contact">Idagdag sa Contact</string>
   <string name="simulation_header_unlimited_asset">Walang limitasyon %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Nagbibigay ito sa gumagastos ng access na gamitin ang token na ito hanggang sa bawiin mo ang pag-apruba o hanggang sa mag-expire ito.</string>
   <string name="simulation_warning_externally_owned_spender_description">Hinahayaan ng pag-aprubang ito ang isang karaniwang wallet address (EOA) na gamitin ang iyong mga asset. Kumpirmahin lang kung pinagkakatiwalaan mo ang address na ito.</string>

--- a/android/ui/src/main/res/values-fil/strings.xml
+++ b/android/ui/src/main/res/values-fil/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Mga Address</string>
   <string name="contacts_state_empty_title">Walang Mga Kontak</string>
   <string name="contacts_state_empty_description">I-save ang iyong mga madalas gamiting address</string>
-  <string name="contacts_create_new_contact">Gumawa ng Contact</string>
+  <string name="contacts_create_new_contact">Gumawa ng Bagong Contact</string>
   <string name="contacts_add_to_existing_contact">Idagdag sa Contact</string>
   <string name="simulation_header_unlimited_asset">Walang limitasyon %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Nagbibigay ito sa gumagastos ng access na gamitin ang token na ito hanggang sa bawiin mo ang pag-apruba o hanggang sa mag-expire ito.</string>

--- a/android/ui/src/main/res/values-fr/strings.xml
+++ b/android/ui/src/main/res/values-fr/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Adresses</string>
   <string name="contacts_state_empty_title">Aucun contact</string>
   <string name="contacts_state_empty_description">Enregistrez vos adresses fréquemment utilisées</string>
-  <string name="contacts_add_to_contacts">Ajouter aux contacts</string>
+  <string name="contacts_create_new_contact">Créer un contact</string>
+  <string name="contacts_add_to_existing_contact">Ajouter à un contact</string>
   <string name="simulation_header_unlimited_asset">Illimité %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Cela donne au détenteur du jeton l\'accès à utiliser jusqu\'à ce que vous révoquiez l\'autorisation ou que celle-ci expire.</string>
   <string name="simulation_warning_externally_owned_spender_description">Cette approbation permet à une adresse de portefeuille classique (EOA) d’utiliser vos actifs. Confirmez uniquement si vous faites confiance à cette adresse.</string>

--- a/android/ui/src/main/res/values-fr/strings.xml
+++ b/android/ui/src/main/res/values-fr/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Adresses</string>
   <string name="contacts_state_empty_title">Aucun contact</string>
   <string name="contacts_state_empty_description">Enregistrez vos adresses fréquemment utilisées</string>
-  <string name="contacts_create_new_contact">Créer un contact</string>
+  <string name="contacts_create_new_contact">Créer un nouveau contact</string>
   <string name="contacts_add_to_existing_contact">Ajouter à un contact</string>
   <string name="simulation_header_unlimited_asset">Illimité %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Cela donne au détenteur du jeton l\'accès à utiliser jusqu\'à ce que vous révoquiez l\'autorisation ou que celle-ci expire.</string>

--- a/android/ui/src/main/res/values-ha/strings.xml
+++ b/android/ui/src/main/res/values-ha/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Adiresoshi</string>
   <string name="contacts_state_empty_title">Babu Lambobin Sadarwa</string>
   <string name="contacts_state_empty_description">Ajiye adiresoshin da ake yawan amfani da su</string>
-  <string name="contacts_create_new_contact">Ƙirƙiri lamba</string>
+  <string name="contacts_create_new_contact">Ƙirƙiri sabon lamba</string>
   <string name="contacts_add_to_existing_contact">Ƙara zuwa lamba</string>
   <string name="simulation_header_unlimited_asset">Unlimited %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Wannan yana ba mai kashewa damar amfani da wannan alamar har sai kun soke amincewa ko kuma ta ƙare.</string>

--- a/android/ui/src/main/res/values-ha/strings.xml
+++ b/android/ui/src/main/res/values-ha/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Adiresoshi</string>
   <string name="contacts_state_empty_title">Babu Lambobin Sadarwa</string>
   <string name="contacts_state_empty_description">Ajiye adiresoshin da ake yawan amfani da su</string>
-  <string name="contacts_add_to_contacts">Ƙara zuwa Lambobin Sadarwa</string>
+  <string name="contacts_create_new_contact">Ƙirƙiri lamba</string>
+  <string name="contacts_add_to_existing_contact">Ƙara zuwa lamba</string>
   <string name="simulation_header_unlimited_asset">Unlimited %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Wannan yana ba mai kashewa damar amfani da wannan alamar har sai kun soke amincewa ko kuma ta ƙare.</string>
   <string name="simulation_warning_externally_owned_spender_description">Wannan amincewar tana ba adireshin walat na yau da kullum (EOA) damar amfani da kadarorinku. Tabbatar kawai idan kun amince da wannan adireshin.</string>

--- a/android/ui/src/main/res/values-hi/strings.xml
+++ b/android/ui/src/main/res/values-hi/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">पतों</string>
   <string name="contacts_state_empty_title">कोई संपर्क नहीं</string>
   <string name="contacts_state_empty_description">अपने अक्सर इस्तेमाल होने वाले पतों को सेव करें</string>
-  <string name="contacts_create_new_contact">संपर्क बनाएं</string>
+  <string name="contacts_create_new_contact">नया संपर्क बनाएं</string>
   <string name="contacts_add_to_existing_contact">संपर्क में जोड़ें</string>
   <string name="simulation_header_unlimited_asset">असीमित %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">इससे खर्च करने वाले को इस टोकन का उपयोग तब तक करने की अनुमति मिलती है जब तक आप अनुमोदन रद्द नहीं कर देते या यह समाप्त नहीं हो जाता।</string>

--- a/android/ui/src/main/res/values-hi/strings.xml
+++ b/android/ui/src/main/res/values-hi/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">पतों</string>
   <string name="contacts_state_empty_title">कोई संपर्क नहीं</string>
   <string name="contacts_state_empty_description">अपने अक्सर इस्तेमाल होने वाले पतों को सेव करें</string>
-  <string name="contacts_add_to_contacts">संपर्क के खाते में जोड़ दे</string>
+  <string name="contacts_create_new_contact">संपर्क बनाएं</string>
+  <string name="contacts_add_to_existing_contact">संपर्क में जोड़ें</string>
   <string name="simulation_header_unlimited_asset">असीमित %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">इससे खर्च करने वाले को इस टोकन का उपयोग तब तक करने की अनुमति मिलती है जब तक आप अनुमोदन रद्द नहीं कर देते या यह समाप्त नहीं हो जाता।</string>
   <string name="simulation_warning_externally_owned_spender_description">यह स्वीकृति एक सामान्य वॉलेट पते (EOA) को आपकी संपत्तियों का उपयोग करने देती है। केवल तभी पुष्टि करें जब आप इस पते पर भरोसा करते हों।</string>

--- a/android/ui/src/main/res/values-id/strings.xml
+++ b/android/ui/src/main/res/values-id/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Alamat</string>
   <string name="contacts_state_empty_title">Tidak ada kontak</string>
   <string name="contacts_state_empty_description">Simpan alamat yang sering Anda gunakan.</string>
-  <string name="contacts_add_to_contacts">Tambahkan ke Kontak</string>
+  <string name="contacts_create_new_contact">Buat Kontak</string>
+  <string name="contacts_add_to_existing_contact">Tambahkan ke Kontak</string>
   <string name="simulation_header_unlimited_asset">Tak terbatas %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Ini memberi pihak yang mengeluarkan dana akses untuk menggunakan token ini hingga Anda mencabut persetujuan atau token tersebut kedaluwarsa.</string>
   <string name="simulation_warning_externally_owned_spender_description">Persetujuan ini memungkinkan alamat dompet biasa (EOA) menggunakan aset Anda. Konfirmasikan hanya jika Anda mempercayai alamat ini.</string>

--- a/android/ui/src/main/res/values-id/strings.xml
+++ b/android/ui/src/main/res/values-id/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Alamat</string>
   <string name="contacts_state_empty_title">Tidak ada kontak</string>
   <string name="contacts_state_empty_description">Simpan alamat yang sering Anda gunakan.</string>
-  <string name="contacts_create_new_contact">Buat Kontak</string>
+  <string name="contacts_create_new_contact">Buat Kontak Baru</string>
   <string name="contacts_add_to_existing_contact">Tambahkan ke Kontak</string>
   <string name="simulation_header_unlimited_asset">Tak terbatas %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Ini memberi pihak yang mengeluarkan dana akses untuk menggunakan token ini hingga Anda mencabut persetujuan atau token tersebut kedaluwarsa.</string>

--- a/android/ui/src/main/res/values-it/strings.xml
+++ b/android/ui/src/main/res/values-it/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Indirizzi</string>
   <string name="contacts_state_empty_title">Nessun contatto</string>
   <string name="contacts_state_empty_description">Salva gli indirizzi che usi più frequentemente</string>
-  <string name="contacts_add_to_contacts">Aggiungi ai contatti</string>
+  <string name="contacts_create_new_contact">Crea contatto</string>
+  <string name="contacts_add_to_existing_contact">Aggiungi a un contatto</string>
   <string name="simulation_header_unlimited_asset">Illimitato %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Ciò consente allo spender di utilizzare questo token finché non revochi l\'approvazione o finché non scade.</string>
   <string name="simulation_warning_externally_owned_spender_description">Questa approvazione consente a un normale indirizzo wallet (EOA) di usare i tuoi asset. Conferma solo se ti fidi di questo indirizzo.</string>

--- a/android/ui/src/main/res/values-it/strings.xml
+++ b/android/ui/src/main/res/values-it/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Indirizzi</string>
   <string name="contacts_state_empty_title">Nessun contatto</string>
   <string name="contacts_state_empty_description">Salva gli indirizzi che usi più frequentemente</string>
-  <string name="contacts_create_new_contact">Crea contatto</string>
+  <string name="contacts_create_new_contact">Crea nuovo contatto</string>
   <string name="contacts_add_to_existing_contact">Aggiungi a un contatto</string>
   <string name="simulation_header_unlimited_asset">Illimitato %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Ciò consente allo spender di utilizzare questo token finché non revochi l\'approvazione o finché non scade.</string>

--- a/android/ui/src/main/res/values-iw/strings.xml
+++ b/android/ui/src/main/res/values-iw/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">כתובות</string>
   <string name="contacts_state_empty_title">אין אנשי קשר</string>
   <string name="contacts_state_empty_description">שמור את הכתובות שאתה משתמש בהן לעתים קרובות</string>
-  <string name="contacts_create_new_contact">צור איש קשר</string>
+  <string name="contacts_create_new_contact">צור איש קשר חדש</string>
   <string name="contacts_add_to_existing_contact">הוסף לאיש קשר</string>
   <string name="simulation_header_unlimited_asset">בִּלתִי מוּגבָּל %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">זה נותן למוציא גישה להשתמש באסימון זה עד שתבטל את האישור או שהוא יפוג תוקפו.</string>

--- a/android/ui/src/main/res/values-iw/strings.xml
+++ b/android/ui/src/main/res/values-iw/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">כתובות</string>
   <string name="contacts_state_empty_title">אין אנשי קשר</string>
   <string name="contacts_state_empty_description">שמור את הכתובות שאתה משתמש בהן לעתים קרובות</string>
-  <string name="contacts_add_to_contacts">הוסף לאנשי קשר</string>
+  <string name="contacts_create_new_contact">צור איש קשר</string>
+  <string name="contacts_add_to_existing_contact">הוסף לאיש קשר</string>
   <string name="simulation_header_unlimited_asset">בִּלתִי מוּגבָּל %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">זה נותן למוציא גישה להשתמש באסימון זה עד שתבטל את האישור או שהוא יפוג תוקפו.</string>
   <string name="simulation_warning_externally_owned_spender_description">אישור זה מאפשר לכתובת ארנק רגילה (EOA) להשתמש בנכסים שלך. אשר רק אם אתה סומך על כתובת זו.</string>

--- a/android/ui/src/main/res/values-ja/strings.xml
+++ b/android/ui/src/main/res/values-ja/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">住所</string>
   <string name="contacts_state_empty_title">連絡先なし</string>
   <string name="contacts_state_empty_description">よく使うアドレスを保存する</string>
-  <string name="contacts_add_to_contacts">連絡先に追加</string>
+  <string name="contacts_create_new_contact">連絡先を作成</string>
+  <string name="contacts_add_to_existing_contact">連絡先に追加</string>
   <string name="simulation_header_unlimited_asset">無制限 %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">これにより、承認を取り消すか期限が切れるまで、支出者はこのトークンを使用できるようになります。</string>
   <string name="simulation_warning_externally_owned_spender_description">この承認により、通常のウォレットアドレス（EOA）があなたの資産を使用できるようになります。このアドレスを信頼できる場合のみ確認してください。</string>

--- a/android/ui/src/main/res/values-ja/strings.xml
+++ b/android/ui/src/main/res/values-ja/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">住所</string>
   <string name="contacts_state_empty_title">連絡先なし</string>
   <string name="contacts_state_empty_description">よく使うアドレスを保存する</string>
-  <string name="contacts_create_new_contact">連絡先を作成</string>
+  <string name="contacts_create_new_contact">新しい連絡先を作成</string>
   <string name="contacts_add_to_existing_contact">連絡先に追加</string>
   <string name="simulation_header_unlimited_asset">無制限 %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">これにより、承認を取り消すか期限が切れるまで、支出者はこのトークンを使用できるようになります。</string>

--- a/android/ui/src/main/res/values-ko/strings.xml
+++ b/android/ui/src/main/res/values-ko/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">구애</string>
   <string name="contacts_state_empty_title">연락처 없음</string>
   <string name="contacts_state_empty_description">자주 사용하는 주소를 저장하세요</string>
-  <string name="contacts_create_new_contact">연락처 만들기</string>
+  <string name="contacts_create_new_contact">새 연락처 만들기</string>
   <string name="contacts_add_to_existing_contact">연락처에 추가</string>
   <string name="simulation_header_unlimited_asset">제한 없는 %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">이렇게 하면 사용자가 승인을 취소하거나 만료될 때까지 해당 토큰을 사용할 수 있습니다.</string>

--- a/android/ui/src/main/res/values-ko/strings.xml
+++ b/android/ui/src/main/res/values-ko/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">구애</string>
   <string name="contacts_state_empty_title">연락처 없음</string>
   <string name="contacts_state_empty_description">자주 사용하는 주소를 저장하세요</string>
-  <string name="contacts_add_to_contacts">연락처에 추가</string>
+  <string name="contacts_create_new_contact">연락처 만들기</string>
+  <string name="contacts_add_to_existing_contact">연락처에 추가</string>
   <string name="simulation_header_unlimited_asset">제한 없는 %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">이렇게 하면 사용자가 승인을 취소하거나 만료될 때까지 해당 토큰을 사용할 수 있습니다.</string>
   <string name="simulation_warning_externally_owned_spender_description">이 승인은 일반 지갑 주소(EOA)가 내 자산을 사용할 수 있게 합니다. 이 주소를 신뢰하는 경우에만 확인하세요.</string>

--- a/android/ui/src/main/res/values-ms/strings.xml
+++ b/android/ui/src/main/res/values-ms/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Alamat</string>
   <string name="contacts_state_empty_title">Tiada Kenalan</string>
   <string name="contacts_state_empty_description">Simpan alamat yang kerap anda gunakan</string>
-  <string name="contacts_create_new_contact">Cipta Kenalan</string>
+  <string name="contacts_create_new_contact">Cipta Kenalan Baharu</string>
   <string name="contacts_add_to_existing_contact">Tambah ke Kenalan</string>
   <string name="simulation_header_unlimited_asset">Tidak terhad %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Ini memberi pembeli akses untuk menggunakan token ini sehingga anda membatalkan kelulusan atau ia tamat tempoh.</string>

--- a/android/ui/src/main/res/values-ms/strings.xml
+++ b/android/ui/src/main/res/values-ms/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Alamat</string>
   <string name="contacts_state_empty_title">Tiada Kenalan</string>
   <string name="contacts_state_empty_description">Simpan alamat yang kerap anda gunakan</string>
-  <string name="contacts_add_to_contacts">Tambah ke Kenalan</string>
+  <string name="contacts_create_new_contact">Cipta Kenalan</string>
+  <string name="contacts_add_to_existing_contact">Tambah ke Kenalan</string>
   <string name="simulation_header_unlimited_asset">Tidak terhad %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Ini memberi pembeli akses untuk menggunakan token ini sehingga anda membatalkan kelulusan atau ia tamat tempoh.</string>
   <string name="simulation_warning_externally_owned_spender_description">Kelulusan ini membenarkan alamat dompet biasa (EOA) menggunakan aset anda. Sahkan hanya jika anda mempercayai alamat ini.</string>

--- a/android/ui/src/main/res/values-nl/strings.xml
+++ b/android/ui/src/main/res/values-nl/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Adressen</string>
   <string name="contacts_state_empty_title">Geen contacten</string>
   <string name="contacts_state_empty_description">Bewaar uw veelgebruikte adressen.</string>
-  <string name="contacts_create_new_contact">Contact maken</string>
+  <string name="contacts_create_new_contact">Nieuw contact maken</string>
   <string name="contacts_add_to_existing_contact">Aan contact toevoegen</string>
   <string name="simulation_header_unlimited_asset">Onbeperkt %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Dit geeft de gebruiker toegang tot het gebruik van dit token totdat u de goedkeuring intrekt of het token verloopt.</string>

--- a/android/ui/src/main/res/values-nl/strings.xml
+++ b/android/ui/src/main/res/values-nl/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Adressen</string>
   <string name="contacts_state_empty_title">Geen contacten</string>
   <string name="contacts_state_empty_description">Bewaar uw veelgebruikte adressen.</string>
-  <string name="contacts_add_to_contacts">Toevoegen aan contacten</string>
+  <string name="contacts_create_new_contact">Contact maken</string>
+  <string name="contacts_add_to_existing_contact">Aan contact toevoegen</string>
   <string name="simulation_header_unlimited_asset">Onbeperkt %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Dit geeft de gebruiker toegang tot het gebruik van dit token totdat u de goedkeuring intrekt of het token verloopt.</string>
   <string name="simulation_warning_externally_owned_spender_description">Met deze goedkeuring kan een gewoon walletadres (EOA) uw assets gebruiken. Bevestig alleen als u dit adres vertrouwt.</string>

--- a/android/ui/src/main/res/values-pl/strings.xml
+++ b/android/ui/src/main/res/values-pl/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Adresy</string>
   <string name="contacts_state_empty_title">Brak kontaktów</string>
   <string name="contacts_state_empty_description">Zapisz często używane adresy</string>
-  <string name="contacts_create_new_contact">Utwórz kontakt</string>
+  <string name="contacts_create_new_contact">Utwórz nowy kontakt</string>
   <string name="contacts_add_to_existing_contact">Dodaj do kontaktu</string>
   <string name="simulation_header_unlimited_asset">Nieograniczony %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Dzięki temu osoba wydająca token uzyskuje dostęp do jego wykorzystania do momentu odwołania zatwierdzenia lub wygaśnięcia.</string>

--- a/android/ui/src/main/res/values-pl/strings.xml
+++ b/android/ui/src/main/res/values-pl/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Adresy</string>
   <string name="contacts_state_empty_title">Brak kontaktów</string>
   <string name="contacts_state_empty_description">Zapisz często używane adresy</string>
-  <string name="contacts_add_to_contacts">Dodaj do kontaktów</string>
+  <string name="contacts_create_new_contact">Utwórz kontakt</string>
+  <string name="contacts_add_to_existing_contact">Dodaj do kontaktu</string>
   <string name="simulation_header_unlimited_asset">Nieograniczony %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Dzięki temu osoba wydająca token uzyskuje dostęp do jego wykorzystania do momentu odwołania zatwierdzenia lub wygaśnięcia.</string>
   <string name="simulation_warning_externally_owned_spender_description">To zatwierdzenie pozwala zwykłemu adresowi portfela (EOA) używać Twoich aktywów. Potwierdź tylko wtedy, gdy ufasz temu adresowi.</string>

--- a/android/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/android/ui/src/main/res/values-pt-rBR/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Endereços</string>
   <string name="contacts_state_empty_title">Sem contatos</string>
   <string name="contacts_state_empty_description">Salve seus endereços usados ​​com frequência.</string>
-  <string name="contacts_add_to_contacts">Adicionar aos contatos</string>
+  <string name="contacts_create_new_contact">Criar contato</string>
+  <string name="contacts_add_to_existing_contact">Adicionar a contato</string>
   <string name="simulation_header_unlimited_asset">Ilimitado %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Isso dá ao gastador acesso ao uso desse token até que você revogue a aprovação ou ele expire.</string>
   <string name="simulation_warning_externally_owned_spender_description">Esta aprovação permite que um endereço de carteira comum (EOA) use seus ativos. Confirme somente se você confia neste endereço.</string>

--- a/android/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/android/ui/src/main/res/values-pt-rBR/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Endereços</string>
   <string name="contacts_state_empty_title">Sem contatos</string>
   <string name="contacts_state_empty_description">Salve seus endereços usados ​​com frequência.</string>
-  <string name="contacts_create_new_contact">Criar contato</string>
+  <string name="contacts_create_new_contact">Criar novo contato</string>
   <string name="contacts_add_to_existing_contact">Adicionar a contato</string>
   <string name="simulation_header_unlimited_asset">Ilimitado %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Isso dá ao gastador acesso ao uso desse token até que você revogue a aprovação ou ele expire.</string>

--- a/android/ui/src/main/res/values-ro/strings.xml
+++ b/android/ui/src/main/res/values-ro/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Adrese</string>
   <string name="contacts_state_empty_title">Niciun contact</string>
   <string name="contacts_state_empty_description">Salvați adresele utilizate frecvent</string>
-  <string name="contacts_create_new_contact">Creează un contact</string>
+  <string name="contacts_create_new_contact">Creează un contact nou</string>
   <string name="contacts_add_to_existing_contact">Adaugă la un contact</string>
   <string name="simulation_header_unlimited_asset">Nelimitat %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Aceasta îi oferă cheltuitorului acces la utilizarea acestui token până când îi revocați aprobarea sau expiră.</string>

--- a/android/ui/src/main/res/values-ro/strings.xml
+++ b/android/ui/src/main/res/values-ro/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Adrese</string>
   <string name="contacts_state_empty_title">Niciun contact</string>
   <string name="contacts_state_empty_description">Salvați adresele utilizate frecvent</string>
-  <string name="contacts_add_to_contacts">Adăugați la Contacte</string>
+  <string name="contacts_create_new_contact">Creează un contact</string>
+  <string name="contacts_add_to_existing_contact">Adaugă la un contact</string>
   <string name="simulation_header_unlimited_asset">Nelimitat %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Aceasta îi oferă cheltuitorului acces la utilizarea acestui token până când îi revocați aprobarea sau expiră.</string>
   <string name="simulation_warning_externally_owned_spender_description">Această aprobare permite unei adrese obișnuite de portofel (EOA) să folosească activele tale. Confirmă doar dacă ai încredere în această adresă.</string>

--- a/android/ui/src/main/res/values-ru/strings.xml
+++ b/android/ui/src/main/res/values-ru/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Адреса</string>
   <string name="contacts_state_empty_title">Нет контактов</string>
   <string name="contacts_state_empty_description">Сохраните часто используемые адреса.</string>
-  <string name="contacts_add_to_contacts">Добавить в контакты</string>
+  <string name="contacts_create_new_contact">Создать контакт</string>
+  <string name="contacts_add_to_existing_contact">Добавить в контакт</string>
   <string name="simulation_header_unlimited_asset">Без ограничений %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Это даёт получателю одобрения доступ к использованию этого токена до тех пор, пока вы не отзовёте разрешение или оно не истечёт.</string>
   <string name="simulation_warning_externally_owned_spender_description">Это разрешение позволяет обычному адресу кошелька (EOA) использовать ваши активы. Подтверждайте только если доверяете этому адресу.</string>

--- a/android/ui/src/main/res/values-ru/strings.xml
+++ b/android/ui/src/main/res/values-ru/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Адреса</string>
   <string name="contacts_state_empty_title">Нет контактов</string>
   <string name="contacts_state_empty_description">Сохраните часто используемые адреса.</string>
-  <string name="contacts_create_new_contact">Создать контакт</string>
+  <string name="contacts_create_new_contact">Создать новый контакт</string>
   <string name="contacts_add_to_existing_contact">Добавить в контакт</string>
   <string name="simulation_header_unlimited_asset">Без ограничений %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Это даёт получателю одобрения доступ к использованию этого токена до тех пор, пока вы не отзовёте разрешение или оно не истечёт.</string>

--- a/android/ui/src/main/res/values-sw/strings.xml
+++ b/android/ui/src/main/res/values-sw/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Anwani</string>
   <string name="contacts_state_empty_title">Hakuna Anwani</string>
   <string name="contacts_state_empty_description">Hifadhi anwani zako zinazotumiwa mara kwa mara</string>
-  <string name="contacts_add_to_contacts">Ongeza kwenye Anwani</string>
+  <string name="contacts_create_new_contact">Unda anwani</string>
+  <string name="contacts_add_to_existing_contact">Ongeza kwa anwani</string>
   <string name="simulation_header_unlimited_asset">Isiyo na kikomo %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Hii inampa mtumiaji uwezo wa kutumia tokeni hii hadi utakapobatilisha idhini au itakapoisha muda wake.</string>
   <string name="simulation_warning_externally_owned_spender_description">Idhini hii inaruhusu anwani ya kawaida ya pochi (EOA) kutumia mali zako. Thibitisha tu ikiwa unaiamini anwani hii.</string>

--- a/android/ui/src/main/res/values-sw/strings.xml
+++ b/android/ui/src/main/res/values-sw/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Anwani</string>
   <string name="contacts_state_empty_title">Hakuna Anwani</string>
   <string name="contacts_state_empty_description">Hifadhi anwani zako zinazotumiwa mara kwa mara</string>
-  <string name="contacts_create_new_contact">Unda anwani</string>
+  <string name="contacts_create_new_contact">Unda anwani mpya</string>
   <string name="contacts_add_to_existing_contact">Ongeza kwa anwani</string>
   <string name="simulation_header_unlimited_asset">Isiyo na kikomo %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Hii inampa mtumiaji uwezo wa kutumia tokeni hii hadi utakapobatilisha idhini au itakapoisha muda wake.</string>

--- a/android/ui/src/main/res/values-th/strings.xml
+++ b/android/ui/src/main/res/values-th/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">ที่อยู่</string>
   <string name="contacts_state_empty_title">ไม่มีข้อมูลติดต่อ</string>
   <string name="contacts_state_empty_description">บันทึกที่อยู่ที่คุณใช้งานบ่อย</string>
-  <string name="contacts_create_new_contact">สร้างรายชื่อ</string>
+  <string name="contacts_create_new_contact">สร้างรายชื่อใหม่</string>
   <string name="contacts_add_to_existing_contact">เพิ่มในรายชื่อ</string>
   <string name="simulation_header_unlimited_asset">ไม่จำกัด %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">สิ่งนี้ให้สิทธิ์ผู้ใช้จ่าย (spender) ในการใช้โทเค็นนี้จนกว่าคุณจะเพิกถอนการอนุมัติหรือโทเค็นหมดอายุ</string>

--- a/android/ui/src/main/res/values-th/strings.xml
+++ b/android/ui/src/main/res/values-th/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">ที่อยู่</string>
   <string name="contacts_state_empty_title">ไม่มีข้อมูลติดต่อ</string>
   <string name="contacts_state_empty_description">บันทึกที่อยู่ที่คุณใช้งานบ่อย</string>
-  <string name="contacts_add_to_contacts">เพิ่มลงในรายชื่อติดต่อ</string>
+  <string name="contacts_create_new_contact">สร้างรายชื่อ</string>
+  <string name="contacts_add_to_existing_contact">เพิ่มในรายชื่อ</string>
   <string name="simulation_header_unlimited_asset">ไม่จำกัด %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">สิ่งนี้ให้สิทธิ์ผู้ใช้จ่าย (spender) ในการใช้โทเค็นนี้จนกว่าคุณจะเพิกถอนการอนุมัติหรือโทเค็นหมดอายุ</string>
   <string name="simulation_warning_externally_owned_spender_description">การอนุมัตินี้ทำให้ที่อยู่กระเป๋าเงินทั่วไป (EOA) สามารถใช้สินทรัพย์ของคุณได้ ยืนยันเฉพาะเมื่อคุณเชื่อถือที่อยู่นี้</string>

--- a/android/ui/src/main/res/values-tr/strings.xml
+++ b/android/ui/src/main/res/values-tr/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Adresler</string>
   <string name="contacts_state_empty_title">İletişim yok</string>
   <string name="contacts_state_empty_description">Sık kullandığınız adresleri kaydedin.</string>
-  <string name="contacts_create_new_contact">Kişi Oluştur</string>
+  <string name="contacts_create_new_contact">Yeni Kişi Oluştur</string>
   <string name="contacts_add_to_existing_contact">Kişiye Ekle</string>
   <string name="simulation_header_unlimited_asset">Sınırsız %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Bu, harcayan tarafa, siz onayı iptal edene veya süresi dolana kadar bu jetonu kullanma erişimi sağlar.</string>

--- a/android/ui/src/main/res/values-tr/strings.xml
+++ b/android/ui/src/main/res/values-tr/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Adresler</string>
   <string name="contacts_state_empty_title">İletişim yok</string>
   <string name="contacts_state_empty_description">Sık kullandığınız adresleri kaydedin.</string>
-  <string name="contacts_add_to_contacts">Kişilere Ekle</string>
+  <string name="contacts_create_new_contact">Kişi Oluştur</string>
+  <string name="contacts_add_to_existing_contact">Kişiye Ekle</string>
   <string name="simulation_header_unlimited_asset">Sınırsız %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Bu, harcayan tarafa, siz onayı iptal edene veya süresi dolana kadar bu jetonu kullanma erişimi sağlar.</string>
   <string name="simulation_warning_externally_owned_spender_description">Bu onay, normal bir cüzdan adresinin (EOA) varlıklarınızı kullanmasına izin verir. Yalnızca bu adrese güveniyorsanız onaylayın.</string>

--- a/android/ui/src/main/res/values-uk/strings.xml
+++ b/android/ui/src/main/res/values-uk/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Адреси</string>
   <string name="contacts_state_empty_title">Немає контактів</string>
   <string name="contacts_state_empty_description">Збережіть часто використовувані адреси</string>
-  <string name="contacts_add_to_contacts">Додати до контактів</string>
+  <string name="contacts_create_new_contact">Створити контакт</string>
+  <string name="contacts_add_to_existing_contact">Додати до контакту</string>
   <string name="simulation_header_unlimited_asset">Безлімітний %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Це надає отримувачу доступ до використання цього токена, доки ви не скасуєте схвалення або термін його дії не закінчиться.</string>
   <string name="simulation_warning_externally_owned_spender_description">Це схвалення дозволяє звичайній адресі гаманця (EOA) використовувати ваші активи. Підтверджуйте лише якщо довіряєте цій адресі.</string>

--- a/android/ui/src/main/res/values-uk/strings.xml
+++ b/android/ui/src/main/res/values-uk/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Адреси</string>
   <string name="contacts_state_empty_title">Немає контактів</string>
   <string name="contacts_state_empty_description">Збережіть часто використовувані адреси</string>
-  <string name="contacts_create_new_contact">Створити контакт</string>
+  <string name="contacts_create_new_contact">Створити новий контакт</string>
   <string name="contacts_add_to_existing_contact">Додати до контакту</string>
   <string name="simulation_header_unlimited_asset">Безлімітний %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Це надає отримувачу доступ до використання цього токена, доки ви не скасуєте схвалення або термін його дії не закінчиться.</string>

--- a/android/ui/src/main/res/values-ur/strings.xml
+++ b/android/ui/src/main/res/values-ur/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">پتے</string>
   <string name="contacts_state_empty_title">کوئی رابطے نہیں</string>
   <string name="contacts_state_empty_description">اپنے اکثر استعمال ہونے والے پتے محفوظ کریں۔</string>
-  <string name="contacts_add_to_contacts">رابطوں میں شامل کریں۔</string>
+  <string name="contacts_create_new_contact">رابطہ بنائیں</string>
+  <string name="contacts_add_to_existing_contact">رابطے میں شامل کریں</string>
   <string name="simulation_header_unlimited_asset">لا محدود %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">یہ خرچ کرنے والے کو اس ٹوکن کو استعمال کرنے تک رسائی دیتا ہے جب تک کہ آپ منظوری منسوخ نہیں کرتے یا اس کی میعاد ختم نہیں ہوجاتی۔</string>
   <string name="simulation_warning_externally_owned_spender_description">یہ منظوری ایک عام والیٹ ایڈریس (EOA) کو آپ کے اثاثے استعمال کرنے دیتی ہے۔ صرف اس صورت میں تصدیق کریں جب آپ اس ایڈریس پر اعتماد کرتے ہیں۔</string>

--- a/android/ui/src/main/res/values-ur/strings.xml
+++ b/android/ui/src/main/res/values-ur/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">پتے</string>
   <string name="contacts_state_empty_title">کوئی رابطے نہیں</string>
   <string name="contacts_state_empty_description">اپنے اکثر استعمال ہونے والے پتے محفوظ کریں۔</string>
-  <string name="contacts_create_new_contact">رابطہ بنائیں</string>
+  <string name="contacts_create_new_contact">نیا رابطہ بنائیں</string>
   <string name="contacts_add_to_existing_contact">رابطے میں شامل کریں</string>
   <string name="simulation_header_unlimited_asset">لا محدود %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">یہ خرچ کرنے والے کو اس ٹوکن کو استعمال کرنے تک رسائی دیتا ہے جب تک کہ آپ منظوری منسوخ نہیں کرتے یا اس کی میعاد ختم نہیں ہوجاتی۔</string>

--- a/android/ui/src/main/res/values-vi/strings.xml
+++ b/android/ui/src/main/res/values-vi/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Địa chỉ</string>
   <string name="contacts_state_empty_title">Không có liên hệ</string>
   <string name="contacts_state_empty_description">Lưu lại những địa chỉ bạn thường dùng.</string>
-  <string name="contacts_add_to_contacts">Thêm vào danh bạ</string>
+  <string name="contacts_create_new_contact">Tạo liên hệ</string>
+  <string name="contacts_add_to_existing_contact">Thêm vào liên hệ</string>
   <string name="simulation_header_unlimited_asset">Không giới hạn %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Điều này cho phép người chi tiêu có quyền sử dụng mã thông báo này cho đến khi bạn thu hồi sự chấp thuận hoặc mã thông báo hết hạn.</string>
   <string name="simulation_warning_externally_owned_spender_description">Phê duyệt này cho phép một địa chỉ ví thông thường (EOA) sử dụng tài sản của bạn. Chỉ xác nhận nếu bạn tin tưởng địa chỉ này.</string>

--- a/android/ui/src/main/res/values-vi/strings.xml
+++ b/android/ui/src/main/res/values-vi/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Địa chỉ</string>
   <string name="contacts_state_empty_title">Không có liên hệ</string>
   <string name="contacts_state_empty_description">Lưu lại những địa chỉ bạn thường dùng.</string>
-  <string name="contacts_create_new_contact">Tạo liên hệ</string>
+  <string name="contacts_create_new_contact">Tạo liên hệ mới</string>
   <string name="contacts_add_to_existing_contact">Thêm vào liên hệ</string>
   <string name="simulation_header_unlimited_asset">Không giới hạn %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">Điều này cho phép người chi tiêu có quyền sử dụng mã thông báo này cho đến khi bạn thu hồi sự chấp thuận hoặc mã thông báo hết hạn.</string>

--- a/android/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/android/ui/src/main/res/values-zh-rCN/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">地址</string>
   <string name="contacts_state_empty_title">无联系方式</string>
   <string name="contacts_state_empty_description">保存您常用的地址</string>
-  <string name="contacts_create_new_contact">创建联系人</string>
+  <string name="contacts_create_new_contact">新建联系人</string>
   <string name="contacts_add_to_existing_contact">添加到联系人</string>
   <string name="simulation_header_unlimited_asset">无限 %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">这样，消费者就可以一直使用该代币，直到你撤销授权或代币过期为止。</string>

--- a/android/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/android/ui/src/main/res/values-zh-rCN/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">地址</string>
   <string name="contacts_state_empty_title">无联系方式</string>
   <string name="contacts_state_empty_description">保存您常用的地址</string>
-  <string name="contacts_add_to_contacts">添加到联系人</string>
+  <string name="contacts_create_new_contact">创建联系人</string>
+  <string name="contacts_add_to_existing_contact">添加到联系人</string>
   <string name="simulation_header_unlimited_asset">无限 %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">这样，消费者就可以一直使用该代币，直到你撤销授权或代币过期为止。</string>
   <string name="simulation_warning_externally_owned_spender_description">此授权允许普通钱包地址 (EOA) 使用你的资产。仅在你信任该地址时确认。</string>

--- a/android/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/android/ui/src/main/res/values-zh-rTW/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">地址</string>
   <string name="contacts_state_empty_title">無聯絡方式</string>
   <string name="contacts_state_empty_description">儲存您常用的地址</string>
-  <string name="contacts_create_new_contact">建立聯絡人</string>
+  <string name="contacts_create_new_contact">建立新聯絡人</string>
   <string name="contacts_add_to_existing_contact">加入聯絡人</string>
   <string name="simulation_header_unlimited_asset">無限 %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">這樣，消費者就可以一直使用該代幣，直到你撤銷授權或代幣過期為止。</string>

--- a/android/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/android/ui/src/main/res/values-zh-rTW/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">地址</string>
   <string name="contacts_state_empty_title">無聯絡方式</string>
   <string name="contacts_state_empty_description">儲存您常用的地址</string>
-  <string name="contacts_add_to_contacts">加入聯絡人</string>
+  <string name="contacts_create_new_contact">建立聯絡人</string>
+  <string name="contacts_add_to_existing_contact">加入聯絡人</string>
   <string name="simulation_header_unlimited_asset">無限 %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">這樣，消費者就可以一直使用該代幣，直到你撤銷授權或代幣過期為止。</string>
   <string name="simulation_warning_externally_owned_spender_description">此授權允許一般錢包地址 (EOA) 使用你的資產。僅在你信任該地址時確認。</string>

--- a/android/ui/src/main/res/values/strings.xml
+++ b/android/ui/src/main/res/values/strings.xml
@@ -564,7 +564,7 @@
   <string name="contacts_addresses">Addresses</string>
   <string name="contacts_state_empty_title">No Contacts</string>
   <string name="contacts_state_empty_description">Save your frequently used addresses</string>
-  <string name="contacts_create_new_contact">Create Contact</string>
+  <string name="contacts_create_new_contact">Create New Contact</string>
   <string name="contacts_add_to_existing_contact">Add to Contact</string>
   <string name="simulation_header_unlimited_asset">Unlimited %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">This gives the spender access to use this token until you revoke the approval or it expires.</string>

--- a/android/ui/src/main/res/values/strings.xml
+++ b/android/ui/src/main/res/values/strings.xml
@@ -564,7 +564,8 @@
   <string name="contacts_addresses">Addresses</string>
   <string name="contacts_state_empty_title">No Contacts</string>
   <string name="contacts_state_empty_description">Save your frequently used addresses</string>
-  <string name="contacts_add_to_contacts">Add to Contacts</string>
+  <string name="contacts_create_new_contact">Create Contact</string>
+  <string name="contacts_add_to_existing_contact">Add to Contact</string>
   <string name="simulation_header_unlimited_asset">Unlimited %1$s</string>
   <string name="simulation_warning_unlimited_token_approval_description">This gives the spender access to use this token until you revoke the approval or it expires.</string>
   <string name="simulation_warning_externally_owned_spender_description">This approval lets a regular wallet address (EOA) use your assets. Confirm only if you trust this address.</string>

--- a/ios/Features/Contacts/Sources/Scenes/ContactsNavigationView.swift
+++ b/ios/Features/Contacts/Sources/Scenes/ContactsNavigationView.swift
@@ -8,20 +8,16 @@ import SwiftUI
 
 public struct ContactsNavigationView: View {
     @State private var model: ContactsViewModel
-    @Binding private var navigationPath: NavigationPath
 
-    public init(
-        model: ContactsViewModel,
-        navigationPath: Binding<NavigationPath>,
-    ) {
+    public init(model: ContactsViewModel) {
         _model = State(initialValue: model)
-        _navigationPath = navigationPath
     }
 
     public var body: some View {
         ContactsScene(model: model)
             .bindQuery(model.query)
             .navigationTitle(model.title)
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button("", systemImage: SystemImage.plus, action: {

--- a/ios/Features/Contacts/Sources/Scenes/ContactsScene.swift
+++ b/ios/Features/Contacts/Sources/Scenes/ContactsScene.swift
@@ -7,6 +7,8 @@ import Style
 import SwiftUI
 
 public struct ContactsScene: View {
+    @Environment(\.dismiss) private var dismiss
+
     let model: ContactsViewModel
 
     public init(model: ContactsViewModel) {
@@ -16,8 +18,16 @@ public struct ContactsScene: View {
     public var body: some View {
         List {
             ForEach(model.contacts) { contact in
-                NavigationLink(value: Scenes.Contact(contact: contact)) {
-                    ListItemView(model: model.listItemModel(for: contact))
+                let item = ListItemView(model: model.listItemModel(for: contact))
+                switch model.mode {
+                case .list:
+                    NavigationLink(value: Scenes.Contact(contact: contact)) { item }
+                case .addAddress:
+                    Button {
+                        model.add(to: contact)
+                        dismiss()
+                    } label: { item }
+                        .buttonStyle(.plain)
                 }
             }
             .onDelete(perform: model.deleteContacts)

--- a/ios/Features/Contacts/Sources/ViewModels/ContactsViewModel.swift
+++ b/ios/Features/Contacts/Sources/ViewModels/ContactsViewModel.swift
@@ -12,8 +12,14 @@ import Style
 @Observable
 @MainActor
 public final class ContactsViewModel {
+    public enum Mode: Sendable {
+        case list
+        case addAddress(ChainRecipient)
+    }
+
     let service: ContactService
     let nameService: any NameServiceable
+    let mode: Mode
 
     public let query: ObservableQuery<ContactsRequest>
     var contacts: [ContactData] {
@@ -25,14 +31,26 @@ public final class ContactsViewModel {
     public init(
         service: ContactService,
         nameService: any NameServiceable,
+        mode: Mode = .list,
     ) {
         self.service = service
         self.nameService = nameService
+        self.mode = mode
         query = ObservableQuery(ContactsRequest(), initialValue: [])
     }
 
     var title: String {
         Localized.Contacts.title
+    }
+
+    func add(to contact: ContactData) {
+        guard case let .addAddress(recipient) = mode else { return }
+        let updated = contact.addAddress(from: recipient)
+        do {
+            try service.updateContact(updated.contact, addresses: updated.addresses)
+        } catch {
+            debugLog("ContactsViewModel add error: \(error)")
+        }
     }
 
     var emptyContent: EmptyContentTypeViewModel {

--- a/ios/Features/Contacts/Tests/ContactsTests/ManageContactViewModelTests.swift
+++ b/ios/Features/Contacts/Tests/ContactsTests/ManageContactViewModelTests.swift
@@ -53,7 +53,6 @@ extension ManageContactViewModel {
             service: ContactService(store: .mock(), addressStore: .mock()),
             nameService: nameService,
             mode: mode,
-            onComplete: nil,
         )
     }
 }

--- a/ios/Features/Transactions/Sources/ItemModels/TransactionParticipantItemModel.swift
+++ b/ios/Features/Transactions/Sources/ItemModels/TransactionParticipantItemModel.swift
@@ -9,15 +9,18 @@ public struct TransactionParticipantItemModel {
     public let title: String
     public let account: SimpleAccount
     public let addressLink: BlockExplorerLink
+    public let onAddContact: ((AddContactType) -> Void)?
 
     public init(
         title: String,
         account: SimpleAccount,
         addressLink: BlockExplorerLink,
+        onAddContact: ((AddContactType) -> Void)? = nil,
     ) {
         self.title = title
         self.account = account
         self.addressLink = addressLink
+        self.onAddContact = onAddContact
     }
 
     public var addressViewModel: AddressListItemViewModel {
@@ -26,6 +29,7 @@ public struct TransactionParticipantItemModel {
             account: account,
             mode: .nameOrAddress,
             addressLink: addressLink,
+            onAddContact: onAddContact,
         )
     }
 }

--- a/ios/Features/Transactions/Sources/Types/TransactionsSheetType.swift
+++ b/ios/Features/Transactions/Sources/Types/TransactionsSheetType.swift
@@ -2,15 +2,18 @@
 
 import Foundation
 import Primitives
+import PrimitivesComponents
 
 public enum TransactionsSheetType: Identifiable {
     case filter
     case selectAsset(SelectAssetType)
+    case addContact(AddContactType)
 
     public var id: String {
         switch self {
         case .filter: "filter"
         case let .selectAsset(type): "selectAsset-\(type.id)"
+        case let .addContact(type): "addContact-\(type.id)"
         }
     }
 }

--- a/ios/Features/Transactions/Sources/ViewModels/TransactionParticipantViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionParticipantViewModel.swift
@@ -8,9 +8,14 @@ import PrimitivesComponents
 
 struct TransactionParticipantViewModel {
     private let transactionViewModel: TransactionViewModel
+    private let onAddContact: ((AddContactType) -> Void)?
 
-    init(transactionViewModel: TransactionViewModel) {
+    init(
+        transactionViewModel: TransactionViewModel,
+        onAddContact: ((AddContactType) -> Void)? = nil,
+    ) {
         self.transactionViewModel = transactionViewModel
+        self.onAddContact = onAddContact
     }
 }
 
@@ -43,6 +48,7 @@ extension TransactionParticipantViewModel {
             name: addressName?.name,
             chain: chain,
             address: address,
+            memo: transactionViewModel.transaction.transaction.memo,
             assetImage: nil,
             addressType: addressName?.type,
         )
@@ -52,8 +58,15 @@ extension TransactionParticipantViewModel {
                 title: participantTitle,
                 account: account,
                 addressLink: transactionViewModel.addressLink(account: account),
+                onAddContact: canAddContact(addressName: addressName) ? onAddContact : nil,
             ),
         )
+    }
+
+    private func canAddContact(addressName: AddressName?) -> Bool {
+        guard addressName == nil else { return false }
+        let type = transactionViewModel.transaction.transaction.type
+        return type == .transfer || type == .transferNFT
     }
 
     private var resourceItemModel: TransactionItemModel {

--- a/ios/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
@@ -18,6 +18,7 @@ public final class TransactionSceneViewModel {
     private let preferences: Preferences
     private let explorerService: ExplorerService
     private let onHeaderAction: ((TransactionHeaderAction) -> Void)?
+    private let onAddContact: ((AddContactType) -> Void)?
 
     public let query: ObservableQuery<TransactionRequest>
     var transactionExtended: TransactionExtended {
@@ -33,10 +34,12 @@ public final class TransactionSceneViewModel {
         preferences: Preferences = Preferences.standard,
         explorerService: ExplorerService = ExplorerService.standard,
         onHeaderAction: ((TransactionHeaderAction) -> Void)? = nil,
+        onAddContact: ((AddContactType) -> Void)? = nil,
     ) {
         self.preferences = preferences
         self.explorerService = explorerService
         self.onHeaderAction = onHeaderAction
+        self.onAddContact = onAddContact
         query = ObservableQuery(TransactionRequest(walletId: walletId, transactionId: transaction.transaction.id), initialValue: transaction)
     }
 
@@ -75,7 +78,7 @@ extension TransactionSceneViewModel: ListSectionProvideable {
         case .swapButton: TransactionSwapButtonViewModel(metadata: model.transaction.transaction.metadata?.decode(TransactionSwapMetadata.self), state: model.transaction.transaction.state)
         case .date: TransactionDateViewModel(date: model.transaction.transaction.createdAt)
         case .status: TransactionStatusViewModel(state: model.transaction.transaction.state, onInfoAction: onSelectStatusInfo)
-        case .participant: TransactionParticipantViewModel(transactionViewModel: model)
+        case .participant: TransactionParticipantViewModel(transactionViewModel: model, onAddContact: onAddContact)
         case .memo: TransactionMemoViewModel(transaction: model.transaction.transaction)
         case .rate: TransactionRateViewModel(transaction: model.transaction, direction: rateDirection)
         case .network: TransactionNetworkViewModel(chain: model.transaction.asset.chain)

--- a/ios/Features/Transfer/Sources/Types/ConfirmTransferSheetType.swift
+++ b/ios/Features/Transfer/Sources/Types/ConfirmTransferSheetType.swift
@@ -14,7 +14,7 @@ public enum ConfirmTransferSheetType: Identifiable, Sendable {
     case fiatConnect(assetAddress: AssetAddress, wallet: Wallet)
     case swapDetails
     case perpetualDetails(PerpetualDetailsViewModel)
-    case addContact(ChainRecipient)
+    case addContact(AddContactType)
 
     public var id: String {
         switch self {
@@ -25,7 +25,7 @@ public enum ConfirmTransferSheetType: Identifiable, Sendable {
         case .fiatConnect: "fiat-connect"
         case .swapDetails: "swap-details"
         case let .perpetualDetails(model): "perpetual-details-\(model.id)"
-        case let .addContact(input): "add-contact-\(input.chain.rawValue)-\(input.recipient.address)"
+        case let .addContact(type): "add-contact-\(type.id)"
         }
     }
 }

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmRecipientViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmRecipientViewModel.swift
@@ -10,13 +10,13 @@ struct ConfirmRecipientViewModel {
     private let model: TransferDataViewModel
     private let addressName: AddressName?
     private let addressLink: BlockExplorerLink
-    private let onAddContact: VoidAction
+    private let onAddContact: ((AddContactType) -> Void)?
 
     init(
         model: TransferDataViewModel,
         addressName: AddressName?,
         addressLink: BlockExplorerLink,
-        onAddContact: VoidAction = nil,
+        onAddContact: ((AddContactType) -> Void)? = nil,
     ) {
         self.model = model
         self.addressName = addressName
@@ -37,6 +37,7 @@ extension ConfirmRecipientViewModel: ItemModelProvidable {
                     name: addressName?.name ?? model.recipient.name,
                     chain: model.chain,
                     address: model.recipient.address,
+                    memo: model.recipient.memo,
                     assetImage: addressNameImage,
                     addressType: addressName?.type,
                 ),

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
@@ -358,8 +358,8 @@ extension ConfirmTransferSceneViewModel {
         isPresentingSheet = .perpetualDetails(model)
     }
 
-    func onSelectAddRecipientToContacts() {
-        isPresentingSheet = .addContact(ChainRecipient(recipient: dataModel.recipient, chain: dataModel.chain))
+    func onSelectAddRecipientToContacts(_ action: AddContactType) {
+        isPresentingSheet = .addContact(action)
     }
 
     func onChangeFeePriority() {

--- a/ios/Features/WalletTab/Sources/Types/WalletSheetType.swift
+++ b/ios/Features/WalletTab/Sources/Types/WalletSheetType.swift
@@ -14,6 +14,7 @@ public enum WalletSheetType: Identifiable, Equatable, Sendable {
     case setPriceAlert(Asset)
     case addAsset
     case portfolio(PortfolioType)
+    case addContact(AddContactType)
 
     public var id: String {
         switch self {
@@ -25,6 +26,7 @@ public enum WalletSheetType: Identifiable, Equatable, Sendable {
         case let .setPriceAlert(asset): "setPriceAlert-\(asset.id.identifier)"
         case .addAsset: "addAsset"
         case let .portfolio(type): "portfolio-\(type.id)"
+        case let .addContact(type): "addContact-\(type.id)"
         }
     }
 }

--- a/ios/Gem.xcodeproj/project.pbxproj
+++ b/ios/Gem.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		B66AFC6C2DDB260A0082C026 /* AppService in Frameworks */ = {isa = PBXBuildFile; productRef = B66AFC6B2DDB260A0082C026 /* AppService */; };
 		B66DEDB02D49F0EA00309D53 /* ImageGalleryService in Frameworks */ = {isa = PBXBuildFile; productRef = B66DEDAF2D49F0EA00309D53 /* ImageGalleryService */; };
 		B67ED5472DDB5DCC009F74E6 /* NavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67ED5462DDB5DCC009F74E6 /* NavigationHandler.swift */; };
+		FADEC0DE000000000000B002 /* AddContactNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADEC0DE000000000000B001 /* AddContactNavigationView.swift */; };
 		B67ED5482DDB5DCD009F74E6 /* NavigationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67ED5492DDB5DCD009F74E6 /* NavigationPresenter.swift */; };
 		B68058312ED9C6F7001273D6 /* XCTestCase+GemUITestsAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B680582E2ED9C6F7001273D6 /* XCTestCase+GemUITestsAppTests.swift */; };
 		B68058322ED9C6F7001273D6 /* XCUIApplication+GemUITestsAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B680582F2ED9C6F7001273D6 /* XCUIApplication+GemUITestsAppTests.swift */; };
@@ -225,6 +226,7 @@
 		B604C2E72F3F537800CBAFDC /* Contacts */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Contacts; sourceTree = "<group>"; };
 		B67B3EEE2EFD25A6007AFA9C /* EventPresenterService */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = EventPresenterService; sourceTree = "<group>"; };
 		B67ED5462DDB5DCC009F74E6 /* NavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationHandler.swift; sourceTree = "<group>"; };
+		FADEC0DE000000000000B001 /* AddContactNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddContactNavigationView.swift; sourceTree = "<group>"; };
 		B67ED5492DDB5DCD009F74E6 /* NavigationPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationPresenter.swift; sourceTree = "<group>"; };
 		B680582E2ED9C6F7001273D6 /* XCTestCase+GemUITestsAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+GemUITestsAppTests.swift"; sourceTree = "<group>"; };
 		B680582F2ED9C6F7001273D6 /* XCUIApplication+GemUITestsAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+GemUITestsAppTests.swift"; sourceTree = "<group>"; };
@@ -495,6 +497,7 @@
 				830FDA442C224316003DA605 /* NavigationStateManager.swift */,
 				B67ED5462DDB5DCC009F74E6 /* NavigationHandler.swift */,
 				B67ED5492DDB5DCD009F74E6 /* NavigationPresenter.swift */,
+				FADEC0DE000000000000B001 /* AddContactNavigationView.swift */,
 				D83BDCB62E3E878A00E41807 /* Perpetuals */,
 			);
 			path = Navigation;
@@ -1166,6 +1169,7 @@
 				D873DA512D7933AF0003F5CE /* MarketsNavigtionStack.swift in Sources */,
 				83B57FAB2CFF92670009319F /* AppResolver.swift in Sources */,
 				B67ED5472DDB5DCC009F74E6 /* NavigationHandler.swift in Sources */,
+				FADEC0DE000000000000B002 /* AddContactNavigationView.swift in Sources */,
 				B67ED5482DDB5DCD009F74E6 /* NavigationPresenter.swift in Sources */,
 				C366790A2A0B7E5800F1D74D /* Environment.swift in Sources */,
 				837A1E6D2D0B096600733AC1 /* WalletConnectorNavigationStack.swift in Sources */,

--- a/ios/Gem/Navigation/AddContactNavigationView.swift
+++ b/ios/Gem/Navigation/AddContactNavigationView.swift
@@ -1,0 +1,29 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Components
+import Contacts
+import ContactService
+import PrimitivesComponents
+import Style
+import SwiftUI
+
+struct AddContactNavigationView: View {
+    @Environment(\.contactService) private var contactService
+    @Environment(\.nameService) private var nameService
+
+    let action: AddContactType
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch action {
+                case let .new(recipient):
+                    ManageContactScene(model: ManageContactViewModel(service: contactService, nameService: nameService, mode: .add(recipient)))
+                case let .existing(recipient):
+                    ContactsNavigationView(model: ContactsViewModel(service: contactService, nameService: nameService, mode: .addAddress(recipient)))
+                }
+            }
+            .toolbarDismissItem(type: .close, placement: .cancellationAction)
+        }
+    }
+}

--- a/ios/Gem/Navigation/Settings/SettingsNavigationStack.swift
+++ b/ios/Gem/Navigation/Settings/SettingsNavigationStack.swift
@@ -196,7 +196,6 @@ struct SettingsNavigationStack: View {
             .navigationDestination(for: Scenes.Contacts.self) { _ in
                 ContactsNavigationView(
                     model: ContactsViewModel(service: contactService, nameService: nameService),
-                    navigationPath: navigationPath,
                 )
             }
             .sheet(isPresented: $isPresentingWallets) {

--- a/ios/Gem/Navigation/Transactions/TransactionsNavigationStack.swift
+++ b/ios/Gem/Navigation/Transactions/TransactionsNavigationStack.swift
@@ -58,6 +58,7 @@ struct TransactionsNavigationStack: View {
                             transaction: $0.transaction,
                             walletId: model.wallet.id,
                             onHeaderAction: onSelectTransactionHeaderAction,
+                            onAddContact: { model.isPresentingSheet = .addContact($0) },
                         ),
                     )
                 }
@@ -93,6 +94,8 @@ struct TransactionsNavigationStack: View {
                                 activityService: activityService,
                             ),
                         )
+                    case let .addContact(action):
+                        AddContactNavigationView(action: action)
                     }
                 }
         }

--- a/ios/Gem/Navigation/Transfer/ConfirmTransferNavigationView.swift
+++ b/ios/Gem/Navigation/Transfer/ConfirmTransferNavigationView.swift
@@ -1,7 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Components
-import Contacts
 import FiatConnect
 import InfoSheet
 import Perpetuals
@@ -14,8 +13,6 @@ import Transfer
 
 struct ConfirmTransferNavigationView: View {
     @Environment(\.viewModelFactory) private var viewModelFactory
-    @Environment(\.contactService) private var contactService
-    @Environment(\.nameService) private var nameService
 
     @State var model: ConfirmTransferSceneViewModel
 
@@ -62,17 +59,8 @@ struct ConfirmTransferNavigationView: View {
                             .presentationDetentsForCurrentDeviceSize(expandable: true)
                             .presentationBackground(Colors.grayBackground)
                     }
-                case let .addContact(input):
-                    NavigationStack {
-                        ManageContactScene(
-                            model: ManageContactViewModel(
-                                service: contactService,
-                                nameService: nameService,
-                                mode: .add(input),
-                            ),
-                        )
-                        .toolbarDismissItem(type: .close, placement: .cancellationAction)
-                    }
+                case let .addContact(action):
+                    AddContactNavigationView(action: action)
                 }
             }
     }

--- a/ios/Gem/Navigation/Wallet/WalletNavigationStack.swift
+++ b/ios/Gem/Navigation/Wallet/WalletNavigationStack.swift
@@ -117,6 +117,7 @@ struct WalletNavigationStack: View {
                         transaction: $0.transaction,
                         walletId: model.wallet.id,
                         onHeaderAction: onSelectTransactionHeaderAction,
+                        onAddContact: { model.isPresentingSheet = .addContact($0) },
                     ),
                 )
             }
@@ -242,6 +243,8 @@ struct WalletNavigationStack: View {
                                 defaultType: defaultType,
                             ),
                         )
+                    case let .addContact(action):
+                        AddContactNavigationView(action: action)
                     }
                 }
                 .id(sheet.id)

--- a/ios/Packages/Localization/Sources/Localized.swift
+++ b/ios/Packages/Localization/Sources/Localized.swift
@@ -337,8 +337,8 @@ public enum Localized {
     public static let addresses = Localized.tr("Localizable", "contacts.addresses", fallback: "Addresses")
     /// Contact
     public static let contact = Localized.tr("Localizable", "contacts.contact", fallback: "Contact")
-    /// Create Contact
-    public static let createNewContact = Localized.tr("Localizable", "contacts.create_new_contact", fallback: "Create Contact")
+    /// Create New Contact
+    public static let createNewContact = Localized.tr("Localizable", "contacts.create_new_contact", fallback: "Create New Contact")
     /// Contacts
     public static let title = Localized.tr("Localizable", "contacts.title", fallback: "Contacts")
     public enum State {

--- a/ios/Packages/Localization/Sources/Localized.swift
+++ b/ios/Packages/Localization/Sources/Localized.swift
@@ -331,12 +331,14 @@ public enum Localized {
     public static let warning = Localized.tr("Localizable", "common.warning", fallback: "Warning")
   }
   public enum Contacts {
-    /// Add to Contacts
-    public static let addToContacts = Localized.tr("Localizable", "contacts.add_to_contacts", fallback: "Add to Contacts")
+    /// Add to Contact
+    public static let addToExistingContact = Localized.tr("Localizable", "contacts.add_to_existing_contact", fallback: "Add to Contact")
     /// Addresses
     public static let addresses = Localized.tr("Localizable", "contacts.addresses", fallback: "Addresses")
     /// Contact
     public static let contact = Localized.tr("Localizable", "contacts.contact", fallback: "Contact")
+    /// Create Contact
+    public static let createNewContact = Localized.tr("Localizable", "contacts.create_new_contact", fallback: "Create Contact")
     /// Contacts
     public static let title = Localized.tr("Localizable", "contacts.title", fallback: "Contacts")
     public enum State {

--- a/ios/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "العناوين";
 "contacts.state.empty.title" = "لا توجد جهات اتصال";
 "contacts.state.empty.description" = "احفظ عناوينك التي تستخدمها بشكل متكرر";
-"contacts.add_to_contacts" = "أضف إلى جهات الاتصال";
+"contacts.create_new_contact" = "إنشاء جهة اتصال";
+"contacts.add_to_existing_contact" = "إضافة إلى جهة اتصال";
 "simulation.header.unlimited_asset" = "غير محدود %@";
 "simulation.warning.unlimited_token_approval.description" = "يمنح هذا المُنفِق إمكانية استخدام هذا الرمز المميز حتى تقوم بإلغاء الموافقة أو تنتهي صلاحيته.";
 "simulation.warning_externally_owned_spender_description" = "تسمح هذه الموافقة لعنوان محفظة عادي (EOA) باستخدام أصولك. أكّد فقط إذا كنت تثق بهذا العنوان.";

--- a/ios/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "العناوين";
 "contacts.state.empty.title" = "لا توجد جهات اتصال";
 "contacts.state.empty.description" = "احفظ عناوينك التي تستخدمها بشكل متكرر";
-"contacts.create_new_contact" = "إنشاء جهة اتصال";
+"contacts.create_new_contact" = "إنشاء جهة اتصال جديدة";
 "contacts.add_to_existing_contact" = "إضافة إلى جهة اتصال";
 "simulation.header.unlimited_asset" = "غير محدود %@";
 "simulation.warning.unlimited_token_approval.description" = "يمنح هذا المُنفِق إمكانية استخدام هذا الرمز المميز حتى تقوم بإلغاء الموافقة أو تنتهي صلاحيته.";

--- a/ios/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "ঠিকানা";
 "contacts.state.empty.title" = "কোনও পরিচিতি নেই";
 "contacts.state.empty.description" = "আপনার ঘন ঘন ব্যবহৃত ঠিকানাগুলি সংরক্ষণ করুন";
-"contacts.add_to_contacts" = "পরিচিতিতে যোগ করুন";
+"contacts.create_new_contact" = "পরিচিতি তৈরি করুন";
+"contacts.add_to_existing_contact" = "পরিচিতিতে যোগ করুন";
 "simulation.header.unlimited_asset" = "সীমাহীন %@";
 "simulation.warning.unlimited_token_approval.description" = "এটি ব্যয়কারীকে এই টোকেনটি ব্যবহার করার অনুমতি দেয় যতক্ষণ না আপনি অনুমোদন প্রত্যাহার করেন অথবা এটির মেয়াদ শেষ হয়ে যায়।";
 "simulation.warning_externally_owned_spender_description" = "এই অনুমোদন একটি সাধারণ ওয়ালেট ঠিকানাকে (EOA) আপনার সম্পদ ব্যবহার করতে দেয়। আপনি এই ঠিকানাকে বিশ্বাস করলেই নিশ্চিত করুন।";

--- a/ios/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "ঠিকানা";
 "contacts.state.empty.title" = "কোনও পরিচিতি নেই";
 "contacts.state.empty.description" = "আপনার ঘন ঘন ব্যবহৃত ঠিকানাগুলি সংরক্ষণ করুন";
-"contacts.create_new_contact" = "পরিচিতি তৈরি করুন";
+"contacts.create_new_contact" = "নতুন পরিচিতি তৈরি করুন";
 "contacts.add_to_existing_contact" = "পরিচিতিতে যোগ করুন";
 "simulation.header.unlimited_asset" = "সীমাহীন %@";
 "simulation.warning.unlimited_token_approval.description" = "এটি ব্যয়কারীকে এই টোকেনটি ব্যবহার করার অনুমতি দেয় যতক্ষণ না আপনি অনুমোদন প্রত্যাহার করেন অথবা এটির মেয়াদ শেষ হয়ে যায়।";

--- a/ios/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Adresy";
 "contacts.state.empty.title" = "Žádné kontakty";
 "contacts.state.empty.description" = "Uložte si často používané adresy";
-"contacts.add_to_contacts" = "Přidat do kontaktů";
+"contacts.create_new_contact" = "Vytvořit kontakt";
+"contacts.add_to_existing_contact" = "Přidat ke kontaktu";
 "simulation.header.unlimited_asset" = "Neomezený %@";
 "simulation.warning.unlimited_token_approval.description" = "To dává utrácející adrese přístup k používání tohoto tokenu, dokud schválení nezrušíte nebo dokud nevyprší jeho platnost.";
 "simulation.warning_externally_owned_spender_description" = "Toto schválení umožní běžné adrese peněženky (EOA) používat vaše aktiva. Potvrďte pouze tehdy, pokud této adrese důvěřujete.";

--- a/ios/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Adresy";
 "contacts.state.empty.title" = "Žádné kontakty";
 "contacts.state.empty.description" = "Uložte si často používané adresy";
-"contacts.create_new_contact" = "Vytvořit kontakt";
+"contacts.create_new_contact" = "Vytvořit nový kontakt";
 "contacts.add_to_existing_contact" = "Přidat ke kontaktu";
 "simulation.header.unlimited_asset" = "Neomezený %@";
 "simulation.warning.unlimited_token_approval.description" = "To dává utrácející adrese přístup k používání tohoto tokenu, dokud schválení nezrušíte nebo dokud nevyprší jeho platnost.";

--- a/ios/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Adresser";
 "contacts.state.empty.title" = "Ingen kontakter";
 "contacts.state.empty.description" = "Gem dine ofte brugte adresser";
-"contacts.create_new_contact" = "Opret kontakt";
+"contacts.create_new_contact" = "Opret ny kontakt";
 "contacts.add_to_existing_contact" = "Føj til kontakt";
 "simulation.header.unlimited_asset" = "Ubegrænset %@";
 "simulation.warning.unlimited_token_approval.description" = "Dette giver brugeren adgang til at bruge denne token, indtil du tilbagekalder godkendelsen, eller den udløber.";

--- a/ios/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Adresser";
 "contacts.state.empty.title" = "Ingen kontakter";
 "contacts.state.empty.description" = "Gem dine ofte brugte adresser";
-"contacts.add_to_contacts" = "Føj til Kontakter";
+"contacts.create_new_contact" = "Opret kontakt";
+"contacts.add_to_existing_contact" = "Føj til kontakt";
 "simulation.header.unlimited_asset" = "Ubegrænset %@";
 "simulation.warning.unlimited_token_approval.description" = "Dette giver brugeren adgang til at bruge denne token, indtil du tilbagekalder godkendelsen, eller den udløber.";
 "simulation.warning_externally_owned_spender_description" = "Denne godkendelse lader en almindelig walletadresse (EOA) bruge dine aktiver. Bekræft kun, hvis du har tillid til denne adresse.";

--- a/ios/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Adressen";
 "contacts.state.empty.title" = "Keine Kontakte";
 "contacts.state.empty.description" = "Speichern Sie Ihre häufig verwendeten Adressen";
-"contacts.add_to_contacts" = "Zu Kontakten hinzufügen";
+"contacts.create_new_contact" = "Kontakt erstellen";
+"contacts.add_to_existing_contact" = "Zu Kontakt hinzufügen";
 "simulation.header.unlimited_asset" = "Unbegrenzt %@";
 "simulation.warning.unlimited_token_approval.description" = "Dadurch erhält der Ausgeber Zugriff auf dieses Token, bis Sie die Genehmigung widerrufen oder es abläuft.";
 "simulation.warning_externally_owned_spender_description" = "Diese Genehmigung erlaubt einer normalen Wallet-Adresse (EOA), Ihre Assets zu verwenden. Bestätigen Sie nur, wenn Sie dieser Adresse vertrauen.";

--- a/ios/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Adressen";
 "contacts.state.empty.title" = "Keine Kontakte";
 "contacts.state.empty.description" = "Speichern Sie Ihre häufig verwendeten Adressen";
-"contacts.create_new_contact" = "Kontakt erstellen";
+"contacts.create_new_contact" = "Neuen Kontakt erstellen";
 "contacts.add_to_existing_contact" = "Zu Kontakt hinzufügen";
 "simulation.header.unlimited_asset" = "Unbegrenzt %@";
 "simulation.warning.unlimited_token_approval.description" = "Dadurch erhält der Ausgeber Zugriff auf dieses Token, bis Sie die Genehmigung widerrufen oder es abläuft.";

--- a/ios/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Addresses";
 "contacts.state.empty.title" = "No Contacts";
 "contacts.state.empty.description" = "Save your frequently used addresses";
-"contacts.create_new_contact" = "Create Contact";
+"contacts.create_new_contact" = "Create New Contact";
 "contacts.add_to_existing_contact" = "Add to Contact";
 "simulation.header.unlimited_asset" = "Unlimited %@";
 "simulation.warning.unlimited_token_approval.description" = "This gives the spender access to use this token until you revoke the approval or it expires.";

--- a/ios/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Addresses";
 "contacts.state.empty.title" = "No Contacts";
 "contacts.state.empty.description" = "Save your frequently used addresses";
-"contacts.add_to_contacts" = "Add to Contacts";
+"contacts.create_new_contact" = "Create Contact";
+"contacts.add_to_existing_contact" = "Add to Contact";
 "simulation.header.unlimited_asset" = "Unlimited %@";
 "simulation.warning.unlimited_token_approval.description" = "This gives the spender access to use this token until you revoke the approval or it expires.";
 "simulation.warning_externally_owned_spender_description" = "This approval lets a regular wallet address (EOA) use your assets. Confirm only if you trust this address.";

--- a/ios/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Direcciones";
 "contacts.state.empty.title" = "Sin contactos";
 "contacts.state.empty.description" = "Guarde sus direcciones de uso frecuente";
-"contacts.add_to_contacts" = "Añadir a contactos";
+"contacts.create_new_contact" = "Crear contacto";
+"contacts.add_to_existing_contact" = "Añadir a un contacto";
 "simulation.header.unlimited_asset" = "Ilimitado %@";
 "simulation.warning.unlimited_token_approval.description" = "Esto le da al gastador acceso para usar este token hasta que revoque la aprobación o expire.";
 "simulation.warning_externally_owned_spender_description" = "Esta aprobación permite que una dirección de billetera normal (EOA) use tus activos. Confirma solo si confías en esta dirección.";

--- a/ios/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Direcciones";
 "contacts.state.empty.title" = "Sin contactos";
 "contacts.state.empty.description" = "Guarde sus direcciones de uso frecuente";
-"contacts.create_new_contact" = "Crear contacto";
+"contacts.create_new_contact" = "Crear nuevo contacto";
 "contacts.add_to_existing_contact" = "Añadir a un contacto";
 "simulation.header.unlimited_asset" = "Ilimitado %@";
 "simulation.warning.unlimited_token_approval.description" = "Esto le da al gastador acceso para usar este token hasta que revoque la aprobación o expire.";

--- a/ios/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "آدرس‌ها";
 "contacts.state.empty.title" = "بدون مخاطب";
 "contacts.state.empty.description" = "آدرس‌های پرکاربرد خود را ذخیره کنید";
-"contacts.add_to_contacts" = "اضافه کردن به مخاطبین";
+"contacts.create_new_contact" = "ایجاد مخاطب";
+"contacts.add_to_existing_contact" = "افزودن به مخاطب";
 "simulation.header.unlimited_asset" = "نامحدود %@";
 "simulation.warning.unlimited_token_approval.description" = "این به خرج‌کننده دسترسی می‌دهد تا زمانی که تأییدیه را لغو کنید یا منقضی شود، از این توکن استفاده کند.";
 "simulation.warning_externally_owned_spender_description" = "این تأییدیه به یک آدرس کیف پول معمولی (EOA) اجازه می‌دهد از دارایی‌های شما استفاده کند. فقط اگر به این آدرس اعتماد دارید تأیید کنید.";

--- a/ios/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "آدرس‌ها";
 "contacts.state.empty.title" = "بدون مخاطب";
 "contacts.state.empty.description" = "آدرس‌های پرکاربرد خود را ذخیره کنید";
-"contacts.create_new_contact" = "ایجاد مخاطب";
+"contacts.create_new_contact" = "ایجاد مخاطب جدید";
 "contacts.add_to_existing_contact" = "افزودن به مخاطب";
 "simulation.header.unlimited_asset" = "نامحدود %@";
 "simulation.warning.unlimited_token_approval.description" = "این به خرج‌کننده دسترسی می‌دهد تا زمانی که تأییدیه را لغو کنید یا منقضی شود، از این توکن استفاده کند.";

--- a/ios/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Mga Address";
 "contacts.state.empty.title" = "Walang Mga Kontak";
 "contacts.state.empty.description" = "I-save ang iyong mga madalas gamiting address";
-"contacts.create_new_contact" = "Gumawa ng Contact";
+"contacts.create_new_contact" = "Gumawa ng Bagong Contact";
 "contacts.add_to_existing_contact" = "Idagdag sa Contact";
 "simulation.header.unlimited_asset" = "Walang limitasyon %@";
 "simulation.warning.unlimited_token_approval.description" = "Nagbibigay ito sa gumagastos ng access na gamitin ang token na ito hanggang sa bawiin mo ang pag-apruba o hanggang sa mag-expire ito.";

--- a/ios/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Mga Address";
 "contacts.state.empty.title" = "Walang Mga Kontak";
 "contacts.state.empty.description" = "I-save ang iyong mga madalas gamiting address";
-"contacts.add_to_contacts" = "Idagdag sa Mga Kontak";
+"contacts.create_new_contact" = "Gumawa ng Contact";
+"contacts.add_to_existing_contact" = "Idagdag sa Contact";
 "simulation.header.unlimited_asset" = "Walang limitasyon %@";
 "simulation.warning.unlimited_token_approval.description" = "Nagbibigay ito sa gumagastos ng access na gamitin ang token na ito hanggang sa bawiin mo ang pag-apruba o hanggang sa mag-expire ito.";
 "simulation.warning_externally_owned_spender_description" = "Hinahayaan ng pag-aprubang ito ang isang karaniwang wallet address (EOA) na gamitin ang iyong mga asset. Kumpirmahin lang kung pinagkakatiwalaan mo ang address na ito.";

--- a/ios/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Adresses";
 "contacts.state.empty.title" = "Aucun contact";
 "contacts.state.empty.description" = "Enregistrez vos adresses fréquemment utilisées";
-"contacts.create_new_contact" = "Créer un contact";
+"contacts.create_new_contact" = "Créer un nouveau contact";
 "contacts.add_to_existing_contact" = "Ajouter à un contact";
 "simulation.header.unlimited_asset" = "Illimité %@";
 "simulation.warning.unlimited_token_approval.description" = "Cela donne au détenteur du jeton l'accès à utiliser jusqu'à ce que vous révoquiez l'autorisation ou que celle-ci expire.";

--- a/ios/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Adresses";
 "contacts.state.empty.title" = "Aucun contact";
 "contacts.state.empty.description" = "Enregistrez vos adresses fréquemment utilisées";
-"contacts.add_to_contacts" = "Ajouter aux contacts";
+"contacts.create_new_contact" = "Créer un contact";
+"contacts.add_to_existing_contact" = "Ajouter à un contact";
 "simulation.header.unlimited_asset" = "Illimité %@";
 "simulation.warning.unlimited_token_approval.description" = "Cela donne au détenteur du jeton l'accès à utiliser jusqu'à ce que vous révoquiez l'autorisation ou que celle-ci expire.";
 "simulation.warning_externally_owned_spender_description" = "Cette approbation permet à une adresse de portefeuille classique (EOA) d’utiliser vos actifs. Confirmez uniquement si vous faites confiance à cette adresse.";

--- a/ios/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Adiresoshi";
 "contacts.state.empty.title" = "Babu Lambobin Sadarwa";
 "contacts.state.empty.description" = "Ajiye adiresoshin da ake yawan amfani da su";
-"contacts.create_new_contact" = "Ƙirƙiri lamba";
+"contacts.create_new_contact" = "Ƙirƙiri sabon lamba";
 "contacts.add_to_existing_contact" = "Ƙara zuwa lamba";
 "simulation.header.unlimited_asset" = "Unlimited %@";
 "simulation.warning.unlimited_token_approval.description" = "Wannan yana ba mai kashewa damar amfani da wannan alamar har sai kun soke amincewa ko kuma ta ƙare.";

--- a/ios/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Adiresoshi";
 "contacts.state.empty.title" = "Babu Lambobin Sadarwa";
 "contacts.state.empty.description" = "Ajiye adiresoshin da ake yawan amfani da su";
-"contacts.add_to_contacts" = "Ƙara zuwa Lambobin Sadarwa";
+"contacts.create_new_contact" = "Ƙirƙiri lamba";
+"contacts.add_to_existing_contact" = "Ƙara zuwa lamba";
 "simulation.header.unlimited_asset" = "Unlimited %@";
 "simulation.warning.unlimited_token_approval.description" = "Wannan yana ba mai kashewa damar amfani da wannan alamar har sai kun soke amincewa ko kuma ta ƙare.";
 "simulation.warning_externally_owned_spender_description" = "Wannan amincewar tana ba adireshin walat na yau da kullum (EOA) damar amfani da kadarorinku. Tabbatar kawai idan kun amince da wannan adireshin.";

--- a/ios/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "כתובות";
 "contacts.state.empty.title" = "אין אנשי קשר";
 "contacts.state.empty.description" = "שמור את הכתובות שאתה משתמש בהן לעתים קרובות";
-"contacts.add_to_contacts" = "הוסף לאנשי קשר";
+"contacts.create_new_contact" = "צור איש קשר";
+"contacts.add_to_existing_contact" = "הוסף לאיש קשר";
 "simulation.header.unlimited_asset" = "בִּלתִי מוּגבָּל %@";
 "simulation.warning.unlimited_token_approval.description" = "זה נותן למוציא גישה להשתמש באסימון זה עד שתבטל את האישור או שהוא יפוג תוקפו.";
 "simulation.warning_externally_owned_spender_description" = "אישור זה מאפשר לכתובת ארנק רגילה (EOA) להשתמש בנכסים שלך. אשר רק אם אתה סומך על כתובת זו.";

--- a/ios/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "כתובות";
 "contacts.state.empty.title" = "אין אנשי קשר";
 "contacts.state.empty.description" = "שמור את הכתובות שאתה משתמש בהן לעתים קרובות";
-"contacts.create_new_contact" = "צור איש קשר";
+"contacts.create_new_contact" = "צור איש קשר חדש";
 "contacts.add_to_existing_contact" = "הוסף לאיש קשר";
 "simulation.header.unlimited_asset" = "בִּלתִי מוּגבָּל %@";
 "simulation.warning.unlimited_token_approval.description" = "זה נותן למוציא גישה להשתמש באסימון זה עד שתבטל את האישור או שהוא יפוג תוקפו.";

--- a/ios/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "पतों";
 "contacts.state.empty.title" = "कोई संपर्क नहीं";
 "contacts.state.empty.description" = "अपने अक्सर इस्तेमाल होने वाले पतों को सेव करें";
-"contacts.add_to_contacts" = "संपर्क के खाते में जोड़ दे";
+"contacts.create_new_contact" = "संपर्क बनाएं";
+"contacts.add_to_existing_contact" = "संपर्क में जोड़ें";
 "simulation.header.unlimited_asset" = "असीमित %@";
 "simulation.warning.unlimited_token_approval.description" = "इससे खर्च करने वाले को इस टोकन का उपयोग तब तक करने की अनुमति मिलती है जब तक आप अनुमोदन रद्द नहीं कर देते या यह समाप्त नहीं हो जाता।";
 "simulation.warning_externally_owned_spender_description" = "यह स्वीकृति एक सामान्य वॉलेट पते (EOA) को आपकी संपत्तियों का उपयोग करने देती है। केवल तभी पुष्टि करें जब आप इस पते पर भरोसा करते हों।";

--- a/ios/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "पतों";
 "contacts.state.empty.title" = "कोई संपर्क नहीं";
 "contacts.state.empty.description" = "अपने अक्सर इस्तेमाल होने वाले पतों को सेव करें";
-"contacts.create_new_contact" = "संपर्क बनाएं";
+"contacts.create_new_contact" = "नया संपर्क बनाएं";
 "contacts.add_to_existing_contact" = "संपर्क में जोड़ें";
 "simulation.header.unlimited_asset" = "असीमित %@";
 "simulation.warning.unlimited_token_approval.description" = "इससे खर्च करने वाले को इस टोकन का उपयोग तब तक करने की अनुमति मिलती है जब तक आप अनुमोदन रद्द नहीं कर देते या यह समाप्त नहीं हो जाता।";

--- a/ios/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Alamat";
 "contacts.state.empty.title" = "Tidak ada kontak";
 "contacts.state.empty.description" = "Simpan alamat yang sering Anda gunakan.";
-"contacts.create_new_contact" = "Buat Kontak";
+"contacts.create_new_contact" = "Buat Kontak Baru";
 "contacts.add_to_existing_contact" = "Tambahkan ke Kontak";
 "simulation.header.unlimited_asset" = "Tak terbatas %@";
 "simulation.warning.unlimited_token_approval.description" = "Ini memberi pihak yang mengeluarkan dana akses untuk menggunakan token ini hingga Anda mencabut persetujuan atau token tersebut kedaluwarsa.";

--- a/ios/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Alamat";
 "contacts.state.empty.title" = "Tidak ada kontak";
 "contacts.state.empty.description" = "Simpan alamat yang sering Anda gunakan.";
-"contacts.add_to_contacts" = "Tambahkan ke Kontak";
+"contacts.create_new_contact" = "Buat Kontak";
+"contacts.add_to_existing_contact" = "Tambahkan ke Kontak";
 "simulation.header.unlimited_asset" = "Tak terbatas %@";
 "simulation.warning.unlimited_token_approval.description" = "Ini memberi pihak yang mengeluarkan dana akses untuk menggunakan token ini hingga Anda mencabut persetujuan atau token tersebut kedaluwarsa.";
 "simulation.warning_externally_owned_spender_description" = "Persetujuan ini memungkinkan alamat dompet biasa (EOA) menggunakan aset Anda. Konfirmasikan hanya jika Anda mempercayai alamat ini.";

--- a/ios/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Indirizzi";
 "contacts.state.empty.title" = "Nessun contatto";
 "contacts.state.empty.description" = "Salva gli indirizzi che usi più frequentemente";
-"contacts.add_to_contacts" = "Aggiungi ai contatti";
+"contacts.create_new_contact" = "Crea contatto";
+"contacts.add_to_existing_contact" = "Aggiungi a un contatto";
 "simulation.header.unlimited_asset" = "Illimitato %@";
 "simulation.warning.unlimited_token_approval.description" = "Ciò consente allo spender di utilizzare questo token finché non revochi l'approvazione o finché non scade.";
 "simulation.warning_externally_owned_spender_description" = "Questa approvazione consente a un normale indirizzo wallet (EOA) di usare i tuoi asset. Conferma solo se ti fidi di questo indirizzo.";

--- a/ios/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Indirizzi";
 "contacts.state.empty.title" = "Nessun contatto";
 "contacts.state.empty.description" = "Salva gli indirizzi che usi più frequentemente";
-"contacts.create_new_contact" = "Crea contatto";
+"contacts.create_new_contact" = "Crea nuovo contatto";
 "contacts.add_to_existing_contact" = "Aggiungi a un contatto";
 "simulation.header.unlimited_asset" = "Illimitato %@";
 "simulation.warning.unlimited_token_approval.description" = "Ciò consente allo spender di utilizzare questo token finché non revochi l'approvazione o finché non scade.";

--- a/ios/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "住所";
 "contacts.state.empty.title" = "連絡先なし";
 "contacts.state.empty.description" = "よく使うアドレスを保存する";
-"contacts.add_to_contacts" = "連絡先に追加";
+"contacts.create_new_contact" = "連絡先を作成";
+"contacts.add_to_existing_contact" = "連絡先に追加";
 "simulation.header.unlimited_asset" = "無制限 %@";
 "simulation.warning.unlimited_token_approval.description" = "これにより、承認を取り消すか期限が切れるまで、支出者はこのトークンを使用できるようになります。";
 "simulation.warning_externally_owned_spender_description" = "この承認により、通常のウォレットアドレス（EOA）があなたの資産を使用できるようになります。このアドレスを信頼できる場合のみ確認してください。";

--- a/ios/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "住所";
 "contacts.state.empty.title" = "連絡先なし";
 "contacts.state.empty.description" = "よく使うアドレスを保存する";
-"contacts.create_new_contact" = "連絡先を作成";
+"contacts.create_new_contact" = "新しい連絡先を作成";
 "contacts.add_to_existing_contact" = "連絡先に追加";
 "simulation.header.unlimited_asset" = "無制限 %@";
 "simulation.warning.unlimited_token_approval.description" = "これにより、承認を取り消すか期限が切れるまで、支出者はこのトークンを使用できるようになります。";

--- a/ios/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "구애";
 "contacts.state.empty.title" = "연락처 없음";
 "contacts.state.empty.description" = "자주 사용하는 주소를 저장하세요";
-"contacts.create_new_contact" = "연락처 만들기";
+"contacts.create_new_contact" = "새 연락처 만들기";
 "contacts.add_to_existing_contact" = "연락처에 추가";
 "simulation.header.unlimited_asset" = "제한 없는 %@";
 "simulation.warning.unlimited_token_approval.description" = "이렇게 하면 사용자가 승인을 취소하거나 만료될 때까지 해당 토큰을 사용할 수 있습니다.";

--- a/ios/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "구애";
 "contacts.state.empty.title" = "연락처 없음";
 "contacts.state.empty.description" = "자주 사용하는 주소를 저장하세요";
-"contacts.add_to_contacts" = "연락처에 추가";
+"contacts.create_new_contact" = "연락처 만들기";
+"contacts.add_to_existing_contact" = "연락처에 추가";
 "simulation.header.unlimited_asset" = "제한 없는 %@";
 "simulation.warning.unlimited_token_approval.description" = "이렇게 하면 사용자가 승인을 취소하거나 만료될 때까지 해당 토큰을 사용할 수 있습니다.";
 "simulation.warning_externally_owned_spender_description" = "이 승인은 일반 지갑 주소(EOA)가 내 자산을 사용할 수 있게 합니다. 이 주소를 신뢰하는 경우에만 확인하세요.";

--- a/ios/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Alamat";
 "contacts.state.empty.title" = "Tiada Kenalan";
 "contacts.state.empty.description" = "Simpan alamat yang kerap anda gunakan";
-"contacts.create_new_contact" = "Cipta Kenalan";
+"contacts.create_new_contact" = "Cipta Kenalan Baharu";
 "contacts.add_to_existing_contact" = "Tambah ke Kenalan";
 "simulation.header.unlimited_asset" = "Tidak terhad %@";
 "simulation.warning.unlimited_token_approval.description" = "Ini memberi pembeli akses untuk menggunakan token ini sehingga anda membatalkan kelulusan atau ia tamat tempoh.";

--- a/ios/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Alamat";
 "contacts.state.empty.title" = "Tiada Kenalan";
 "contacts.state.empty.description" = "Simpan alamat yang kerap anda gunakan";
-"contacts.add_to_contacts" = "Tambah ke Kenalan";
+"contacts.create_new_contact" = "Cipta Kenalan";
+"contacts.add_to_existing_contact" = "Tambah ke Kenalan";
 "simulation.header.unlimited_asset" = "Tidak terhad %@";
 "simulation.warning.unlimited_token_approval.description" = "Ini memberi pembeli akses untuk menggunakan token ini sehingga anda membatalkan kelulusan atau ia tamat tempoh.";
 "simulation.warning_externally_owned_spender_description" = "Kelulusan ini membenarkan alamat dompet biasa (EOA) menggunakan aset anda. Sahkan hanya jika anda mempercayai alamat ini.";

--- a/ios/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Adressen";
 "contacts.state.empty.title" = "Geen contacten";
 "contacts.state.empty.description" = "Bewaar uw veelgebruikte adressen.";
-"contacts.add_to_contacts" = "Toevoegen aan contacten";
+"contacts.create_new_contact" = "Contact maken";
+"contacts.add_to_existing_contact" = "Aan contact toevoegen";
 "simulation.header.unlimited_asset" = "Onbeperkt %@";
 "simulation.warning.unlimited_token_approval.description" = "Dit geeft de gebruiker toegang tot het gebruik van dit token totdat u de goedkeuring intrekt of het token verloopt.";
 "simulation.warning_externally_owned_spender_description" = "Met deze goedkeuring kan een gewoon walletadres (EOA) uw assets gebruiken. Bevestig alleen als u dit adres vertrouwt.";

--- a/ios/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Adressen";
 "contacts.state.empty.title" = "Geen contacten";
 "contacts.state.empty.description" = "Bewaar uw veelgebruikte adressen.";
-"contacts.create_new_contact" = "Contact maken";
+"contacts.create_new_contact" = "Nieuw contact maken";
 "contacts.add_to_existing_contact" = "Aan contact toevoegen";
 "simulation.header.unlimited_asset" = "Onbeperkt %@";
 "simulation.warning.unlimited_token_approval.description" = "Dit geeft de gebruiker toegang tot het gebruik van dit token totdat u de goedkeuring intrekt of het token verloopt.";

--- a/ios/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Adresy";
 "contacts.state.empty.title" = "Brak kontaktów";
 "contacts.state.empty.description" = "Zapisz często używane adresy";
-"contacts.add_to_contacts" = "Dodaj do kontaktów";
+"contacts.create_new_contact" = "Utwórz kontakt";
+"contacts.add_to_existing_contact" = "Dodaj do kontaktu";
 "simulation.header.unlimited_asset" = "Nieograniczony %@";
 "simulation.warning.unlimited_token_approval.description" = "Dzięki temu osoba wydająca token uzyskuje dostęp do jego wykorzystania do momentu odwołania zatwierdzenia lub wygaśnięcia.";
 "simulation.warning_externally_owned_spender_description" = "To zatwierdzenie pozwala zwykłemu adresowi portfela (EOA) używać Twoich aktywów. Potwierdź tylko wtedy, gdy ufasz temu adresowi.";

--- a/ios/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Adresy";
 "contacts.state.empty.title" = "Brak kontaktów";
 "contacts.state.empty.description" = "Zapisz często używane adresy";
-"contacts.create_new_contact" = "Utwórz kontakt";
+"contacts.create_new_contact" = "Utwórz nowy kontakt";
 "contacts.add_to_existing_contact" = "Dodaj do kontaktu";
 "simulation.header.unlimited_asset" = "Nieograniczony %@";
 "simulation.warning.unlimited_token_approval.description" = "Dzięki temu osoba wydająca token uzyskuje dostęp do jego wykorzystania do momentu odwołania zatwierdzenia lub wygaśnięcia.";

--- a/ios/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Endereços";
 "contacts.state.empty.title" = "Sem contatos";
 "contacts.state.empty.description" = "Salve seus endereços usados ​​com frequência.";
-"contacts.add_to_contacts" = "Adicionar aos contatos";
+"contacts.create_new_contact" = "Criar contato";
+"contacts.add_to_existing_contact" = "Adicionar a contato";
 "simulation.header.unlimited_asset" = "Ilimitado %@";
 "simulation.warning.unlimited_token_approval.description" = "Isso dá ao gastador acesso ao uso desse token até que você revogue a aprovação ou ele expire.";
 "simulation.warning_externally_owned_spender_description" = "Esta aprovação permite que um endereço de carteira comum (EOA) use seus ativos. Confirme somente se você confia neste endereço.";

--- a/ios/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Endereços";
 "contacts.state.empty.title" = "Sem contatos";
 "contacts.state.empty.description" = "Salve seus endereços usados ​​com frequência.";
-"contacts.create_new_contact" = "Criar contato";
+"contacts.create_new_contact" = "Criar novo contato";
 "contacts.add_to_existing_contact" = "Adicionar a contato";
 "simulation.header.unlimited_asset" = "Ilimitado %@";
 "simulation.warning.unlimited_token_approval.description" = "Isso dá ao gastador acesso ao uso desse token até que você revogue a aprovação ou ele expire.";

--- a/ios/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Adrese";
 "contacts.state.empty.title" = "Niciun contact";
 "contacts.state.empty.description" = "Salvați adresele utilizate frecvent";
-"contacts.add_to_contacts" = "Adăugați la Contacte";
+"contacts.create_new_contact" = "Creează un contact";
+"contacts.add_to_existing_contact" = "Adaugă la un contact";
 "simulation.header.unlimited_asset" = "Nelimitat %@";
 "simulation.warning.unlimited_token_approval.description" = "Aceasta îi oferă cheltuitorului acces la utilizarea acestui token până când îi revocați aprobarea sau expiră.";
 "simulation.warning_externally_owned_spender_description" = "Această aprobare permite unei adrese obișnuite de portofel (EOA) să folosească activele tale. Confirmă doar dacă ai încredere în această adresă.";

--- a/ios/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Adrese";
 "contacts.state.empty.title" = "Niciun contact";
 "contacts.state.empty.description" = "Salvați adresele utilizate frecvent";
-"contacts.create_new_contact" = "Creează un contact";
+"contacts.create_new_contact" = "Creează un contact nou";
 "contacts.add_to_existing_contact" = "Adaugă la un contact";
 "simulation.header.unlimited_asset" = "Nelimitat %@";
 "simulation.warning.unlimited_token_approval.description" = "Aceasta îi oferă cheltuitorului acces la utilizarea acestui token până când îi revocați aprobarea sau expiră.";

--- a/ios/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Адреса";
 "contacts.state.empty.title" = "Нет контактов";
 "contacts.state.empty.description" = "Сохраните часто используемые адреса.";
-"contacts.create_new_contact" = "Создать контакт";
+"contacts.create_new_contact" = "Создать новый контакт";
 "contacts.add_to_existing_contact" = "Добавить в контакт";
 "simulation.header.unlimited_asset" = "Без ограничений %@";
 "simulation.warning.unlimited_token_approval.description" = "Это даёт получателю одобрения доступ к использованию этого токена до тех пор, пока вы не отзовёте разрешение или оно не истечёт.";

--- a/ios/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Адреса";
 "contacts.state.empty.title" = "Нет контактов";
 "contacts.state.empty.description" = "Сохраните часто используемые адреса.";
-"contacts.add_to_contacts" = "Добавить в контакты";
+"contacts.create_new_contact" = "Создать контакт";
+"contacts.add_to_existing_contact" = "Добавить в контакт";
 "simulation.header.unlimited_asset" = "Без ограничений %@";
 "simulation.warning.unlimited_token_approval.description" = "Это даёт получателю одобрения доступ к использованию этого токена до тех пор, пока вы не отзовёте разрешение или оно не истечёт.";
 "simulation.warning_externally_owned_spender_description" = "Это разрешение позволяет обычному адресу кошелька (EOA) использовать ваши активы. Подтверждайте только если доверяете этому адресу.";

--- a/ios/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Anwani";
 "contacts.state.empty.title" = "Hakuna Anwani";
 "contacts.state.empty.description" = "Hifadhi anwani zako zinazotumiwa mara kwa mara";
-"contacts.create_new_contact" = "Unda anwani";
+"contacts.create_new_contact" = "Unda anwani mpya";
 "contacts.add_to_existing_contact" = "Ongeza kwa anwani";
 "simulation.header.unlimited_asset" = "Isiyo na kikomo %@";
 "simulation.warning.unlimited_token_approval.description" = "Hii inampa mtumiaji uwezo wa kutumia tokeni hii hadi utakapobatilisha idhini au itakapoisha muda wake.";

--- a/ios/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Anwani";
 "contacts.state.empty.title" = "Hakuna Anwani";
 "contacts.state.empty.description" = "Hifadhi anwani zako zinazotumiwa mara kwa mara";
-"contacts.add_to_contacts" = "Ongeza kwenye Anwani";
+"contacts.create_new_contact" = "Unda anwani";
+"contacts.add_to_existing_contact" = "Ongeza kwa anwani";
 "simulation.header.unlimited_asset" = "Isiyo na kikomo %@";
 "simulation.warning.unlimited_token_approval.description" = "Hii inampa mtumiaji uwezo wa kutumia tokeni hii hadi utakapobatilisha idhini au itakapoisha muda wake.";
 "simulation.warning_externally_owned_spender_description" = "Idhini hii inaruhusu anwani ya kawaida ya pochi (EOA) kutumia mali zako. Thibitisha tu ikiwa unaiamini anwani hii.";

--- a/ios/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "ที่อยู่";
 "contacts.state.empty.title" = "ไม่มีข้อมูลติดต่อ";
 "contacts.state.empty.description" = "บันทึกที่อยู่ที่คุณใช้งานบ่อย";
-"contacts.add_to_contacts" = "เพิ่มลงในรายชื่อติดต่อ";
+"contacts.create_new_contact" = "สร้างรายชื่อ";
+"contacts.add_to_existing_contact" = "เพิ่มในรายชื่อ";
 "simulation.header.unlimited_asset" = "ไม่จำกัด %@";
 "simulation.warning.unlimited_token_approval.description" = "สิ่งนี้ให้สิทธิ์ผู้ใช้จ่าย (spender) ในการใช้โทเค็นนี้จนกว่าคุณจะเพิกถอนการอนุมัติหรือโทเค็นหมดอายุ";
 "simulation.warning_externally_owned_spender_description" = "การอนุมัตินี้ทำให้ที่อยู่กระเป๋าเงินทั่วไป (EOA) สามารถใช้สินทรัพย์ของคุณได้ ยืนยันเฉพาะเมื่อคุณเชื่อถือที่อยู่นี้";

--- a/ios/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "ที่อยู่";
 "contacts.state.empty.title" = "ไม่มีข้อมูลติดต่อ";
 "contacts.state.empty.description" = "บันทึกที่อยู่ที่คุณใช้งานบ่อย";
-"contacts.create_new_contact" = "สร้างรายชื่อ";
+"contacts.create_new_contact" = "สร้างรายชื่อใหม่";
 "contacts.add_to_existing_contact" = "เพิ่มในรายชื่อ";
 "simulation.header.unlimited_asset" = "ไม่จำกัด %@";
 "simulation.warning.unlimited_token_approval.description" = "สิ่งนี้ให้สิทธิ์ผู้ใช้จ่าย (spender) ในการใช้โทเค็นนี้จนกว่าคุณจะเพิกถอนการอนุมัติหรือโทเค็นหมดอายุ";

--- a/ios/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Adresler";
 "contacts.state.empty.title" = "İletişim yok";
 "contacts.state.empty.description" = "Sık kullandığınız adresleri kaydedin.";
-"contacts.create_new_contact" = "Kişi Oluştur";
+"contacts.create_new_contact" = "Yeni Kişi Oluştur";
 "contacts.add_to_existing_contact" = "Kişiye Ekle";
 "simulation.header.unlimited_asset" = "Sınırsız %@";
 "simulation.warning.unlimited_token_approval.description" = "Bu, harcayan tarafa, siz onayı iptal edene veya süresi dolana kadar bu jetonu kullanma erişimi sağlar.";

--- a/ios/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Adresler";
 "contacts.state.empty.title" = "İletişim yok";
 "contacts.state.empty.description" = "Sık kullandığınız adresleri kaydedin.";
-"contacts.add_to_contacts" = "Kişilere Ekle";
+"contacts.create_new_contact" = "Kişi Oluştur";
+"contacts.add_to_existing_contact" = "Kişiye Ekle";
 "simulation.header.unlimited_asset" = "Sınırsız %@";
 "simulation.warning.unlimited_token_approval.description" = "Bu, harcayan tarafa, siz onayı iptal edene veya süresi dolana kadar bu jetonu kullanma erişimi sağlar.";
 "simulation.warning_externally_owned_spender_description" = "Bu onay, normal bir cüzdan adresinin (EOA) varlıklarınızı kullanmasına izin verir. Yalnızca bu adrese güveniyorsanız onaylayın.";

--- a/ios/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Адреси";
 "contacts.state.empty.title" = "Немає контактів";
 "contacts.state.empty.description" = "Збережіть часто використовувані адреси";
-"contacts.create_new_contact" = "Створити контакт";
+"contacts.create_new_contact" = "Створити новий контакт";
 "contacts.add_to_existing_contact" = "Додати до контакту";
 "simulation.header.unlimited_asset" = "Безлімітний %@";
 "simulation.warning.unlimited_token_approval.description" = "Це надає отримувачу доступ до використання цього токена, доки ви не скасуєте схвалення або термін його дії не закінчиться.";

--- a/ios/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Адреси";
 "contacts.state.empty.title" = "Немає контактів";
 "contacts.state.empty.description" = "Збережіть часто використовувані адреси";
-"contacts.add_to_contacts" = "Додати до контактів";
+"contacts.create_new_contact" = "Створити контакт";
+"contacts.add_to_existing_contact" = "Додати до контакту";
 "simulation.header.unlimited_asset" = "Безлімітний %@";
 "simulation.warning.unlimited_token_approval.description" = "Це надає отримувачу доступ до використання цього токена, доки ви не скасуєте схвалення або термін його дії не закінчиться.";
 "simulation.warning_externally_owned_spender_description" = "Це схвалення дозволяє звичайній адресі гаманця (EOA) використовувати ваші активи. Підтверджуйте лише якщо довіряєте цій адресі.";

--- a/ios/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "پتے";
 "contacts.state.empty.title" = "کوئی رابطے نہیں";
 "contacts.state.empty.description" = "اپنے اکثر استعمال ہونے والے پتے محفوظ کریں۔";
-"contacts.add_to_contacts" = "رابطوں میں شامل کریں۔";
+"contacts.create_new_contact" = "رابطہ بنائیں";
+"contacts.add_to_existing_contact" = "رابطے میں شامل کریں";
 "simulation.header.unlimited_asset" = "لا محدود %@";
 "simulation.warning.unlimited_token_approval.description" = "یہ خرچ کرنے والے کو اس ٹوکن کو استعمال کرنے تک رسائی دیتا ہے جب تک کہ آپ منظوری منسوخ نہیں کرتے یا اس کی میعاد ختم نہیں ہوجاتی۔";
 "simulation.warning_externally_owned_spender_description" = "یہ منظوری ایک عام والیٹ ایڈریس (EOA) کو آپ کے اثاثے استعمال کرنے دیتی ہے۔ صرف اس صورت میں تصدیق کریں جب آپ اس ایڈریس پر اعتماد کرتے ہیں۔";

--- a/ios/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "پتے";
 "contacts.state.empty.title" = "کوئی رابطے نہیں";
 "contacts.state.empty.description" = "اپنے اکثر استعمال ہونے والے پتے محفوظ کریں۔";
-"contacts.create_new_contact" = "رابطہ بنائیں";
+"contacts.create_new_contact" = "نیا رابطہ بنائیں";
 "contacts.add_to_existing_contact" = "رابطے میں شامل کریں";
 "simulation.header.unlimited_asset" = "لا محدود %@";
 "simulation.warning.unlimited_token_approval.description" = "یہ خرچ کرنے والے کو اس ٹوکن کو استعمال کرنے تک رسائی دیتا ہے جب تک کہ آپ منظوری منسوخ نہیں کرتے یا اس کی میعاد ختم نہیں ہوجاتی۔";

--- a/ios/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "Địa chỉ";
 "contacts.state.empty.title" = "Không có liên hệ";
 "contacts.state.empty.description" = "Lưu lại những địa chỉ bạn thường dùng.";
-"contacts.create_new_contact" = "Tạo liên hệ";
+"contacts.create_new_contact" = "Tạo liên hệ mới";
 "contacts.add_to_existing_contact" = "Thêm vào liên hệ";
 "simulation.header.unlimited_asset" = "Không giới hạn %@";
 "simulation.warning.unlimited_token_approval.description" = "Điều này cho phép người chi tiêu có quyền sử dụng mã thông báo này cho đến khi bạn thu hồi sự chấp thuận hoặc mã thông báo hết hạn.";

--- a/ios/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "Địa chỉ";
 "contacts.state.empty.title" = "Không có liên hệ";
 "contacts.state.empty.description" = "Lưu lại những địa chỉ bạn thường dùng.";
-"contacts.add_to_contacts" = "Thêm vào danh bạ";
+"contacts.create_new_contact" = "Tạo liên hệ";
+"contacts.add_to_existing_contact" = "Thêm vào liên hệ";
 "simulation.header.unlimited_asset" = "Không giới hạn %@";
 "simulation.warning.unlimited_token_approval.description" = "Điều này cho phép người chi tiêu có quyền sử dụng mã thông báo này cho đến khi bạn thu hồi sự chấp thuận hoặc mã thông báo hết hạn.";
 "simulation.warning_externally_owned_spender_description" = "Phê duyệt này cho phép một địa chỉ ví thông thường (EOA) sử dụng tài sản của bạn. Chỉ xác nhận nếu bạn tin tưởng địa chỉ này.";

--- a/ios/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "地址";
 "contacts.state.empty.title" = "无联系方式";
 "contacts.state.empty.description" = "保存您常用的地址";
-"contacts.create_new_contact" = "创建联系人";
+"contacts.create_new_contact" = "新建联系人";
 "contacts.add_to_existing_contact" = "添加到联系人";
 "simulation.header.unlimited_asset" = "无限 %@";
 "simulation.warning.unlimited_token_approval.description" = "这样，消费者就可以一直使用该代币，直到你撤销授权或代币过期为止。";

--- a/ios/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "地址";
 "contacts.state.empty.title" = "无联系方式";
 "contacts.state.empty.description" = "保存您常用的地址";
-"contacts.add_to_contacts" = "添加到联系人";
+"contacts.create_new_contact" = "创建联系人";
+"contacts.add_to_existing_contact" = "添加到联系人";
 "simulation.header.unlimited_asset" = "无限 %@";
 "simulation.warning.unlimited_token_approval.description" = "这样，消费者就可以一直使用该代币，直到你撤销授权或代币过期为止。";
 "simulation.warning_externally_owned_spender_description" = "此授权允许普通钱包地址 (EOA) 使用你的资产。仅在你信任该地址时确认。";

--- a/ios/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -549,7 +549,8 @@
 "contacts.addresses" = "地址";
 "contacts.state.empty.title" = "無聯絡方式";
 "contacts.state.empty.description" = "儲存您常用的地址";
-"contacts.add_to_contacts" = "加入聯絡人";
+"contacts.create_new_contact" = "建立聯絡人";
+"contacts.add_to_existing_contact" = "加入聯絡人";
 "simulation.header.unlimited_asset" = "無限 %@";
 "simulation.warning.unlimited_token_approval.description" = "這樣，消費者就可以一直使用該代幣，直到你撤銷授權或代幣過期為止。";
 "simulation.warning_externally_owned_spender_description" = "此授權允許一般錢包地址 (EOA) 使用你的資產。僅在你信任該地址時確認。";

--- a/ios/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ios/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -549,7 +549,7 @@
 "contacts.addresses" = "地址";
 "contacts.state.empty.title" = "無聯絡方式";
 "contacts.state.empty.description" = "儲存您常用的地址";
-"contacts.create_new_contact" = "建立聯絡人";
+"contacts.create_new_contact" = "建立新聯絡人";
 "contacts.add_to_existing_contact" = "加入聯絡人";
 "simulation.header.unlimited_asset" = "無限 %@";
 "simulation.warning.unlimited_token_approval.description" = "這樣，消費者就可以一直使用該代幣，直到你撤銷授權或代幣過期為止。";

--- a/ios/Packages/Primitives/Sources/Extensions/Contact+Primitives.swift
+++ b/ios/Packages/Primitives/Sources/Extensions/Contact+Primitives.swift
@@ -19,6 +19,21 @@ public extension Contact {
     }
 }
 
+public extension ContactData {
+    func addAddress(from recipient: ChainRecipient) -> ContactData {
+        let address = ContactAddress.new(
+            contactId: contact.id,
+            chain: recipient.chain,
+            address: recipient.recipient.address,
+            memo: recipient.recipient.memo,
+        )
+        guard !addresses.contains(where: { $0.id == address.id }) else {
+            return self
+        }
+        return ContactData(contact: contact, addresses: addresses + [address])
+    }
+}
+
 public extension ContactAddress {
     static func new(
         contactId: String,

--- a/ios/Packages/PrimitivesComponents/Sources/Components/AddressListItemView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/AddressListItemView.swift
@@ -35,10 +35,16 @@ public struct AddressListItemView: View {
             .url(title: model.addressExplorerText, onOpen: { isPresentingUrl = model.addressExplorerUrl }),
         ]
         if let onAddContact = model.onAddContact {
+            let recipient = model.addContactRecipient
             items.append(.custom(
-                title: model.addToContactsTitle,
-                systemImage: model.addToContactsImage,
-                action: onAddContact,
+                title: model.createContactTitle,
+                systemImage: model.createContactImage,
+                action: { onAddContact(.new(recipient)) },
+            ))
+            items.append(.custom(
+                title: model.addToExistingContactTitle,
+                systemImage: model.addToExistingContactImage,
+                action: { onAddContact(.existing(recipient)) },
             ))
         }
         return items

--- a/ios/Packages/PrimitivesComponents/Sources/Types/SimpleAccount.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Types/SimpleAccount.swift
@@ -8,13 +8,15 @@ public struct SimpleAccount {
     public let name: String?
     public let chain: Chain
     public let address: String
+    public let memo: String?
     public let assetImage: AssetImage?
     public let addressType: AddressType?
 
-    public init(name: String?, chain: Chain, address: String, assetImage: AssetImage?, addressType: AddressType? = nil) {
+    public init(name: String?, chain: Chain, address: String, memo: String? = nil, assetImage: AssetImage?, addressType: AddressType? = nil) {
         self.name = name
         self.chain = chain
         self.address = address
+        self.memo = memo
         self.assetImage = assetImage
         self.addressType = addressType
     }

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/AddContactType.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/AddContactType.swift
@@ -1,0 +1,15 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Primitives
+
+public enum AddContactType: Hashable, Sendable {
+    case new(ChainRecipient)
+    case existing(ChainRecipient)
+
+    public var id: String {
+        switch self {
+        case let .new(recipient): "new-\(recipient.chain.rawValue)-\(recipient.recipient.address)"
+        case let .existing(recipient): "existing-\(recipient.chain.rawValue)-\(recipient.recipient.address)"
+        }
+    }
+}

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/AddressListItemViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/AddressListItemViewModel.swift
@@ -31,7 +31,7 @@ public struct AddressListItemViewModel {
     public let title: String
     public let account: SimpleAccount
     public let mode: Mode
-    public let onAddContact: VoidAction
+    public let onAddContact: ((AddContactType) -> Void)?
     private let addressLink: BlockExplorerLink
 
     public init(
@@ -39,7 +39,7 @@ public struct AddressListItemViewModel {
         account: SimpleAccount,
         mode: Mode,
         addressLink: BlockExplorerLink,
-        onAddContact: VoidAction = nil,
+        onAddContact: ((AddContactType) -> Void)? = nil,
     ) {
         self.title = title
         self.account = account
@@ -82,12 +82,27 @@ public struct AddressListItemViewModel {
         addressLink.url
     }
 
-    public var addToContactsTitle: String {
-        Localized.Contacts.addToContacts
+    public var createContactTitle: String {
+        Localized.Contacts.createNewContact
     }
 
-    public var addToContactsImage: String {
+    public var createContactImage: String {
         SystemImage.personBadgePlus
+    }
+
+    public var addToExistingContactTitle: String {
+        Localized.Contacts.addToExistingContact
+    }
+
+    public var addToExistingContactImage: String {
+        SystemImage.personCircle
+    }
+
+    public var addContactRecipient: ChainRecipient {
+        ChainRecipient(
+            recipient: Recipient(name: nil, address: account.address, memo: account.memo),
+            chain: account.chain,
+        )
     }
 
     public var canToggleAddress: Bool {

--- a/ios/Packages/Store/Sources/Stores/ContactStore.swift
+++ b/ios/Packages/Store/Sources/Stores/ContactStore.swift
@@ -31,6 +31,10 @@ public struct ContactStore: Sendable {
                 ])
 
             if deleteAddressIds.isNotEmpty {
+                let removed = try ContactAddressRecord
+                    .filter(deleteAddressIds.contains(ContactAddressRecord.Columns.id))
+                    .fetchAll(db)
+                try deleteAddressNames(db, for: removed)
                 try ContactAddressRecord
                     .filter(deleteAddressIds.contains(ContactAddressRecord.Columns.id))
                     .deleteAll(db)
@@ -54,20 +58,28 @@ public struct ContactStore: Sendable {
     @discardableResult
     public func deleteContact(id: String) throws -> Bool {
         try db.write { db in
-            let addressesByChain = try ContactAddressRecord
+            let records = try ContactAddressRecord
                 .filter(ContactAddressRecord.Columns.contactId == id)
                 .fetchAll(db)
-                .reduce(into: [Chain: [String]]()) { $0[$1.chain, default: []].append($1.address) }
-
-            for (chain, addresses) in addressesByChain {
-                try AddressRecord
-                    .filter(AddressRecord.Columns.chain == chain.rawValue)
-                    .filter(addresses.contains(AddressRecord.Columns.address))
-                    .filter(AddressRecord.Columns.type == AddressType.contact.rawValue)
-                    .deleteAll(db)
-            }
+            try deleteAddressNames(db, for: records)
 
             return try ContactRecord.deleteOne(db, key: id)
+        }
+    }
+}
+
+// MARK: - Private
+
+extension ContactStore {
+    private func deleteAddressNames(_ db: Database, for records: [ContactAddressRecord]) throws {
+        let addressesByChain = records.reduce(into: [Chain: [String]]()) { $0[$1.chain, default: []].append($1.address) }
+
+        for (chain, addresses) in addressesByChain {
+            try AddressRecord
+                .filter(AddressRecord.Columns.chain == chain.rawValue)
+                .filter(addresses.contains(AddressRecord.Columns.address))
+                .filter(AddressRecord.Columns.type == AddressType.contact.rawValue)
+                .deleteAll(db)
         }
     }
 }

--- a/ios/Packages/Store/Tests/StoreTests/ContactStoreTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/ContactStoreTests.swift
@@ -31,7 +31,35 @@ struct ContactStoreTests {
 
         try test.contactStore.deleteContact(id: test.contact.id)
 
-        #expect(try test.addressStore.getAddressName(chain: test.chain, address: test.address)?.type == .contract)
+        #expect(try test.addressStore.getAddressName(chain: test.chain, address: test.address) == test.addressName)
+    }
+
+    @Test
+    func updateContactRemovesAddressNameForRemovedAddress() throws {
+        let test = try setupTest(
+            chain: .bitcoin,
+            address: "bc1qml9s2f9k8wc0882x63lyplzp97srzg2c39fyaw",
+            addressType: .contact,
+        )
+        let addressIds = try test.contactStore.getAddressIds(contactId: test.contact.id)
+
+        try test.contactStore.updateContact(test.contact, deleteAddressIds: addressIds, addresses: [])
+
+        #expect(try test.addressStore.getAddressName(chain: test.chain, address: test.address) == nil)
+    }
+
+    @Test
+    func updateContactPreservesNonContactAddressName() throws {
+        let test = try setupTest(
+            chain: .ethereum,
+            address: "0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7",
+            addressType: .contract,
+        )
+        let addressIds = try test.contactStore.getAddressIds(contactId: test.contact.id)
+
+        try test.contactStore.updateContact(test.contact, deleteAddressIds: addressIds, addresses: [])
+
+        #expect(try test.addressStore.getAddressName(chain: test.chain, address: test.address) == test.addressName)
     }
 }
 
@@ -42,19 +70,18 @@ extension ContactStoreTests {
         chain: Chain,
         address: String,
         addressType: AddressType,
-    ) throws -> (contactStore: ContactStore, addressStore: AddressStore, contact: Contact, chain: Chain, address: String) {
+    ) throws -> (contactStore: ContactStore, addressStore: AddressStore, contact: Contact, chain: Chain, address: String, addressName: AddressName) {
         let db = DB.mockWithChains([chain])
         let contactStore = ContactStore(db: db)
         let addressStore = AddressStore(db: db)
         let contact = Contact.mock()
+        let addressName = AddressName.mock(chain: chain, address: address, name: contact.name, type: addressType)
 
         try contactStore.addContact(contact, addresses: [
             .mock(contactId: contact.id, address: address, chain: chain),
         ])
-        try addressStore.addAddressNames([
-            .mock(chain: chain, address: address, name: contact.name, type: addressType),
-        ])
+        try addressStore.addAddressNames([addressName])
 
-        return (contactStore, addressStore, contact, chain, address)
+        return (contactStore, addressStore, contact, chain, address, addressName)
     }
 }

--- a/ios/Packages/Style/Sources/SystemImage.swift
+++ b/ios/Packages/Style/Sources/SystemImage.swift
@@ -57,6 +57,7 @@ public enum SystemImage {
     public static let arrowTriangleUp = "arrowtriangle.up.fill"
     public static let arrowTriangleDown = "arrowtriangle.down.fill"
     public static let person = "person"
+    public static let personCircle = "person.crop.circle"
     public static let personCircleFill = "person.crop.circle.fill"
     public static let personBadgePlus = "person.crop.circle.badge.plus"
     public static let chartLineUptrendXyaxis = "chart.line.uptrend.xyaxis"

--- a/localization/app/ar.ftl
+++ b/localization/app/ar.ftl
@@ -711,7 +711,7 @@ contacts_contact = اتصال
 contacts_addresses = العناوين
 contacts_state_empty_title = لا توجد جهات اتصال
 contacts_state_empty_description = احفظ عناوينك التي تستخدمها بشكل متكرر
-contacts_create_new_contact = إنشاء جهة اتصال
+contacts_create_new_contact = إنشاء جهة اتصال جديدة
 contacts_add_to_existing_contact = إضافة إلى جهة اتصال
 
 # Simulation

--- a/localization/app/ar.ftl
+++ b/localization/app/ar.ftl
@@ -711,7 +711,8 @@ contacts_contact = اتصال
 contacts_addresses = العناوين
 contacts_state_empty_title = لا توجد جهات اتصال
 contacts_state_empty_description = احفظ عناوينك التي تستخدمها بشكل متكرر
-contacts_add_to_contacts = أضف إلى جهات الاتصال
+contacts_create_new_contact = إنشاء جهة اتصال
+contacts_add_to_existing_contact = إضافة إلى جهة اتصال
 
 # Simulation
 

--- a/localization/app/bn.ftl
+++ b/localization/app/bn.ftl
@@ -711,7 +711,7 @@ contacts_contact = যোগাযোগ
 contacts_addresses = ঠিকানা
 contacts_state_empty_title = কোনও পরিচিতি নেই
 contacts_state_empty_description = আপনার ঘন ঘন ব্যবহৃত ঠিকানাগুলি সংরক্ষণ করুন
-contacts_create_new_contact = পরিচিতি তৈরি করুন
+contacts_create_new_contact = নতুন পরিচিতি তৈরি করুন
 contacts_add_to_existing_contact = পরিচিতিতে যোগ করুন
 
 # Simulation

--- a/localization/app/bn.ftl
+++ b/localization/app/bn.ftl
@@ -711,7 +711,8 @@ contacts_contact = যোগাযোগ
 contacts_addresses = ঠিকানা
 contacts_state_empty_title = কোনও পরিচিতি নেই
 contacts_state_empty_description = আপনার ঘন ঘন ব্যবহৃত ঠিকানাগুলি সংরক্ষণ করুন
-contacts_add_to_contacts = পরিচিতিতে যোগ করুন
+contacts_create_new_contact = পরিচিতি তৈরি করুন
+contacts_add_to_existing_contact = পরিচিতিতে যোগ করুন
 
 # Simulation
 

--- a/localization/app/cs.ftl
+++ b/localization/app/cs.ftl
@@ -711,7 +711,7 @@ contacts_contact = Kontakt
 contacts_addresses = Adresy
 contacts_state_empty_title = Žádné kontakty
 contacts_state_empty_description = Uložte si často používané adresy
-contacts_create_new_contact = Vytvořit kontakt
+contacts_create_new_contact = Vytvořit nový kontakt
 contacts_add_to_existing_contact = Přidat ke kontaktu
 
 # Simulation

--- a/localization/app/cs.ftl
+++ b/localization/app/cs.ftl
@@ -711,7 +711,8 @@ contacts_contact = Kontakt
 contacts_addresses = Adresy
 contacts_state_empty_title = Žádné kontakty
 contacts_state_empty_description = Uložte si často používané adresy
-contacts_add_to_contacts = Přidat do kontaktů
+contacts_create_new_contact = Vytvořit kontakt
+contacts_add_to_existing_contact = Přidat ke kontaktu
 
 # Simulation
 

--- a/localization/app/da.ftl
+++ b/localization/app/da.ftl
@@ -711,7 +711,8 @@ contacts_contact = Kontakte
 contacts_addresses = Adresser
 contacts_state_empty_title = Ingen kontakter
 contacts_state_empty_description = Gem dine ofte brugte adresser
-contacts_add_to_contacts = Føj til Kontakter
+contacts_create_new_contact = Opret kontakt
+contacts_add_to_existing_contact = Føj til kontakt
 
 # Simulation
 

--- a/localization/app/da.ftl
+++ b/localization/app/da.ftl
@@ -711,7 +711,7 @@ contacts_contact = Kontakte
 contacts_addresses = Adresser
 contacts_state_empty_title = Ingen kontakter
 contacts_state_empty_description = Gem dine ofte brugte adresser
-contacts_create_new_contact = Opret kontakt
+contacts_create_new_contact = Opret ny kontakt
 contacts_add_to_existing_contact = Føj til kontakt
 
 # Simulation

--- a/localization/app/de.ftl
+++ b/localization/app/de.ftl
@@ -711,7 +711,7 @@ contacts_contact = Kontakt
 contacts_addresses = Adressen
 contacts_state_empty_title = Keine Kontakte
 contacts_state_empty_description = Speichern Sie Ihre häufig verwendeten Adressen
-contacts_create_new_contact = Kontakt erstellen
+contacts_create_new_contact = Neuen Kontakt erstellen
 contacts_add_to_existing_contact = Zu Kontakt hinzufügen
 
 # Simulation

--- a/localization/app/de.ftl
+++ b/localization/app/de.ftl
@@ -711,7 +711,8 @@ contacts_contact = Kontakt
 contacts_addresses = Adressen
 contacts_state_empty_title = Keine Kontakte
 contacts_state_empty_description = Speichern Sie Ihre häufig verwendeten Adressen
-contacts_add_to_contacts = Zu Kontakten hinzufügen
+contacts_create_new_contact = Kontakt erstellen
+contacts_add_to_existing_contact = Zu Kontakt hinzufügen
 
 # Simulation
 

--- a/localization/app/en.ftl
+++ b/localization/app/en.ftl
@@ -1300,7 +1300,7 @@ contacts_state_empty_title = No Contacts
 # Used in contacts UI for the state empty description.
 contacts_state_empty_description = Save your frequently used addresses
 # Used in the address context menu to create a new contact from an address.
-contacts_create_new_contact = Create Contact
+contacts_create_new_contact = Create New Contact
 # Used in the address context menu to add an address to an existing contact.
 contacts_add_to_existing_contact = Add to Contact
 

--- a/localization/app/en.ftl
+++ b/localization/app/en.ftl
@@ -1299,8 +1299,10 @@ contacts_addresses = Addresses
 contacts_state_empty_title = No Contacts
 # Used in contacts UI for the state empty description.
 contacts_state_empty_description = Save your frequently used addresses
-# Used in contacts UI for the add to contacts label.
-contacts_add_to_contacts = Add to Contacts
+# Used in the address context menu to create a new contact from an address.
+contacts_create_new_contact = Create Contact
+# Used in the address context menu to add an address to an existing contact.
+contacts_add_to_existing_contact = Add to Contact
 
 # Simulation
 

--- a/localization/app/es.ftl
+++ b/localization/app/es.ftl
@@ -711,7 +711,7 @@ contacts_contact = Contacto
 contacts_addresses = Direcciones
 contacts_state_empty_title = Sin contactos
 contacts_state_empty_description = Guarde sus direcciones de uso frecuente
-contacts_create_new_contact = Crear contacto
+contacts_create_new_contact = Crear nuevo contacto
 contacts_add_to_existing_contact = Añadir a un contacto
 
 # Simulation

--- a/localization/app/es.ftl
+++ b/localization/app/es.ftl
@@ -711,7 +711,8 @@ contacts_contact = Contacto
 contacts_addresses = Direcciones
 contacts_state_empty_title = Sin contactos
 contacts_state_empty_description = Guarde sus direcciones de uso frecuente
-contacts_add_to_contacts = Añadir a contactos
+contacts_create_new_contact = Crear contacto
+contacts_add_to_existing_contact = Añadir a un contacto
 
 # Simulation
 

--- a/localization/app/fa.ftl
+++ b/localization/app/fa.ftl
@@ -711,7 +711,7 @@ contacts_contact = تماس
 contacts_addresses = آدرس‌ها
 contacts_state_empty_title = بدون مخاطب
 contacts_state_empty_description = آدرس‌های پرکاربرد خود را ذخیره کنید
-contacts_create_new_contact = ایجاد مخاطب
+contacts_create_new_contact = ایجاد مخاطب جدید
 contacts_add_to_existing_contact = افزودن به مخاطب
 
 # Simulation

--- a/localization/app/fa.ftl
+++ b/localization/app/fa.ftl
@@ -711,7 +711,8 @@ contacts_contact = تماس
 contacts_addresses = آدرس‌ها
 contacts_state_empty_title = بدون مخاطب
 contacts_state_empty_description = آدرس‌های پرکاربرد خود را ذخیره کنید
-contacts_add_to_contacts = اضافه کردن به مخاطبین
+contacts_create_new_contact = ایجاد مخاطب
+contacts_add_to_existing_contact = افزودن به مخاطب
 
 # Simulation
 

--- a/localization/app/fil.ftl
+++ b/localization/app/fil.ftl
@@ -711,7 +711,8 @@ contacts_contact = Makipag-ugnayan
 contacts_addresses = Mga Address
 contacts_state_empty_title = Walang Mga Kontak
 contacts_state_empty_description = I-save ang iyong mga madalas gamiting address
-contacts_add_to_contacts = Idagdag sa Mga Kontak
+contacts_create_new_contact = Gumawa ng Contact
+contacts_add_to_existing_contact = Idagdag sa Contact
 
 # Simulation
 

--- a/localization/app/fil.ftl
+++ b/localization/app/fil.ftl
@@ -711,7 +711,7 @@ contacts_contact = Makipag-ugnayan
 contacts_addresses = Mga Address
 contacts_state_empty_title = Walang Mga Kontak
 contacts_state_empty_description = I-save ang iyong mga madalas gamiting address
-contacts_create_new_contact = Gumawa ng Contact
+contacts_create_new_contact = Gumawa ng Bagong Contact
 contacts_add_to_existing_contact = Idagdag sa Contact
 
 # Simulation

--- a/localization/app/fr.ftl
+++ b/localization/app/fr.ftl
@@ -711,7 +711,8 @@ contacts_contact = Contacter
 contacts_addresses = Adresses
 contacts_state_empty_title = Aucun contact
 contacts_state_empty_description = Enregistrez vos adresses fréquemment utilisées
-contacts_add_to_contacts = Ajouter aux contacts
+contacts_create_new_contact = Créer un contact
+contacts_add_to_existing_contact = Ajouter à un contact
 
 # Simulation
 

--- a/localization/app/fr.ftl
+++ b/localization/app/fr.ftl
@@ -711,7 +711,7 @@ contacts_contact = Contacter
 contacts_addresses = Adresses
 contacts_state_empty_title = Aucun contact
 contacts_state_empty_description = Enregistrez vos adresses fréquemment utilisées
-contacts_create_new_contact = Créer un contact
+contacts_create_new_contact = Créer un nouveau contact
 contacts_add_to_existing_contact = Ajouter à un contact
 
 # Simulation

--- a/localization/app/ha.ftl
+++ b/localization/app/ha.ftl
@@ -711,7 +711,7 @@ contacts_contact = Tuntuɓi
 contacts_addresses = Adiresoshi
 contacts_state_empty_title = Babu Lambobin Sadarwa
 contacts_state_empty_description = Ajiye adiresoshin da ake yawan amfani da su
-contacts_create_new_contact = Ƙirƙiri lamba
+contacts_create_new_contact = Ƙirƙiri sabon lamba
 contacts_add_to_existing_contact = Ƙara zuwa lamba
 
 # Simulation

--- a/localization/app/ha.ftl
+++ b/localization/app/ha.ftl
@@ -711,7 +711,8 @@ contacts_contact = Tuntuɓi
 contacts_addresses = Adiresoshi
 contacts_state_empty_title = Babu Lambobin Sadarwa
 contacts_state_empty_description = Ajiye adiresoshin da ake yawan amfani da su
-contacts_add_to_contacts = Ƙara zuwa Lambobin Sadarwa
+contacts_create_new_contact = Ƙirƙiri lamba
+contacts_add_to_existing_contact = Ƙara zuwa lamba
 
 # Simulation
 

--- a/localization/app/he.ftl
+++ b/localization/app/he.ftl
@@ -711,7 +711,7 @@ contacts_contact = מַגָע
 contacts_addresses = כתובות
 contacts_state_empty_title = אין אנשי קשר
 contacts_state_empty_description = שמור את הכתובות שאתה משתמש בהן לעתים קרובות
-contacts_create_new_contact = צור איש קשר
+contacts_create_new_contact = צור איש קשר חדש
 contacts_add_to_existing_contact = הוסף לאיש קשר
 
 # Simulation

--- a/localization/app/he.ftl
+++ b/localization/app/he.ftl
@@ -711,7 +711,8 @@ contacts_contact = מַגָע
 contacts_addresses = כתובות
 contacts_state_empty_title = אין אנשי קשר
 contacts_state_empty_description = שמור את הכתובות שאתה משתמש בהן לעתים קרובות
-contacts_add_to_contacts = הוסף לאנשי קשר
+contacts_create_new_contact = צור איש קשר
+contacts_add_to_existing_contact = הוסף לאיש קשר
 
 # Simulation
 

--- a/localization/app/hi.ftl
+++ b/localization/app/hi.ftl
@@ -711,7 +711,7 @@ contacts_contact = संपर्क
 contacts_addresses = पतों
 contacts_state_empty_title = कोई संपर्क नहीं
 contacts_state_empty_description = अपने अक्सर इस्तेमाल होने वाले पतों को सेव करें
-contacts_create_new_contact = संपर्क बनाएं
+contacts_create_new_contact = नया संपर्क बनाएं
 contacts_add_to_existing_contact = संपर्क में जोड़ें
 
 # Simulation

--- a/localization/app/hi.ftl
+++ b/localization/app/hi.ftl
@@ -711,7 +711,8 @@ contacts_contact = संपर्क
 contacts_addresses = पतों
 contacts_state_empty_title = कोई संपर्क नहीं
 contacts_state_empty_description = अपने अक्सर इस्तेमाल होने वाले पतों को सेव करें
-contacts_add_to_contacts = संपर्क के खाते में जोड़ दे
+contacts_create_new_contact = संपर्क बनाएं
+contacts_add_to_existing_contact = संपर्क में जोड़ें
 
 # Simulation
 

--- a/localization/app/id.ftl
+++ b/localization/app/id.ftl
@@ -711,7 +711,8 @@ contacts_contact = Kontak
 contacts_addresses = Alamat
 contacts_state_empty_title = Tidak ada kontak
 contacts_state_empty_description = Simpan alamat yang sering Anda gunakan.
-contacts_add_to_contacts = Tambahkan ke Kontak
+contacts_create_new_contact = Buat Kontak
+contacts_add_to_existing_contact = Tambahkan ke Kontak
 
 # Simulation
 

--- a/localization/app/id.ftl
+++ b/localization/app/id.ftl
@@ -711,7 +711,7 @@ contacts_contact = Kontak
 contacts_addresses = Alamat
 contacts_state_empty_title = Tidak ada kontak
 contacts_state_empty_description = Simpan alamat yang sering Anda gunakan.
-contacts_create_new_contact = Buat Kontak
+contacts_create_new_contact = Buat Kontak Baru
 contacts_add_to_existing_contact = Tambahkan ke Kontak
 
 # Simulation

--- a/localization/app/it.ftl
+++ b/localization/app/it.ftl
@@ -711,7 +711,8 @@ contacts_contact = Contatto
 contacts_addresses = Indirizzi
 contacts_state_empty_title = Nessun contatto
 contacts_state_empty_description = Salva gli indirizzi che usi più frequentemente
-contacts_add_to_contacts = Aggiungi ai contatti
+contacts_create_new_contact = Crea contatto
+contacts_add_to_existing_contact = Aggiungi a un contatto
 
 # Simulation
 

--- a/localization/app/it.ftl
+++ b/localization/app/it.ftl
@@ -711,7 +711,7 @@ contacts_contact = Contatto
 contacts_addresses = Indirizzi
 contacts_state_empty_title = Nessun contatto
 contacts_state_empty_description = Salva gli indirizzi che usi più frequentemente
-contacts_create_new_contact = Crea contatto
+contacts_create_new_contact = Crea nuovo contatto
 contacts_add_to_existing_contact = Aggiungi a un contatto
 
 # Simulation

--- a/localization/app/ja.ftl
+++ b/localization/app/ja.ftl
@@ -711,7 +711,8 @@ contacts_contact = 接触
 contacts_addresses = 住所
 contacts_state_empty_title = 連絡先なし
 contacts_state_empty_description = よく使うアドレスを保存する
-contacts_add_to_contacts = 連絡先に追加
+contacts_create_new_contact = 連絡先を作成
+contacts_add_to_existing_contact = 連絡先に追加
 
 # Simulation
 

--- a/localization/app/ja.ftl
+++ b/localization/app/ja.ftl
@@ -711,7 +711,7 @@ contacts_contact = 接触
 contacts_addresses = 住所
 contacts_state_empty_title = 連絡先なし
 contacts_state_empty_description = よく使うアドレスを保存する
-contacts_create_new_contact = 連絡先を作成
+contacts_create_new_contact = 新しい連絡先を作成
 contacts_add_to_existing_contact = 連絡先に追加
 
 # Simulation

--- a/localization/app/ko.ftl
+++ b/localization/app/ko.ftl
@@ -711,7 +711,7 @@ contacts_contact = 연락하다
 contacts_addresses = 구애
 contacts_state_empty_title = 연락처 없음
 contacts_state_empty_description = 자주 사용하는 주소를 저장하세요
-contacts_create_new_contact = 연락처 만들기
+contacts_create_new_contact = 새 연락처 만들기
 contacts_add_to_existing_contact = 연락처에 추가
 
 # Simulation

--- a/localization/app/ko.ftl
+++ b/localization/app/ko.ftl
@@ -711,7 +711,8 @@ contacts_contact = 연락하다
 contacts_addresses = 구애
 contacts_state_empty_title = 연락처 없음
 contacts_state_empty_description = 자주 사용하는 주소를 저장하세요
-contacts_add_to_contacts = 연락처에 추가
+contacts_create_new_contact = 연락처 만들기
+contacts_add_to_existing_contact = 연락처에 추가
 
 # Simulation
 

--- a/localization/app/ms.ftl
+++ b/localization/app/ms.ftl
@@ -711,7 +711,8 @@ contacts_contact = Hubungi
 contacts_addresses = Alamat
 contacts_state_empty_title = Tiada Kenalan
 contacts_state_empty_description = Simpan alamat yang kerap anda gunakan
-contacts_add_to_contacts = Tambah ke Kenalan
+contacts_create_new_contact = Cipta Kenalan
+contacts_add_to_existing_contact = Tambah ke Kenalan
 
 # Simulation
 

--- a/localization/app/ms.ftl
+++ b/localization/app/ms.ftl
@@ -711,7 +711,7 @@ contacts_contact = Hubungi
 contacts_addresses = Alamat
 contacts_state_empty_title = Tiada Kenalan
 contacts_state_empty_description = Simpan alamat yang kerap anda gunakan
-contacts_create_new_contact = Cipta Kenalan
+contacts_create_new_contact = Cipta Kenalan Baharu
 contacts_add_to_existing_contact = Tambah ke Kenalan
 
 # Simulation

--- a/localization/app/nl.ftl
+++ b/localization/app/nl.ftl
@@ -711,7 +711,7 @@ contacts_contact = Contacteer
 contacts_addresses = Adressen
 contacts_state_empty_title = Geen contacten
 contacts_state_empty_description = Bewaar uw veelgebruikte adressen.
-contacts_create_new_contact = Contact maken
+contacts_create_new_contact = Nieuw contact maken
 contacts_add_to_existing_contact = Aan contact toevoegen
 
 # Simulation

--- a/localization/app/nl.ftl
+++ b/localization/app/nl.ftl
@@ -711,7 +711,8 @@ contacts_contact = Contacteer
 contacts_addresses = Adressen
 contacts_state_empty_title = Geen contacten
 contacts_state_empty_description = Bewaar uw veelgebruikte adressen.
-contacts_add_to_contacts = Toevoegen aan contacten
+contacts_create_new_contact = Contact maken
+contacts_add_to_existing_contact = Aan contact toevoegen
 
 # Simulation
 

--- a/localization/app/pl.ftl
+++ b/localization/app/pl.ftl
@@ -711,7 +711,7 @@ contacts_contact = Kontakt
 contacts_addresses = Adresy
 contacts_state_empty_title = Brak kontaktów
 contacts_state_empty_description = Zapisz często używane adresy
-contacts_create_new_contact = Utwórz kontakt
+contacts_create_new_contact = Utwórz nowy kontakt
 contacts_add_to_existing_contact = Dodaj do kontaktu
 
 # Simulation

--- a/localization/app/pl.ftl
+++ b/localization/app/pl.ftl
@@ -711,7 +711,8 @@ contacts_contact = Kontakt
 contacts_addresses = Adresy
 contacts_state_empty_title = Brak kontaktów
 contacts_state_empty_description = Zapisz często używane adresy
-contacts_add_to_contacts = Dodaj do kontaktów
+contacts_create_new_contact = Utwórz kontakt
+contacts_add_to_existing_contact = Dodaj do kontaktu
 
 # Simulation
 

--- a/localization/app/pt-BR.ftl
+++ b/localization/app/pt-BR.ftl
@@ -711,7 +711,7 @@ contacts_contact = Contato
 contacts_addresses = Endereços
 contacts_state_empty_title = Sem contatos
 contacts_state_empty_description = Salve seus endereços usados ​​com frequência.
-contacts_create_new_contact = Criar contato
+contacts_create_new_contact = Criar novo contato
 contacts_add_to_existing_contact = Adicionar a contato
 
 # Simulation

--- a/localization/app/pt-BR.ftl
+++ b/localization/app/pt-BR.ftl
@@ -711,7 +711,8 @@ contacts_contact = Contato
 contacts_addresses = Endereços
 contacts_state_empty_title = Sem contatos
 contacts_state_empty_description = Salve seus endereços usados ​​com frequência.
-contacts_add_to_contacts = Adicionar aos contatos
+contacts_create_new_contact = Criar contato
+contacts_add_to_existing_contact = Adicionar a contato
 
 # Simulation
 

--- a/localization/app/ro.ftl
+++ b/localization/app/ro.ftl
@@ -711,7 +711,8 @@ contacts_contact = Contact
 contacts_addresses = Adrese
 contacts_state_empty_title = Niciun contact
 contacts_state_empty_description = Salvați adresele utilizate frecvent
-contacts_add_to_contacts = Adăugați la Contacte
+contacts_create_new_contact = Creează un contact
+contacts_add_to_existing_contact = Adaugă la un contact
 
 # Simulation
 

--- a/localization/app/ro.ftl
+++ b/localization/app/ro.ftl
@@ -711,7 +711,7 @@ contacts_contact = Contact
 contacts_addresses = Adrese
 contacts_state_empty_title = Niciun contact
 contacts_state_empty_description = Salvați adresele utilizate frecvent
-contacts_create_new_contact = Creează un contact
+contacts_create_new_contact = Creează un contact nou
 contacts_add_to_existing_contact = Adaugă la un contact
 
 # Simulation

--- a/localization/app/ru.ftl
+++ b/localization/app/ru.ftl
@@ -711,7 +711,7 @@ contacts_contact = Контакт
 contacts_addresses = Адреса
 contacts_state_empty_title = Нет контактов
 contacts_state_empty_description = Сохраните часто используемые адреса.
-contacts_create_new_contact = Создать контакт
+contacts_create_new_contact = Создать новый контакт
 contacts_add_to_existing_contact = Добавить в контакт
 
 # Simulation

--- a/localization/app/ru.ftl
+++ b/localization/app/ru.ftl
@@ -711,7 +711,8 @@ contacts_contact = Контакт
 contacts_addresses = Адреса
 contacts_state_empty_title = Нет контактов
 contacts_state_empty_description = Сохраните часто используемые адреса.
-contacts_add_to_contacts = Добавить в контакты
+contacts_create_new_contact = Создать контакт
+contacts_add_to_existing_contact = Добавить в контакт
 
 # Simulation
 

--- a/localization/app/sw.ftl
+++ b/localization/app/sw.ftl
@@ -711,7 +711,7 @@ contacts_contact = Mawasiliano
 contacts_addresses = Anwani
 contacts_state_empty_title = Hakuna Anwani
 contacts_state_empty_description = Hifadhi anwani zako zinazotumiwa mara kwa mara
-contacts_create_new_contact = Unda anwani
+contacts_create_new_contact = Unda anwani mpya
 contacts_add_to_existing_contact = Ongeza kwa anwani
 
 # Simulation

--- a/localization/app/sw.ftl
+++ b/localization/app/sw.ftl
@@ -711,7 +711,8 @@ contacts_contact = Mawasiliano
 contacts_addresses = Anwani
 contacts_state_empty_title = Hakuna Anwani
 contacts_state_empty_description = Hifadhi anwani zako zinazotumiwa mara kwa mara
-contacts_add_to_contacts = Ongeza kwenye Anwani
+contacts_create_new_contact = Unda anwani
+contacts_add_to_existing_contact = Ongeza kwa anwani
 
 # Simulation
 

--- a/localization/app/th.ftl
+++ b/localization/app/th.ftl
@@ -711,7 +711,7 @@ contacts_contact = ติดต่อ
 contacts_addresses = ที่อยู่
 contacts_state_empty_title = ไม่มีข้อมูลติดต่อ
 contacts_state_empty_description = บันทึกที่อยู่ที่คุณใช้งานบ่อย
-contacts_create_new_contact = สร้างรายชื่อ
+contacts_create_new_contact = สร้างรายชื่อใหม่
 contacts_add_to_existing_contact = เพิ่มในรายชื่อ
 
 # Simulation

--- a/localization/app/th.ftl
+++ b/localization/app/th.ftl
@@ -711,7 +711,8 @@ contacts_contact = ติดต่อ
 contacts_addresses = ที่อยู่
 contacts_state_empty_title = ไม่มีข้อมูลติดต่อ
 contacts_state_empty_description = บันทึกที่อยู่ที่คุณใช้งานบ่อย
-contacts_add_to_contacts = เพิ่มลงในรายชื่อติดต่อ
+contacts_create_new_contact = สร้างรายชื่อ
+contacts_add_to_existing_contact = เพิ่มในรายชื่อ
 
 # Simulation
 

--- a/localization/app/tr.ftl
+++ b/localization/app/tr.ftl
@@ -711,7 +711,8 @@ contacts_contact = Temas etmek
 contacts_addresses = Adresler
 contacts_state_empty_title = İletişim yok
 contacts_state_empty_description = Sık kullandığınız adresleri kaydedin.
-contacts_add_to_contacts = Kişilere Ekle
+contacts_create_new_contact = Kişi Oluştur
+contacts_add_to_existing_contact = Kişiye Ekle
 
 # Simulation
 

--- a/localization/app/tr.ftl
+++ b/localization/app/tr.ftl
@@ -711,7 +711,7 @@ contacts_contact = Temas etmek
 contacts_addresses = Adresler
 contacts_state_empty_title = İletişim yok
 contacts_state_empty_description = Sık kullandığınız adresleri kaydedin.
-contacts_create_new_contact = Kişi Oluştur
+contacts_create_new_contact = Yeni Kişi Oluştur
 contacts_add_to_existing_contact = Kişiye Ekle
 
 # Simulation

--- a/localization/app/uk.ftl
+++ b/localization/app/uk.ftl
@@ -711,7 +711,8 @@ contacts_contact = Контакти
 contacts_addresses = Адреси
 contacts_state_empty_title = Немає контактів
 contacts_state_empty_description = Збережіть часто використовувані адреси
-contacts_add_to_contacts = Додати до контактів
+contacts_create_new_contact = Створити контакт
+contacts_add_to_existing_contact = Додати до контакту
 
 # Simulation
 

--- a/localization/app/uk.ftl
+++ b/localization/app/uk.ftl
@@ -711,7 +711,7 @@ contacts_contact = Контакти
 contacts_addresses = Адреси
 contacts_state_empty_title = Немає контактів
 contacts_state_empty_description = Збережіть часто використовувані адреси
-contacts_create_new_contact = Створити контакт
+contacts_create_new_contact = Створити новий контакт
 contacts_add_to_existing_contact = Додати до контакту
 
 # Simulation

--- a/localization/app/ur.ftl
+++ b/localization/app/ur.ftl
@@ -711,7 +711,8 @@ contacts_contact = رابطہ کریں۔
 contacts_addresses = پتے
 contacts_state_empty_title = کوئی رابطے نہیں
 contacts_state_empty_description = اپنے اکثر استعمال ہونے والے پتے محفوظ کریں۔
-contacts_add_to_contacts = رابطوں میں شامل کریں۔
+contacts_create_new_contact = رابطہ بنائیں
+contacts_add_to_existing_contact = رابطے میں شامل کریں
 
 # Simulation
 

--- a/localization/app/ur.ftl
+++ b/localization/app/ur.ftl
@@ -711,7 +711,7 @@ contacts_contact = رابطہ کریں۔
 contacts_addresses = پتے
 contacts_state_empty_title = کوئی رابطے نہیں
 contacts_state_empty_description = اپنے اکثر استعمال ہونے والے پتے محفوظ کریں۔
-contacts_create_new_contact = رابطہ بنائیں
+contacts_create_new_contact = نیا رابطہ بنائیں
 contacts_add_to_existing_contact = رابطے میں شامل کریں
 
 # Simulation

--- a/localization/app/vi.ftl
+++ b/localization/app/vi.ftl
@@ -711,7 +711,8 @@ contacts_contact = Liên hệ
 contacts_addresses = Địa chỉ
 contacts_state_empty_title = Không có liên hệ
 contacts_state_empty_description = Lưu lại những địa chỉ bạn thường dùng.
-contacts_add_to_contacts = Thêm vào danh bạ
+contacts_create_new_contact = Tạo liên hệ
+contacts_add_to_existing_contact = Thêm vào liên hệ
 
 # Simulation
 

--- a/localization/app/vi.ftl
+++ b/localization/app/vi.ftl
@@ -711,7 +711,7 @@ contacts_contact = Liên hệ
 contacts_addresses = Địa chỉ
 contacts_state_empty_title = Không có liên hệ
 contacts_state_empty_description = Lưu lại những địa chỉ bạn thường dùng.
-contacts_create_new_contact = Tạo liên hệ
+contacts_create_new_contact = Tạo liên hệ mới
 contacts_add_to_existing_contact = Thêm vào liên hệ
 
 # Simulation

--- a/localization/app/zh-Hans.ftl
+++ b/localization/app/zh-Hans.ftl
@@ -711,7 +711,7 @@ contacts_contact = 接触
 contacts_addresses = 地址
 contacts_state_empty_title = 无联系方式
 contacts_state_empty_description = 保存您常用的地址
-contacts_create_new_contact = 创建联系人
+contacts_create_new_contact = 新建联系人
 contacts_add_to_existing_contact = 添加到联系人
 
 # Simulation

--- a/localization/app/zh-Hans.ftl
+++ b/localization/app/zh-Hans.ftl
@@ -711,7 +711,8 @@ contacts_contact = 接触
 contacts_addresses = 地址
 contacts_state_empty_title = 无联系方式
 contacts_state_empty_description = 保存您常用的地址
-contacts_add_to_contacts = 添加到联系人
+contacts_create_new_contact = 创建联系人
+contacts_add_to_existing_contact = 添加到联系人
 
 # Simulation
 

--- a/localization/app/zh-Hant.ftl
+++ b/localization/app/zh-Hant.ftl
@@ -711,7 +711,8 @@ contacts_contact = 接觸
 contacts_addresses = 地址
 contacts_state_empty_title = 無聯絡方式
 contacts_state_empty_description = 儲存您常用的地址
-contacts_add_to_contacts = 加入聯絡人
+contacts_create_new_contact = 建立聯絡人
+contacts_add_to_existing_contact = 加入聯絡人
 
 # Simulation
 

--- a/localization/app/zh-Hant.ftl
+++ b/localization/app/zh-Hant.ftl
@@ -711,7 +711,7 @@ contacts_contact = 接觸
 contacts_addresses = 地址
 contacts_state_empty_title = 無聯絡方式
 contacts_state_empty_description = 儲存您常用的地址
-contacts_create_new_contact = 建立聯絡人
+contacts_create_new_contact = 建立新聯絡人
 contacts_add_to_existing_contact = 加入聯絡人
 
 # Simulation


### PR DESCRIPTION
Long-press a sender/recipient address on a transaction (or the recipient on the send confirmation) to save it to contacts — create a new contact or add the address to an existing one.

<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-06-30 at 23 17 22" src="https://github.com/user-attachments/assets/b20e9c9e-0a26-4607-acec-27e7de7a6717" />

<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-06-29 at 23 25 31" src="https://github.com/user-attachments/assets/6a778a4c-5d4e-4fad-8aa2-6860490ea150" />
<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-06-29 at 23 38 47" src="https://github.com/user-attachments/assets/c515f92d-c0ad-49cd-b2d6-f27b703d32c8" />
