### PR TITLE
Improve NFT screen when a wallet has only unverified NFTs

### DIFF
--- a/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
+++ b/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
@@ -182,7 +182,9 @@ internal fun NftListScene(
 
             Column(modifier = Modifier.fillMaxSize()) {
                 LazyVerticalGrid(
-                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                    modifier = Modifier
+                        .then(if (items.isEmpty()) Modifier else Modifier.weight(1f))
+                        .fillMaxWidth(),
                     columns = GridCells.Adaptive(minSize = 150.dp),
                     state = listState,
                     contentPadding = PaddingValues(paddingSmall, paddingDefault)

--- a/ios/Features/NFT/Sources/Scenes/CollectionsScene.swift
+++ b/ios/Features/NFT/Sources/Scenes/CollectionsScene.swift
@@ -25,7 +25,9 @@ public struct CollectionsScene<ViewModel: CollectionsViewable>: View {
                     }
                     .padding(.horizontal, Spacing.medium + Spacing.tiny)
 
-                    Spacer(minLength: .medium)
+                    if model.content.items.isNotEmpty {
+                        Spacer(minLength: .medium)
+                    }
 
                     if let unverifiedCount = model.content.unverifiedCount {
                         List {
@@ -40,13 +42,13 @@ public struct CollectionsScene<ViewModel: CollectionsViewable>: View {
                         .frame(height: .list.minHeight)
                     }
                 }
-                .frame(minHeight: geometry.size.height)
+                .frame(minHeight: geometry.size.height, alignment: .top)
             }
         }
         .bindQuery(model.query)
         .contentMargins(.top, .scene.top, for: .scrollContent)
         .overlay {
-            if model.content.items.isEmpty {
+            if model.content.items.isEmpty, model.content.unverifiedCount == nil {
                 EmptyContentView(model: model.emptyContentModel)
             }
         }

--- a/ios/Features/NFT/Sources/Scenes/CollectionsScene.swift
+++ b/ios/Features/NFT/Sources/Scenes/CollectionsScene.swift
@@ -20,12 +20,12 @@ public struct CollectionsScene<ViewModel: CollectionsViewable>: View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(spacing: .zero) {
-                    LazyVGrid(columns: model.columns) {
-                        collectionsView
-                    }
-                    .padding(.horizontal, Spacing.medium + Spacing.tiny)
-
                     if model.content.items.isNotEmpty {
+                        LazyVGrid(columns: model.columns) {
+                            collectionsView
+                        }
+                        .padding(.horizontal, Spacing.medium + Spacing.tiny)
+
                         Spacer(minLength: .medium)
                     }
 
@@ -38,6 +38,7 @@ public struct CollectionsScene<ViewModel: CollectionsViewable>: View {
                                 )
                             }
                         }
+                        .contentMargins(.top, .zero, for: .scrollContent)
                         .scrollDisabled(true)
                         .frame(height: .list.minHeight)
                     }

--- a/ios/Packages/Style/Sources/Spacing.swift
+++ b/ios/Packages/Style/Sources/Spacing.swift
@@ -110,7 +110,7 @@ public extension Sizing {
 
     enum list {
         /// 100
-        public static let minHeight: CGFloat = 100
+        public static let minHeight: CGFloat = 84
         /// 16
         public static let accessory: CGFloat = 16
         /// 22


### PR DESCRIPTION
When a wallet has only unverified NFTs, the NFT screen no longer shows the "Your NFTs will appear here" empty state as if there were nothing. The Unverified row now appears at the top as the main content.

Applies to both iOS and Android.

<img width="320" alt="Screenshot_1782894570" src="https://github.com/user-attachments/assets/c0439a53-9100-4e34-9bbf-aa02fe231309" />

<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-07-01 at 12 17 11" src="https://github.com/user-attachments/assets/5fe1fdaf-6f4d-441a-a167-e250722e7b1c" />


