### PR TITLE
Preflight device registration and wallet subscription for REST calls

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/di/InteractsModule.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/di/InteractsModule.kt
@@ -25,7 +25,7 @@ import com.gemwallet.android.blockchain.operators.gemstone.GemValidatePhraseOper
 import com.gemwallet.android.blockchain.services.GemSignAuthOperator
 import com.gemwallet.android.blockchain.services.GemSignMessageOperator
 import com.gemwallet.android.blockchain.services.GemSignTransactionOperator
-import com.gemwallet.android.cases.device.SyncSubscription
+import com.gemwallet.android.cases.device.InvalidateSubscriptions
 import com.gemwallet.android.cases.wallet.ImportWalletService
 import com.gemwallet.android.data.password.TinkPasswordStore
 import com.gemwallet.android.data.password.TinkSecurityStore
@@ -133,7 +133,7 @@ object InteractsModule {
         phraseValidate: ValidatePhraseOperator,
         addressValidate: ValidateAddressOperator,
         passwordStore: PasswordStore,
-        syncSubscription: SyncSubscription,
+        invalidateSubscriptions: InvalidateSubscriptions,
         walletImportSync: SyncWalletImport,
     ): ImportWalletService = PhraseAddressImportWalletService(
         walletsRepository = walletsRepository,
@@ -143,7 +143,7 @@ object InteractsModule {
         phraseValidate = phraseValidate,
         addressValidate = addressValidate,
         passwordStore = passwordStore,
-        syncSubscription = syncSubscription,
+        invalidateSubscriptions = invalidateSubscriptions,
         walletImportSync = walletImportSync,
     )
 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/services/SyncService.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/services/SyncService.kt
@@ -13,8 +13,8 @@ class SyncService @Inject constructor(
 
     suspend fun sync() {
         withContext(Dispatchers.IO) {
-            runCatching { syncFiatAssets() }
             runCatching { syncDeviceInfo.syncDeviceInfo() }
+            runCatching { syncFiatAssets() }
         }
     }
 }

--- a/android/app/src/test/kotlin/com/gemwallet/android/services/SyncServiceTest.kt
+++ b/android/app/src/test/kotlin/com/gemwallet/android/services/SyncServiceTest.kt
@@ -1,0 +1,35 @@
+package com.gemwallet.android.services
+
+import com.gemwallet.android.application.fiat.coordinators.SyncFiatAssets
+import com.gemwallet.android.cases.device.SyncDeviceInfo
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Test
+
+class SyncServiceTest {
+    private val syncFiatAssets = mockk<SyncFiatAssets>(relaxed = true)
+    private val syncDeviceInfo = mockk<SyncDeviceInfo>(relaxed = true)
+
+    private val subject = SyncService(
+        syncFiatAssets = syncFiatAssets,
+        syncDeviceInfo = syncDeviceInfo,
+    )
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun sync_registersDeviceBeforeSyncingFiatAssets() = runBlocking {
+        subject.sync()
+
+        coVerifyOrder {
+            syncDeviceInfo.syncDeviceInfo()
+            syncFiatAssets()
+        }
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -67,6 +67,7 @@ class DeviceRepository(
     private val Context.dataStore by preferencesDataStore(name = "device_config")
 
     private val registrationMutex = Mutex()
+    private val subscriptionMutex = Mutex()
 
     override suspend fun syncDeviceInfo() {
         synchronizeDevice(
@@ -158,6 +159,11 @@ class DeviceRepository(
 
     override suspend fun invoke() {
         if (isDeviceRegistered()) return
+        syncDeviceInfo()
+    }
+
+    suspend fun ensureSubscriptionsSynced() = subscriptionMutex.withLock {
+        if (!hasPendingSubscriptionChanges()) return@withLock
         syncDeviceInfo()
     }
 
@@ -299,7 +305,7 @@ class DeviceRepository(
         configStore.putBoolean(Keys.SubscriptionVersionHasChange.string, hasChange)
     }
 
-    private fun invalidateSubscriptions() {
+    fun invalidateSubscriptions() {
         val invalidatedState = getSubscriptionSyncState().invalidate()
         setSubscriptionVersion(invalidatedState.version)
         setSubscriptionVersionHasChange(invalidatedState.hasPendingChanges)

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
 import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
+import com.gemwallet.android.cases.device.EnsureDeviceRegistered
 import com.gemwallet.android.cases.device.GetPushEnabled
 import com.gemwallet.android.cases.device.GetPushToken
 import com.gemwallet.android.cases.device.IsDeviceRegistered
@@ -36,6 +37,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.Locale
 import kotlin.collections.firstOrNull
 import kotlin.collections.map
@@ -58,9 +61,12 @@ class DeviceRepository(
     GetPushToken,
     SetPushToken,
     SyncSubscription,
-    IsDeviceRegistered
+    IsDeviceRegistered,
+    EnsureDeviceRegistered
 {
     private val Context.dataStore by preferencesDataStore(name = "device_config")
+
+    private val registrationMutex = Mutex()
 
     override suspend fun syncDeviceInfo() {
         synchronizeDevice(
@@ -150,18 +156,23 @@ class DeviceRepository(
         return context.dataStore.data.map { it[Key.DeviceRegistered] }.firstOrNull() == true
     }
 
-    private suspend fun getOrCreateDevice(device: Device): Device {
+    override suspend fun invoke() {
+        if (isDeviceRegistered()) return
+        syncDeviceInfo()
+    }
+
+    private suspend fun getOrCreateDevice(device: Device): Device = registrationMutex.withLock {
         if (isDeviceRegistered() || gemDeviceApiClient.isDeviceRegistered()) {
             gemDeviceApiClient.getDevice()?.let { remoteDevice ->
                 setDeviceRegistered(true)
-                return remoteDevice
+                return@withLock remoteDevice
             }
             setDeviceRegistered(false)
         }
 
         val registeredDevice = gemDeviceApiClient.registerDevice(device) ?: device
         setDeviceRegistered(gemDeviceApiClient.isDeviceRegistered())
-        return registeredDevice
+        registeredDevice
     }
 
     private suspend fun updateDevice(remote: Device, request: Device) {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -33,12 +33,11 @@ import com.wallet.core.primitives.WalletSubscription
 import com.wallet.core.primitives.WalletSubscriptionChains
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import java.util.Locale
 import kotlin.collections.firstOrNull
 import kotlin.collections.map
@@ -66,8 +65,8 @@ class DeviceRepository(
 {
     private val Context.dataStore by preferencesDataStore(name = "device_config")
 
-    private val registrationMutex = Mutex()
-    private val subscriptionMutex = Mutex()
+    private val syncScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val syncCoordinator = DeviceSyncCoordinator(syncScope)
 
     override suspend fun syncDeviceInfo() {
         synchronizeDevice(
@@ -115,11 +114,16 @@ class DeviceRepository(
         shouldInvalidateSubscriptions: Boolean,
         pushTokenOverride: String? = null,
     ) {
-        try {
-            if (shouldInvalidateSubscriptions) {
-                invalidateSubscriptions()
-            }
+        if (shouldInvalidateSubscriptions) {
+            invalidateSubscriptions()
+        }
+        syncCoordinator.coordinate {
+            runDeviceSync(wallets, pushTokenOverride)
+        }
+    }
 
+    private suspend fun runDeviceSync(wallets: List<Wallet>, pushTokenOverride: String?) {
+        try {
             val subscriptionState = getSubscriptionSyncState()
             val pushState = resolvePushState(
                 wallets = wallets,
@@ -162,23 +166,24 @@ class DeviceRepository(
         syncDeviceInfo()
     }
 
-    suspend fun ensureSubscriptionsSynced() = subscriptionMutex.withLock {
-        if (!hasPendingSubscriptionChanges()) return@withLock
+    suspend fun ensureSubscriptionsSynced() {
+        syncCoordinator.waitForSyncIfNeeded()
+        if (!hasPendingSubscriptionChanges()) return
         syncDeviceInfo()
     }
 
-    private suspend fun getOrCreateDevice(device: Device): Device = registrationMutex.withLock {
+    private suspend fun getOrCreateDevice(device: Device): Device {
         if (isDeviceRegistered() || gemDeviceApiClient.isDeviceRegistered()) {
             gemDeviceApiClient.getDevice()?.let { remoteDevice ->
                 setDeviceRegistered(true)
-                return@withLock remoteDevice
+                return remoteDevice
             }
             setDeviceRegistered(false)
         }
 
         val registeredDevice = gemDeviceApiClient.registerDevice(device) ?: device
         setDeviceRegistered(gemDeviceApiClient.isDeviceRegistered())
-        registeredDevice
+        return registeredDevice
     }
 
     private suspend fun updateDevice(remote: Device, request: Device) {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinator.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinator.kt
@@ -1,0 +1,28 @@
+package com.gemwallet.android.data.repositories.device
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class DeviceSyncCoordinator(private val scope: CoroutineScope) {
+    private val mutex = Mutex()
+    private var syncJob: Deferred<Unit>? = null
+
+    suspend fun waitForSyncIfNeeded() {
+        val job = mutex.withLock { syncJob }
+        job?.let { runCatching { it.await() } }
+    }
+
+    suspend fun coordinate(operation: suspend () -> Unit) {
+        val job = mutex.withLock {
+            syncJob?.takeIf { it.isActive } ?: scope.async { operation() }.also { syncJob = it }
+        }
+        try {
+            runCatching { job.await() }
+        } finally {
+            mutex.withLock { if (syncJob === job) syncJob = null }
+        }
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
@@ -7,8 +7,7 @@ import com.gemwallet.android.application.fiat.coordinators.SyncFiatTransactions
 import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAlerts
 import com.gemwallet.android.blockchain.services.BalancesService
 import com.gemwallet.android.blockchain.services.PerpetualService
-import com.gemwallet.android.cases.device.IsDeviceRegistered
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.EnsureDeviceRegistered
 import com.gemwallet.android.cases.nft.SyncNfts
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
@@ -150,8 +149,7 @@ object AssetsModule {
         deviceRequestSigner: DeviceRequestSigner,
         streamSubscriptionService: StreamSubscriptionService,
         eventHandler: StreamEventHandler,
-        syncDeviceInfo: SyncDeviceInfo,
-        isDeviceRegistered: IsDeviceRegistered,
+        ensureDeviceRegistered: EnsureDeviceRegistered,
     ): StreamObserverService = StreamObserverService(
         sessionRepository = sessionRepository,
         userConfig = userConfig,
@@ -168,8 +166,7 @@ object AssetsModule {
             },
             reconnection = ExponentialReconnection(maxDelay = 30.0),
         ),
-        syncDeviceInfo = syncDeviceInfo,
-        isDeviceRegistered = isDeviceRegistered,
+        ensureDeviceRegistered = ensureDeviceRegistered,
     )
 
     @Provides

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.data.repositories.di
 import android.content.Context
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
 import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
+import com.gemwallet.android.cases.device.EnsureDeviceRegistered
 import com.gemwallet.android.cases.device.GetPushEnabled
 import com.gemwallet.android.cases.device.GetPushToken
 import com.gemwallet.android.cases.device.IsDeviceRegistered
@@ -15,6 +16,7 @@ import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.data.service.store.ConfigStore
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
+import com.gemwallet.android.data.services.gemapi.di.DeviceApiWithoutRegistration
 import com.gemwallet.android.model.BuildInfo
 import dagger.Module
 import dagger.Provides
@@ -33,7 +35,7 @@ object DeviceModule {
     fun provideDeviceRepository(
         @ApplicationContext context: Context,
         buildInfo: BuildInfo,
-        gemDeviceApiClient: GemDeviceApiClient,
+        @DeviceApiWithoutRegistration gemDeviceApiClient: GemDeviceApiClient,
         getDeviceId: GetDeviceId,
         priceAlertRepository: PriceAlertRepository,
         getCurrentCurrency: GetCurrentCurrency,
@@ -73,4 +75,7 @@ object DeviceModule {
 
     @Provides
     fun provideIsDeviceRegisteredCase(repository: DeviceRepository): IsDeviceRegistered = repository
+
+    @Provides
+    fun provideEnsureDeviceRegisteredCase(repository: DeviceRepository): EnsureDeviceRegistered = repository
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
 import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
 import com.gemwallet.android.cases.device.EnsureDeviceRegistered
+import com.gemwallet.android.cases.device.EnsureSubscriptionsSynced
 import com.gemwallet.android.cases.device.GetPushEnabled
 import com.gemwallet.android.cases.device.GetPushToken
+import com.gemwallet.android.cases.device.InvalidateSubscriptions
 import com.gemwallet.android.cases.device.IsDeviceRegistered
 import com.gemwallet.android.cases.device.SetPushToken
 import com.gemwallet.android.cases.device.SwitchPushEnabled
@@ -78,4 +80,12 @@ object DeviceModule {
 
     @Provides
     fun provideEnsureDeviceRegisteredCase(repository: DeviceRepository): EnsureDeviceRegistered = repository
+
+    @Provides
+    fun provideEnsureSubscriptionsSyncedCase(repository: DeviceRepository): EnsureSubscriptionsSynced =
+        EnsureSubscriptionsSynced { repository.ensureSubscriptionsSynced() }
+
+    @Provides
+    fun provideInvalidateSubscriptionsCase(repository: DeviceRepository): InvalidateSubscriptions =
+        InvalidateSubscriptions { repository.invalidateSubscriptions() }
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
@@ -3,8 +3,7 @@ package com.gemwallet.android.data.repositories.stream
 import android.util.Log
 import com.gemwallet.android.application.assets.coordinators.SyncAssets
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetuals
-import com.gemwallet.android.cases.device.IsDeviceRegistered
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.EnsureDeviceRegistered
 import com.gemwallet.android.data.repositories.config.UserConfig
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.ext.hasPerpetualsSupport
@@ -31,8 +30,7 @@ class StreamObserverService(
     private val subscriptionService: StreamSubscriptionService,
     private val eventHandler: StreamEventHandler,
     private val connection: WebSocketConnectable,
-    private val syncDeviceInfo: SyncDeviceInfo,
-    private val isDeviceRegistered: IsDeviceRegistered,
+    private val ensureDeviceRegistered: EnsureDeviceRegistered,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
 ) {
     private var connectionJob: Job? = null
@@ -61,9 +59,7 @@ class StreamObserverService(
         if (sessionRepository.session().value?.wallet == null) return
 
         connectionJob = scope.launch {
-            if (!isDeviceRegistered.isDeviceRegistered()) {
-                registerDevice()
-            }
+            ensureDeviceRegistered()
             launch {
                 for (message in subscriptionService.messages) {
                     connection.send(message.toJson())
@@ -77,11 +73,6 @@ class StreamObserverService(
                 }
             }
         }
-    }
-
-    private suspend fun registerDevice() {
-        runCatching { syncDeviceInfo.syncDeviceInfo() }
-            .onFailure { Log.e(TAG, "Device registration error", it) }
     }
 
     fun stop() {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/wallets/PhraseAddressImportWalletService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/wallets/PhraseAddressImportWalletService.kt
@@ -7,7 +7,7 @@ import com.gemwallet.android.blockchain.operators.InvalidWords
 import com.gemwallet.android.blockchain.operators.StorePhraseOperator
 import com.gemwallet.android.blockchain.operators.ValidateAddressOperator
 import com.gemwallet.android.blockchain.operators.ValidatePhraseOperator
-import com.gemwallet.android.cases.device.SyncSubscription
+import com.gemwallet.android.cases.device.InvalidateSubscriptions
 import com.gemwallet.android.cases.wallet.ImportError
 import com.gemwallet.android.cases.wallet.ImportWalletService
 import com.gemwallet.android.cases.wallet.WalletImportResult
@@ -29,7 +29,7 @@ class PhraseAddressImportWalletService(
     private val phraseValidate: ValidatePhraseOperator,
     private val addressValidate: ValidateAddressOperator,
     private val passwordStore: PasswordStore,
-    private val syncSubscription: SyncSubscription,
+    private val invalidateSubscriptions: InvalidateSubscriptions,
     private val walletImportSync: SyncWalletImport,
 ) : ImportWalletService {
 
@@ -58,12 +58,12 @@ class PhraseAddressImportWalletService(
         val wallet = handlePhrase(ImportType(WalletType.Multicoin), walletName, data, WalletSource.Create)
 
         setupWallet(wallet)
-        syncSubscription.syncSubscription(listOf(wallet))
 
         return wallet
     }
 
     private suspend fun setupWallet(wallet: Wallet) {
+        invalidateSubscriptions()
         assetsRepository.createAssets(wallet)
         sessionRepository.setWallet(wallet)
     }

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinatorTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinatorTest.kt
@@ -1,0 +1,81 @@
+package com.gemwallet.android.data.repositories.device
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+class DeviceSyncCoordinatorTest {
+
+    @Test
+    fun coalescesConcurrentCallsIntoSingleRun() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val coordinator = DeviceSyncCoordinator(scope)
+        val runs = AtomicInteger(0)
+        val gate = CompletableDeferred<Unit>()
+
+        repeat(3) {
+            scope.launch {
+                coordinator.coordinate {
+                    runs.incrementAndGet()
+                    gate.await()
+                }
+            }
+        }
+        assertEquals(1, runs.get())
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(1, runs.get())
+        scope.cancel()
+    }
+
+    @Test
+    fun runsAgainForCallAfterPreviousCompleted() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val coordinator = DeviceSyncCoordinator(scope)
+        val runs = AtomicInteger(0)
+
+        coordinator.coordinate { runs.incrementAndGet() }
+        coordinator.coordinate { runs.incrementAndGet() }
+
+        assertEquals(2, runs.get())
+        scope.cancel()
+    }
+
+    @Test
+    fun waitForSyncIfNeededAwaitsInFlightSync() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val coordinator = DeviceSyncCoordinator(scope)
+        val gate = CompletableDeferred<Unit>()
+        val opCompleted = AtomicBoolean(false)
+        scope.launch {
+            coordinator.coordinate {
+                gate.await()
+                opCompleted.set(true)
+            }
+        }
+
+        val waitCompleted = AtomicBoolean(false)
+        scope.launch {
+            coordinator.waitForSyncIfNeeded()
+            waitCompleted.set(true)
+        }
+        assertFalse(waitCompleted.get())
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertTrue(opCompleted.get())
+        assertTrue(waitCompleted.get())
+        scope.cancel()
+    }
+}

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/wallets/PhraseAddressImportWalletServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/wallets/PhraseAddressImportWalletServiceTest.kt
@@ -1,0 +1,82 @@
+package com.gemwallet.android.data.repositories.wallets
+
+import com.gemwallet.android.application.PasswordStore
+import com.gemwallet.android.application.wallet_import.coordinators.SyncWalletImport
+import com.gemwallet.android.blockchain.operators.StorePhraseOperator
+import com.gemwallet.android.blockchain.operators.StoredWalletSecret
+import com.gemwallet.android.blockchain.operators.ValidateAddressOperator
+import com.gemwallet.android.blockchain.operators.ValidatePhraseOperator
+import com.gemwallet.android.cases.device.InvalidateSubscriptions
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.model.ImportType
+import com.gemwallet.android.testkit.mockWallet
+import com.wallet.core.primitives.WalletType
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class PhraseAddressImportWalletServiceTest {
+
+    private val walletsRepository = mockk<WalletsRepository>()
+    private val assetsRepository = mockk<AssetsRepository>()
+    private val sessionRepository = mockk<SessionRepository>()
+    private val storePhraseOperator = mockk<StorePhraseOperator>()
+    private val phraseValidate = mockk<ValidatePhraseOperator>()
+    private val addressValidate = mockk<ValidateAddressOperator>()
+    private val passwordStore = mockk<PasswordStore>()
+    private val invalidateSubscriptions = mockk<InvalidateSubscriptions>(relaxed = true)
+    private val walletImportSync = mockk<SyncWalletImport>(relaxed = true)
+
+    private val wallet = mockWallet(id = "multicoin_0xabc")
+
+    private val subject = PhraseAddressImportWalletService(
+        walletsRepository = walletsRepository,
+        assetsRepository = assetsRepository,
+        sessionRepository = sessionRepository,
+        storePhraseOperator = storePhraseOperator,
+        phraseValidate = phraseValidate,
+        addressValidate = addressValidate,
+        passwordStore = passwordStore,
+        invalidateSubscriptions = invalidateSubscriptions,
+        walletImportSync = walletImportSync,
+    )
+
+    private fun stubHappyPath() {
+        every { phraseValidate(any()) } returns Result.success(true)
+        coEvery { walletsRepository.addControlled(any(), any(), any(), any(), any()) } returns wallet
+        every { passwordStore.createPassword(any()) } returns "password"
+        coEvery { storePhraseOperator(any(), any(), any()) } returns Result.success(StoredWalletSecret("keystore"))
+        coEvery { assetsRepository.createAssets(wallet) } just Runs
+        coEvery { sessionRepository.setWallet(wallet) } just Runs
+    }
+
+    @Test
+    fun createWallet_invalidatesSubscriptionsBeforeActivatingSession() = runTest {
+        stubHappyPath()
+
+        subject.createWallet("Wallet", "phrase words for the new wallet flow")
+
+        coVerifyOrder {
+            invalidateSubscriptions()
+            sessionRepository.setWallet(wallet)
+        }
+    }
+
+    @Test
+    fun importWallet_invalidatesSubscriptionsBeforeActivatingSession() = runTest {
+        stubHappyPath()
+
+        subject.importWallet(ImportType(WalletType.Multicoin), "Wallet", "phrase words for the wallet flow")
+
+        coVerifyOrder {
+            invalidateSubscriptions()
+            sessionRepository.setWallet(wallet)
+        }
+    }
+}

--- a/android/data/services/remote-gem/build.gradle.kts
+++ b/android/data/services/remote-gem/build.gradle.kts
@@ -61,6 +61,8 @@ dependencies {
     implementation(libs.tink)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk.android)
     testImplementation(testFixtures(project(":gemcore")))
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/di/ClientsModule.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/di/ClientsModule.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import com.gemwallet.android.Constants
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
 import com.gemwallet.android.cases.device.EnsureDeviceRegistered
+import com.gemwallet.android.cases.device.EnsureSubscriptionsSynced
 import com.gemwallet.android.data.services.gemapi.GemApiClient
 import com.gemwallet.android.data.services.gemapi.GemApiStaticClient
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
@@ -12,6 +13,7 @@ import com.gemwallet.android.data.services.gemapi.Mime
 import com.gemwallet.android.data.services.gemapi.http.DeviceRegistrationInterceptor
 import com.gemwallet.android.data.services.gemapi.http.GemApiErrorInterceptor
 import com.gemwallet.android.data.services.gemapi.http.SecurityInterceptor
+import com.gemwallet.android.data.services.gemapi.http.SubscriptionSyncInterceptor
 import com.gemwallet.android.model.BuildInfo
 import com.gemwallet.android.serializer.jsonEncoder
 import dagger.Module
@@ -38,6 +40,12 @@ object ClientsModule {
     fun provideDeviceRegistrationInterceptor(
         ensureDeviceRegistered: EnsureDeviceRegistered,
     ) = DeviceRegistrationInterceptor(ensureDeviceRegistered)
+
+    @Provides
+    @Singleton
+    fun provideSubscriptionSyncInterceptor(
+        ensureSubscriptionsSynced: EnsureSubscriptionsSynced,
+    ) = SubscriptionSyncInterceptor(ensureSubscriptionsSynced)
 
     @Provides
     @Singleton
@@ -93,8 +101,9 @@ object ClientsModule {
     fun provideGemDeviceApiClient(
         httpClient: OkHttpClient,
         deviceRegistrationInterceptor: DeviceRegistrationInterceptor,
+        subscriptionSyncInterceptor: SubscriptionSyncInterceptor,
         securityInterceptor: SecurityInterceptor,
-    ): GemDeviceApiClient = deviceApiClient(httpClient, deviceRegistrationInterceptor, securityInterceptor)
+    ): GemDeviceApiClient = deviceApiClient(httpClient, deviceRegistrationInterceptor, subscriptionSyncInterceptor, securityInterceptor)
 
     private fun deviceApiClient(
         httpClient: OkHttpClient,

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/di/ClientsModule.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/di/ClientsModule.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import android.os.Build
 import com.gemwallet.android.Constants
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
+import com.gemwallet.android.cases.device.EnsureDeviceRegistered
 import com.gemwallet.android.data.services.gemapi.GemApiClient
 import com.gemwallet.android.data.services.gemapi.GemApiStaticClient
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
 import com.gemwallet.android.data.services.gemapi.Mime
+import com.gemwallet.android.data.services.gemapi.http.DeviceRegistrationInterceptor
 import com.gemwallet.android.data.services.gemapi.http.GemApiErrorInterceptor
 import com.gemwallet.android.data.services.gemapi.http.SecurityInterceptor
 import com.gemwallet.android.model.BuildInfo
@@ -19,6 +21,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.Cache
 import okhttp3.ConnectionPool
+import okhttp3.Dispatcher
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -28,6 +32,12 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 @Module
 object ClientsModule {
+
+    @Provides
+    @Singleton
+    fun provideDeviceRegistrationInterceptor(
+        ensureDeviceRegistered: EnsureDeviceRegistered,
+    ) = DeviceRegistrationInterceptor(ensureDeviceRegistered)
 
     @Provides
     @Singleton
@@ -72,16 +82,31 @@ object ClientsModule {
 
     @Provides
     @Singleton
-    fun provideGemDeviceApiClient(
+    @DeviceApiWithoutRegistration
+    fun provideDeviceApiWithoutRegistration(
         httpClient: OkHttpClient,
         securityInterceptor: SecurityInterceptor,
+    ): GemDeviceApiClient = deviceApiClient(httpClient, securityInterceptor)
+
+    @Provides
+    @Singleton
+    fun provideGemDeviceApiClient(
+        httpClient: OkHttpClient,
+        deviceRegistrationInterceptor: DeviceRegistrationInterceptor,
+        securityInterceptor: SecurityInterceptor,
+    ): GemDeviceApiClient = deviceApiClient(httpClient, deviceRegistrationInterceptor, securityInterceptor)
+
+    private fun deviceApiClient(
+        httpClient: OkHttpClient,
+        vararg interceptors: Interceptor,
     ): GemDeviceApiClient {
-        val httpClient = httpClient.newBuilder()
-            .addInterceptor(securityInterceptor)
+        val client = httpClient.newBuilder()
+            .dispatcher(Dispatcher())
+            .apply { interceptors.forEach { addInterceptor(it) } }
             .build()
         return Retrofit.Builder()
             .baseUrl(Constants.API_URL)
-            .client(httpClient)
+            .client(client)
             .addConverterFactory(jsonEncoder.asConverterFactory(Mime.Json.value))
             .build()
             .create(GemDeviceApiClient::class.java)

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/di/DeviceApiWithoutRegistration.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/di/DeviceApiWithoutRegistration.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.data.services.gemapi.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DeviceApiWithoutRegistration

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRegistrationInterceptor.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRegistrationInterceptor.kt
@@ -1,0 +1,20 @@
+package com.gemwallet.android.data.services.gemapi.http
+
+import com.gemwallet.android.cases.device.EnsureDeviceRegistered
+import com.wallet.core.primitives.WalletId
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class DeviceRegistrationInterceptor(
+    private val ensureDeviceRegistered: EnsureDeviceRegistered,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        if (request.tag(WalletId::class.java) != null) {
+            runCatching { runBlocking { ensureDeviceRegistered() } }
+        }
+        return chain.proceed(request)
+    }
+}

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/SubscriptionSyncInterceptor.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/SubscriptionSyncInterceptor.kt
@@ -1,0 +1,20 @@
+package com.gemwallet.android.data.services.gemapi.http
+
+import com.gemwallet.android.cases.device.EnsureSubscriptionsSynced
+import com.wallet.core.primitives.WalletId
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class SubscriptionSyncInterceptor(
+    private val ensureSubscriptionsSynced: EnsureSubscriptionsSynced,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        if (request.tag(WalletId::class.java) != null) {
+            runCatching { runBlocking { ensureSubscriptionsSynced() } }
+        }
+        return chain.proceed(request)
+    }
+}

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRegistrationInterceptorTest.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/DeviceRegistrationInterceptorTest.kt
@@ -1,0 +1,107 @@
+package com.gemwallet.android.data.services.gemapi.http
+
+import com.gemwallet.android.cases.device.EnsureDeviceRegistered
+import com.gemwallet.android.testkit.mockMulticoinWalletId
+import com.wallet.core.primitives.WalletId
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import java.util.concurrent.TimeUnit
+import okhttp3.Call
+import okhttp3.Connection
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class DeviceRegistrationInterceptorTest {
+    private val events = mutableListOf<String>()
+    private val ensureDeviceRegistered = mockk<EnsureDeviceRegistered>()
+    private val subject = DeviceRegistrationInterceptor(ensureDeviceRegistered)
+
+    @Before
+    fun setUp() {
+        coEvery { ensureDeviceRegistered() } answers { events.add("preflight") }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun walletScopedRequest_runsRegistrationPreflightBeforeProceeding() {
+        val request = Request.Builder()
+            .url("https://api.gemwallet.com/v2/devices/rewards")
+            .tag(WalletId::class.java, mockMulticoinWalletId())
+            .build()
+
+        subject.intercept(RecordingChain(request, events))
+
+        assertEquals(listOf("preflight", "proceed"), events)
+    }
+
+    @Test
+    fun walletScopedRequest_proceedsEvenWhenPreflightFails() {
+        coEvery { ensureDeviceRegistered() } throws RuntimeException("registration failed")
+        val request = Request.Builder()
+            .url("https://api.gemwallet.com/v2/devices/rewards")
+            .tag(WalletId::class.java, mockMulticoinWalletId())
+            .build()
+
+        val response = subject.intercept(RecordingChain(request, events))
+
+        assertEquals(200, response.code)
+        assertEquals(listOf("proceed"), events)
+    }
+
+    @Test
+    fun deviceScopedRequest_proceedsWithoutRegistrationPreflight() {
+        val request = Request.Builder()
+            .url("https://api.gemwallet.com/v2/devices")
+            .build()
+
+        subject.intercept(RecordingChain(request, events))
+
+        coVerify(exactly = 0) { ensureDeviceRegistered() }
+        assertEquals(listOf("proceed"), events)
+    }
+}
+
+private class RecordingChain(
+    private val request: Request,
+    private val events: MutableList<String>,
+) : Interceptor.Chain {
+    override fun request(): Request = request
+
+    override fun proceed(request: Request): Response {
+        events.add("proceed")
+        return Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_2)
+            .code(200)
+            .message("OK")
+            .build()
+    }
+
+    override fun connection(): Connection? = null
+
+    override fun call(): Call = error("not used")
+
+    override fun connectTimeoutMillis(): Int = 0
+
+    override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = this
+
+    override fun readTimeoutMillis(): Int = 0
+
+    override fun withReadTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = this
+
+    override fun writeTimeoutMillis(): Int = 0
+
+    override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = this
+}

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/SubscriptionSyncInterceptorTest.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/SubscriptionSyncInterceptorTest.kt
@@ -1,0 +1,107 @@
+package com.gemwallet.android.data.services.gemapi.http
+
+import com.gemwallet.android.cases.device.EnsureSubscriptionsSynced
+import com.gemwallet.android.testkit.mockMulticoinWalletId
+import com.wallet.core.primitives.WalletId
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import java.util.concurrent.TimeUnit
+import okhttp3.Call
+import okhttp3.Connection
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class SubscriptionSyncInterceptorTest {
+    private val events = mutableListOf<String>()
+    private val ensureSubscriptionsSynced = mockk<EnsureSubscriptionsSynced>()
+    private val subject = SubscriptionSyncInterceptor(ensureSubscriptionsSynced)
+
+    @Before
+    fun setUp() {
+        coEvery { ensureSubscriptionsSynced() } answers { events.add("preflight") }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun walletScopedRequest_runsSubscriptionPreflightBeforeProceeding() {
+        val request = Request.Builder()
+            .url("https://api.gemwallet.com/v2/devices/assets")
+            .tag(WalletId::class.java, mockMulticoinWalletId())
+            .build()
+
+        subject.intercept(SubscriptionRecordingChain(request, events))
+
+        assertEquals(listOf("preflight", "proceed"), events)
+    }
+
+    @Test
+    fun walletScopedRequest_proceedsEvenWhenPreflightFails() {
+        coEvery { ensureSubscriptionsSynced() } throws RuntimeException("subscription failed")
+        val request = Request.Builder()
+            .url("https://api.gemwallet.com/v2/devices/assets")
+            .tag(WalletId::class.java, mockMulticoinWalletId())
+            .build()
+
+        val response = subject.intercept(SubscriptionRecordingChain(request, events))
+
+        assertEquals(200, response.code)
+        assertEquals(listOf("proceed"), events)
+    }
+
+    @Test
+    fun deviceScopedRequest_proceedsWithoutSubscriptionPreflight() {
+        val request = Request.Builder()
+            .url("https://api.gemwallet.com/v2/devices")
+            .build()
+
+        subject.intercept(SubscriptionRecordingChain(request, events))
+
+        coVerify(exactly = 0) { ensureSubscriptionsSynced() }
+        assertEquals(listOf("proceed"), events)
+    }
+}
+
+private class SubscriptionRecordingChain(
+    private val request: Request,
+    private val events: MutableList<String>,
+) : Interceptor.Chain {
+    override fun request(): Request = request
+
+    override fun proceed(request: Request): Response {
+        events.add("proceed")
+        return Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_2)
+            .code(200)
+            .message("OK")
+            .build()
+    }
+
+    override fun connection(): Connection? = null
+
+    override fun call(): Call = error("not used")
+
+    override fun connectTimeoutMillis(): Int = 0
+
+    override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = this
+
+    override fun readTimeoutMillis(): Int = 0
+
+    override fun withReadTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = this
+
+    override fun writeTimeoutMillis(): Int = 0
+
+    override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = this
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/EnsureDeviceRegistered.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/EnsureDeviceRegistered.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.cases.device
+
+interface EnsureDeviceRegistered {
+    suspend operator fun invoke()
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/EnsureSubscriptionsSynced.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/EnsureSubscriptionsSynced.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.cases.device
+
+fun interface EnsureSubscriptionsSynced {
+    suspend operator fun invoke()
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/InvalidateSubscriptions.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/InvalidateSubscriptions.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.cases.device
+
+fun interface InvalidateSubscriptions {
+    operator fun invoke()
+}


### PR DESCRIPTION
Wallet-scoped device REST calls could 404 on fresh state:
- **Device not found** — the call fired before the device was registered.
- **Wallet not found** — a new wallet's assets were fetched before it was subscribed on the backend.

Both are fixed with a transport-level preflight: wallet-tagged requests wait until the device is registered and its subscriptions are synced before proceeding. Subscriptions are marked dirty on wallet create/import and reconciled lazily, matching iOS.

Closes #550
Closes #603
Closes https://github.com/gemwalletcom/wallet/issues/620

## TODO: testing
- [x] Manual on-device testing