### PR TITLE
Add periodic refresh and tap-to-open to prices widget

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -284,6 +284,7 @@ dependencies {
 
     implementation(libs.widgets)
     implementation(libs.widgets.material3)
+    implementation(libs.work.runtime)
 
     // Legacy encrypted preferences migration
     implementation(libs.androidx.security.crypto)

--- a/android/app/src/main/kotlin/com/gemwallet/android/AppLifecycleCoordinator.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/AppLifecycleCoordinator.kt
@@ -1,17 +1,28 @@
 package com.gemwallet.android
 
+import android.content.Context
+import androidx.glance.appwidget.updateAll
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.gemwallet.android.data.repositories.perpetual.HyperliquidObserverService
 import com.gemwallet.android.data.repositories.stream.StreamObserverService
+import com.gemwallet.android.features.widgets.PricesWidget
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class AppLifecycleCoordinator @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val streamObserver: StreamObserverService,
     private val hyperliquidObserver: HyperliquidObserverService,
 ) : DefaultLifecycleObserver {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onStart(owner: LifecycleOwner) {
         streamObserver.start()
@@ -21,5 +32,6 @@ class AppLifecycleCoordinator @Inject constructor(
     override fun onStop(owner: LifecycleOwner) {
         streamObserver.stop()
         hyperliquidObserver.stop()
+        scope.launch { PricesWidget().updateAll(context) }
     }
 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/AppLifecycleCoordinator.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/AppLifecycleCoordinator.kt
@@ -1,28 +1,17 @@
 package com.gemwallet.android
 
-import android.content.Context
-import androidx.glance.appwidget.updateAll
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.gemwallet.android.data.repositories.perpetual.HyperliquidObserverService
 import com.gemwallet.android.data.repositories.stream.StreamObserverService
-import com.gemwallet.android.features.widgets.PricesWidget
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class AppLifecycleCoordinator @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val streamObserver: StreamObserverService,
     private val hyperliquidObserver: HyperliquidObserverService,
 ) : DefaultLifecycleObserver {
-
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onStart(owner: LifecycleOwner) {
         streamObserver.start()
@@ -32,6 +21,5 @@ class AppLifecycleCoordinator @Inject constructor(
     override fun onStop(owner: LifecycleOwner) {
         streamObserver.stop()
         hyperliquidObserver.stop()
-        scope.launch { PricesWidget().updateAll(context) }
     }
 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/features/widgets/GemPricesWidgetReceiver.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/widgets/GemPricesWidgetReceiver.kt
@@ -1,10 +1,20 @@
 package com.gemwallet.android.features.widgets
 
+import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 
 class GemPricesWidgetReceiver : GlanceAppWidgetReceiver() {
 
-
     override val glanceAppWidget: GlanceAppWidget = PricesWidget()
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        WidgetPriceSyncWorker.schedule(context)
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        WidgetPriceSyncWorker.cancel(context)
+    }
 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/features/widgets/PricesWidget.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/widgets/PricesWidget.kt
@@ -1,14 +1,10 @@
 package com.gemwallet.android.features.widgets
 
 import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -17,8 +13,9 @@ import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
-import androidx.glance.LocalContext
+import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
 import androidx.glance.layout.Alignment
@@ -37,11 +34,10 @@ import androidx.glance.text.TextAlign
 import androidx.glance.text.TextDefaults.defaultTextStyle
 import androidx.glance.unit.ColorProvider
 import coil3.imageLoader
-import coil3.request.CachePolicy
-import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.toBitmap
+import com.gemwallet.android.MainActivity
 import com.gemwallet.android.data.repositories.di.WidgetEntryPoint
 import com.gemwallet.android.domains.asset.getIconUrl
 import com.gemwallet.android.domains.percentage.formatAsPercentage
@@ -54,8 +50,13 @@ import com.gemwallet.android.ui.theme.paddingSmall
 import com.wallet.core.primitives.Currency
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
+
+private data class WidgetAsset(val info: AssetInfo, val icon: Bitmap?)
 
 class PricesWidget : GlanceAppWidget() {
 
@@ -66,21 +67,25 @@ class PricesWidget : GlanceAppWidget() {
         val assetsRepository = EntryPointAccessors.fromApplication(context, WidgetEntryPoint::class.java).assetsRepository()
         val sessionRepository = EntryPointAccessors.fromApplication(context, WidgetEntryPoint::class.java).sessionRepository()
         val noData = context.getString(R.string.errors_no_data_available)
-        val assets = try {
+        val items = try {
             val currency = sessionRepository.session().firstOrNull()?.currency ?: Currency.USD
-            assetsRepository.getWidgetTokens(currency)
+            loadItems(context, assetsRepository.getWidgetTokens(currency))
         } catch (_: Throwable) {
             emptyList()
         }
 
         provideContent {
+            val launchAppIntent = Intent(context, MainActivity::class.java)
             GlanceTheme {
-                if (assets.isNotEmpty()) {
-                    Assets(assets)
-                } else {
-                    Box(
-                        modifier = GlanceModifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
-                    ) {
+                Box(
+                    modifier = GlanceModifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background)
+                        .clickable(actionStartActivity(launchAppIntent)),
+                ) {
+                    if (items.isNotEmpty()) {
+                        Assets(items)
+                    } else {
                         Text(
                             modifier = GlanceModifier.fillMaxSize().padding(paddingDefault),
                             text = noData,
@@ -92,16 +97,27 @@ class PricesWidget : GlanceAppWidget() {
         }
     }
 
+    private suspend fun loadItems(context: Context, assets: List<AssetInfo>): List<WidgetAsset> = coroutineScope {
+        assets.map { asset ->
+            async { WidgetAsset(asset, loadIcon(context, asset.id().getIconUrl())) }
+        }.awaitAll()
+    }
+
+    private suspend fun loadIcon(context: Context, url: String): Bitmap? = withContext(Dispatchers.IO) {
+        runCatching {
+            val request = ImageRequest.Builder(context).data(url).build()
+            (context.imageLoader.execute(request) as? SuccessResult)?.image?.toBitmap()
+        }.getOrNull()
+    }
+
     @Composable
-    private fun Assets(assets: List<AssetInfo>) {
+    private fun Assets(items: List<WidgetAsset>) {
         Column(
-            modifier = GlanceModifier
-                .background(MaterialTheme.colorScheme.background)
-                .fillMaxSize(),
-            verticalAlignment = Alignment.Top,
+            modifier = GlanceModifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            assets.forEach {
+            items.forEach {
                 AssetItem(it)
             }
         }
@@ -115,25 +131,8 @@ class PricesWidget : GlanceAppWidget() {
 }
 
 @Composable
-private fun AssetItem(asset: AssetInfo) {
-    val context = LocalContext.current
-    val imageUrl = asset.id().getIconUrl()
-    var loadedBitmap by remember() { mutableStateOf<Bitmap?>(null) }
-
-    LaunchedEffect(imageUrl) {
-        withContext(Dispatchers.IO) {
-            val request = ImageRequest.Builder(context).data(imageUrl).apply {
-                memoryCachePolicy(CachePolicy.DISABLED)
-                diskCachePolicy(CachePolicy.DISABLED)
-            }.build()
-
-            // Request the image to be loaded and return null if an error has occurred
-            loadedBitmap = when (val result = context.imageLoader.execute(request)) {
-                is ErrorResult -> null
-                is SuccessResult -> result.image.toBitmap()
-            }
-        }
-    }
+private fun AssetItem(item: WidgetAsset) {
+    val asset = item.info
     Row(
         modifier = GlanceModifier
             .fillMaxWidth()
@@ -143,7 +142,7 @@ private fun AssetItem(asset: AssetInfo) {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box() {
-            loadedBitmap?.let {
+            item.icon?.let {
                 Image(
                     ImageProvider(it),
                     contentDescription = ""

--- a/android/app/src/main/kotlin/com/gemwallet/android/features/widgets/WidgetPriceSyncWorker.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/widgets/WidgetPriceSyncWorker.kt
@@ -1,0 +1,53 @@
+package com.gemwallet.android.features.widgets
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.glance.appwidget.updateAll
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import java.util.concurrent.TimeUnit
+
+class WidgetPriceSyncWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            PricesWidget().updateAll(applicationContext)
+            Result.success()
+        } catch (_: Throwable) {
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val WORK_NAME = "widget_price_sync"
+        private const val REFRESH_INTERVAL_MINUTES = 15L
+
+        fun schedule(context: Context) {
+            val request = PeriodicWorkRequestBuilder<WidgetPriceSyncWorker>(
+                REFRESH_INTERVAL_MINUTES, TimeUnit.MINUTES
+            )
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request,
+            )
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+        }
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
@@ -231,7 +231,7 @@ class AssetsRepository @Inject constructor(
     suspend fun getWidgetTokens(currency: Currency): List<AssetInfo> = withContext(Dispatchers.IO) {
         val widgetAssetIds = listOf(AssetId(Chain.Bitcoin), AssetId(Chain.Ethereum), AssetId(Chain.Solana))
 
-        searchTokensCase.search(widgetAssetIds, currency)
+        runCatching { searchTokensCase.search(widgetAssetIds, currency) }
         getTokensInfo(widgetAssetIds.map { it.toIdentifier() }).firstOrNull() ?: emptyList()
     }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ espressoCore = "3.7.0"
 
 
 glance-widgets = "1.3.0-alpha01"
+work = "2.11.2"
 
 tink = "1.22.0"
 
@@ -83,6 +84,7 @@ webview = { module = "io.github.kevinnzou:compose-webview", version.ref = "web-v
 #App widgets
 widgets = { module = "androidx.glance:glance-appwidget", version.ref = "glance-widgets"}
 widgets-material3 = { module = "androidx.glance:glance-material3", version.ref = "glance-widgets"}
+work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 
 # Sqlite room
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }


### PR DESCRIPTION
The prices widget didn't refresh on its own. Now it updates every 15 minutes, refreshes when you leave the app, and opens the app on tap. Also fixes the flicker when it refreshes.

<!-- screenshot -->