### PR TITLE
Show screenshot warning on Android secret screens

### DIFF
--- a/android/features/create_wallet/presents/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/CheckPhrase.kt
+++ b/android/features/create_wallet/presents/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/CheckPhrase.kt
@@ -18,7 +18,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import com.gemwallet.android.AppUrl
 import com.gemwallet.android.features.create_wallet.components.WordChip
+import com.gemwallet.android.ui.DetectScreenshot
 import com.gemwallet.android.ui.DisableScreenShooting
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.CenteredDescriptionText
@@ -32,6 +34,7 @@ import com.gemwallet.android.ui.theme.WindowDimension
 import com.gemwallet.android.ui.theme.isCompactDimension
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.sceneContentPaddingValues
+import uniffi.gemstone.DocsUrl
 import kotlin.math.min
 
 private const val wordsPerGroup = 4
@@ -45,6 +48,7 @@ internal fun CheckPhrase(
     onCancel: () -> Unit,
 ) {
     DisableScreenShooting()
+    DetectScreenshot(AppUrl.docs(DocsUrl.HowToSecureSecretPhrase))
 
     val random = remember {
         val shuffled = mutableListOf<Pair<Int, String>>()

--- a/android/features/create_wallet/presents/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/CreateWalletScreen.kt
+++ b/android/features/create_wallet/presents/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/CreateWalletScreen.kt
@@ -29,9 +29,12 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gemwallet.android.AppUrl
 import com.gemwallet.android.features.create_wallet.viewmodels.CreateWalletViewModel
+import com.gemwallet.android.ui.DetectScreenshot
 import com.gemwallet.android.ui.DisableScreenShooting
 import com.gemwallet.android.ui.R
+import uniffi.gemstone.DocsUrl
 import com.gemwallet.android.ui.components.buttons.CopyButton
 import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.clipboard.setPlainText
@@ -50,6 +53,7 @@ fun CreateWalletScreen(
     onCreated: (walletId: WalletId?) -> Unit,
 ) {
     DisableScreenShooting()
+    DetectScreenshot(AppUrl.docs(DocsUrl.HowToSecureSecretPhrase))
 
     val viewModel: CreateWalletViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()

--- a/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/views/ImportScreen.kt
+++ b/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/views/ImportScreen.kt
@@ -48,7 +48,9 @@ import com.gemwallet.android.features.import_wallet.components.importTypeTabInde
 import com.gemwallet.android.features.import_wallet.components.importWalletTabs
 import com.gemwallet.android.features.import_wallet.components.supportsPhraseSuggestions
 import com.gemwallet.android.features.import_wallet.viewmodels.ImportViewModel
+import com.gemwallet.android.AppUrl
 import com.gemwallet.android.model.ImportType
+import com.gemwallet.android.ui.DetectScreenshot
 import com.gemwallet.android.ui.DisableScreenShooting
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.InfoBottomSheet
@@ -66,6 +68,7 @@ import com.wallet.core.primitives.NameRecord
 import com.wallet.core.primitives.WalletType
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import uniffi.gemstone.DocsUrl
 
 internal sealed interface ImportSceneTitle {
     data class Resource(val resId: Int) : ImportSceneTitle
@@ -89,6 +92,7 @@ fun ImportScreen(
     onCancel: () -> Unit
 ) {
     DisableScreenShooting()
+    DetectScreenshot(AppUrl.docs(DocsUrl.HowToSecureSecretPhrase))
 
     val viewModel: ImportViewModel = hiltViewModel()
 

--- a/android/features/wallet-details/presents/build.gradle.kts
+++ b/android/features/wallet-details/presents/build.gradle.kts
@@ -42,6 +42,7 @@ android {
 dependencies {
 
     implementation(project(":ui"))
+    implementation(project(":gemcore"))
     implementation(project(":features:wallet-details:viewmodels"))
 
     implementation(libs.hilt.android)

--- a/android/features/wallet-details/presents/src/main/kotlin/com/gemwallet/android/features/wallet/presents/WalletSecretDataNavScreen.kt
+++ b/android/features/wallet-details/presents/src/main/kotlin/com/gemwallet/android/features/wallet/presents/WalletSecretDataNavScreen.kt
@@ -20,7 +20,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gemwallet.android.AppUrl
 import com.gemwallet.android.features.wallet.viewmodels.WalletSecretDataViewModel
+import com.gemwallet.android.ui.DetectScreenshot
 import com.gemwallet.android.ui.DisableScreenShooting
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.CopyButton
@@ -35,6 +37,7 @@ import com.gemwallet.android.ui.theme.paddingMiddle
 import com.gemwallet.android.ui.theme.sceneContentPaddingValues
 import com.gemwallet.android.ui.theme.space8
 import com.wallet.core.primitives.WalletType
+import uniffi.gemstone.DocsUrl
 
 internal data class WalletSecretDataContent(
     val titleRes: Int,
@@ -65,6 +68,7 @@ fun WalletSecretDataNavScreen(
     viewModel: WalletSecretDataViewModel = hiltViewModel()
 ) {
     DisableScreenShooting()
+    DetectScreenshot(AppUrl.docs(DocsUrl.HowToSecureSecretPhrase))
 
     val value by viewModel.data.collectAsStateWithLifecycle()
     val walletType by viewModel.walletType.collectAsStateWithLifecycle()

--- a/android/ui/src/main/AndroidManifest.xml
+++ b/android/ui/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" />
 
 </manifest>

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/DetectScreenshot.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/DetectScreenshot.kt
@@ -1,0 +1,68 @@
+package com.gemwallet.android.ui
+
+import android.app.Activity
+import android.os.Build
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+
+@Composable
+fun DetectScreenshot(docsUrl: String) {
+    val context = LocalContext.current
+    var showWarning by remember { mutableStateOf(false) }
+
+    DisposableEffect(context) {
+        val activity = context.findActivity()
+        if (activity != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val callback = Activity.ScreenCaptureCallback { showWarning = true }
+            activity.registerScreenCaptureCallback(activity.mainExecutor, callback)
+            onDispose { activity.unregisterScreenCaptureCallback(callback) }
+        } else {
+            onDispose { }
+        }
+    }
+
+    if (showWarning) {
+        ScreenshotDetectedDialog(
+            docsUrl = docsUrl,
+            onDismiss = { showWarning = false },
+        )
+    }
+}
+
+@Composable
+private fun ScreenshotDetectedDialog(docsUrl: String, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(R.string.secret_phrase_screenshot_detected_title)) },
+        text = { Text(text = stringResource(R.string.secret_phrase_screenshot_detected_description)) },
+        confirmButton = {
+            Button(onClick = onDismiss) {
+                Text(text = stringResource(R.string.common_done))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = {
+                    uriHandler.open(context, docsUrl)
+                    onDismiss()
+                }
+            ) {
+                Text(text = stringResource(R.string.common_learn_more))
+            }
+        },
+    )
+}


### PR DESCRIPTION
Android showed a blank screenshot on secret screens but no warning, unlike iOS. This adds a warning dialog when a screenshot is taken on the secret phrase, verify and import screens