### PR TITLE
Add Sui Dappkit WalletConnect support: sui_getAccounts and JSON tx

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/BridgesRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/BridgesRepository.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.data.repositories.bridge
 
 import android.util.Log
 import androidx.core.net.toUri
+import com.gemwallet.android.ext.toGem
 import com.wallet.core.primitives.WalletConnection
 import com.wallet.core.primitives.Wallet as GemWallet
 import kotlinx.coroutines.CoroutineScope
@@ -147,6 +148,7 @@ class BridgesRepository(
         val sessionProperties = WalletConnect().configSessionProperties(
             properties = proposal.properties ?: emptyMap(),
             caip2Chains = sessionNamespaces.values.flatMap { it.chains.orEmpty() },
+            accounts = wallet.accounts.map { it.toGem() },
         )
         approveAndStoreSession(wallet, "Connection failed", onSuccess, onError) { onApproved, onFailure ->
             walletConnectClient.approveSession(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/Namespace.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/Namespace.kt
@@ -35,6 +35,7 @@ enum class ChainNamespace(val string: String, val methods: List<WalletConnection
     Sui(
         Chain.Sui.string,
         listOf(
+            WalletConnectionMethods.SuiGetAccounts,
             WalletConnectionMethods.SuiSignPersonalMessage,
             WalletConnectionMethods.SuiSignTransaction,
             WalletConnectionMethods.SuiSignAndExecuteTransaction,

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
@@ -13,11 +13,15 @@ import com.gemwallet.android.data.repositories.bridge.WalletConnectVerifyContext
 import com.gemwallet.android.data.repositories.bridge.fromWalletConnectChainId
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.ext.getAccount
+import com.gemwallet.android.ext.toChain
+import com.gemwallet.android.ext.toGem
 import com.gemwallet.android.features.bridge.viewmodels.model.BridgeRequestError
 import com.gemwallet.android.features.bridge.viewmodels.model.WCRequest
+import com.gemwallet.android.features.bridge.viewmodels.model.payload
 import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectOriginVerifier
 import com.wallet.core.primitives.Account
 import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.WalletConnection
 import com.wallet.core.primitives.WalletConnectionSession
 import com.wallet.core.primitives.WalletConnectionSessionAppMetadata
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -87,6 +91,10 @@ class WCRequestViewModel @Inject constructor(
                     handleChainOperation(action, sessionRequest, onError)
                     return@launch
                 }
+                if (action is WalletConnectAction.GetAccounts) {
+                    handleGetAccounts(action, sessionRequest, connection, onError)
+                    return@launch
+                }
 
                 val wallet = walletsRepository.getWallet(connection.wallet.id).firstOrNull()
                 if (wallet == null) {
@@ -153,6 +161,21 @@ class WCRequestViewModel @Inject constructor(
         }
     }
 
+    private fun handleGetAccounts(
+        action: WalletConnectAction.GetAccounts,
+        sessionRequest: WalletConnectSessionRequest,
+        connection: WalletConnection,
+        onError: (String) -> Unit,
+    ) {
+        val chain = action.chain.toChain() ?: throw BridgeRequestError.ChainUnsupported
+        validateChain(chain, connection.session)
+
+        val accounts = connection.wallet.accounts
+            .filter { it.chain == chain }
+            .map { it.toGem() }
+        response(sessionRequest.topic, sessionRequest.request.id, walletConnect.encodeGetAccounts(action.chain, accounts).payload(), onError)
+    }
+
     private suspend fun buildRequest(
         action: WalletConnectAction,
         sessionRequest: WalletConnectSessionRequest,
@@ -198,7 +221,8 @@ class WCRequestViewModel @Inject constructor(
             )
         }
 
-        is WalletConnectAction.ChainOperation -> error("Immediate WalletConnect responses must be handled before request resolution")
+        is WalletConnectAction.ChainOperation,
+        is WalletConnectAction.GetAccounts -> error("Immediate WalletConnect responses must be handled before request resolution")
         is WalletConnectAction.Unsupported -> throw BridgeRequestError.MethodUnsupported
     }
 

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WCRequest.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WCRequest.kt
@@ -192,7 +192,7 @@ sealed class WCRequest(
     }
 }
 
-private fun WalletConnectResponseType.payload(): String = when (this) {
+internal fun WalletConnectResponseType.payload(): String = when (this) {
     is WalletConnectResponseType.Object -> json
     is WalletConnectResponseType.String -> value
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/WalletConnector.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/WalletConnector.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.ext
 
+import com.wallet.core.primitives.Account
 import com.wallet.core.primitives.WalletConnectionSessionAppMetadata
 import uniffi.gemstone.GemWalletConnectionSessionAppMetadata
 import uniffi.gemstone.walletConnectAppShortName
@@ -9,6 +10,13 @@ fun WalletConnectionSessionAppMetadata.toGem() = GemWalletConnectionSessionAppMe
     description = description,
     url = url,
     icon = icon,
+)
+
+fun Account.toGem() = uniffi.gemstone.Account(
+    chain = chain.string,
+    address = address,
+    derivationPath = derivationPath,
+    extendedPublicKey = extendedPublicKey,
 )
 
 val WalletConnectionSessionAppMetadata.shortName: String

--- a/android/gemcore/src/main/kotlin/com/wallet/core/primitives/generated/WalletConnector.kt
+++ b/android/gemcore/src/main/kotlin/com/wallet/core/primitives/generated/WalletConnector.kt
@@ -108,6 +108,8 @@ enum class WalletConnectionMethods(val string: String) {
 	SolanaSignAndSendTransaction("solana_signAndSendTransaction"),
 	@SerialName("solana_signAllTransactions")
 	SolanaSignAllTransactions("solana_signAllTransactions"),
+	@SerialName("sui_getAccounts")
+	SuiGetAccounts("sui_getAccounts"),
 	@SerialName("sui_signPersonalMessage")
 	SuiSignPersonalMessage("sui_signPersonalMessage"),
 	@SerialName("sui_signTransaction")

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -20,7 +20,7 @@ Read this file first, then load the relevant skills for your current task. `proj
 
 Subsystem references live in [docs/](docs). Read the relevant one before changing that area:
 
-- [Gem Keystore v4](docs/KEYSTORE_V4.md) — keystore file format, v3 migration, and the keystore-internal signing / device-auth contract (key never crosses the FFI boundary)
+- [Gem Keystore v4](docs/KEYSTORE_V4.md) — keystore file format, v3 migration, account public keys, and the keystore-internal signing / device-auth contract (key never crosses the FFI boundary)
 - [Device Authentication](docs/DEVICE_AUTHENTICATION.md) — Ed25519 request signing and the `Gem` Authorization header
 - [Wallet Authentication](docs/WALLET_AUTHENTICATION.md)
 - [Device WebSockets](docs/DEVICE_WEBSOCKETS.md)

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3577,6 +3577,7 @@ dependencies = [
  "async-trait",
  "gem_client",
  "hex",
+ "percent-encoding",
  "primitives",
  "reqwest 0.13.4",
  "serde",
@@ -3817,6 +3818,7 @@ dependencies = [
 name = "gem_wallet_connect"
 version = "1.0.0"
 dependencies = [
+ "base64",
  "gem_evm",
  "gem_ton",
  "hex",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -73,6 +73,7 @@ reqwest = { version = "0.13.4", features = [
 ] }
 
 url = { version = "2.5.8" }
+percent-encoding = { version = "2.3.2" }
 config = { version = "0.15.23", features = ["yaml"] }
 rocket = { version = "0.5.1", features = ["json"] }
 rocket_ws = { version = "0.1.1" }

--- a/core/crates/gem_jsonrpc/Cargo.toml
+++ b/core/crates/gem_jsonrpc/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 default = ["types"]
 types = []
 client = ["dep:gem_client", "dep:async-trait", "dep:primitives", "dep:hex"]
-reqwest = ["client", "dep:reqwest", "gem_client/reqwest"]
+reqwest = ["client", "dep:reqwest", "dep:percent-encoding", "gem_client/reqwest"]
 testkit = ["client", "gem_client/testkit"]
 
 [dependencies]
@@ -19,6 +19,7 @@ async-trait = { workspace = true, optional = true }
 primitives = { path = "../primitives", optional = true }
 hex = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+percent-encoding = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/crates/gem_jsonrpc/src/grpc/mod.rs
+++ b/core/crates/gem_jsonrpc/src/grpc/mod.rs
@@ -6,6 +6,11 @@ use crate::{
     rpc::{HttpMethod, Target},
 };
 
+#[cfg(feature = "reqwest")]
+mod reqwest_transport;
+#[cfg(feature = "reqwest")]
+pub use reqwest_transport::ReqwestGrpcTransport;
+
 #[async_trait]
 pub trait GrpcTransport: Send + Sync + fmt::Debug {
     async fn unary(&self, endpoint: &str, path: &str, body: Vec<u8>) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>>;
@@ -20,7 +25,7 @@ fn unary_target(endpoint: &str, path: &str, body: Vec<u8>) -> Target {
     }
 }
 
-fn ensure_success_status(status: Option<u16>) -> Result<(), Box<dyn Error + Send + Sync>> {
+fn validate_http_status(status: Option<u16>) -> Result<(), Box<dyn Error + Send + Sync>> {
     if let Some(status) = status
         && !(200..300).contains(&status)
     {
@@ -58,51 +63,7 @@ impl fmt::Debug for AlienGrpcTransport {
 impl GrpcTransport for AlienGrpcTransport {
     async fn unary(&self, endpoint: &str, path: &str, body: Vec<u8>) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
         let response = self.provider.request(unary_target(endpoint, path, body)).await?;
-        ensure_success_status(response.status)?;
+        validate_http_status(response.status)?;
         Ok(response.data)
-    }
-}
-
-#[cfg(feature = "reqwest")]
-#[derive(Clone, Debug)]
-pub struct ReqwestGrpcTransport {
-    client: reqwest::Client,
-}
-
-#[cfg(feature = "reqwest")]
-impl ReqwestGrpcTransport {
-    pub fn new() -> Self {
-        Self { client: reqwest::Client::new() }
-    }
-
-    pub fn new_with_client(client: reqwest::Client) -> Self {
-        Self { client }
-    }
-}
-
-#[cfg(feature = "reqwest")]
-impl Default for ReqwestGrpcTransport {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg(feature = "reqwest")]
-#[async_trait]
-impl GrpcTransport for ReqwestGrpcTransport {
-    async fn unary(&self, endpoint: &str, path: &str, body: Vec<u8>) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
-        let response = self
-            .client
-            .post(format!("{}{}", endpoint.trim_end_matches('/'), path))
-            .header("Content-Type", "application/grpc+proto")
-            .header("Accept", "application/grpc+proto")
-            .header("TE", "trailers")
-            .body(body)
-            .send()
-            .await?;
-        let status = response.status().as_u16();
-        let bytes = response.bytes().await?.to_vec();
-        ensure_success_status(Some(status))?;
-        Ok(bytes)
     }
 }

--- a/core/crates/gem_jsonrpc/src/grpc/reqwest_transport.rs
+++ b/core/crates/gem_jsonrpc/src/grpc/reqwest_transport.rs
@@ -1,0 +1,75 @@
+use async_trait::async_trait;
+use std::error::Error;
+
+use super::{GrpcTransport, validate_http_status};
+
+#[derive(Clone, Debug)]
+pub struct ReqwestGrpcTransport {
+    client: reqwest::Client,
+}
+
+impl ReqwestGrpcTransport {
+    pub fn new() -> Self {
+        Self { client: reqwest::Client::new() }
+    }
+
+    pub fn new_with_client(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Default for ReqwestGrpcTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl GrpcTransport for ReqwestGrpcTransport {
+    async fn unary(&self, endpoint: &str, path: &str, body: Vec<u8>) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
+        let response = self
+            .client
+            .post(format!("{}{}", endpoint.trim_end_matches('/'), path))
+            .header("Content-Type", "application/grpc+proto")
+            .header("Accept", "application/grpc+proto")
+            .header("TE", "trailers")
+            .body(body)
+            .send()
+            .await?;
+        let status = response.status().as_u16();
+        validate_grpc_status(&response)?;
+        let bytes = response.bytes().await?.to_vec();
+        validate_http_status(Some(status))?;
+        Ok(bytes)
+    }
+}
+
+fn validate_grpc_status(response: &reqwest::Response) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let header = |name: &str| response.headers().get(name).and_then(|value| value.to_str().ok());
+    if let Some(code) = header("grpc-status")
+        && code != "0"
+    {
+        let message = decode_grpc_status_message(header("grpc-message").unwrap_or_default());
+        return Err(format!("gRPC error {code}: {message}").into());
+    }
+    Ok(())
+}
+
+fn decode_grpc_status_message(value: &str) -> String {
+    percent_encoding::percent_decode_str(value).decode_utf8_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_grpc_status_message() {
+        assert_eq!(
+            decode_grpc_status_message("Available%20amount%3A%200%20%3C%2014999840000"),
+            "Available amount: 0 < 14999840000"
+        );
+        assert_eq!(decode_grpc_status_message("plain message"), "plain message");
+        assert_eq!(decode_grpc_status_message("trailing%2"), "trailing%2");
+    }
+}

--- a/core/crates/gem_sui/src/provider/preload.rs
+++ b/core/crates/gem_sui/src/provider/preload.rs
@@ -7,6 +7,7 @@ use chain_traits::ChainTransactionLoad;
 use num_bigint::BigInt;
 use primitives::{
     FeeRate, GasPriceType, StakeType, TransactionFee, TransactionInputType, TransactionLoadData, TransactionLoadInput, TransactionLoadMetadata, TransactionPreloadInput,
+    TransferDataExtra,
 };
 
 use crate::{
@@ -17,6 +18,7 @@ use crate::{
 use crate::{
     provider::preload_mapper::{map_transaction_data, map_transaction_rate_rates},
     rpc::client::SuiClient,
+    tx_builder::{finish_transaction_json, is_transaction_json},
 };
 
 #[cfg(feature = "rpc")]
@@ -27,6 +29,7 @@ impl ChainTransactionLoad for SuiClient {
     }
 
     async fn get_transaction_load(&self, input: TransactionLoadInput) -> Result<TransactionLoadData, Box<dyn Error + Sync + Send>> {
+        let input = self.finish_transaction_json_input(input).await?;
         let (sui_coins, token_coins, objects) = self.get_coins_for_input_type(input.sender_address.as_str(), input.input_type.clone()).await?;
 
         let estimate_bytes = map_transaction_data(input.clone(), sui_coins.clone(), token_coins.clone(), objects.clone(), ESTIMATION_GAS_BUDGET)?;
@@ -57,6 +60,46 @@ fn estimated_gas_budget(input_type: &TransactionInputType, fee: &TransactionFee)
 }
 
 impl SuiClient {
+    async fn finish_transaction_json_input(&self, input: TransactionLoadInput) -> Result<TransactionLoadInput, Box<dyn Error + Send + Sync>> {
+        let TransactionLoadInput {
+            sender_address,
+            destination_address,
+            value,
+            input_type,
+            gas_price,
+            memo,
+            is_max_value,
+            metadata,
+        } = input;
+
+        let input_type = match input_type {
+            TransactionInputType::Generic(asset, app_metadata, extra) if extra.data.as_deref().is_some_and(is_transaction_json) => {
+                TransactionInputType::Generic(asset, app_metadata, self.finish_transaction_json_extra(&sender_address, extra).await?)
+            }
+            other => other,
+        };
+
+        Ok(TransactionLoadInput {
+            sender_address,
+            destination_address,
+            value,
+            input_type,
+            gas_price,
+            memo,
+            is_max_value,
+            metadata,
+        })
+    }
+
+    async fn finish_transaction_json_extra(&self, sender_address: &str, extra: TransferDataExtra) -> Result<TransferDataExtra, Box<dyn Error + Send + Sync>> {
+        let transaction_json = String::from_utf8(extra.data.clone().unwrap_or_default()).map_err(|_| "Invalid UTF-8 data for Sui generic input")?;
+        let output = finish_transaction_json(self, &transaction_json, sender_address).await?;
+        Ok(TransferDataExtra {
+            data: Some(output.base64_encoded().into_bytes()),
+            ..extra
+        })
+    }
+
     async fn estimate_fee(&self, tx_data: &str, gas_price: &GasPriceType, is_max_value: bool) -> Result<TransactionFee, Box<dyn Error + Send + Sync>> {
         let tx_data_only = tx_data.split('_').next().unwrap_or(tx_data);
         let result = self.dry_run(tx_data_only.to_string()).await?;

--- a/core/crates/gem_sui/src/provider/simulation.rs
+++ b/core/crates/gem_sui/src/provider/simulation.rs
@@ -8,14 +8,21 @@ use primitives::{Asset, Chain, SimulationBalanceChange, SimulationInput, Simulat
 use crate::decode_transaction;
 use crate::provider::simulation_mapper::map_simulation_result;
 use crate::rpc::client::SuiClient;
+use crate::tx_builder::{finish_transaction_json_from_sender, is_transaction_json};
+use gem_encoding::encode_base64;
 
 #[async_trait]
 impl ChainSimulation for SuiClient {
     async fn simulate_transaction(&self, input: SimulationInput) -> Result<SimulationResult, Box<dyn Error + Send + Sync>> {
-        let transaction: sui_types::Transaction = decode_transaction(&input.encoded_transaction).map_err(|err| format!("parse transaction: {err}"))?;
+        let encoded_transaction = if is_transaction_json(input.encoded_transaction.as_bytes()) {
+            encode_base64(&finish_transaction_json_from_sender(self, &input.encoded_transaction).await?.tx_data)
+        } else {
+            input.encoded_transaction
+        };
+        let transaction: sui_types::Transaction = decode_transaction(&encoded_transaction).map_err(|err| format!("parse transaction: {err}"))?;
         let sender = transaction.sender.to_string();
 
-        let simulated = self.simulate_encoded_transaction(&input.encoded_transaction).await?;
+        let simulated = self.simulate_encoded_transaction(&encoded_transaction).await?;
         let mut result = map_simulation_result(&sender, &simulated);
 
         let changes = std::mem::take(&mut result.balance_changes);

--- a/core/crates/gem_sui/src/tx_builder/mod.rs
+++ b/core/crates/gem_sui/src/tx_builder/mod.rs
@@ -18,6 +18,9 @@ pub use prefetch::PrefetchedTransactionData;
 pub use stake::*;
 pub(crate) use transaction::build_amount_coin;
 pub use transaction::{build_input_coin, decode_transaction, finish_transaction, move_call, validate_and_hash, zero_coin};
+pub use transaction_json::is_transaction_json;
 #[cfg(feature = "rpc")]
-pub use transaction_json::{ReplayedTransaction, TransactionJsonReplay, prepare_transaction_json_replay, replay_transaction_json};
+pub use transaction_json::{
+    ReplayedTransaction, TransactionJsonReplay, finish_transaction_json, finish_transaction_json_from_sender, prepare_transaction_json_replay, replay_transaction_json,
+};
 pub use transfer::*;

--- a/core/crates/gem_sui/src/tx_builder/transaction_json/builder.rs
+++ b/core/crates/gem_sui/src/tx_builder/transaction_json/builder.rs
@@ -1,4 +1,6 @@
-use super::model::{TransactionArgument, TransactionCommand, TransactionInput, TransactionObject};
+use super::model::{
+    FundsWithdrawalInput, TransactionArgument, TransactionCommand, TransactionInput, TransactionObject, WithdrawalReservation, WithdrawalSource, WithdrawalTypeArg,
+};
 use crate::{SuiError, address::SuiAddress, tx_builder::move_call as sui_move_call};
 use gem_encoding::decode_base64;
 use std::{collections::HashMap, str::FromStr};
@@ -23,8 +25,21 @@ pub(super) fn replay_input(txb: &mut TransactionBuilder, index: usize, input: &T
                 .cloned()
                 .ok_or_else(|| SuiError::invalid_input("Missing resolved Sui object input"))?,
         )),
+        TransactionInput::FundsWithdrawal { funds_withdrawal } => funds_withdrawal_input(txb, funds_withdrawal),
         TransactionInput::UnresolvedPure { pure } => Err(SuiError::invalid_input(format!("Sui transaction contains unresolved pure input: {pure}"))),
     }
+}
+
+fn funds_withdrawal_input(txb: &mut TransactionBuilder, funds_withdrawal: &FundsWithdrawalInput) -> Result<Argument, SuiError> {
+    let WithdrawalSource::Sender { .. } = funds_withdrawal.withdraw_from else {
+        return Err(SuiError::invalid_input("Unsupported Sui funds withdrawal source"));
+    };
+    let WithdrawalReservation::MaxAmountU64 { max_amount } = funds_withdrawal.reservation;
+    let WithdrawalTypeArg::Balance { balance } = &funds_withdrawal.type_arg;
+    let coin_type: TypeTag = balance
+        .parse()
+        .map_err(|err| SuiError::invalid_input(format!("Invalid Sui withdrawal balance type {balance}: {err}")))?;
+    Ok(txb.funds_withdrawal(coin_type, max_amount))
 }
 
 pub(super) fn replay_command(txb: &mut TransactionBuilder, command: TransactionCommand, inputs: &[Argument], outputs: &[CommandOutput]) -> Result<CommandOutput, SuiError> {
@@ -149,6 +164,24 @@ fn input_or_output_argument(txb: &mut TransactionBuilder, argument: &Transaction
     }
 }
 
-fn digest(value: &str) -> Result<Digest, SuiError> {
+pub(super) fn digest(value: &str) -> Result<Digest, SuiError> {
     Digest::from_str(value).map_err(|err| SuiError::invalid_input(format!("Invalid Sui object digest {value}: {err}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_replay_funds_withdrawal_input() {
+        let input: TransactionInput = serde_json::from_str(include_str!("../../../testdata/funds_withdrawal_sender.json")).unwrap();
+
+        let mut txb = TransactionBuilder::new();
+        assert!(replay_input(&mut txb, 0, &input, &HashMap::new()).is_ok());
+
+        let sponsored: TransactionInput = serde_json::from_str(include_str!("../../../testdata/funds_withdrawal_sponsor.json")).unwrap();
+
+        let mut txb = TransactionBuilder::new();
+        assert!(replay_input(&mut txb, 0, &sponsored, &HashMap::new()).is_err());
+    }
 }

--- a/core/crates/gem_sui/src/tx_builder/transaction_json/finish.rs
+++ b/core/crates/gem_sui/src/tx_builder/transaction_json/finish.rs
@@ -1,0 +1,214 @@
+use std::collections::HashSet;
+
+use futures::try_join;
+use num_traits::ToPrimitive;
+use sui_transaction_builder::ObjectInput;
+use sui_types::Address;
+
+use super::{
+    builder::digest,
+    model::{GasData, ObjectRef, TransactionBuilderJson, TransactionInput},
+    replay::{TransactionJsonReplay, parse_transaction_json, prepare_replay},
+};
+use crate::{
+    ESTIMATION_GAS_BUDGET, SUI_COIN_TYPE, SuiClient, SuiError,
+    address::SuiAddress,
+    gas_budget::GAS_BUDGET_MULTIPLIER,
+    models::{Coin, TxOutput},
+    tx_builder::{TransactionBuilderInput, finish_transaction},
+};
+
+pub async fn finish_transaction_json(client: &SuiClient, transaction_json: &str, sender: &str) -> Result<TxOutput, SuiError> {
+    let transaction = parse_transaction_json(transaction_json)?;
+    validate_sender(&transaction, sender)?;
+    finish_parsed(client, transaction, sender).await
+}
+
+pub async fn finish_transaction_json_from_sender(client: &SuiClient, transaction_json: &str) -> Result<TxOutput, SuiError> {
+    let transaction = parse_transaction_json(transaction_json)?;
+    let sender = transaction.sender.clone().ok_or_else(|| SuiError::invalid_input("Missing Sui transaction sender"))?;
+    finish_parsed(client, transaction, &sender).await
+}
+
+async fn finish_parsed(client: &SuiClient, transaction: TransactionBuilderJson, sender: &str) -> Result<TxOutput, SuiError> {
+    validate_expiration(&transaction)?;
+
+    let gas_data = transaction.gas_data.clone().unwrap_or_default();
+    let replay = prepare_replay(client, transaction).await?;
+    let (gas_price, gas_objects) = try_join!(gas_price(client, &gas_data), gas_objects(client, &replay, &gas_data, sender))?;
+
+    let builder_input = TransactionBuilderInput::new(sender, gas_price, ESTIMATION_GAS_BUDGET, gas_objects);
+    let budget = match gas_data.budget {
+        Some(budget) => budget,
+        None => estimate_gas_budget(client, &replay, &builder_input).await?,
+    };
+
+    finish_transaction(replay.replay()?.txb, builder_input.with_gas_budget(budget))
+}
+
+fn validate_sender(transaction: &TransactionBuilderJson, sender: &str) -> Result<(), SuiError> {
+    let Some(transaction_sender) = transaction.sender.as_deref() else {
+        return Ok(());
+    };
+    if Address::from(SuiAddress::parse(transaction_sender)?) != Address::from(SuiAddress::parse(sender)?) {
+        return Err(SuiError::invalid_input(format!("Sui transaction sender mismatch: {transaction_sender}")));
+    }
+    Ok(())
+}
+
+fn validate_expiration(transaction: &TransactionBuilderJson) -> Result<(), SuiError> {
+    match &transaction.expiration {
+        None | Some(serde_json::Value::Null) => Ok(()),
+        Some(expiration) => Err(SuiError::invalid_input(format!("Unsupported Sui transaction expiration: {expiration}"))),
+    }
+}
+
+async fn gas_price(client: &SuiClient, gas_data: &GasData) -> Result<u64, SuiError> {
+    match gas_data.price {
+        Some(price) => Ok(price),
+        None => client
+            .get_gas_price()
+            .await
+            .map_err(SuiError::from_display)?
+            .to_u64()
+            .ok_or_else(|| SuiError::invalid_input("Sui gas price overflow")),
+    }
+}
+
+async fn gas_objects(client: &SuiClient, replay: &TransactionJsonReplay, gas_data: &GasData, sender: &str) -> Result<Vec<ObjectInput>, SuiError> {
+    if let Some(payment) = gas_data.payment.as_deref()
+        && !payment.is_empty()
+    {
+        return payment.iter().map(payment_object).collect();
+    }
+
+    let coins = client.get_coins(sender, SUI_COIN_TYPE).await.map_err(SuiError::from_display)?;
+    let input_objects = input_object_ids(&replay.transaction.inputs)?;
+    let gas_objects = coins
+        .coins
+        .iter()
+        .filter(|coin| !input_objects.contains(&coin.object.object_id))
+        .map(Coin::to_input)
+        .collect::<Vec<_>>();
+    if gas_objects.is_empty() {
+        return Err(SuiError::NoGasCoins);
+    }
+    Ok(gas_objects)
+}
+
+fn payment_object(object: &ObjectRef) -> Result<ObjectInput, SuiError> {
+    Ok(ObjectInput::owned(SuiAddress::parse(&object.object_id)?.into(), object.version, digest(&object.digest)?))
+}
+
+/// Coin objects already consumed as transaction inputs cannot double as gas payment.
+fn input_object_ids(inputs: &[TransactionInput]) -> Result<HashSet<Address>, SuiError> {
+    inputs
+        .iter()
+        .filter_map(|input| match input {
+            TransactionInput::Object { object } => Some(object.object_id()),
+            TransactionInput::UnresolvedObject { object } => Some(object.object_id.as_str()),
+            TransactionInput::Pure { .. } | TransactionInput::FundsWithdrawal { .. } | TransactionInput::UnresolvedPure { .. } => None,
+        })
+        .map(|object_id| Ok(SuiAddress::parse(object_id)?.into()))
+        .collect()
+}
+
+async fn estimate_gas_budget(client: &SuiClient, replay: &TransactionJsonReplay, builder_input: &TransactionBuilderInput) -> Result<u64, SuiError> {
+    let estimate = finish_transaction(replay.replay()?.txb, builder_input.clone())?;
+    let dry_run = client
+        .dry_run(estimate.base64_encoded())
+        .await
+        .map_err(|err| SuiError::invalid_input(format!("Sui gas estimation failed: {err}")))?;
+    let fee = dry_run.effects.gas_used.calculate_gas_budget().map_err(SuiError::from_display)?;
+    Ok(fee * GAS_BUDGET_MULTIPLIER / 100)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_sender() {
+        let transaction = parse_transaction_json(include_str!("../../../testdata/wc_sign_transaction_cetus.json")).unwrap();
+        let sender = "0xa9bd0493f9bd1f792a4aedc1f99d54535a75a46c38fd56a8f2c6b7c8d75817a1";
+
+        assert!(validate_sender(&transaction, sender).is_ok());
+        assert!(validate_sender(&transaction, "0x2cd8382c19e6994f16df204e9b8cddd04bdc486c251de75ac66ac4e48e3e7081").is_err());
+
+        let senderless = TransactionBuilderJson { sender: None, ..transaction };
+        assert!(validate_sender(&senderless, sender).is_ok());
+    }
+
+    #[test]
+    fn test_input_object_ids_excludes_input_coins() {
+        let transaction = parse_transaction_json(include_str!("../../../testdata/wc_sign_transaction_cetus.json")).unwrap();
+
+        let input_objects = input_object_ids(&transaction.inputs).unwrap();
+
+        assert_eq!(input_objects.len(), 10);
+        let input_coin: Address = SuiAddress::parse("0xee23d0cd34718145602307f4dccb3228334afbefb2a89919b98e97c420361d5a").unwrap().into();
+        assert!(input_objects.contains(&input_coin));
+    }
+}
+
+#[cfg(all(test, feature = "chain_integration_tests"))]
+mod chain_integration_tests {
+    use super::*;
+    use crate::provider::testkit::{TEST_ADDRESS, create_sui_test_client};
+    use gem_encoding::encode_base64;
+    use std::str::FromStr;
+
+    #[tokio::test]
+    async fn test_finish_transaction_json() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let client = create_sui_test_client();
+        let recipient = encode_base64(&bcs::to_bytes(&Address::from_str(TEST_ADDRESS)?)?);
+        let transaction_json = serde_json::json!({
+            "version": 2,
+            "sender": TEST_ADDRESS,
+            "expiration": null,
+            "gasData": { "budget": null, "price": null, "owner": null, "payment": null },
+            "inputs": [
+                { "Pure": { "bytes": "6AMAAAAAAAA=" } },
+                { "Pure": { "bytes": recipient } },
+                { "UnresolvedObject": { "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006" } }
+            ],
+            "commands": [
+                { "SplitCoins": { "coin": { "GasCoin": true }, "amounts": [{ "Input": 0 }] } },
+                { "MoveCall": { "package": "0x2", "module": "clock", "function": "timestamp_ms", "typeArguments": [], "arguments": [{ "Input": 2 }] } },
+                { "TransferObjects": { "objects": [{ "NestedResult": [0, 0] }], "address": { "Input": 1 } } }
+            ]
+        })
+        .to_string();
+
+        let output = finish_transaction_json(&client, &transaction_json, TEST_ADDRESS).await?;
+
+        let transaction: sui_types::Transaction = bcs::from_bytes(&output.tx_data)?;
+        assert_eq!(transaction.sender.to_string(), TEST_ADDRESS);
+        assert!(!transaction.gas_payment.objects.is_empty());
+        assert!(transaction.gas_payment.budget > 0);
+        assert!(transaction.gas_payment.price > 0);
+
+        let dry_run = client.dry_run(output.base64_encoded()).await?;
+        assert_eq!(dry_run.effects.status.status, "success", "dry run failed: {:?}", dry_run.effects.status.error);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_finish_transaction_json_funds_withdrawal() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let client = create_sui_test_client();
+        let transaction_json = include_str!("../../../testdata/wc_sign_transaction_cetus_funds_withdrawal.json");
+        let sender = "0xa9bd0493f9bd1f792a4aedc1f99d54535a75a46c38fd56a8f2c6b7c8d75817a1";
+
+        let output = finish_transaction_json(&client, transaction_json, sender).await?;
+
+        let transaction: sui_types::Transaction = bcs::from_bytes(&output.tx_data)?;
+        assert_eq!(transaction.sender.to_string(), sender);
+
+        // Dry run depends on the sender's live address balance, so only resolution and build are asserted.
+        let dry_run = client.dry_run(output.base64_encoded()).await;
+        println!("dry run result: {dry_run:?}");
+
+        Ok(())
+    }
+}

--- a/core/crates/gem_sui/src/tx_builder/transaction_json/mod.rs
+++ b/core/crates/gem_sui/src/tx_builder/transaction_json/mod.rs
@@ -5,11 +5,19 @@ mod model;
 #[cfg(feature = "rpc")]
 mod builder;
 #[cfg(feature = "rpc")]
+mod finish;
+#[cfg(feature = "rpc")]
 mod replay;
 #[cfg(feature = "rpc")]
 mod resolver;
 
 pub use model::*;
 
+pub fn is_transaction_json(data: &[u8]) -> bool {
+    data.trim_ascii_start().starts_with(b"{")
+}
+
+#[cfg(feature = "rpc")]
+pub use finish::{finish_transaction_json, finish_transaction_json_from_sender};
 #[cfg(feature = "rpc")]
 pub use replay::{ReplayedTransaction, TransactionJsonReplay, prepare_transaction_json_replay, replay_transaction_json};

--- a/core/crates/gem_sui/src/tx_builder/transaction_json/model.rs
+++ b/core/crates/gem_sui/src/tx_builder/transaction_json/model.rs
@@ -1,13 +1,27 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use serde_serializers::deserialize_u64_from_str_or_int;
+use serde_serializers::{deserialize_option_u64_from_str_or_int, deserialize_u64_from_str_or_int};
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionBuilderJson {
     pub version: u8,
+    pub sender: Option<String>,
+    pub expiration: Option<Value>,
+    pub gas_data: Option<GasData>,
     pub inputs: Vec<TransactionInput>,
     pub commands: Vec<TransactionCommand>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GasData {
+    #[serde(default, deserialize_with = "deserialize_option_u64_from_str_or_int")]
+    pub budget: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_option_u64_from_str_or_int")]
+    pub price: Option<u64>,
+    pub owner: Option<String>,
+    pub payment: Option<Vec<ObjectRef>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -25,9 +39,52 @@ pub enum TransactionInput {
         #[serde(rename = "UnresolvedObject")]
         object: UnresolvedObject,
     },
+    FundsWithdrawal {
+        #[serde(rename = "FundsWithdrawal")]
+        funds_withdrawal: FundsWithdrawalInput,
+    },
     UnresolvedPure {
         #[serde(rename = "UnresolvedPure")]
         pure: Value,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FundsWithdrawalInput {
+    pub reservation: WithdrawalReservation,
+    pub type_arg: WithdrawalTypeArg,
+    pub withdraw_from: WithdrawalSource,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum WithdrawalReservation {
+    MaxAmountU64 {
+        #[serde(rename = "MaxAmountU64", deserialize_with = "deserialize_u64_from_str_or_int")]
+        max_amount: u64,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum WithdrawalTypeArg {
+    Balance {
+        #[serde(rename = "Balance")]
+        balance: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum WithdrawalSource {
+    Sender {
+        #[serde(rename = "Sender")]
+        sender: bool,
+    },
+    Sponsor {
+        #[serde(rename = "Sponsor")]
+        sponsor: bool,
     },
 }
 
@@ -57,6 +114,15 @@ pub enum TransactionObject {
         #[serde(rename = "Receiving")]
         object: ObjectRef,
     },
+}
+
+impl TransactionObject {
+    pub fn object_id(&self) -> &str {
+        match self {
+            Self::ImmOrOwnedObject { object } | Self::Receiving { object } => &object.object_id,
+            Self::SharedObject { object } => &object.object_id,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -178,5 +244,29 @@ mod tests {
         assert_eq!(transaction.version, 2);
         assert_eq!(transaction.inputs.len(), 2);
         assert_eq!(transaction.commands.len(), 2);
+        assert_eq!(transaction.sender, None);
+        assert!(transaction.gas_data.is_none());
+    }
+
+    #[test]
+    fn test_decode_wallet_connect_sign_transaction_json() {
+        let transaction: TransactionBuilderJson = serde_json::from_str(include_str!("../../../testdata/wc_sign_transaction_cetus.json")).unwrap();
+
+        assert_eq!(transaction.inputs.len(), 23);
+        assert_eq!(transaction.commands.len(), 8);
+        assert_eq!(transaction.gas_data.unwrap().budget, Some(50_000_000));
+
+        match &transaction.inputs[20] {
+            TransactionInput::Object {
+                object: TransactionObject::ImmOrOwnedObject { object },
+            } => assert_eq!(object.version, 936480130),
+            other => panic!("expected owned object input, got {other:?}"),
+        }
+        match &transaction.commands[2] {
+            TransactionCommand::MoveCall { move_call } => {
+                assert_eq!(move_call.arguments[3], TransactionArgument::NestedResult { nested_result: [1, 0] });
+            }
+            other => panic!("expected move call command, got {other:?}"),
+        }
     }
 }

--- a/core/crates/gem_sui/src/tx_builder/transaction_json/replay.rs
+++ b/core/crates/gem_sui/src/tx_builder/transaction_json/replay.rs
@@ -19,7 +19,7 @@ impl ReplayedTransaction {
 }
 
 pub struct TransactionJsonReplay {
-    transaction: TransactionBuilderJson,
+    pub(super) transaction: TransactionBuilderJson,
     object_inputs: HashMap<usize, ObjectInput>,
 }
 
@@ -49,11 +49,18 @@ pub async fn replay_transaction_json(client: &SuiClient, transaction_json: &str)
 }
 
 pub async fn prepare_transaction_json_replay(client: &SuiClient, transaction_json: &str) -> Result<TransactionJsonReplay, SuiError> {
+    prepare_replay(client, parse_transaction_json(transaction_json)?).await
+}
+
+pub(super) fn parse_transaction_json(transaction_json: &str) -> Result<TransactionBuilderJson, SuiError> {
     let transaction: TransactionBuilderJson = serde_json::from_str(transaction_json).map_err(|err| SuiError::invalid_input(format!("Invalid Sui transaction JSON: {err}")))?;
     if transaction.version != 2 {
         return Err(SuiError::invalid_input(format!("Unsupported Sui transaction JSON version {}", transaction.version)));
     }
+    Ok(transaction)
+}
 
+pub(super) async fn prepare_replay(client: &SuiClient, transaction: TransactionBuilderJson) -> Result<TransactionJsonReplay, SuiError> {
     let input_mutability = input_mutability(client, &transaction.commands).await?;
     let object_inputs = object_inputs(client, &transaction.inputs, &input_mutability).await?;
     Ok(TransactionJsonReplay { transaction, object_inputs })

--- a/core/crates/gem_sui/src/tx_builder/transaction_json/resolver.rs
+++ b/core/crates/gem_sui/src/tx_builder/transaction_json/resolver.rs
@@ -69,7 +69,7 @@ pub(super) async fn object_inputs(client: &SuiClient, inputs: &[TransactionInput
         .iter()
         .filter_map(|input| match input {
             TransactionInput::UnresolvedObject { object } => Some(object.object_id.clone()),
-            TransactionInput::Pure { .. } | TransactionInput::Object { .. } | TransactionInput::UnresolvedPure { .. } => None,
+            TransactionInput::Pure { .. } | TransactionInput::Object { .. } | TransactionInput::FundsWithdrawal { .. } | TransactionInput::UnresolvedPure { .. } => None,
         })
         .collect::<HashSet<_>>()
         .into_iter()
@@ -93,7 +93,7 @@ pub(super) async fn object_inputs(client: &SuiClient, inputs: &[TransactionInput
         .enumerate()
         .filter_map(|(index, input)| match input {
             TransactionInput::UnresolvedObject { object } => Some(object_input_from_fetched(index, &object.object_id, &fetched, input_mutability)),
-            TransactionInput::Pure { .. } | TransactionInput::Object { .. } | TransactionInput::UnresolvedPure { .. } => None,
+            TransactionInput::Pure { .. } | TransactionInput::Object { .. } | TransactionInput::FundsWithdrawal { .. } | TransactionInput::UnresolvedPure { .. } => None,
         })
         .collect()
 }

--- a/core/crates/gem_sui/testdata/funds_withdrawal_sender.json
+++ b/core/crates/gem_sui/testdata/funds_withdrawal_sender.json
@@ -1,0 +1,16 @@
+{
+  "FundsWithdrawal": {
+    "reservation": {
+      "MaxAmountU64": "14999840000",
+      "$kind": "MaxAmountU64"
+    },
+    "typeArg": {
+      "Balance": "0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca::blue::BLUE",
+      "$kind": "Balance"
+    },
+    "withdrawFrom": {
+      "Sender": true,
+      "$kind": "Sender"
+    }
+  }
+}

--- a/core/crates/gem_sui/testdata/funds_withdrawal_sponsor.json
+++ b/core/crates/gem_sui/testdata/funds_withdrawal_sponsor.json
@@ -1,0 +1,16 @@
+{
+  "FundsWithdrawal": {
+    "reservation": {
+      "MaxAmountU64": 1000,
+      "$kind": "MaxAmountU64"
+    },
+    "typeArg": {
+      "Balance": "0x2::sui::SUI",
+      "$kind": "Balance"
+    },
+    "withdrawFrom": {
+      "Sponsor": true,
+      "$kind": "Sponsor"
+    }
+  }
+}

--- a/core/crates/gem_sui/testdata/wc_sign_transaction_cetus.json
+++ b/core/crates/gem_sui/testdata/wc_sign_transaction_cetus.json
@@ -1,0 +1,325 @@
+{
+  "version": 2,
+  "sender": "0xa9bd0493f9bd1f792a4aedc1f99d54535a75a46c38fd56a8f2c6b7c8d75817a1",
+  "expiration": null,
+  "gasData": {
+    "budget": "50000000",
+    "price": null,
+    "owner": null,
+    "payment": null
+  },
+  "inputs": [
+    {
+      "Pure": {
+        "bytes": "IDU3NGM0OWUzNDYyZGE2ODQxZmIzYmM1NmE3YTQ4MThj"
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "qQ9ZJQIAAAA="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "WOWZIgIAAAA="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "AAAAAA=="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0x2cd8382c19e6994f16df204e9b8cddd04bdc486c251de75ac66ac4e48e3e7081"
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0x150df55277f700daa9577d833426cb0d36ba9ee7ddef16ebd7e429c859015f0d"
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "AQ=="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "//////////8="
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006"
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0x27565d24a4cd51127ac90e4074a841bbe356cca7bf5759ddc14a975be1632abc"
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0x67624a1533b5aff5d0dfcf5e598684350efd38134d2d245f475524c03a64e656"
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "CgAAAAAAAAA="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "//////////8="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "AA=="
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0xdaa46292632c3c4d8f31f23ea0f9b36a28ff3677e9684980e4438403a67a3d8f"
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0x238f7e4648e62751de29c982cbf639b4225547c31db7bd866982d7d56fc2c7a8"
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0xeb863165a109f7791a3182be08aff1438ab2a429314fc135ae19d953afe1edd6"
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "AQ=="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "//////////8="
+      }
+    },
+    {
+      "Object": {
+        "ImmOrOwnedObject": {
+          "objectId": "0xee23d0cd34718145602307f4dccb3228334afbefb2a89919b98e97c420361d5a",
+          "version": "936480130",
+          "digest": "2VNLwUneAbpQGaV78VNwT1krujmKm8yknmEUeTWzgTnA"
+        }
+      }
+    },
+    {
+      "Object": {
+        "ImmOrOwnedObject": {
+          "objectId": "0x8f6dadd965ad36d25ff1a4b3aabe9f8e53c8a37b68f2b4519aeeb89c0668cb70",
+          "version": "658419224",
+          "digest": "92KHVRKECNWCb45uySUkvcFJeu7urKr3vHbb9pTtinQk"
+        }
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "ANYRfgMAAAA="
+      }
+    }
+  ],
+  "commands": [
+    {
+      "MergeCoins": {
+        "destination": {
+          "Input": 20
+        },
+        "sources": [
+          {
+            "Input": 21
+          }
+        ]
+      }
+    },
+    {
+      "SplitCoins": {
+        "coin": {
+          "Input": 20
+        },
+        "amounts": [
+          {
+            "Input": 22
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0xde5d696a79714ca5cb910b9aed99d41f67353abb00715ceaeb0663d57ee39640",
+        "module": "router",
+        "function": "new_swap_context",
+        "typeArguments": [
+          "0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca::blue::BLUE",
+          "0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS"
+        ],
+        "arguments": [
+          {
+            "Input": 0
+          },
+          {
+            "Input": 1
+          },
+          {
+            "Input": 2
+          },
+          {
+            "NestedResult": [
+              1,
+              0
+            ]
+          },
+          {
+            "Input": 3
+          },
+          {
+            "Input": 4
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0x3aeee81b8b88da7e9b4b22ceca217fc198dac1e5be61e417a8cb7733acb1b8a8",
+        "module": "ferra_clmm",
+        "function": "swap",
+        "typeArguments": [
+          "0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca::blue::BLUE",
+          "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC"
+        ],
+        "arguments": [
+          {
+            "Result": 2
+          },
+          {
+            "Input": 5
+          },
+          {
+            "Input": 6
+          },
+          {
+            "Input": 7
+          },
+          {
+            "Input": 8
+          },
+          {
+            "Input": 9
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0x66d7bfb7ca9002c4e0a2a8bfb763ca224011be912f24025a52a4e19be0cb0ac0",
+        "module": "flowx_clmm",
+        "function": "swap",
+        "typeArguments": [
+          "0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN",
+          "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC"
+        ],
+        "arguments": [
+          {
+            "Result": 2
+          },
+          {
+            "Input": 10
+          },
+          {
+            "Input": 11
+          },
+          {
+            "Input": 12
+          },
+          {
+            "Input": 13
+          },
+          {
+            "Input": 14
+          },
+          {
+            "Input": 9
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0x721d950e57259cd97d41010887ab502ee7753b0a3deb4b6a80099aad0c833928",
+        "module": "cetus",
+        "function": "swap",
+        "typeArguments": [
+          "0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN",
+          "0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS"
+        ],
+        "arguments": [
+          {
+            "Result": 2
+          },
+          {
+            "Input": 15
+          },
+          {
+            "Input": 16
+          },
+          {
+            "Input": 17
+          },
+          {
+            "Input": 18
+          },
+          {
+            "Input": 19
+          },
+          {
+            "Input": 9
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0xde5d696a79714ca5cb910b9aed99d41f67353abb00715ceaeb0663d57ee39640",
+        "module": "router",
+        "function": "confirm_swap",
+        "typeArguments": [
+          "0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS"
+        ],
+        "arguments": [
+          {
+            "Result": 2
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0xde5d696a79714ca5cb910b9aed99d41f67353abb00715ceaeb0663d57ee39640",
+        "module": "router",
+        "function": "transfer_or_destroy_coin",
+        "typeArguments": [
+          "0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS"
+        ],
+        "arguments": [
+          {
+            "Result": 6
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/core/crates/gem_sui/testdata/wc_sign_transaction_cetus_funds_withdrawal.json
+++ b/core/crates/gem_sui/testdata/wc_sign_transaction_cetus_funds_withdrawal.json
@@ -1,0 +1,360 @@
+{
+  "version": 2,
+  "sender": "0xa9bd0493f9bd1f792a4aedc1f99d54535a75a46c38fd56a8f2c6b7c8d75817a1",
+  "expiration": null,
+  "gasData": {
+    "budget": "50000000",
+    "price": null,
+    "owner": null,
+    "payment": null
+  },
+  "inputs": [
+    {
+      "Pure": {
+        "bytes": "IGQ4YmY2NDIwZWM2ZDUzOTU2YTM0NmM0YjQyNzE3OTI1"
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "A48WJAIAAAA="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "fwFZIQIAAAA="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "AAAAAA=="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0x2cd8382c19e6994f16df204e9b8cddd04bdc486c251de75ac66ac4e48e3e7081"
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0x150df55277f700daa9577d833426cb0d36ba9ee7ddef16ebd7e429c859015f0d"
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "AQ=="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "//////////8="
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006"
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0xdaa46292632c3c4d8f31f23ea0f9b36a28ff3677e9684980e4438403a67a3d8f"
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0xaa020ad81e1621d98d4fb82c4acb80dc064722f24ef828ab633bef50fc28268b"
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0xeb863165a109f7791a3182be08aff1438ab2a429314fc135ae19d953afe1edd6"
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "AQ=="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "//////////8="
+      }
+    },
+    {
+      "UnresolvedObject": {
+        "objectId": "0x77ec5b840d9a465dfaae8bb415682c0faeaa707247af4eec8c5ce8ee6e1314e6"
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "AQ=="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "//////////8="
+      }
+    },
+    {
+      "Object": {
+        "ImmOrOwnedObject": {
+          "objectId": "0x8f6dadd965ad36d25ff1a4b3aabe9f8e53c8a37b68f2b4519aeeb89c0668cb70",
+          "version": "658419224",
+          "digest": "92KHVRKECNWCb45uySUkvcFJeu7urKr3vHbb9pTtinQk"
+        }
+      }
+    },
+    {
+      "FundsWithdrawal": {
+        "reservation": {
+          "MaxAmountU64": "14999840000",
+          "$kind": "MaxAmountU64"
+        },
+        "typeArg": {
+          "Balance": "0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca::blue::BLUE",
+          "$kind": "Balance"
+        },
+        "withdrawFrom": {
+          "Sender": true,
+          "$kind": "Sender"
+        }
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "ANYRfgMAAAA="
+      }
+    },
+    {
+      "Pure": {
+        "bytes": "qb0Ek/m9H3kqSu3B+Z1UU1p1pGw4/Vao8sa3yNdYF6E="
+      }
+    }
+  ],
+  "commands": [
+    {
+      "MoveCall": {
+        "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+        "module": "coin",
+        "function": "redeem_funds",
+        "typeArguments": [
+          "0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca::blue::BLUE"
+        ],
+        "arguments": [
+          {
+            "Input": 19
+          }
+        ]
+      }
+    },
+    {
+      "MergeCoins": {
+        "destination": {
+          "Input": 18
+        },
+        "sources": [
+          {
+            "Result": 0
+          }
+        ]
+      }
+    },
+    {
+      "SplitCoins": {
+        "coin": {
+          "Input": 18
+        },
+        "amounts": [
+          {
+            "Input": 20
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0xde5d696a79714ca5cb910b9aed99d41f67353abb00715ceaeb0663d57ee39640",
+        "module": "router",
+        "function": "new_swap_context",
+        "typeArguments": [
+          "0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca::blue::BLUE",
+          "0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS"
+        ],
+        "arguments": [
+          {
+            "Input": 0
+          },
+          {
+            "Input": 1
+          },
+          {
+            "Input": 2
+          },
+          {
+            "NestedResult": [
+              2,
+              0
+            ]
+          },
+          {
+            "Input": 3
+          },
+          {
+            "Input": 4
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0x3aeee81b8b88da7e9b4b22ceca217fc198dac1e5be61e417a8cb7733acb1b8a8",
+        "module": "ferra_clmm",
+        "function": "swap",
+        "typeArguments": [
+          "0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca::blue::BLUE",
+          "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC"
+        ],
+        "arguments": [
+          {
+            "Result": 3
+          },
+          {
+            "Input": 5
+          },
+          {
+            "Input": 6
+          },
+          {
+            "Input": 7
+          },
+          {
+            "Input": 8
+          },
+          {
+            "Input": 9
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0x721d950e57259cd97d41010887ab502ee7753b0a3deb4b6a80099aad0c833928",
+        "module": "cetus",
+        "function": "swap",
+        "typeArguments": [
+          "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC",
+          "0xbde4ba4c2e274a60ce15c1cfff9e5c42e41654ac8b6d906a57efa4bd3c29f47d::hasui::HASUI"
+        ],
+        "arguments": [
+          {
+            "Result": 3
+          },
+          {
+            "Input": 10
+          },
+          {
+            "Input": 11
+          },
+          {
+            "Input": 12
+          },
+          {
+            "Input": 13
+          },
+          {
+            "Input": 14
+          },
+          {
+            "Input": 9
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0x721d950e57259cd97d41010887ab502ee7753b0a3deb4b6a80099aad0c833928",
+        "module": "cetus",
+        "function": "swap",
+        "typeArguments": [
+          "0xbde4ba4c2e274a60ce15c1cfff9e5c42e41654ac8b6d906a57efa4bd3c29f47d::hasui::HASUI",
+          "0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS"
+        ],
+        "arguments": [
+          {
+            "Result": 3
+          },
+          {
+            "Input": 10
+          },
+          {
+            "Input": 15
+          },
+          {
+            "Input": 12
+          },
+          {
+            "Input": 16
+          },
+          {
+            "Input": 17
+          },
+          {
+            "Input": 9
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0xde5d696a79714ca5cb910b9aed99d41f67353abb00715ceaeb0663d57ee39640",
+        "module": "router",
+        "function": "confirm_swap",
+        "typeArguments": [
+          "0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS"
+        ],
+        "arguments": [
+          {
+            "Result": 3
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0xde5d696a79714ca5cb910b9aed99d41f67353abb00715ceaeb0663d57ee39640",
+        "module": "router",
+        "function": "transfer_or_destroy_coin",
+        "typeArguments": [
+          "0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS"
+        ],
+        "arguments": [
+          {
+            "Result": 7
+          }
+        ]
+      }
+    },
+    {
+      "MoveCall": {
+        "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+        "module": "coin",
+        "function": "send_funds",
+        "typeArguments": [
+          "0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca::blue::BLUE"
+        ],
+        "arguments": [
+          {
+            "Input": 18
+          },
+          {
+            "Input": 21
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/core/crates/gem_wallet_connect/Cargo.toml
+++ b/core/crates/gem_wallet_connect/Cargo.toml
@@ -8,6 +8,7 @@ primitives = { path = "../primitives" }
 gem_evm = { path = "../gem_evm" }
 gem_ton = { path = "../gem_ton", features = ["signer"] }
 
+base64 = { workspace = true }
 hex = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }

--- a/core/crates/gem_wallet_connect/src/accounts.rs
+++ b/core/crates/gem_wallet_connect/src/accounts.rs
@@ -1,0 +1,55 @@
+use base64::{Engine, engine::general_purpose::STANDARD};
+use primitives::{Account, Chain, hex};
+use serde_json::Value;
+
+pub const SUI_GET_ACCOUNTS_PROPERTY: &str = "sui_getAccounts";
+const SUI_ED25519_SCHEME_FLAG: u8 = 0x00;
+const ED25519_PUBLIC_KEY_LENGTH: usize = 32;
+
+/// sui_getAccounts payload: pubkey is base64 of the ed25519 scheme flag + 32-byte public key.
+pub fn map_sui_get_accounts(accounts: &[Account]) -> Vec<Value> {
+    accounts.iter().filter(|account| account.chain == Chain::Sui).filter_map(sui_account_value).collect()
+}
+
+fn sui_account_value(account: &Account) -> Option<Value> {
+    let public_key = hex::decode_hex(account.extended_public_key.as_deref()?).ok()?;
+    if public_key.len() != ED25519_PUBLIC_KEY_LENGTH {
+        return None;
+    }
+    let flagged_key = [&[SUI_ED25519_SCHEME_FLAG][..], &public_key].concat();
+    Some(serde_json::json!({ "pubkey": STANDARD.encode(flagged_key), "address": account.address }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::{TEST_SUI_ADDRESS, TEST_SUI_PUBLIC_KEY_BASE64, mock_sui_account};
+    use primitives::testkit::signer_mock::TEST_EVM_SENDER;
+
+    #[test]
+    fn test_map_sui_get_accounts() {
+        let accounts = vec![
+            mock_sui_account(),
+            Account {
+                chain: Chain::Ethereum,
+                address: TEST_EVM_SENDER.to_string(),
+                extended_public_key: Some("11".repeat(32)),
+                ..mock_sui_account()
+            },
+            Account {
+                extended_public_key: None,
+                ..mock_sui_account()
+            },
+            Account {
+                extended_public_key: Some("0xdeadbeef".to_string()),
+                ..mock_sui_account()
+            },
+        ];
+
+        assert_eq!(
+            map_sui_get_accounts(&accounts),
+            vec![serde_json::json!({ "pubkey": TEST_SUI_PUBLIC_KEY_BASE64, "address": TEST_SUI_ADDRESS })]
+        );
+        assert_eq!(map_sui_get_accounts(&[]), Vec::<Value>::new());
+    }
+}

--- a/core/crates/gem_wallet_connect/src/actions.rs
+++ b/core/crates/gem_wallet_connect/src/actions.rs
@@ -26,6 +26,9 @@ pub enum WalletConnectAction {
     ChainOperation {
         operation: WalletConnectChainOperation,
     },
+    GetAccounts {
+        chain: Chain,
+    },
     Unsupported {
         method: String,
     },

--- a/core/crates/gem_wallet_connect/src/lib.rs
+++ b/core/crates/gem_wallet_connect/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod accounts;
 pub mod actions;
 pub mod decode;
 pub mod request_handler;
@@ -6,6 +7,9 @@ pub mod session;
 pub mod sign_type;
 pub mod validator;
 pub mod verifier;
+
+#[cfg(test)]
+mod testkit;
 
 pub use actions::*;
 pub use decode::decode_sign_message;

--- a/core/crates/gem_wallet_connect/src/request_handler/mod.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/mod.rs
@@ -63,6 +63,7 @@ impl WalletConnectRequestHandler {
             WalletConnectionMethods::SolanaSignTransaction => SolanaRequestHandler::parse_sign_transaction(Chain::Solana, params),
             WalletConnectionMethods::SolanaSignAndSendTransaction => SolanaRequestHandler::parse_send_transaction(Chain::Solana, params),
             WalletConnectionMethods::SolanaSignAllTransactions => SolanaRequestHandler::parse_sign_all_transactions(params),
+            WalletConnectionMethods::SuiGetAccounts => Ok(WalletConnectAction::GetAccounts { chain: Chain::Sui }),
             WalletConnectionMethods::SuiSignPersonalMessage => SuiRequestHandler::parse_sign_message(Chain::Sui, params, domain),
             WalletConnectionMethods::SuiSignTransaction => SuiRequestHandler::parse_sign_transaction(Chain::Sui, params),
             WalletConnectionMethods::SuiSignAndExecuteTransaction => SuiRequestHandler::parse_send_transaction(Chain::Sui, params),
@@ -160,6 +161,15 @@ mod tests {
             WalletConnectAction::Unsupported {
                 method: "sendTransfer".to_string()
             }
+        );
+    }
+
+    #[test]
+    fn test_sui_get_accounts() {
+        let request = WalletConnectRequest::mock("sui_getAccounts", "{}", Some("sui:mainnet"));
+        assert_eq!(
+            WalletConnectRequestHandler::parse_request(request).unwrap(),
+            WalletConnectAction::GetAccounts { chain: Chain::Sui }
         );
     }
 

--- a/core/crates/gem_wallet_connect/src/response_handler.rs
+++ b/core/crates/gem_wallet_connect/src/response_handler.rs
@@ -1,5 +1,8 @@
+use crate::accounts::map_sui_get_accounts;
 use crate::actions::WalletConnectResponseType;
+use primitives::Account;
 use primitives::ChainType;
+use serde_json::Value;
 
 pub struct WalletConnectResponseHandler;
 
@@ -44,6 +47,16 @@ impl WalletConnectResponseHandler {
         }
     }
 
+    pub fn encode_get_accounts(chain_type: ChainType, accounts: &[Account]) -> WalletConnectResponseType {
+        let result = match chain_type {
+            ChainType::Sui => map_sui_get_accounts(accounts),
+            _ => vec![],
+        };
+        WalletConnectResponseType::Object {
+            json: Value::Array(result).to_string(),
+        }
+    }
+
     pub fn encode_sign_all_transactions(signed_transactions: Vec<String>) -> WalletConnectResponseType {
         WalletConnectResponseType::Object {
             json: serde_json::json!({ "transactions": signed_transactions }).to_string(),
@@ -66,6 +79,7 @@ impl WalletConnectResponseHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testkit::{TEST_SUI_ADDRESS, TEST_SUI_PUBLIC_KEY_BASE64, mock_sui_account};
 
     fn object(json: &str) -> WalletConnectResponseType {
         WalletConnectResponseType::Object { json: json.to_string() }
@@ -118,6 +132,15 @@ mod tests {
             WalletConnectResponseHandler::encode_send_transaction(ChainType::Tron, "txid123".to_string()),
             object(r#"{"result":true,"txid":"txid123"}"#)
         );
+    }
+
+    #[test]
+    fn test_encode_get_accounts() {
+        assert_eq!(
+            WalletConnectResponseHandler::encode_get_accounts(ChainType::Sui, &[mock_sui_account()]),
+            object(&format!(r#"[{{"pubkey":"{TEST_SUI_PUBLIC_KEY_BASE64}","address":"{TEST_SUI_ADDRESS}"}}]"#))
+        );
+        assert_eq!(WalletConnectResponseHandler::encode_get_accounts(ChainType::Ethereum, &[mock_sui_account()]), object("[]"));
     }
 
     #[test]

--- a/core/crates/gem_wallet_connect/src/session.rs
+++ b/core/crates/gem_wallet_connect/src/session.rs
@@ -1,13 +1,20 @@
 use std::collections::HashMap;
 
 use primitives::Chain;
+use serde_json::Value;
+
+use crate::accounts::{SUI_GET_ACCOUNTS_PROPERTY, map_sui_get_accounts};
+use primitives::Account;
 
 const TRON_METHOD_VERSION_KEY: &str = "tron_method_version";
 const TRON_METHOD_VERSION_VALUE: &str = "v1";
 
-pub fn config_session_properties(mut properties: HashMap<String, String>, chains: &[Chain]) -> HashMap<String, String> {
+pub fn config_session_properties(mut properties: HashMap<String, String>, chains: &[Chain], accounts: &[Account]) -> HashMap<String, String> {
     if chains.contains(&Chain::Tron) {
         properties = tron_session_properties(properties);
+    }
+    if chains.contains(&Chain::Sui) {
+        properties = sui_session_properties(properties, accounts);
     }
     properties
 }
@@ -19,13 +26,22 @@ fn tron_session_properties(mut properties: HashMap<String, String>) -> HashMap<S
     properties
 }
 
+fn sui_session_properties(mut properties: HashMap<String, String>, accounts: &[Account]) -> HashMap<String, String> {
+    let sui_accounts = map_sui_get_accounts(accounts);
+    if !sui_accounts.is_empty() {
+        properties.insert(SUI_GET_ACCOUNTS_PROPERTY.to_string(), Value::Array(sui_accounts).to_string());
+    }
+    properties
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testkit::{TEST_SUI_ADDRESS, TEST_SUI_PUBLIC_KEY_BASE64, mock_sui_account};
 
     #[test]
     fn test_config_session_properties_adds_tron() {
-        let result = config_session_properties(HashMap::new(), &[Chain::Tron]);
+        let result = config_session_properties(HashMap::new(), &[Chain::Tron], &[]);
         assert_eq!(result.get("tron_method_version").unwrap(), "v1");
     }
 
@@ -33,13 +49,35 @@ mod tests {
     fn test_config_session_properties_preserves_existing() {
         let mut props = HashMap::new();
         props.insert("tron_method_version".to_string(), "v2".to_string());
-        let result = config_session_properties(props, &[Chain::Tron]);
+        let result = config_session_properties(props, &[Chain::Tron], &[]);
         assert_eq!(result.get("tron_method_version").unwrap(), "v2");
     }
 
     #[test]
     fn test_config_session_properties_no_tron() {
-        let result = config_session_properties(HashMap::new(), &[Chain::Ethereum]);
+        let result = config_session_properties(HashMap::new(), &[Chain::Ethereum], &[]);
         assert!(!result.contains_key("tron_method_version"));
+    }
+
+    #[test]
+    fn test_config_session_properties_adds_sui_get_accounts() {
+        let result = config_session_properties(HashMap::new(), &[Chain::Sui], &[mock_sui_account()]);
+        assert_eq!(
+            result.get("sui_getAccounts").unwrap(),
+            &format!(r#"[{{"pubkey":"{TEST_SUI_PUBLIC_KEY_BASE64}","address":"{TEST_SUI_ADDRESS}"}}]"#)
+        );
+    }
+
+    #[test]
+    fn test_config_session_properties_skips_sui_without_public_key() {
+        let account = Account {
+            extended_public_key: None,
+            ..mock_sui_account()
+        };
+        let result = config_session_properties(HashMap::new(), &[Chain::Sui], &[account]);
+        assert!(!result.contains_key("sui_getAccounts"));
+
+        let result = config_session_properties(HashMap::new(), &[Chain::Ethereum], &[mock_sui_account()]);
+        assert!(!result.contains_key("sui_getAccounts"));
     }
 }

--- a/core/crates/gem_wallet_connect/src/testkit.rs
+++ b/core/crates/gem_wallet_connect/src/testkit.rs
@@ -1,0 +1,15 @@
+use primitives::{Account, Chain};
+
+// sui_getAccounts example from the WalletConnect Sui RPC reference.
+pub const TEST_SUI_ADDRESS: &str = "0x3cd077f41680eebca0176baad3915b2ea26dbbdfd10161865234732bb1f2ac50";
+pub const TEST_SUI_PUBLIC_KEY_HEX: &str = "2ebc3f9e960824c5d275045f7d7f5796f5c2a883d69bdf73c16a97c74f20f0c0";
+pub const TEST_SUI_PUBLIC_KEY_BASE64: &str = "AC68P56WCCTF0nUEX31/V5b1wqiD1pvfc8Fql8dPIPDA";
+
+pub fn mock_sui_account() -> Account {
+    Account {
+        chain: Chain::Sui,
+        address: TEST_SUI_ADDRESS.to_string(),
+        derivation_path: "m/44'/784'/0'/0'/0'".to_string(),
+        extended_public_key: Some(TEST_SUI_PUBLIC_KEY_HEX.to_string()),
+    }
+}

--- a/core/crates/primitives/src/wallet_connector.rs
+++ b/core/crates/primitives/src/wallet_connector.rs
@@ -47,6 +47,8 @@ pub enum WalletConnectionMethods {
     SolanaSignAndSendTransaction,
     #[serde(rename = "solana_signAllTransactions")]
     SolanaSignAllTransactions,
+    #[serde(rename = "sui_getAccounts")]
+    SuiGetAccounts,
     #[serde(rename = "sui_signPersonalMessage")]
     SuiSignPersonalMessage,
     #[serde(rename = "sui_signTransaction")]

--- a/core/docs/KEYSTORE_V4.md
+++ b/core/docs/KEYSTORE_V4.md
@@ -1,6 +1,6 @@
 # Gem Keystore v4 Implementation Source of Truth
 
-Last checked against implementation: 2026-06-10.
+Last checked against implementation: 2026-07-04.
 
 This is the short as-built reference for Gem Keystore v4. The long design doc keeps history and rationale; this file records the current implementation contract. The code remains canonical.
 
@@ -11,7 +11,7 @@ Gem Keystore v4 stores one encrypted secret file per controlled wallet. Wallet/a
 ## Core Ownership
 
 - `gem_keystore`: BIP-39 helpers, v4 encrypted file format, v3 WalletCore reader, raw secret storage.
-- `gem_derivation`: wallet id derivation, account derivation, private-key import validation, chain address creation.
+- `gem_derivation`: wallet id derivation, account derivation, private-key import validation, chain address creation, account public keys (`Account.extended_public_key`).
 - `gem_auth`: shared device-auth header format (Ed25519 build + verify), used by both the client and the backend.
 - `gemstone`: UniFFI boundary over `gem_keystore` and `gem_derivation`, plus keystore-internal signing (`GemKeystore.sign`/`sign_auth`, `MessageSigner.sign_with_keystore`) routed over the per-chain `gem_*` signer crates, and the client device-auth wrappers.
 - Mobile apps own wallet name, order, current wallet, account rows, duplicate checks, subscriptions, UI, and secure password storage.
@@ -87,6 +87,18 @@ The encrypted payload is exactly one of:
 - raw private-key bytes
 
 v4 does not store wallet names, app wallet ids, account lists, addresses, public keys, derivation paths, xpubs, or WalletCore `activeAccounts`.
+
+## Account Public Keys
+
+Public keys live in the mobile DB account rows (`Account.extended_public_key`), not in the keystore file. `gem_derivation` populates the field whenever it creates an account (import, create, and chain backfill via `add_accounts`):
+
+- Bitcoin-family chains store the extended public key (xpub/zpub).
+- Cardano stores nothing (no single reusable public key).
+- Every other chain stores the hex-encoded raw public key (secp256k1 or ed25519 per chain).
+
+Consumers read the field from the app DB — e.g. WalletConnect serializes the Sui account public key into `sessionProperties.sui_getAccounts`.
+
+Caveat: account rows created by the pre-v4 WalletCore import only carry Bitcoin-family xpubs (empty otherwise). v3 migration moves the secret file only and never rewrites DB account rows, and chain backfill only adds accounts for missing chains. Rows from old imports therefore keep an empty public key until the user re-imports the wallet — that re-import is the supported remedy when a flow needs the public key (e.g. Sui WalletConnect).
 
 ## Recovery Phrase Generation
 

--- a/core/gemstone/src/wallet_connect/mod.rs
+++ b/core/gemstone/src/wallet_connect/mod.rs
@@ -5,7 +5,7 @@ use gem_wallet_connect::{
     WalletConnectTransactionType as WcWalletConnectTransactionType, WalletConnectVerifier, config_session_properties,
 };
 use primitives::{
-    Chain, ChainAddress, TransferDataOutputType, WCEthereumTransaction, WalletConnectCAIP2, WalletConnectLink, WalletConnectRequest, WalletConnectionVerificationStatus,
+    Account, Chain, ChainAddress, TransferDataOutputType, WCEthereumTransaction, WalletConnectCAIP2, WalletConnectLink, WalletConnectRequest, WalletConnectionVerificationStatus,
 };
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -50,6 +50,14 @@ pub struct WCEthereumTransactionData {
     pub data: Option<String>,
 }
 
+#[uniffi::remote(Record)]
+pub struct Account {
+    pub chain: Chain,
+    pub address: String,
+    pub derivation_path: String,
+    pub extended_public_key: Option<String>,
+}
+
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct WCSolanaTransactionData {
     pub transaction: String,
@@ -85,6 +93,9 @@ pub enum WalletConnectAction {
     },
     ChainOperation {
         operation: WalletConnectChainOperation,
+    },
+    GetAccounts {
+        chain: Chain,
     },
     Unsupported {
         method: String,
@@ -249,6 +260,7 @@ impl From<WcWalletConnectAction> for WalletConnectAction {
                 data,
             },
             WcWalletConnectAction::ChainOperation { operation } => Self::ChainOperation { operation: operation.into() },
+            WcWalletConnectAction::GetAccounts { chain } => Self::GetAccounts { chain },
             WcWalletConnectAction::Unsupported { method } => Self::Unsupported { method },
         }
     }
@@ -366,6 +378,10 @@ impl WalletConnect {
         WalletConnectResponseHandler::encode_sign_all_transactions(signed_transactions).into()
     }
 
+    pub fn encode_get_accounts(&self, chain: Chain, accounts: Vec<Account>) -> WalletConnectResponseType {
+        WalletConnectResponseHandler::encode_get_accounts(chain.chain_type(), &accounts).into()
+    }
+
     pub fn encode_send_transaction(&self, chain: Chain, transaction_id: String) -> WalletConnectResponseType {
         WalletConnectResponseHandler::encode_send_transaction(chain.chain_type(), transaction_id).into()
     }
@@ -374,9 +390,9 @@ impl WalletConnect {
         simulation::decode_message(chain, sign_type, data)
     }
 
-    pub fn config_session_properties(&self, properties: HashMap<String, String>, caip2_chains: Vec<String>) -> HashMap<String, String> {
+    pub fn config_session_properties(&self, properties: HashMap<String, String>, caip2_chains: Vec<String>, accounts: Vec<Account>) -> HashMap<String, String> {
         let chains: Vec<Chain> = caip2_chains.into_iter().filter_map(|caip2| WalletConnectCAIP2::resolve_chain(Some(caip2)).ok()).collect();
-        config_session_properties(properties, &chains)
+        config_session_properties(properties, &chains, &accounts)
     }
 
     pub fn decode_send_transaction(&self, transaction_type: WalletConnectTransactionType, data: String) -> Result<WalletConnectTransaction, GemstoneError> {

--- a/ios/Features/WalletConnector/Sources/WalletConnector/Services/WalletConnectorSigner.swift
+++ b/ios/Features/WalletConnector/Sources/WalletConnector/Services/WalletConnectorSigner.swift
@@ -44,8 +44,10 @@ public final class WalletConnectorSigner: WalletConnectorSignable {
         wallet.accounts.map(\.chain).asSet().intersection(allChains).asArray()
     }
 
-    public func getAccounts(wallet: Wallet, chains: [Primitives.Chain]) -> [Primitives.Account] {
-        wallet.accounts.filter { chains.contains($0.chain) }
+    public func getAccounts(sessionId: String, chain: Primitives.Chain) throws -> [Primitives.Account] {
+        let connection = try connectionsStore.getConnection(id: sessionId)
+        try validate(chain: chain, session: connection.session)
+        return connection.wallet.accounts.filter { $0.chain == chain }
     }
 
     public func getWallets(for proposal: Session.Proposal) throws -> [Wallet] {

--- a/ios/Packages/ChainServices/WalletConnectorService/Extensions/Account+ChainServices.swift
+++ b/ios/Packages/ChainServices/WalletConnectorService/Extensions/Account+ChainServices.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
+import struct Gemstone.Account
 import class Gemstone.WalletConnect
 import Primitives
 import ReownWalletKit
@@ -8,9 +9,18 @@ import ReownWalletKit
 extension Primitives.Account {
     var blockchain: WalletConnectUtils.Account? {
         if let blockchain = chain.blockchain {
-            return Account(blockchain: blockchain, address: address)
+            return WalletConnectUtils.Account(blockchain: blockchain, address: address)
         }
         return .none
+    }
+
+    func mapToGem() -> Gemstone.Account {
+        Gemstone.Account(
+            chain: chain.rawValue,
+            address: address,
+            derivationPath: derivationPath,
+            extendedPublicKey: extendedPublicKey,
+        )
     }
 }
 

--- a/ios/Packages/ChainServices/WalletConnectorService/TestKit/WalletConnectorSignableMock.swift
+++ b/ios/Packages/ChainServices/WalletConnectorService/TestKit/WalletConnectorSignableMock.swift
@@ -27,7 +27,7 @@ public struct WalletConnectorSignableMock: WalletConnectorSignable {
         []
     }
 
-    public func getAccounts(wallet _: Wallet, chains _: [Chain]) -> [Primitives.Account] {
+    public func getAccounts(sessionId _: String, chain _: Chain) throws -> [Primitives.Account] {
         []
     }
 

--- a/ios/Packages/ChainServices/WalletConnectorService/WalletConnectorService.swift
+++ b/ios/Packages/ChainServices/WalletConnectorService/WalletConnectorService.swift
@@ -264,6 +264,10 @@ extension WalletConnectorService {
             return .response(response.map())
         case let .chainOperation(operation):
             return handleChainOperation(operation: operation)
+        case let .getAccounts(chain):
+            let accounts = try signer.getAccounts(sessionId: sessionId, chain: chain.map())
+            let response = walletConnect.encodeGetAccounts(chain: chain, accounts: accounts.map { $0.mapToGem() })
+            return .response(response.map())
         case let .unsupported(method):
             throw WalletConnectorServiceError.unresolvedMethod(method)
         }
@@ -326,7 +330,7 @@ extension WalletConnectorService {
 
     private func acceptProposal(proposal: Session.Proposal, wallet: Wallet) async throws -> Session {
         let chains = signer.getChains(wallet: wallet)
-        let accounts = signer.getAccounts(wallet: wallet, chains: chains)
+        let accounts = wallet.accounts.filter { chains.contains($0.chain) }
         let events = signer.getEvents()
         let methods = signer.getMethods()
         let supportedAccounts = accounts.compactMap(\.blockchain)
@@ -343,6 +347,7 @@ extension WalletConnectorService {
         let sessionProperties = walletConnect.configSessionProperties(
             properties: proposal.sessionProperties ?? [:],
             caip2Chains: caip2Chains,
+            accounts: accounts.map { $0.mapToGem() },
         )
 
         return try await WalletKit.instance.approve(

--- a/ios/Packages/ChainServices/WalletConnectorService/WalletConnectorSignable.swift
+++ b/ios/Packages/ChainServices/WalletConnectorService/WalletConnectorSignable.swift
@@ -15,7 +15,7 @@ public protocol WalletConnectorSignable: Sendable {
     func getCurrentWallet() throws -> Primitives.Wallet
     func getWallet(id: WalletId) throws -> Primitives.Wallet
     func getChains(wallet: Wallet) -> [Primitives.Chain]
-    func getAccounts(wallet: Wallet, chains: [Primitives.Chain]) -> [Primitives.Account]
+    func getAccounts(sessionId: String, chain: Primitives.Chain) throws -> [Primitives.Account]
     func getWallets(for proposal: Session.Proposal) throws -> [Wallet]
     func getMethods() -> [WalletConnectionMethods]
     func getEvents() -> [WalletConnectionEvents]

--- a/ios/Packages/GemstonePrimitives/Sources/Extensions/GemKeystore+GemstonePrimitives.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/Extensions/GemKeystore+GemstonePrimitives.swift
@@ -4,8 +4,8 @@ import Gemstone
 import Primitives
 
 public extension GemKeystoreAccount {
-    func mapToAccount() throws -> Account {
-        try Account(
+    func mapToAccount() throws -> Primitives.Account {
+        try Primitives.Account(
             chain: chain.map(),
             address: address,
             derivationPath: derivationPath,
@@ -53,7 +53,7 @@ public extension GemStoredWallet {
 }
 
 public extension Wallet {
-    func adding(accounts newAccounts: [Account]) -> Wallet {
+    func adding(accounts newAccounts: [Primitives.Account]) -> Wallet {
         Wallet(
             id: id,
             externalId: externalId,

--- a/ios/Packages/Primitives/Sources/Generated/WalletConnector.swift
+++ b/ios/Packages/Primitives/Sources/Generated/WalletConnector.swift
@@ -106,6 +106,7 @@ public enum WalletConnectionMethods: String, Codable, CaseIterable, Sendable {
 	case solanaSignTransaction = "solana_signTransaction"
 	case solanaSignAndSendTransaction = "solana_signAndSendTransaction"
 	case solanaSignAllTransactions = "solana_signAllTransactions"
+	case suiGetAccounts = "sui_getAccounts"
 	case suiSignPersonalMessage = "sui_signPersonalMessage"
 	case suiSignTransaction = "sui_signTransaction"
 	case suiSignAndExecuteTransaction = "sui_signAndExecuteTransaction"


### PR DESCRIPTION
- Implement sui_getAccounts and serialize the account public key into sessionProperties at approval so Sui Dappkit dapps can connect
- Resolve TS SDK Transaction.toJSON() payloads (unresolved objects, FundsWithdrawal inputs, missing gas) into signed-ready BCS for preload, signing, and balance-change simulation
- Surface trailers-only gRPC errors with decoded grpc-message
- Document account public keys in the keystore docs

Cetus swap
<img width="45%"  alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-04 at 23 19 12" src="https://github.com/user-attachments/assets/e93d9a6d-52fd-4401-ba6d-4019f0613327" />
