### PR TITLE
Sort perpetual positions by value

### DIFF
--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/PerpetualPositionDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/PerpetualPositionDao.kt
@@ -46,7 +46,12 @@ interface PerpetualPositionDao {
     suspend fun getPositionsByProvider(walletId: String, provider: PerpetualProvider): List<DbPerpetualPosition>
 
     @Transaction
-    @Query("SELECT * FROM perpetuals_positions WHERE walletId = :walletId ORDER BY updatedAt DESC")
+    @Query(
+        "SELECT perpetuals_positions.* FROM perpetuals_positions " +
+            "INNER JOIN perpetuals ON perpetuals.id = perpetuals_positions.perpetualId " +
+            "WHERE perpetuals_positions.walletId = :walletId " +
+            "ORDER BY ABS(perpetuals_positions.size) * perpetuals.price DESC"
+    )
     fun getPositionsData(walletId: String): Flow<List<DbPerpetualPositionData>>
 
     @Transaction


### PR DESCRIPTION
Sort open perpetual positions by value (largest first) so they no longer jump around while prices update, matching iOS.

Closes #625