### PR TITLE
fix(core): harden WalletConnect chain validation

### DIFF
--- a/core/crates/gem_wallet_connect/src/request_handler/ethereum.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/ethereum.rs
@@ -1,11 +1,21 @@
 use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
-use primitives::{Chain, ValueAccess, WCEthereumTransaction};
+use primitives::{Chain, ValueAccess, WCEthereumTransaction, WalletConnectionMethods};
 use serde_json::Value;
 
 pub struct EthereumRequestHandler;
 
 impl EthereumRequestHandler {
+    pub fn parse_request(method: WalletConnectionMethods, chain: Chain, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
+        match method {
+            WalletConnectionMethods::PersonalSign => Self::parse_sign_message(chain, params, domain),
+            WalletConnectionMethods::EthSignTypedData | WalletConnectionMethods::EthSignTypedDataV4 => Self::parse_sign_typed_data(chain, params),
+            WalletConnectionMethods::EthSignTransaction => Self::parse_sign_transaction(chain, params),
+            WalletConnectionMethods::EthSendTransaction => Self::parse_send_transaction(chain, params),
+            _ => Err("Method not supported".to_string()),
+        }
+    }
+
     pub fn parse_sign_message(chain: Chain, params: Value, _domain: &str) -> Result<WalletConnectAction, String> {
         let data = params.at(0)?.string()?.to_string();
 

--- a/core/crates/gem_wallet_connect/src/request_handler/ethereum.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/ethereum.rs
@@ -1,6 +1,6 @@
 use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
-use primitives::{Chain, ValueAccess};
+use primitives::{Chain, ValueAccess, WCEthereumTransaction};
 use serde_json::Value;
 
 pub struct EthereumRequestHandler;
@@ -24,10 +24,7 @@ impl EthereumRequestHandler {
             serde_json::to_string(typed_data).map_err(|e| format!("Failed to serialize typed data: {}", e))?
         };
 
-        let expected_chain_id = chain
-            .network_id()
-            .parse::<u64>()
-            .map_err(|_| format!("Chain {} does not have a numeric network ID", chain))?;
+        let expected_chain_id = Self::expected_chain_id(chain)?;
         gem_evm::eip712::validate_eip712_chain_id(&data, expected_chain_id)?;
 
         Ok(WalletConnectAction::SignMessage {
@@ -38,8 +35,7 @@ impl EthereumRequestHandler {
     }
 
     pub fn parse_sign_transaction(chain: Chain, params: Value) -> Result<WalletConnectAction, String> {
-        let transaction = params.at(0)?;
-        let data = serde_json::to_string(transaction).map_err(|e| format!("Failed to serialize transaction: {}", e))?;
+        let data = Self::parse_transaction_data(chain, params)?;
 
         Ok(WalletConnectAction::SignTransaction {
             chain,
@@ -49,14 +45,36 @@ impl EthereumRequestHandler {
     }
 
     pub fn parse_send_transaction(chain: Chain, params: Value) -> Result<WalletConnectAction, String> {
-        let transaction = params.at(0)?;
-        let data = serde_json::to_string(transaction).map_err(|e| format!("Failed to serialize transaction: {}", e))?;
+        let data = Self::parse_transaction_data(chain, params)?;
 
         Ok(WalletConnectAction::SendTransaction {
             chain,
             transaction_type: WalletConnectTransactionType::Ethereum,
             data,
         })
+    }
+
+    fn parse_transaction_data(chain: Chain, params: Value) -> Result<String, String> {
+        let transaction = params.at(0)?.clone();
+        transaction.as_object().ok_or_else(|| "Expected Ethereum transaction object".to_string())?;
+        let parsed: WCEthereumTransaction = serde_json::from_value(transaction.clone()).map_err(|error| error.to_string())?;
+        Self::validate_transaction_chain_id(chain, parsed.chain_id)?;
+        serde_json::to_string(&transaction).map_err(|e| format!("Failed to serialize transaction: {}", e))
+    }
+
+    fn validate_transaction_chain_id(chain: Chain, chain_id: Option<u64>) -> Result<(), String> {
+        let Some(actual) = chain_id else {
+            return Ok(());
+        };
+        let expected = Self::expected_chain_id(chain)?;
+        if actual != expected {
+            return Err(format!("Transaction chainId mismatch: expected {expected}, got {actual}"));
+        }
+        Ok(())
+    }
+
+    fn expected_chain_id(chain: Chain) -> Result<u64, String> {
+        chain.network_id_value().ok_or_else(|| format!("Chain {} does not have a numeric network ID", chain))
     }
 }
 
@@ -156,14 +174,24 @@ mod tests {
 
     #[test]
     fn test_parse_send_transaction() {
-        let params = serde_json::from_str(r#"[{"to":"0x123","value":"0x0"}]"#).unwrap();
-        assert_eq!(
-            EthereumRequestHandler::parse_send_transaction(Chain::Ethereum, params).unwrap(),
-            WalletConnectAction::SendTransaction {
-                chain: Chain::Ethereum,
-                transaction_type: WalletConnectTransactionType::Ethereum,
-                data: r#"{"to":"0x123","value":"0x0"}"#.to_string(),
+        let params = serde_json::from_str(r#"[{"from":"0xsender","to":"0x123","value":"0x0","chainId":"0x1"}]"#).unwrap();
+        let action = EthereumRequestHandler::parse_send_transaction(Chain::Ethereum, params).unwrap();
+        match action {
+            WalletConnectAction::SendTransaction { chain, transaction_type, data } => {
+                let transaction: Value = serde_json::from_str(&data).unwrap();
+                assert_eq!(chain, Chain::Ethereum);
+                assert_eq!(transaction_type, WalletConnectTransactionType::Ethereum);
+                assert_eq!(transaction["from"], "0xsender");
+                assert_eq!(transaction["chainId"], "0x1");
             }
-        );
+            _ => panic!("Expected SendTransaction action"),
+        }
+    }
+
+    #[test]
+    fn test_parse_send_transaction_chain_id_mismatch_rejects() {
+        let params = serde_json::from_str(r#"[{"from":"0xabc","to":"0x123","value":"0x0","chainId":"0x89"}]"#).unwrap();
+        let result = EthereumRequestHandler::parse_send_transaction(Chain::Ethereum, params);
+        assert_eq!(result.unwrap_err(), "Transaction chainId mismatch: expected 1, got 137");
     }
 }

--- a/core/crates/gem_wallet_connect/src/request_handler/mod.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/mod.rs
@@ -35,7 +35,9 @@ impl WalletConnectRequestHandler {
             | WalletConnectionMethods::EthSignTypedData
             | WalletConnectionMethods::EthSignTypedDataV4
             | WalletConnectionMethods::EthSignTransaction
-            | WalletConnectionMethods::EthSendTransaction) => Self::parse_evm_request(method, chain_id, params, &domain),
+            | WalletConnectionMethods::EthSendTransaction) => {
+                EthereumRequestHandler::parse_request(method, Self::parse_required_chain(chain_id, ChainType::Ethereum)?, params, &domain)
+            }
             WalletConnectionMethods::EthSendRawTransaction => Err("Method not supported".to_string()),
             WalletConnectionMethods::EthChainId => Ok(WalletConnectAction::ChainOperation {
                 operation: WalletConnectChainOperation::GetChainId,
@@ -52,67 +54,21 @@ impl WalletConnectRequestHandler {
             method @ (WalletConnectionMethods::SolanaSignMessage
             | WalletConnectionMethods::SolanaSignTransaction
             | WalletConnectionMethods::SolanaSignAndSendTransaction
-            | WalletConnectionMethods::SolanaSignAllTransactions) => Self::parse_solana_request(method, chain_id, params, &domain),
+            | WalletConnectionMethods::SolanaSignAllTransactions) => {
+                SolanaRequestHandler::parse_request(method, Self::parse_required_chain(chain_id, ChainType::Solana)?, params, &domain)
+            }
             method @ (WalletConnectionMethods::SuiGetAccounts
             | WalletConnectionMethods::SuiSignPersonalMessage
             | WalletConnectionMethods::SuiSignTransaction
-            | WalletConnectionMethods::SuiSignAndExecuteTransaction) => Self::parse_sui_request(method, chain_id, params, &domain),
-            method @ (WalletConnectionMethods::TonSignData | WalletConnectionMethods::TonSendMessage) => Self::parse_ton_request(method, chain_id, params, &domain),
-            method @ (WalletConnectionMethods::TronSignMessage | WalletConnectionMethods::TronSignTransaction | WalletConnectionMethods::TronSendTransaction) => {
-                Self::parse_tron_request(method, chain_id, params, &domain)
+            | WalletConnectionMethods::SuiSignAndExecuteTransaction) => {
+                SuiRequestHandler::parse_request(method, Self::parse_required_chain(chain_id, ChainType::Sui)?, params, &domain)
             }
-        }
-    }
-
-    fn parse_evm_request(method: WalletConnectionMethods, chain_id: Option<String>, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
-        let chain = Self::resolve_required_chain(chain_id, ChainType::Ethereum)?;
-        match method {
-            WalletConnectionMethods::PersonalSign => EthereumRequestHandler::parse_sign_message(chain, params, domain),
-            WalletConnectionMethods::EthSignTypedData | WalletConnectionMethods::EthSignTypedDataV4 => EthereumRequestHandler::parse_sign_typed_data(chain, params),
-            WalletConnectionMethods::EthSignTransaction => EthereumRequestHandler::parse_sign_transaction(chain, params),
-            WalletConnectionMethods::EthSendTransaction => EthereumRequestHandler::parse_send_transaction(chain, params),
-            _ => Err("Method not supported".to_string()),
-        }
-    }
-
-    fn parse_solana_request(method: WalletConnectionMethods, chain_id: Option<String>, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
-        let chain = Self::resolve_required_chain(chain_id, ChainType::Solana)?;
-        match method {
-            WalletConnectionMethods::SolanaSignMessage => SolanaRequestHandler::parse_sign_message(chain, params, domain),
-            WalletConnectionMethods::SolanaSignTransaction => SolanaRequestHandler::parse_sign_transaction(chain, params),
-            WalletConnectionMethods::SolanaSignAndSendTransaction => SolanaRequestHandler::parse_send_transaction(chain, params),
-            WalletConnectionMethods::SolanaSignAllTransactions => SolanaRequestHandler::parse_sign_all_transactions(params),
-            _ => Err("Method not supported".to_string()),
-        }
-    }
-
-    fn parse_sui_request(method: WalletConnectionMethods, chain_id: Option<String>, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
-        let chain = Self::resolve_required_chain(chain_id, ChainType::Sui)?;
-        match method {
-            WalletConnectionMethods::SuiGetAccounts => Ok(WalletConnectAction::GetAccounts { chain }),
-            WalletConnectionMethods::SuiSignPersonalMessage => SuiRequestHandler::parse_sign_message(chain, params, domain),
-            WalletConnectionMethods::SuiSignTransaction => SuiRequestHandler::parse_sign_transaction(chain, params),
-            WalletConnectionMethods::SuiSignAndExecuteTransaction => SuiRequestHandler::parse_send_transaction(chain, params),
-            _ => Err("Method not supported".to_string()),
-        }
-    }
-
-    fn parse_ton_request(method: WalletConnectionMethods, chain_id: Option<String>, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
-        let chain = Self::resolve_required_chain(chain_id, ChainType::Ton)?;
-        match method {
-            WalletConnectionMethods::TonSignData => TonRequestHandler::parse_sign_message(chain, params, domain),
-            WalletConnectionMethods::TonSendMessage => TonRequestHandler::parse_send_transaction(chain, params),
-            _ => Err("Method not supported".to_string()),
-        }
-    }
-
-    fn parse_tron_request(method: WalletConnectionMethods, chain_id: Option<String>, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
-        let chain = Self::resolve_required_chain(chain_id, ChainType::Tron)?;
-        match method {
-            WalletConnectionMethods::TronSignMessage => TronRequestHandler::parse_sign_message(chain, params, domain),
-            WalletConnectionMethods::TronSignTransaction => TronRequestHandler::parse_sign_transaction(chain, params),
-            WalletConnectionMethods::TronSendTransaction => TronRequestHandler::parse_send_transaction(chain, params),
-            _ => Err("Method not supported".to_string()),
+            method @ (WalletConnectionMethods::TonSignData | WalletConnectionMethods::TonSendMessage) => {
+                TonRequestHandler::parse_request(method, Self::parse_required_chain(chain_id, ChainType::Ton)?, params, &domain)
+            }
+            method @ (WalletConnectionMethods::TronSignMessage | WalletConnectionMethods::TronSignTransaction | WalletConnectionMethods::TronSendTransaction) => {
+                TronRequestHandler::parse_request(method, Self::parse_required_chain(chain_id, ChainType::Tron)?, params, &domain)
+            }
         }
     }
 
@@ -156,12 +112,8 @@ impl WalletConnectRequestHandler {
         }
     }
 
-    fn resolve_chain(chain_id: Option<String>) -> Result<Chain, String> {
-        WalletConnectCAIP2::resolve_chain(chain_id)
-    }
-
-    fn resolve_required_chain(chain_id: Option<String>, required: ChainType) -> Result<Chain, String> {
-        let chain = Self::resolve_chain(chain_id)?;
+    fn parse_required_chain(chain_id: Option<String>, required: ChainType) -> Result<Chain, String> {
+        let chain = WalletConnectCAIP2::get_chain_from_id(chain_id)?;
         if chain.chain_type() != required {
             if required == ChainType::Ethereum {
                 return Err(format!("WalletConnect method requires an EVM chain, got {chain}"));

--- a/core/crates/gem_wallet_connect/src/request_handler/mod.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/mod.rs
@@ -6,7 +6,7 @@ mod tron;
 
 use crate::actions::{WCSolanaTransactionData, WCSuiTransactionData, WalletConnectAction, WalletConnectChainOperation, WalletConnectTransaction, WalletConnectTransactionType};
 use ethereum::EthereumRequestHandler;
-use primitives::{Chain, ValueAccess, WCEthereumTransaction, WalletConnectCAIP2, WalletConnectRequest, WalletConnectionMethods, hex};
+use primitives::{Chain, ChainType, ValueAccess, WCEthereumTransaction, WalletConnectCAIP2, WalletConnectRequest, WalletConnectionMethods, hex};
 use serde_json::Value;
 use solana::SolanaRequestHandler;
 use sui::SuiRequestHandler;
@@ -17,35 +17,25 @@ pub struct WalletConnectRequestHandler;
 
 impl WalletConnectRequestHandler {
     pub fn parse_request(request: WalletConnectRequest) -> Result<WalletConnectAction, String> {
-        let method = match serde_json::from_value::<WalletConnectionMethods>(serde_json::Value::String(request.method.clone())) {
+        let WalletConnectRequest {
+            method, params, chain_id, domain, ..
+        } = request;
+        let method = match serde_json::from_value::<WalletConnectionMethods>(serde_json::Value::String(method.clone())) {
             Ok(m) => m,
-            Err(_) => return Ok(WalletConnectAction::Unsupported { method: request.method }),
+            Err(_) => return Ok(WalletConnectAction::Unsupported { method }),
         };
-        let params = serde_json::from_str::<Value>(&request.params).map_err(|e| format!("Failed to parse params: {}", e))?;
+        let params = serde_json::from_str::<Value>(&params).map_err(|e| format!("Failed to parse params: {}", e))?;
         let params = match params {
             Value::String(raw_json) => serde_json::from_str::<Value>(&raw_json).unwrap_or(Value::String(raw_json)),
             value => value,
         };
 
-        let domain = &request.domain;
-
         match method {
-            WalletConnectionMethods::PersonalSign => {
-                let chain = Self::resolve_chain(request.chain_id)?;
-                EthereumRequestHandler::parse_sign_message(chain, params, domain)
-            }
-            WalletConnectionMethods::EthSignTypedData | WalletConnectionMethods::EthSignTypedDataV4 => {
-                let chain = Self::resolve_chain(request.chain_id)?;
-                EthereumRequestHandler::parse_sign_typed_data(chain, params)
-            }
-            WalletConnectionMethods::EthSignTransaction => {
-                let chain = Self::resolve_chain(request.chain_id)?;
-                EthereumRequestHandler::parse_sign_transaction(chain, params)
-            }
-            WalletConnectionMethods::EthSendTransaction => {
-                let chain = Self::resolve_chain(request.chain_id)?;
-                EthereumRequestHandler::parse_send_transaction(chain, params)
-            }
+            method @ (WalletConnectionMethods::PersonalSign
+            | WalletConnectionMethods::EthSignTypedData
+            | WalletConnectionMethods::EthSignTypedDataV4
+            | WalletConnectionMethods::EthSignTransaction
+            | WalletConnectionMethods::EthSendTransaction) => Self::parse_evm_request(method, chain_id, params, &domain),
             WalletConnectionMethods::EthSendRawTransaction => Err("Method not supported".to_string()),
             WalletConnectionMethods::EthChainId => Ok(WalletConnectAction::ChainOperation {
                 operation: WalletConnectChainOperation::GetChainId,
@@ -59,19 +49,70 @@ impl WalletConnectRequestHandler {
                     operation: WalletConnectChainOperation::SwitchChain { chain },
                 })
             }
-            WalletConnectionMethods::SolanaSignMessage => SolanaRequestHandler::parse_sign_message(Chain::Solana, params, domain),
-            WalletConnectionMethods::SolanaSignTransaction => SolanaRequestHandler::parse_sign_transaction(Chain::Solana, params),
-            WalletConnectionMethods::SolanaSignAndSendTransaction => SolanaRequestHandler::parse_send_transaction(Chain::Solana, params),
+            method @ (WalletConnectionMethods::SolanaSignMessage
+            | WalletConnectionMethods::SolanaSignTransaction
+            | WalletConnectionMethods::SolanaSignAndSendTransaction
+            | WalletConnectionMethods::SolanaSignAllTransactions) => Self::parse_solana_request(method, chain_id, params, &domain),
+            method @ (WalletConnectionMethods::SuiGetAccounts
+            | WalletConnectionMethods::SuiSignPersonalMessage
+            | WalletConnectionMethods::SuiSignTransaction
+            | WalletConnectionMethods::SuiSignAndExecuteTransaction) => Self::parse_sui_request(method, chain_id, params, &domain),
+            method @ (WalletConnectionMethods::TonSignData | WalletConnectionMethods::TonSendMessage) => Self::parse_ton_request(method, chain_id, params, &domain),
+            method @ (WalletConnectionMethods::TronSignMessage | WalletConnectionMethods::TronSignTransaction | WalletConnectionMethods::TronSendTransaction) => {
+                Self::parse_tron_request(method, chain_id, params, &domain)
+            }
+        }
+    }
+
+    fn parse_evm_request(method: WalletConnectionMethods, chain_id: Option<String>, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
+        let chain = Self::resolve_required_chain(chain_id, ChainType::Ethereum)?;
+        match method {
+            WalletConnectionMethods::PersonalSign => EthereumRequestHandler::parse_sign_message(chain, params, domain),
+            WalletConnectionMethods::EthSignTypedData | WalletConnectionMethods::EthSignTypedDataV4 => EthereumRequestHandler::parse_sign_typed_data(chain, params),
+            WalletConnectionMethods::EthSignTransaction => EthereumRequestHandler::parse_sign_transaction(chain, params),
+            WalletConnectionMethods::EthSendTransaction => EthereumRequestHandler::parse_send_transaction(chain, params),
+            _ => Err("Method not supported".to_string()),
+        }
+    }
+
+    fn parse_solana_request(method: WalletConnectionMethods, chain_id: Option<String>, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
+        let chain = Self::resolve_required_chain(chain_id, ChainType::Solana)?;
+        match method {
+            WalletConnectionMethods::SolanaSignMessage => SolanaRequestHandler::parse_sign_message(chain, params, domain),
+            WalletConnectionMethods::SolanaSignTransaction => SolanaRequestHandler::parse_sign_transaction(chain, params),
+            WalletConnectionMethods::SolanaSignAndSendTransaction => SolanaRequestHandler::parse_send_transaction(chain, params),
             WalletConnectionMethods::SolanaSignAllTransactions => SolanaRequestHandler::parse_sign_all_transactions(params),
-            WalletConnectionMethods::SuiGetAccounts => Ok(WalletConnectAction::GetAccounts { chain: Chain::Sui }),
-            WalletConnectionMethods::SuiSignPersonalMessage => SuiRequestHandler::parse_sign_message(Chain::Sui, params, domain),
-            WalletConnectionMethods::SuiSignTransaction => SuiRequestHandler::parse_sign_transaction(Chain::Sui, params),
-            WalletConnectionMethods::SuiSignAndExecuteTransaction => SuiRequestHandler::parse_send_transaction(Chain::Sui, params),
-            WalletConnectionMethods::TonSignData => TonRequestHandler::parse_sign_message(Chain::Ton, params, domain),
-            WalletConnectionMethods::TonSendMessage => TonRequestHandler::parse_send_transaction(Chain::Ton, params),
-            WalletConnectionMethods::TronSignMessage => TronRequestHandler::parse_sign_message(Chain::Tron, params, domain),
-            WalletConnectionMethods::TronSignTransaction => TronRequestHandler::parse_sign_transaction(Chain::Tron, params),
-            WalletConnectionMethods::TronSendTransaction => TronRequestHandler::parse_send_transaction(Chain::Tron, params),
+            _ => Err("Method not supported".to_string()),
+        }
+    }
+
+    fn parse_sui_request(method: WalletConnectionMethods, chain_id: Option<String>, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
+        let chain = Self::resolve_required_chain(chain_id, ChainType::Sui)?;
+        match method {
+            WalletConnectionMethods::SuiGetAccounts => Ok(WalletConnectAction::GetAccounts { chain }),
+            WalletConnectionMethods::SuiSignPersonalMessage => SuiRequestHandler::parse_sign_message(chain, params, domain),
+            WalletConnectionMethods::SuiSignTransaction => SuiRequestHandler::parse_sign_transaction(chain, params),
+            WalletConnectionMethods::SuiSignAndExecuteTransaction => SuiRequestHandler::parse_send_transaction(chain, params),
+            _ => Err("Method not supported".to_string()),
+        }
+    }
+
+    fn parse_ton_request(method: WalletConnectionMethods, chain_id: Option<String>, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
+        let chain = Self::resolve_required_chain(chain_id, ChainType::Ton)?;
+        match method {
+            WalletConnectionMethods::TonSignData => TonRequestHandler::parse_sign_message(chain, params, domain),
+            WalletConnectionMethods::TonSendMessage => TonRequestHandler::parse_send_transaction(chain, params),
+            _ => Err("Method not supported".to_string()),
+        }
+    }
+
+    fn parse_tron_request(method: WalletConnectionMethods, chain_id: Option<String>, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
+        let chain = Self::resolve_required_chain(chain_id, ChainType::Tron)?;
+        match method {
+            WalletConnectionMethods::TronSignMessage => TronRequestHandler::parse_sign_message(chain, params, domain),
+            WalletConnectionMethods::TronSignTransaction => TronRequestHandler::parse_sign_transaction(chain, params),
+            WalletConnectionMethods::TronSendTransaction => TronRequestHandler::parse_send_transaction(chain, params),
+            _ => Err("Method not supported".to_string()),
         }
     }
 
@@ -117,6 +158,17 @@ impl WalletConnectRequestHandler {
 
     fn resolve_chain(chain_id: Option<String>) -> Result<Chain, String> {
         WalletConnectCAIP2::resolve_chain(chain_id)
+    }
+
+    fn resolve_required_chain(chain_id: Option<String>, required: ChainType) -> Result<Chain, String> {
+        let chain = Self::resolve_chain(chain_id)?;
+        if chain.chain_type() != required {
+            if required == ChainType::Ethereum {
+                return Err(format!("WalletConnect method requires an EVM chain, got {chain}"));
+            }
+            return Err(format!("WalletConnect method requires {}, got {chain}", required.as_ref()));
+        }
+        Ok(chain)
     }
 
     fn parse_switch_chain_id(params: &Value) -> Result<Chain, String> {
@@ -170,6 +222,33 @@ mod tests {
         assert_eq!(
             WalletConnectRequestHandler::parse_request(request).unwrap(),
             WalletConnectAction::GetAccounts { chain: Chain::Sui }
+        );
+    }
+
+    #[test]
+    fn test_sui_get_accounts_rejects_wrong_namespace() {
+        let request = WalletConnectRequest::mock("sui_getAccounts", "{}", Some("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"));
+        assert_eq!(
+            WalletConnectRequestHandler::parse_request(request).unwrap_err(),
+            "WalletConnect method requires sui, got solana"
+        );
+    }
+
+    #[test]
+    fn test_solana_method_rejects_wrong_namespace() {
+        let request = WalletConnectRequest::mock("solana_signMessage", r#"["hello"]"#, Some("sui:mainnet"));
+        assert_eq!(
+            WalletConnectRequestHandler::parse_request(request).unwrap_err(),
+            "WalletConnect method requires solana, got sui"
+        );
+    }
+
+    #[test]
+    fn test_evm_method_rejects_non_evm_namespace() {
+        let request = WalletConnectRequest::mock("personal_sign", r#"["0x48656c6c6f"]"#, Some("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"));
+        assert_eq!(
+            WalletConnectRequestHandler::parse_request(request).unwrap_err(),
+            "WalletConnect method requires an EVM chain, got solana"
         );
     }
 

--- a/core/crates/gem_wallet_connect/src/request_handler/solana.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/solana.rs
@@ -1,11 +1,21 @@
 use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
-use primitives::{Chain, TransferDataOutputType, ValueAccess};
+use primitives::{Chain, TransferDataOutputType, ValueAccess, WalletConnectionMethods};
 use serde_json::Value;
 
 pub struct SolanaRequestHandler;
 
 impl SolanaRequestHandler {
+    pub fn parse_request(method: WalletConnectionMethods, chain: Chain, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
+        match method {
+            WalletConnectionMethods::SolanaSignMessage => Self::parse_sign_message(chain, params, domain),
+            WalletConnectionMethods::SolanaSignTransaction => Self::parse_sign_transaction(chain, params),
+            WalletConnectionMethods::SolanaSignAndSendTransaction => Self::parse_send_transaction(chain, params),
+            WalletConnectionMethods::SolanaSignAllTransactions => Self::parse_sign_all_transactions(params),
+            _ => Err("Method not supported".to_string()),
+        }
+    }
+
     pub fn parse_sign_message(_chain: Chain, params: Value, _domain: &str) -> Result<WalletConnectAction, String> {
         let message = params.get_value("message")?.string()?.to_string();
 

--- a/core/crates/gem_wallet_connect/src/request_handler/sui.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/sui.rs
@@ -1,11 +1,21 @@
 use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
-use primitives::{Chain, TransferDataOutputType, ValueAccess};
+use primitives::{Chain, TransferDataOutputType, ValueAccess, WalletConnectionMethods};
 use serde_json::Value;
 
 pub struct SuiRequestHandler;
 
 impl SuiRequestHandler {
+    pub fn parse_request(method: WalletConnectionMethods, chain: Chain, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
+        match method {
+            WalletConnectionMethods::SuiGetAccounts => Ok(WalletConnectAction::GetAccounts { chain }),
+            WalletConnectionMethods::SuiSignPersonalMessage => Self::parse_sign_message(chain, params, domain),
+            WalletConnectionMethods::SuiSignTransaction => Self::parse_sign_transaction(chain, params),
+            WalletConnectionMethods::SuiSignAndExecuteTransaction => Self::parse_send_transaction(chain, params),
+            _ => Err("Method not supported".to_string()),
+        }
+    }
+
     pub fn parse_sign_message(_chain: Chain, params: Value, _domain: &str) -> Result<WalletConnectAction, String> {
         let message = params.get_value("message")?.string()?.to_string();
 

--- a/core/crates/gem_wallet_connect/src/request_handler/ton.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/ton.rs
@@ -1,7 +1,7 @@
 use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
 use gem_ton::signer::TonSignMessageData;
-use primitives::{Chain, TransferDataOutputType, ValueAccess};
+use primitives::{Chain, TransferDataOutputType, ValueAccess, WalletConnectionMethods};
 use serde_json::Value;
 
 pub struct TonRequestHandler;
@@ -11,6 +11,14 @@ fn extract_host(url: &str) -> String {
 }
 
 impl TonRequestHandler {
+    pub fn parse_request(method: WalletConnectionMethods, chain: Chain, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
+        match method {
+            WalletConnectionMethods::TonSignData => Self::parse_sign_message(chain, params, domain),
+            WalletConnectionMethods::TonSendMessage => Self::parse_send_transaction(chain, params),
+            _ => Err("Method not supported".to_string()),
+        }
+    }
+
     pub fn parse_sign_message(_chain: Chain, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
         let payload = params.at(0)?.clone();
         let from = payload.get_value("from")?.string()?.to_string();

--- a/core/crates/gem_wallet_connect/src/request_handler/tron.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/tron.rs
@@ -1,11 +1,20 @@
 use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
-use primitives::{Chain, TransferDataOutputType, ValueAccess};
+use primitives::{Chain, TransferDataOutputType, ValueAccess, WalletConnectionMethods};
 use serde_json::Value;
 
 pub struct TronRequestHandler;
 
 impl TronRequestHandler {
+    pub fn parse_request(method: WalletConnectionMethods, chain: Chain, params: Value, domain: &str) -> Result<WalletConnectAction, String> {
+        match method {
+            WalletConnectionMethods::TronSignMessage => Self::parse_sign_message(chain, params, domain),
+            WalletConnectionMethods::TronSignTransaction => Self::parse_sign_transaction(chain, params),
+            WalletConnectionMethods::TronSendTransaction => Self::parse_send_transaction(chain, params),
+            _ => Err("Method not supported".to_string()),
+        }
+    }
+
     pub fn parse_sign_message(_chain: Chain, params: Value, _domain: &str) -> Result<WalletConnectAction, String> {
         let message = params.get_value("message")?.string()?.to_string();
 

--- a/core/crates/primitives/src/wallet_connect_namespace.rs
+++ b/core/crates/primitives/src/wallet_connect_namespace.rs
@@ -92,7 +92,7 @@ impl WalletConnectCAIP2 {
         Some(ChainAddress::new(Self::get_chain(namespace.to_string(), reference.to_string())?, address.to_string()))
     }
 
-    pub fn resolve_chain(chain_id: Option<String>) -> Result<Chain, String> {
+    pub fn get_chain_from_id(chain_id: Option<String>) -> Result<Chain, String> {
         let chain_id = chain_id.ok_or("Chain ID is required")?;
         if Self::parse_chain_id_parts(&chain_id).is_none() {
             return Err("Invalid chain ID format".to_string());
@@ -141,21 +141,21 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_chain() {
-        assert_eq!(WalletConnectCAIP2::resolve_chain(Some("eip155:1".to_string())), Ok(Chain::Ethereum));
-        assert_eq!(WalletConnectCAIP2::resolve_chain(Some("eip155:4663".to_string())), Ok(Chain::Robinhood));
+    fn test_get_chain_from_id() {
+        assert_eq!(WalletConnectCAIP2::get_chain_from_id(Some("eip155:1".to_string())), Ok(Chain::Ethereum));
+        assert_eq!(WalletConnectCAIP2::get_chain_from_id(Some("eip155:4663".to_string())), Ok(Chain::Robinhood));
         assert_eq!(
-            WalletConnectCAIP2::resolve_chain(Some("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".to_string())),
+            WalletConnectCAIP2::get_chain_from_id(Some("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".to_string())),
             Ok(Chain::Solana)
         );
-        assert_eq!(WalletConnectCAIP2::resolve_chain(Some("sui:mainnet".to_string())), Ok(Chain::Sui));
-        assert_eq!(WalletConnectCAIP2::resolve_chain(Some("ton:-239".to_string())), Ok(Chain::Ton));
-        assert_eq!(WalletConnectCAIP2::resolve_chain(Some("tron:0x2b6653dc".to_string())), Ok(Chain::Tron));
-        assert!(WalletConnectCAIP2::resolve_chain(Some("bip122:000000000019d6689c085ae165831e93".to_string())).is_err());
-        assert!(WalletConnectCAIP2::resolve_chain(Some("invalid".to_string())).is_err());
-        assert!(WalletConnectCAIP2::resolve_chain(Some("eip155:1:extra".to_string())).is_err());
-        assert!(WalletConnectCAIP2::resolve_chain(None).is_err());
-        assert!(WalletConnectCAIP2::resolve_chain(Some("unknown:chain".to_string())).is_err());
+        assert_eq!(WalletConnectCAIP2::get_chain_from_id(Some("sui:mainnet".to_string())), Ok(Chain::Sui));
+        assert_eq!(WalletConnectCAIP2::get_chain_from_id(Some("ton:-239".to_string())), Ok(Chain::Ton));
+        assert_eq!(WalletConnectCAIP2::get_chain_from_id(Some("tron:0x2b6653dc".to_string())), Ok(Chain::Tron));
+        assert!(WalletConnectCAIP2::get_chain_from_id(Some("bip122:000000000019d6689c085ae165831e93".to_string())).is_err());
+        assert!(WalletConnectCAIP2::get_chain_from_id(Some("invalid".to_string())).is_err());
+        assert!(WalletConnectCAIP2::get_chain_from_id(Some("eip155:1:extra".to_string())).is_err());
+        assert!(WalletConnectCAIP2::get_chain_from_id(None).is_err());
+        assert!(WalletConnectCAIP2::get_chain_from_id(Some("unknown:chain".to_string())).is_err());
     }
 
     #[test]

--- a/core/crates/signer/src/eip712/hash_impl.rs
+++ b/core/crates/signer/src/eip712/hash_impl.rs
@@ -2,13 +2,11 @@ use alloy_primitives::hex;
 use gem_hash::keccak::keccak256;
 use primitives::SignerError;
 use serde_json::{Map, Value};
-use std::borrow::Cow;
 use std::collections::BTreeSet;
 
 use super::data::{TypeField, TypedData};
 use super::parse::{
-    ADDR_LENGTH, MAX_WORD_BYTES, adjust_signed_value, base_type_name, left_pad, parse_array_type, parse_fixed_bytes_size, parse_int_value, parse_numeric_bits, parse_uint_value,
-    right_pad,
+    MAX_WORD_BYTES, adjust_signed_value, base_type_name, left_pad, parse_array_type, parse_fixed_bytes_size, parse_int_value, parse_numeric_bits, parse_uint_value, right_pad,
 };
 
 const PREFIX_PERSONAL_MESSAGE: &[u8] = b"\x19\x01";
@@ -58,9 +56,9 @@ fn hash_struct(primary_type: &str, data: Option<&Value>, types: &std::collection
         .get(primary_type)
         .ok_or_else(|| SignerError::invalid_input(format!("Unknown EIP-712 type '{primary_type}'")))?;
 
-    let data_map: Cow<Map<String, Value>> = match data {
-        Some(Value::Object(map)) => Cow::Borrowed(map),
-        Some(Value::Null) | None => Cow::Owned(Map::new()),
+    let data_map: &Map<String, Value> = match data {
+        Some(Value::Object(map)) => map,
+        Some(Value::Null) | None => return Err(SignerError::invalid_input(format!("Missing object for type '{primary_type}'"))),
         Some(other) => return Err(SignerError::invalid_input(format!("Expected object for type '{primary_type}', got {}", other))),
     };
 
@@ -77,11 +75,16 @@ fn hash_struct(primary_type: &str, data: Option<&Value>, types: &std::collection
 }
 
 fn encode_value(type_name: &str, value: Option<&Value>, types: &std::collections::HashMap<String, Vec<TypeField>>) -> Result<[u8; 32], SignerError> {
-    if let Some((element_type, expected_len)) = parse_array_type(type_name) {
+    let value = value.ok_or_else(|| SignerError::invalid_input(format!("Missing value for type '{type_name}'")))?;
+    if value.is_null() {
+        return Err(SignerError::invalid_input(format!("Missing value for type '{type_name}'")));
+    }
+
+    if let Some((element_type, expected_len)) = parse_array_type(type_name)? {
         let mut concatenated = Vec::new();
 
         match value {
-            Some(Value::Array(items)) => {
+            Value::Array(items) => {
                 if let Some(len) = expected_len
                     && items.len() != len
                 {
@@ -97,17 +100,7 @@ fn encode_value(type_name: &str, value: Option<&Value>, types: &std::collections
                     concatenated.extend_from_slice(&element_bytes);
                 }
             }
-            Some(Value::Null) | None => {
-                if let Some(len) = expected_len
-                    && len != 0
-                {
-                    return Err(SignerError::invalid_input(format!(
-                        "Expected array of length {len} for type '{ty}', but value was null",
-                        ty = type_name
-                    )));
-                }
-            }
-            Some(other) => {
+            other => {
                 return Err(SignerError::invalid_input(format!("Expected array for type '{ty}', got {}", other, ty = type_name)));
             }
         }
@@ -117,7 +110,7 @@ fn encode_value(type_name: &str, value: Option<&Value>, types: &std::collections
 
     let base_type = base_type_name(type_name);
     if types.contains_key(base_type) {
-        return hash_struct(base_type, value, types);
+        return hash_struct(base_type, Some(value), types);
     }
 
     match base_type {
@@ -127,9 +120,9 @@ fn encode_value(type_name: &str, value: Option<&Value>, types: &std::collections
         "address" => encode_address(value),
         _ => {
             if base_type.starts_with("uint") || base_type == "uint" {
-                encode_uint(base_type, value)
+                encode_uint(base_type, Some(value))
             } else if base_type.starts_with("int") {
-                encode_int(base_type, value)
+                encode_int(base_type, Some(value))
             } else if base_type.starts_with("bytes") {
                 encode_fixed_bytes(base_type, value)
             } else {
@@ -139,52 +132,48 @@ fn encode_value(type_name: &str, value: Option<&Value>, types: &std::collections
     }
 }
 
-fn encode_string(value: Option<&Value>) -> Result<[u8; 32], SignerError> {
+fn encode_string(value: &Value) -> Result<[u8; 32], SignerError> {
     let string_value = match value {
-        Some(Value::String(s)) => s.as_str(),
-        Some(Value::Null) | None => "",
-        Some(other) => return Err(SignerError::invalid_input(format!("Expected string value, got {}", other))),
+        Value::String(s) => s.as_str(),
+        other => return Err(SignerError::invalid_input(format!("Expected string value, got {}", other))),
     };
 
     Ok(keccak256(string_value.as_bytes()))
 }
 
-fn encode_bytes(value: Option<&Value>) -> Result<[u8; 32], SignerError> {
+fn encode_bytes(value: &Value) -> Result<[u8; 32], SignerError> {
     let bytes = match value {
-        Some(Value::String(s)) => hex::decode(s).map_err(SignerError::from_display)?,
-        Some(Value::Null) | None => Vec::new(),
-        Some(other) => return Err(SignerError::invalid_input(format!("Expected hex string for bytes value, got {}", other))),
+        Value::String(s) => hex::decode(s).map_err(SignerError::from_display)?,
+        other => return Err(SignerError::invalid_input(format!("Expected hex string for bytes value, got {}", other))),
     };
 
     Ok(keccak256(&bytes))
 }
 
-fn encode_bool(value: Option<&Value>) -> Result<[u8; 32], SignerError> {
+fn encode_bool(value: &Value) -> Result<[u8; 32], SignerError> {
     let bool_value = match value {
-        Some(Value::Bool(b)) => *b,
-        Some(Value::Null) | None => false,
-        Some(Value::Number(num)) => match (num.as_u64(), num.as_i64()) {
+        Value::Bool(b) => *b,
+        Value::Number(num) => match (num.as_u64(), num.as_i64()) {
             (Some(v), _) => v != 0,
             (_, Some(v)) => v != 0,
             _ => return Err(SignerError::invalid_input("Invalid numeric value for bool")),
         },
-        Some(other) => return Err(SignerError::invalid_input(format!("Expected boolean value, got {}", other))),
+        other => return Err(SignerError::invalid_input(format!("Expected boolean value, got {}", other))),
     };
 
     if bool_value { Ok(left_pad(&[1])) } else { Ok([0u8; 32]) }
 }
 
-fn encode_address(value: Option<&Value>) -> Result<[u8; 32], SignerError> {
+fn encode_address(value: &Value) -> Result<[u8; 32], SignerError> {
     let bytes = match value {
-        Some(Value::String(s)) => {
+        Value::String(s) => {
             let raw = hex::decode(s).map_err(SignerError::from_display)?;
             if raw.len() != 20 {
                 return Err(SignerError::invalid_input(format!("Invalid address length for '{s}'")));
             }
             raw
         }
-        Some(Value::Null) | None => vec![0u8; ADDR_LENGTH],
-        Some(other) => return Err(SignerError::invalid_input(format!("Expected address string, got {}", other))),
+        other => return Err(SignerError::invalid_input(format!("Expected address string, got {}", other))),
     };
 
     Ok(left_pad(&bytes))
@@ -210,13 +199,12 @@ fn encode_int(type_name: &str, value: Option<&Value>) -> Result<[u8; 32], Signer
     Ok(unsigned.to_be_bytes::<MAX_WORD_BYTES>())
 }
 
-fn encode_fixed_bytes(type_name: &str, value: Option<&Value>) -> Result<[u8; 32], SignerError> {
+fn encode_fixed_bytes(type_name: &str, value: &Value) -> Result<[u8; 32], SignerError> {
     let size = parse_fixed_bytes_size(type_name)?;
     let mut bytes = match value {
-        Some(Value::String(s)) if s.is_empty() => Vec::new(),
-        Some(Value::String(s)) => hex::decode(s).map_err(SignerError::from_display)?,
-        Some(Value::Null) | None => Vec::new(),
-        Some(other) => return Err(SignerError::invalid_input(format!("Expected hex string for {type_name}, got {}", other))),
+        Value::String(s) if s.is_empty() => Vec::new(),
+        Value::String(s) => hex::decode(s).map_err(SignerError::from_display)?,
+        other => return Err(SignerError::invalid_input(format!("Expected hex string for {type_name}, got {}", other))),
     };
 
     if bytes.len() > size {

--- a/core/crates/signer/src/eip712/mod.rs
+++ b/core/crates/signer/src/eip712/mod.rs
@@ -44,6 +44,30 @@ mod tests {
     }
 
     #[test]
+    fn hash_rejects_missing_field_value() {
+        let mut value: serde_json::Value = serde_json::from_str(include_str!("../../testdata/eip712_reference_vector.json")).unwrap();
+        value.get_mut("message").and_then(serde_json::Value::as_object_mut).unwrap().remove("contents");
+
+        let err = hash_typed_data(&value.to_string()).expect_err("missing field returns error");
+        assert!(err.to_string().contains("Missing value for type 'string'"));
+    }
+
+    #[test]
+    fn hash_rejects_null_field_value_and_malformed_array_type() {
+        let mut value: serde_json::Value = serde_json::from_str(include_str!("../../testdata/eip712_arrays_nested.json")).unwrap();
+        value["message"]["nested"] = serde_json::Value::Null;
+
+        let err = hash_typed_data(&value.to_string()).expect_err("null field returns error");
+        assert!(err.to_string().contains("Missing value for type 'Inner'"));
+
+        let mut value: serde_json::Value = serde_json::from_str(include_str!("../../testdata/eip712_arrays_nested.json")).unwrap();
+        value["types"]["Group"][0]["type"] = serde_json::Value::String("address[abc]".to_string());
+
+        let err = hash_typed_data(&value.to_string()).expect_err("malformed array type returns error");
+        assert!(err.to_string().contains("Invalid array length"));
+    }
+
+    #[test]
     fn hash_supports_signed_integers() {
         let json = include_str!("../../testdata/eip712_signed_integers.json");
 

--- a/core/crates/signer/src/eip712/parse.rs
+++ b/core/crates/signer/src/eip712/parse.rs
@@ -4,20 +4,35 @@ use serde_json::Value;
 use std::str::FromStr;
 
 pub const MAX_WORD_BYTES: usize = 32;
-pub const ADDR_LENGTH: usize = 20;
 
-pub fn parse_array_type(type_name: &str) -> Option<(String, Option<usize>)> {
+pub fn parse_array_type(type_name: &str) -> Result<Option<(String, Option<usize>)>, SignerError> {
     if !type_name.ends_with(']') {
-        return None;
+        if type_name.contains('[') {
+            return SignerError::invalid_input_err(format!("Malformed array type '{type_name}'"));
+        }
+        return Ok(None);
     }
 
-    let start = type_name.rfind('[')?;
+    let start = type_name
+        .rfind('[')
+        .ok_or_else(|| SignerError::invalid_input(format!("Malformed array type '{type_name}'")))?;
     let length_str = &type_name[start + 1..type_name.len() - 1];
     let element_type = type_name[..start].to_string();
+    if element_type.is_empty() {
+        return SignerError::invalid_input_err(format!("Malformed array type '{type_name}'"));
+    }
 
-    let length = if length_str.is_empty() { None } else { Some(length_str.parse().ok()?) };
+    let length = if length_str.is_empty() {
+        None
+    } else {
+        Some(
+            length_str
+                .parse()
+                .map_err(|_| SignerError::invalid_input(format!("Invalid array length for type '{type_name}'")))?,
+        )
+    };
 
-    Some((element_type, length))
+    Ok(Some((element_type, length)))
 }
 
 pub fn base_type_name(type_name: &str) -> &str {
@@ -71,7 +86,7 @@ pub fn parse_uint_value(value: Option<&Value>) -> Result<U256, SignerError> {
 
             Err(SignerError::invalid_input("Unsupported numeric value for unsigned integer"))
         }
-        Some(Value::Null) | None => Ok(U256::ZERO),
+        Some(Value::Null) | None => SignerError::invalid_input_err("Missing unsigned integer value"),
         Some(other) => Err(SignerError::invalid_input(format!("Expected integer value, got {}", other))),
     }
 }
@@ -90,7 +105,7 @@ pub fn parse_int_value(value: Option<&Value>) -> Result<I256, SignerError> {
 
             Err(SignerError::invalid_input("Unsupported numeric value for signed integer"))
         }
-        Some(Value::Null) | None => Ok(I256::ZERO),
+        Some(Value::Null) | None => SignerError::invalid_input_err("Missing signed integer value"),
         Some(other) => Err(SignerError::invalid_input(format!("Expected integer value, got {}", other))),
     }
 }

--- a/core/gemstone/src/wallet_connect/mod.rs
+++ b/core/gemstone/src/wallet_connect/mod.rs
@@ -391,7 +391,10 @@ impl WalletConnect {
     }
 
     pub fn config_session_properties(&self, properties: HashMap<String, String>, caip2_chains: Vec<String>, accounts: Vec<Account>) -> HashMap<String, String> {
-        let chains: Vec<Chain> = caip2_chains.into_iter().filter_map(|caip2| WalletConnectCAIP2::resolve_chain(Some(caip2)).ok()).collect();
+        let chains: Vec<Chain> = caip2_chains
+            .into_iter()
+            .filter_map(|caip2| WalletConnectCAIP2::get_chain_from_id(Some(caip2)).ok())
+            .collect();
         config_session_properties(properties, &chains, &accounts)
     }
 


### PR DESCRIPTION
Validate EIP-712 domain chain IDs before signing and reject malformed typed-data fields.

Require WalletConnect methods to match the resolved chain family, and reject Ethereum transaction chainId mismatches using the existing transaction decoder.