### PR TITLE
Surface unverified assets on wallet screen

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/features/main/views/MainScreen.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/main/views/MainScreen.kt
@@ -203,6 +203,7 @@ fun MainScreen(
                                     AssetsAction.Buy -> navigator.openBuy()
                                     AssetsAction.Swap -> navigator.openSwap()
                                     AssetsAction.Perpetuals -> navigator.openPerpetuals()
+                                    AssetsAction.ShowHiddenAssets -> navigator.openHiddenAssets()
                                     is AssetsAction.OpenPerpetualDetails -> navigator.openPerpetualDetails(action.assetId)
                                     is AssetsAction.OpenAsset -> navigator.openAsset(action.assetId)
                                 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/RootRoute.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/RootRoute.kt
@@ -34,6 +34,7 @@ import com.gemwallet.android.ui.navigation.routes.AmountRoute
 import com.gemwallet.android.ui.navigation.routes.AssetChartRoute
 import com.gemwallet.android.ui.navigation.routes.AssetRoute
 import com.gemwallet.android.ui.navigation.routes.assetsRoute
+import com.gemwallet.android.ui.navigation.routes.HiddenAssetsRoute
 import com.gemwallet.android.ui.navigation.routes.BridgeConnectionDetailsRoute
 import com.gemwallet.android.ui.navigation.routes.BridgeConnectionsRoute
 import com.gemwallet.android.ui.navigation.routes.AddContactRoute
@@ -172,6 +173,7 @@ class WalletNavigator(
     fun openWallets() = push(WalletsRoute)
     fun openAcceptTerms(destination: AcceptTermsDestination) = push(AcceptTermsRoute(destination))
     fun openAssetsManage() = push(AssetsManageRoute)
+    fun openHiddenAssets() = push(HiddenAssetsRoute)
     fun openAssetsSearch() = push(WalletSearchRoute)
     fun openAssetsResults(query: String, scope: WalletSearchTag) = push(AssetsResultsRoute(query, scope))
     fun openAssetsResultsList(listId: String, title: String) = push(AssetsResultsRoute(query = "", scope = WalletSearchTag.List(listId), title = title))

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/WalletNavGraph.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/WalletNavGraph.kt
@@ -40,6 +40,7 @@ import com.gemwallet.android.ui.navigation.routes.assetScreen
 import com.gemwallet.android.ui.navigation.routes.bridgesScreen
 import com.gemwallet.android.ui.navigation.routes.confirm
 import com.gemwallet.android.ui.navigation.routes.fiatScreen
+import com.gemwallet.android.ui.navigation.routes.hiddenAssetsScreen
 import com.gemwallet.android.ui.navigation.routes.nftCollection
 import com.gemwallet.android.ui.navigation.routes.perpetualScreen
 import com.gemwallet.android.ui.navigation.routes.receiveScreen
@@ -121,6 +122,11 @@ fun WalletNavGraph(
                         is AssetDetailsAction.Confirm -> navigator.openConfirm(action.params)
                     }
                 },
+            )
+
+            hiddenAssetsScreen(
+                onOpenAsset = navigator::openAsset,
+                onCancel = onCancel,
             )
 
             assetChartScreen(

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/routes/Asset.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/routes/Asset.kt
@@ -7,6 +7,8 @@ import com.gemwallet.android.ui.navigation.routeArguments
 import com.gemwallet.android.features.asset.presents.chart.AssetChartScene
 import com.gemwallet.android.features.asset.presents.details.AssetDetailsAction
 import com.gemwallet.android.features.asset.presents.details.AssetDetailsScreen
+import com.gemwallet.android.features.assets.views.HiddenAssetsAction
+import com.gemwallet.android.features.assets.views.HiddenAssetsScreen
 import com.wallet.core.primitives.AssetId
 import kotlinx.serialization.Serializable
 
@@ -18,6 +20,9 @@ data class AssetRoute(val assetId: AssetId) : NavKey
 @Serializable
 data class AssetChartRoute(val assetId: AssetId) : NavKey
 
+@Serializable
+data object HiddenAssetsRoute : NavKey
+
 fun EntryProviderScope<NavKey>.assetScreen(
     onAction: (AssetDetailsAction.Navigation) -> Unit,
 ) {
@@ -25,6 +30,22 @@ fun EntryProviderScope<NavKey>.assetScreen(
         metadata = { key -> routeArguments(assetIdArgument(key.assetId)) },
     ) {
         AssetDetailsScreen(onAction = onAction)
+    }
+}
+
+fun EntryProviderScope<NavKey>.hiddenAssetsScreen(
+    onOpenAsset: (AssetId) -> Unit,
+    onCancel: () -> Unit,
+) {
+    entry<HiddenAssetsRoute> {
+        HiddenAssetsScreen(
+            onAction = { action ->
+                when (action) {
+                    HiddenAssetsAction.Close -> onCancel()
+                    is HiddenAssetsAction.OpenAsset -> onOpenAsset(action.assetId)
+                }
+            },
+        )
     }
 }
 

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetActiveAssetsInfoImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetActiveAssetsInfoImpl.kt
@@ -20,6 +20,11 @@ class GetActiveAssetsInfoImpl(
         assetsRepository.getAssetsInfo()
             .map { items -> items.map { it.toAssetInfoDataAggregate(hideBalance) } }
             .distinctUntilChanged()
+
+    override fun getHiddenAssetsInfo(hideBalance: Boolean): Flow<List<AssetInfoDataAggregate>> =
+        assetsRepository.getHiddenAssetsInfo()
+            .map { items -> items.map { it.toAssetInfoDataAggregate(hideBalance) } }
+            .distinctUntilChanged()
 }
 
 internal fun AssetInfo.toAssetInfoDataAggregate(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
@@ -64,6 +64,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import uniffi.gemstone.defaultTokenRank
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -187,6 +188,11 @@ class AssetsRepository @Inject constructor(
 
     fun getAssetsInfo(assetsId: List<AssetId>): Flow<List<AssetInfo>> = currentWalletId()
         .flatMapLatest { walletId -> assetsDao.getAssetsInfo(walletId, assetsId.map { it.toIdentifier() }) }
+        .toAssetInfoModel()
+        .flowOn(Dispatchers.IO)
+
+    fun getHiddenAssetsInfo(): Flow<List<AssetInfo>> = currentWalletId()
+        .flatMapLatest { walletId -> assetsDao.getHiddenAssetsInfo(walletId, defaultTokenRank()) }
         .toAssetInfoModel()
         .flowOn(Dispatchers.IO)
 

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
@@ -236,6 +236,9 @@ interface AssetsDao {
     @Query("SELECT * FROM $ASSET_INFO WHERE walletId = :walletId AND visible != 0 AND assetRank > 0 ORDER BY balanceFiatTotalAmount DESC")
     fun getAssetsInfo(walletId: String): Flow<List<DbAssetInfo>>
 
+    @Query("SELECT * FROM $ASSET_INFO WHERE walletId = :walletId AND balanceTotalAmount > 0 AND assetRank <= :rankLimit AND (COALESCE(visible, 0) = 0 OR assetRank <= 0) ORDER BY balanceFiatTotalAmount DESC")
+    fun getHiddenAssetsInfo(walletId: String, rankLimit: Int): Flow<List<DbAssetInfo>>
+
     @Query("SELECT * FROM $ASSET_INFO WHERE id IN (:ids) AND walletId = :walletId ORDER BY balanceFiatTotalAmount DESC")
     fun getAssetsInfo(walletId: String, ids: List<String>): Flow<List<DbAssetInfo>>
 

--- a/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsAction.kt
+++ b/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsAction.kt
@@ -11,6 +11,7 @@ sealed interface AssetsAction {
     data object Buy : AssetsAction
     data object Swap : AssetsAction
     data object Perpetuals : AssetsAction
+    data object ShowHiddenAssets : AssetsAction
     data class OpenPerpetualDetails(val assetId: AssetId) : AssetsAction
     data class OpenAsset(val assetId: AssetId) : AssetsAction
 }

--- a/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsScreen.kt
+++ b/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsScreen.kt
@@ -51,7 +51,11 @@ import com.gemwallet.android.features.perpetual.views.PerpetualsPreviewSection
 import com.gemwallet.android.features.update_app.presents.InAppUpdateBanner
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.AssetContextActions
+import com.gemwallet.android.ui.components.list_item.LinkItem
+import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
+import com.gemwallet.android.ui.components.list_item.property.PropertyDataText
 import com.gemwallet.android.ui.models.AssetsGroupType
+import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.open
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.paddingSmall
@@ -66,6 +70,7 @@ private const val BannersItemKey = "banners"
 private const val ImportingItemKey = "importing"
 private const val FooterItemKey = "footer"
 private const val PerpetualsSectionItemKey = "perpetuals_section"
+private const val UnverifiedAssetsItemKey = "unverified_assets"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -81,6 +86,7 @@ fun AssetsScreen(
     val walletSummary by viewModel.walletSummary.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val showWelcomeBanner by viewModel.showWelcomeBanner.collectAsStateWithLifecycle()
+    val hiddenAssetsCount by viewModel.hiddenAssetsCount.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
@@ -212,6 +218,21 @@ fun AssetsScreen(
                     onAssetClick = { onAction(AssetsAction.OpenAsset(it)) },
                     actions = assetActions,
                 )
+                if (hiddenAssetsCount > 0) {
+                    item(key = UnverifiedAssetsItemKey) {
+                        LinkItem(
+                            title = stringResource(R.string.asset_verification_unverified),
+                            listPosition = ListPosition.Single,
+                            trailingContent = {
+                                PropertyDataText(
+                                    text = hiddenAssetsCount.toString(),
+                                    badge = { DataBadgeChevron() },
+                                )
+                            },
+                            onClick = { onAction(AssetsAction.ShowHiddenAssets) },
+                        )
+                    }
+                }
                 item(key = FooterItemKey) { AssetsListFooter { onAction(AssetsAction.Manage) } }
             }
         }

--- a/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/HiddenAssetsAction.kt
+++ b/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/HiddenAssetsAction.kt
@@ -1,0 +1,8 @@
+package com.gemwallet.android.features.assets.views
+
+import com.wallet.core.primitives.AssetId
+
+sealed interface HiddenAssetsAction {
+    data object Close : HiddenAssetsAction
+    data class OpenAsset(val assetId: AssetId) : HiddenAssetsAction
+}

--- a/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/HiddenAssetsScreen.kt
+++ b/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/HiddenAssetsScreen.kt
@@ -1,0 +1,51 @@
+package com.gemwallet.android.features.assets.views
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gemwallet.android.features.assets.viewmodels.HiddenAssetsViewModel
+import com.gemwallet.android.features.assets.views.components.assets
+import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.list_item.AssetContextActions
+import com.gemwallet.android.ui.components.screen.Scene
+import com.gemwallet.android.ui.models.AssetsGroupType
+import com.wallet.core.primitives.AssetId
+
+@Composable
+fun HiddenAssetsScreen(
+    onAction: (HiddenAssetsAction) -> Unit,
+    viewModel: HiddenAssetsViewModel = hiltViewModel(),
+) {
+    val hiddenAssets by viewModel.hiddenAssets.collectAsStateWithLifecycle()
+    val longPressedAsset = remember { mutableStateOf<AssetId?>(null) }
+    val assetActions = remember(viewModel) {
+        AssetContextActions(
+            onTogglePin = viewModel::togglePin,
+            onHide = viewModel::hideAsset,
+        )
+    }
+
+    Scene(
+        title = stringResource(R.string.asset_verification_unverified),
+        onClose = { onAction(HiddenAssetsAction.Close) },
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            assets(
+                items = hiddenAssets,
+                longPressState = longPressedAsset,
+                group = AssetsGroupType.None,
+                onAssetClick = { onAction(HiddenAssetsAction.OpenAsset(it)) },
+                actions = assetActions,
+            )
+        }
+    }
+}

--- a/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsViewModel.kt
+++ b/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsViewModel.kt
@@ -73,6 +73,10 @@ class AssetsViewModel @Inject constructor(
         .map { it.unpinned }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
+    val hiddenAssetsCount = getActiveAssetsInfo.getHiddenAssetsInfo(false)
+        .map { it.size }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, 0)
+
     val walletSummary = getWalletSummary.getWalletSummary()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 

--- a/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/HiddenAssetsViewModel.kt
+++ b/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/HiddenAssetsViewModel.kt
@@ -1,0 +1,38 @@
+package com.gemwallet.android.features.assets.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.assets.coordinators.GetActiveAssetsInfo
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
+import com.gemwallet.android.application.assets.coordinators.HideAsset
+import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
+import com.wallet.core.primitives.AssetId
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class HiddenAssetsViewModel @Inject constructor(
+    private val hideAsset: HideAsset,
+    private val toggleAssetPin: ToggleAssetPin,
+    getActiveAssetsInfo: GetActiveAssetsInfo,
+    getHideBalancesState: GetHideBalancesState,
+) : ViewModel() {
+
+    val hiddenAssets = getHideBalancesState()
+        .flatMapLatest { hideBalance -> getActiveAssetsInfo.getHiddenAssetsInfo(hideBalance) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    fun hideAsset(assetId: AssetId) = viewModelScope.launch {
+        hideAsset.invoke(assetId)
+    }
+
+    fun togglePin(assetId: AssetId) = viewModelScope.launch {
+        toggleAssetPin(assetId)
+    }
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetActiveAssetsInfo.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/assets/coordinators/GetActiveAssetsInfo.kt
@@ -11,4 +11,6 @@ interface GetActiveAssetsInfo {
 
     fun getAssetsInfo(hideBalance: Flow<Boolean>): Flow<List<AssetInfoDataAggregate>>
        = hideBalance.flatMapLatest { getAssetsInfo(it) }
+
+    fun getHiddenAssetsInfo(hideBalance: Boolean): Flow<List<AssetInfoDataAggregate>>
 }

--- a/ios/Features/WalletTab/Sources/Scenes/HiddenAssetsScene.swift
+++ b/ios/Features/WalletTab/Sources/Scenes/HiddenAssetsScene.swift
@@ -1,0 +1,35 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Components
+import Localization
+import Primitives
+import PrimitivesComponents
+import Store
+import Style
+import SwiftUI
+
+public struct HiddenAssetsScene: View {
+    @State private var model: HiddenAssetsSceneViewModel
+
+    public init(model: HiddenAssetsSceneViewModel) {
+        _model = State(initialValue: model)
+    }
+
+    public var body: some View {
+        @Bindable var preferences = model.observablePreferences
+
+        List {
+            WalletAssetsList(
+                assets: model.assets,
+                currencyCode: model.currencyCode,
+                onHideAsset: model.onHideAsset,
+                onPinAsset: model.onPinAsset,
+                showBalancePrivacy: $preferences.isHideBalanceEnabled,
+            )
+            .listRowInsets(.assetListRowInsets)
+        }
+        .bindQuery(model.assetsQuery)
+        .navigationTitle(model.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/ios/Features/WalletTab/Sources/Scenes/WalletScene.swift
+++ b/ios/Features/WalletTab/Sources/Scenes/WalletScene.swift
@@ -84,7 +84,22 @@ public struct WalletScene: View {
                         .listRowInsets(.assetListRowInsets)
                         .textCase(nil)
                 }
-            } footer: {
+            }
+            .listRowInsets(.assetListRowInsets)
+
+            if let hiddenAssetsCount = model.hiddenAssetsCount {
+                Section {
+                    NavigationLink(value: Scenes.HiddenAssets()) {
+                        ListItemView(
+                            title: Localized.Asset.Verification.unverified,
+                            subtitle: hiddenAssetsCount,
+                        )
+                    }
+                }
+                .listRowInsets(.assetListRowInsets)
+            }
+
+            Section {} footer: {
                 ListButton(
                     title: model.manageTokenTitle,
                     image: model.manageImage,

--- a/ios/Features/WalletTab/Sources/ViewModels/HiddenAssetsSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/HiddenAssetsSceneViewModel.swift
@@ -1,0 +1,65 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import BalanceService
+import Foundation
+import GemstonePrimitives
+import Localization
+import Preferences
+import Primitives
+import PrimitivesComponents
+import Store
+import SwiftUI
+
+@Observable
+@MainActor
+public final class HiddenAssetsSceneViewModel: Sendable {
+    private let balanceService: BalanceService
+
+    let observablePreferences: ObservablePreferences
+
+    public var wallet: Wallet
+
+    public let assetsQuery: ObservableQuery<AssetsRequest>
+
+    public init(
+        balanceService: BalanceService,
+        observablePreferences: ObservablePreferences,
+        wallet: Wallet,
+    ) {
+        self.balanceService = balanceService
+        self.observablePreferences = observablePreferences
+        self.wallet = wallet
+        assetsQuery = ObservableQuery(
+            AssetsRequest(walletId: wallet.id, filters: [.hiddenBalance, .hasBalance, .assetRank(lessThanOrEqualTo: AssetScore.defaultScore)]),
+            initialValue: [],
+        )
+    }
+
+    var title: String {
+        Localized.Asset.Verification.unverified
+    }
+
+    var assets: [AssetData] {
+        assetsQuery.value
+    }
+
+    var currencyCode: String {
+        observablePreferences.preferences.currency
+    }
+
+    func onHideAsset(_ assetId: AssetId) {
+        do {
+            try balanceService.hideAsset(walletId: wallet.id, assetId: assetId)
+        } catch {
+            debugLog("HiddenAssetsSceneViewModel hide asset error: \(error)")
+        }
+    }
+
+    func onPinAsset(_ asset: Asset, value: Bool) {
+        do {
+            try balanceService.setPinned(value, walletId: wallet.id, assetId: asset.id)
+        } catch {
+            debugLog("HiddenAssetsSceneViewModel pin asset error: \(error)")
+        }
+    }
+}

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -6,6 +6,7 @@ import Components
 import DiscoverAssetsService
 import Formatters
 import Foundation
+import GemstonePrimitives
 import InfoSheet
 import Localization
 import Preferences
@@ -31,6 +32,7 @@ public final class WalletSceneViewModel: Sendable {
     // db queries
     public let totalFiatQuery: ObservableQuery<TotalValueRequest>
     public let assetsQuery: ObservableQuery<AssetsRequest>
+    public let hiddenAssetsQuery: ObservableQuery<AssetsRequest>
     public let bannersQuery: ObservableQuery<BannersRequest>
 
     /// db observed values
@@ -40,6 +42,14 @@ public final class WalletSceneViewModel: Sendable {
 
     public var assets: [AssetData] {
         assetsQuery.value
+    }
+
+    public var hiddenAssets: [AssetData] {
+        hiddenAssetsQuery.value
+    }
+
+    var hiddenAssetsCount: String? {
+        hiddenAssets.isEmpty ? nil : hiddenAssets.count.asString
     }
 
     public var banners: [Banner] {
@@ -72,6 +82,7 @@ public final class WalletSceneViewModel: Sendable {
 
         totalFiatQuery = ObservableQuery(TotalValueRequest(walletId: wallet.id, type: .wallet), initialValue: .zero)
         assetsQuery = ObservableQuery(AssetsRequest(walletId: wallet.id, filters: [.enabledBalance]), initialValue: [])
+        hiddenAssetsQuery = ObservableQuery(AssetsRequest(walletId: wallet.id, filters: [.hiddenBalance, .hasBalance, .assetRank(lessThanOrEqualTo: AssetScore.defaultScore)]), initialValue: [])
         bannersQuery = ObservableQuery(BannersRequest(walletId: wallet.id, assetId: .none, chain: .none, events: [.accountBlockedMultiSignature, .onboarding]), initialValue: [])
         self.isPresentingSelectedAssetInput = isPresentingSelectedAssetInput
     }
@@ -299,6 +310,7 @@ extension WalletSceneViewModel {
         wallet = newWallet
         totalFiatQuery.request.walletId = newWallet.id
         assetsQuery.request.walletId = newWallet.id
+        hiddenAssetsQuery.request.walletId = newWallet.id
         bannersQuery.request.walletId = newWallet.id
 
         Task { await fetchOnce(wallet: newWallet) }

--- a/ios/Gem/Navigation/Wallet/WalletNavigationStack.swift
+++ b/ios/Gem/Navigation/Wallet/WalletNavigationStack.swift
@@ -75,7 +75,7 @@ struct WalletNavigationStack: View {
             }
             .onChange(of: model.currentWallet, model.onChangeWallet)
             .onChange(of: navigationState.walletTabReselected, model.onWalletTabReselected)
-            .bindQuery(model.assetsQuery, model.bannersQuery, model.totalFiatQuery)
+            .bindQuery(model.assetsQuery, model.hiddenAssetsQuery, model.bannersQuery, model.totalFiatQuery)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 if !model.isPresentingSearch {
@@ -108,6 +108,15 @@ struct WalletNavigationStack: View {
                             asset: $0.asset,
                         ),
                         isPresentingSelectedAssetInput: model.isPresentingSelectedAssetInput,
+                    ),
+                )
+            }
+            .navigationDestination(for: Scenes.HiddenAssets.self) { _ in
+                HiddenAssetsScene(
+                    model: HiddenAssetsSceneViewModel(
+                        balanceService: balanceService,
+                        observablePreferences: preferences,
+                        wallet: model.wallet,
                     ),
                 )
             }

--- a/ios/Packages/Primitives/Sources/Scenes.swift
+++ b/ios/Packages/Primitives/Sources/Scenes.swift
@@ -119,6 +119,10 @@ public enum Scenes {
         }
     }
 
+    public struct HiddenAssets: Hashable, Codable, Sendable {
+        public init() {}
+    }
+
     public struct ChainSettings: Hashable, Codable {
         public let chain: Primitives.Chain
 

--- a/ios/Packages/Store/Sources/Requests/AssetsRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/AssetsRequest.swift
@@ -50,7 +50,9 @@ public struct AssetsRequest: DatabaseQueryable {
                  .chainsOrAssets,
                  .search,
                  .enabledBalance,
+                 .hiddenBalance,
                  .hasBalance,
+                 .assetRank,
                  .priceAlerts:
                 request = Self.applyFilter(request: request, filter)
             }
@@ -122,6 +124,16 @@ extension AssetsRequest {
             return request
                 .filter(
                     TableAlias(name: BalanceRecord.databaseTableName)[BalanceRecord.Columns.isEnabled] == true,
+                )
+        case .hiddenBalance:
+            return request
+                .filter(
+                    TableAlias(name: BalanceRecord.databaseTableName)[BalanceRecord.Columns.isEnabled] == false,
+                )
+        case let .assetRank(lessThanOrEqualTo: rank):
+            return request
+                .filter(
+                    AssetRecord.Columns.rank <= rank,
                 )
         case let .chains(chains):
             if chains.isEmpty {

--- a/ios/Packages/Store/Sources/Types/AssetsRequestFilter.swift
+++ b/ios/Packages/Store/Sources/Types/AssetsRequestFilter.swift
@@ -9,7 +9,9 @@ public enum AssetsRequestFilter {
     case swappable
     case stakeable
     case enabledBalance
+    case hiddenBalance
     case hasBalance
+    case assetRank(lessThanOrEqualTo: Int)
     // include all assets of these chains
     case chains([String])
     case chainsOrAssets([String], [String])

--- a/ios/Packages/Store/Tests/StoreTests/Requests/AssetsRequestTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/Requests/AssetsRequestTests.swift
@@ -58,6 +58,35 @@ struct AssetsRequestTests {
         }
     }
 
+    @Test func hiddenUnverifiedAssets() throws {
+        let unverifiedHidden = AssetId(chain: .smartChain)
+        let verifiedHidden = AssetId(chain: .ethereum)
+        let unverifiedEnabled = AssetId(chain: .solana)
+        let unverifiedNoBalance = AssetId(chain: .base)
+
+        let db = DB.mockAssets(assets: [
+            .mock(asset: .mock(id: unverifiedHidden), score: .mock(rank: 15)),
+            .mock(asset: .mock(id: verifiedHidden), score: .mock(rank: 16)),
+            .mock(asset: .mock(id: unverifiedEnabled), score: .mock(rank: 10)),
+            .mock(asset: .mock(id: unverifiedNoBalance), score: .mock(rank: 10)),
+        ])
+        let balanceStore = BalanceStore(db: db)
+
+        try balanceStore.updateBalances([
+            .mockCoin(assetId: unverifiedHidden, available: 1),
+            .mockCoin(assetId: verifiedHidden, available: 1),
+            .mockCoin(assetId: unverifiedEnabled, available: 1),
+            .mockCoin(assetId: unverifiedNoBalance, available: 0),
+        ], for: .mock())
+        _ = try balanceStore.setIsEnabled(walletId: .mock(), assetIds: [unverifiedHidden, verifiedHidden, unverifiedNoBalance], value: false)
+
+        try db.dbQueue.read { db in
+            let assets = try AssetsRequest.mock(filters: [.hiddenBalance, .hasBalance, .assetRank(lessThanOrEqualTo: 15)]).fetch(db)
+
+            #expect(assets.map(\.asset.id) == [unverifiedHidden])
+        }
+    }
+
     @Test func assetProperties() throws {
         let db = DB.mockAssets()
         let assetStore = AssetStore(db: db)


### PR DESCRIPTION
Regular tokens that aren't in the verified or price-backed list stay hidden from the wallet screen until manually added, so received tokens can look missing. This adds an "Unverified" row to the wallet screen — like the unverified NFT collections — that surfaces held unverified tokens and opens a list to view them.

Closes #627
