### PR TITLE
Align section headers and swap inputs with content

### DIFF
--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/components/SwapItem.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/components/SwapItem.kt
@@ -40,7 +40,7 @@ import com.gemwallet.android.ui.components.progress.CircularProgressIndicator16
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.theme.listItemIconSize
-import com.gemwallet.android.ui.theme.paddingDefault
+import com.gemwallet.android.ui.theme.paddingHalfSmall
 import com.gemwallet.android.ui.theme.paddingMiddle
 import com.gemwallet.android.ui.theme.paddingSmall
 import com.gemwallet.android.ui.theme.space2
@@ -60,7 +60,7 @@ internal fun SwapItem(
     Row(
         modifier = Modifier
             .listItem(ListPosition.Single)
-            .padding(horizontal = paddingDefault, vertical = paddingMiddle)
+            .padding(horizontal = paddingMiddle, vertical = paddingMiddle)
             .fillMaxWidth()
             .heightIn(min = listItemIconSize),
         verticalAlignment = Alignment.CenterVertically,
@@ -163,7 +163,7 @@ private fun AssetPickerChevron() {
 @Composable
 private fun SwapEquivalent(calculating: Boolean, equivalent: String) {
     Text(
-        modifier = Modifier.smallPadding(),
+        modifier = Modifier.padding(vertical = paddingHalfSmall),
         text = if (calculating) "" else equivalent,
         minLines = 1,
         maxLines = 1,
@@ -216,7 +216,7 @@ private fun SwapItemInput(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .smallPadding()
+            .padding(vertical = paddingHalfSmall)
             .heightIn(min = listItemIconSize),
         contentAlignment = Alignment.CenterStart,
     ) {

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/SectionHeaderItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/SectionHeaderItem.kt
@@ -5,9 +5,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import com.gemwallet.android.ui.models.ListPosition
+import com.gemwallet.android.ui.theme.adaptivePadding
 import com.gemwallet.android.ui.theme.paddingDefault
+import com.gemwallet.android.ui.theme.paddingMiddle
+import com.gemwallet.android.ui.theme.paddingSmall
 
-val sectionHeaderHorizontalPadding = paddingDefault * 2
+val sectionHeaderHorizontalPadding: Dp
+    @Composable get() = adaptivePadding(default = paddingDefault, compact = paddingSmall) + paddingMiddle
 
 @Composable
 fun Modifier.sectionHeaderItem(paddingVertical: Dp? = null): Modifier = fillMaxWidth().listItem(


### PR DESCRIPTION
Section headers were not aligned with list content across the app, and on the Swap screen the asset amount inputs were off from the section headers and the card edge. This lines them all up on a single left edge and makes the inset adaptive on narrow screens.

<img width="320" alt="Screenshot_1783520442" src="https://github.com/user-attachments/assets/68ccb98a-e9ae-42e3-a06f-65b195c4cbb4" />
<img width="320" alt="Screenshot_1783520484" src="https://github.com/user-attachments/assets/74234e3c-d775-4046-82e9-0022fe7122a2" />

