### PR TITLE
Use USD for fiat provider values

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/FiatModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/FiatModule.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.data.coordinators.di
 import android.content.Context
 import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
 import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
+import com.gemwallet.android.application.fiat.coordinators.GetAssetPriceUsd
 import com.gemwallet.android.application.fiat.coordinators.GetBuyAssetInfo
 import com.gemwallet.android.application.fiat.coordinators.GetBuyQuoteUrl
 import com.gemwallet.android.application.fiat.coordinators.GetBuyQuotes
@@ -12,6 +13,7 @@ import com.gemwallet.android.application.fiat.coordinators.GetSellableFiatAssets
 import com.gemwallet.android.application.fiat.coordinators.ObserveFiatTransactions
 import com.gemwallet.android.application.fiat.coordinators.SyncFiatAssets
 import com.gemwallet.android.application.fiat.coordinators.SyncFiatTransactions
+import com.gemwallet.android.data.coordinators.fiat.GetAssetPriceUsdImpl
 import com.gemwallet.android.data.coordinators.fiat.GetBuyAssetInfoImpl
 import com.gemwallet.android.data.coordinators.fiat.GetBuyQuoteUrlImpl
 import com.gemwallet.android.data.coordinators.fiat.GetBuyQuotesImpl
@@ -25,6 +27,7 @@ import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.service.store.ConfigStore
 import com.gemwallet.android.data.service.store.database.FiatTransactionsDao
+import com.gemwallet.android.data.service.store.database.PricesDao
 import com.gemwallet.android.data.services.gemapi.GemApiClient
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
 import dagger.Module
@@ -138,6 +141,14 @@ object FiatModule {
         assetsRepository: AssetsRepository,
     ): GetBuyAssetInfo {
         return GetBuyAssetInfoImpl(sessionRepository, assetsRepository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideGetAssetPriceUsd(
+        pricesDao: PricesDao,
+    ): GetAssetPriceUsd {
+        return GetAssetPriceUsdImpl(pricesDao)
     }
 
     @Provides

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/fiat/GetAssetPriceUsdImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/fiat/GetAssetPriceUsdImpl.kt
@@ -1,0 +1,14 @@
+package com.gemwallet.android.data.coordinators.fiat
+
+import com.gemwallet.android.application.fiat.coordinators.GetAssetPriceUsd
+import com.gemwallet.android.data.service.store.database.PricesDao
+import com.gemwallet.android.ext.toIdentifier
+import com.wallet.core.primitives.AssetId
+import kotlinx.coroutines.flow.Flow
+
+class GetAssetPriceUsdImpl(
+    private val pricesDao: PricesDao,
+) : GetAssetPriceUsd {
+
+    override fun invoke(assetId: AssetId): Flow<Double?> = pricesDao.getUsdPrice(assetId.toIdentifier())
+}

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/PricesDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/PricesDao.kt
@@ -30,6 +30,9 @@ interface PricesDao {
     @Query("SELECT * FROM prices WHERE asset_id IN (:assetsId)")
     suspend fun getByAssets(assetsId: List<String>): List<DbPrice>
 
+    @Query("SELECT usd_value FROM prices WHERE asset_id = :assetId LIMIT 1")
+    fun getUsdPrice(assetId: String): Flow<Double?>
+
     @Query("DELETE FROM prices")
     suspend fun deleteAll()
 

--- a/android/features/buy/viewmodels/src/main/kotlin/com/gemwallet/android/features/buy/viewmodels/FiatViewModel.kt
+++ b/android/features/buy/viewmodels/src/main/kotlin/com/gemwallet/android/features/buy/viewmodels/FiatViewModel.kt
@@ -4,6 +4,7 @@ import android.text.format.DateUtils
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.fiat.coordinators.GetAssetPriceUsd
 import com.gemwallet.android.application.fiat.coordinators.GetBuyAssetInfo
 import com.gemwallet.android.application.fiat.coordinators.GetBuyQuoteUrl
 import com.gemwallet.android.application.fiat.coordinators.GetBuyQuotes
@@ -62,6 +63,7 @@ class FiatViewModel @Inject constructor(
     private val getBuyQuotes: GetBuyQuotes,
     private val getBuyQuoteUrl: GetBuyQuoteUrl,
     getBuyAssetInfo: GetBuyAssetInfo,
+    getAssetPriceUsd: GetAssetPriceUsd,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -97,6 +99,10 @@ class FiatViewModel @Inject constructor(
 
     private val assetData: StateFlow<AssetData?> = assetId
         .flatMapLatest { getBuyAssetInfo(it) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    private val assetPriceUsd: StateFlow<Double?> = assetId
+        .flatMapLatest { getAssetPriceUsd(it) }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     val assetInfoUIModel = assetData
@@ -202,9 +208,9 @@ class FiatViewModel @Inject constructor(
         }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    val providers = combine(assetInfoUIModel.filterNotNull(), quotes) { asset, quotes ->
+    val providers = combine(assetInfoUIModel.filterNotNull(), quotes, assetPriceUsd) { asset, quotes, priceUsd ->
         quotes.map { quote ->
-            quote.toProviderUIModel(asset.asset, currency, asset.assetInfo.price?.price?.price)
+            quote.toProviderUIModel(asset.asset, currency, priceUsd)
         }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 

--- a/android/features/buy/viewmodels/src/main/kotlin/com/gemwallet/android/features/buy/viewmodels/models/BuyFiatProviderUIModel.kt
+++ b/android/features/buy/viewmodels/src/main/kotlin/com/gemwallet/android/features/buy/viewmodels/models/BuyFiatProviderUIModel.kt
@@ -2,12 +2,14 @@ package com.gemwallet.android.features.buy.viewmodels.models
 
 import androidx.compose.runtime.Stable
 import com.gemwallet.android.model.CurrencyFormatter
+import com.gemwallet.android.model.ValueFormatter
 import com.gemwallet.android.ui.models.CryptoFormattedUIModel
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.FiatProvider
 import com.wallet.core.primitives.FiatQuote
 import com.wallet.core.primitives.FiatQuoteType
+import java.math.BigDecimal
 
 @Stable
 data class BuyFiatProviderUIModel(
@@ -19,10 +21,11 @@ data class BuyFiatProviderUIModel(
 ) : CryptoFormattedUIModel {
 
     override val cryptoFormatted: String
-        get() = "≈ ${super.cryptoFormatted}"
+        get() = "≈ $cryptoText"
 
     val cryptoText: String
-        get() = super.cryptoFormatted
+        get() = ValueFormatter(style = ValueFormatter.Style.Auto)
+            .string(BigDecimal.valueOf(cryptoAmount), asset.symbol)
 }
 
 fun FiatQuote.toProviderUIModel(

--- a/android/features/buy/viewmodels/src/test/kotlin/com/gemwallet/android/features/buy/viewmodels/FiatViewModelTest.kt
+++ b/android/features/buy/viewmodels/src/test/kotlin/com/gemwallet/android/features/buy/viewmodels/FiatViewModelTest.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.features.buy.viewmodels
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.fiat.coordinators.GetAssetPriceUsd
 import com.gemwallet.android.application.fiat.coordinators.GetBuyAssetInfo
 import com.gemwallet.android.application.fiat.coordinators.GetBuyQuoteUrl
 import com.gemwallet.android.application.fiat.coordinators.GetBuyQuotes
@@ -10,6 +11,7 @@ import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.features.buy.viewmodels.models.FiatSuggestion
 import com.gemwallet.android.model.AssetBalance
 import com.gemwallet.android.model.AssetData
+import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.testkit.mockAsset
 import com.gemwallet.android.testkit.mockAssetData
 import com.gemwallet.android.testkit.mockAssetMetaData
@@ -56,6 +58,11 @@ class FiatViewModelTest {
     private val getBuyAssetInfo = object : GetBuyAssetInfo {
         override fun invoke(assetId: AssetId): Flow<AssetData?> = assetDataFlow
     }
+    private val assetPriceUsdFlow = MutableStateFlow<Double?>(100.0)
+    private val getAssetPriceUsd = object : GetAssetPriceUsd {
+        override fun invoke(assetId: AssetId): Flow<Double?> = assetPriceUsdFlow
+    }
+    private val fiatFormatter = CurrencyFormatter(type = CurrencyFormatter.Type.Fiat, currency = Currency.USD)
     private val getBuyQuotes = mockk<GetBuyQuotes>(relaxed = true) {
         coEvery {
             invoke(
@@ -251,6 +258,22 @@ class FiatViewModelTest {
         }
     }
 
+    @Test
+    fun `provider fiat uses usd price source not session price`() = runTest(testDispatcher) {
+        assetDataFlow.value = assetData(price = 100.0)
+        assetPriceUsdFlow.value = 200.0
+        val viewModel = createViewModel()
+
+        try {
+            runCurrent()
+
+            val provider = viewModel.providers.value.first()
+            assertEquals(fiatFormatter.string(200.0 * provider.cryptoAmount), provider.fiatFormatted)
+        } finally {
+            viewModel.viewModelScope.cancel()
+        }
+    }
+
     private fun createViewModel(initialAmount: Double? = null): FiatViewModel {
         val arguments = mutableMapOf<String, Any>(
             RouteArgument.AssetId.key to asset.id.toIdentifier(),
@@ -260,6 +283,7 @@ class FiatViewModelTest {
             getBuyQuotes = getBuyQuotes,
             getBuyQuoteUrl = getBuyQuoteUrl,
             getBuyAssetInfo = getBuyAssetInfo,
+            getAssetPriceUsd = getAssetPriceUsd,
             savedStateHandle = SavedStateHandle(arguments),
         )
     }

--- a/android/features/buy/viewmodels/src/test/kotlin/com/gemwallet/android/features/buy/viewmodels/models/BuyFiatProviderUIModelTest.kt
+++ b/android/features/buy/viewmodels/src/test/kotlin/com/gemwallet/android/features/buy/viewmodels/models/BuyFiatProviderUIModelTest.kt
@@ -6,6 +6,7 @@ import com.gemwallet.android.testkit.mockFiatQuote
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.FiatQuoteType
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 class BuyFiatProviderUIModelTest {
@@ -37,5 +38,13 @@ class BuyFiatProviderUIModelTest {
         val model = quote.toProviderUIModel(testAsset, Currency.USD, assetPrice = 100000.0)
 
         assertEquals(formatter.string(48.0), model.fiatFormatted)
+    }
+
+    @Test
+    fun `cryptoText keeps significant digits for amounts sharing four decimals`() {
+        val first = mockFiatQuote(cryptoAmount = 0.00077).toProviderUIModel(testAsset, Currency.USD)
+        val second = mockFiatQuote(cryptoAmount = 0.0007578).toProviderUIModel(testAsset, Currency.USD)
+
+        assertNotEquals(first.cryptoText, second.cryptoText)
     }
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/fiat/coordinators/GetAssetPriceUsd.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/fiat/coordinators/GetAssetPriceUsd.kt
@@ -1,0 +1,8 @@
+package com.gemwallet.android.application.fiat.coordinators
+
+import com.wallet.core.primitives.AssetId
+import kotlinx.coroutines.flow.Flow
+
+interface GetAssetPriceUsd {
+    operator fun invoke(assetId: AssetId): Flow<Double?>
+}

--- a/ios/Features/FiatConnect/Sources/Navigation/FiatConnectNavigationView.swift
+++ b/ios/Features/FiatConnect/Sources/Navigation/FiatConnectNavigationView.swift
@@ -19,6 +19,7 @@ public struct FiatConnectNavigationView: View {
             model: model,
         )
         .onChangeBindQuery(model.assetQuery, action: model.onAssetDataChange)
+        .bindQuery(model.priceUsdQuery)
         .ifElse(
             model.showFiatTypePicker,
             ifContent: {

--- a/ios/Features/FiatConnect/Sources/ViewModels/FiatSceneViewModel.swift
+++ b/ios/Features/FiatConnect/Sources/ViewModels/FiatSceneViewModel.swift
@@ -25,6 +25,7 @@ public final class FiatSceneViewModel {
     private let currencyFormatter: CurrencyFormatter
     private let valueFormatter = ValueFormatter(locale: .US, style: .auto)
 
+    public let priceUsdQuery: ObservableQuery<PriceUsdRequest>
     public let assetQuery: ObservableQuery<AssetRequest>
     var assetData: AssetData {
         assetQuery.value
@@ -55,6 +56,7 @@ public final class FiatSceneViewModel {
         self.assetsEnabler = assetsEnabler
         self.type = type
         assetQuery = ObservableQuery(AssetRequest(walletId: wallet.id, assetId: assetAddress.asset.id), initialValue: .with(asset: assetAddress.asset))
+        priceUsdQuery = ObservableQuery(PriceUsdRequest(assetId: assetAddress.asset.id), initialValue: nil)
 
         let buyOperation = BuyOperation(
             service: fiatService,
@@ -192,7 +194,7 @@ public final class FiatSceneViewModel {
                 FiatQuoteViewModel(
                     asset: asset,
                     quote: $0,
-                    assetPrice: assetData.price?.price,
+                    assetPrice: priceUsdQuery.value,
                     isSelected: $0.provider == selectedQuote?.provider,
                     formatter: currencyFormatter,
                 )

--- a/ios/Features/FiatConnect/Tests/FiatSceneViewModelTests.swift
+++ b/ios/Features/FiatConnect/Tests/FiatSceneViewModelTests.swift
@@ -341,4 +341,17 @@ final class FiatSceneViewModelTests {
 
         #expect(model.buyViewModel.shouldSkipFetch(for: 200.0) == false)
     }
+
+    @Test
+    func fiatProviderRowsUseUsdPriceSource() {
+        let model = FiatSceneViewModelTests.mock()
+        let quote = FiatQuote.mock(fiatAmount: 50, cryptoAmount: 0.000488, type: .buy)
+        model.buyViewModel.quotesState = .data(FiatQuotes(amount: 50, quotes: [quote]))
+        model.priceUsdQuery.value = 100_000
+
+        let row = model.fiatProviderViewModel.state.value?.items.first
+
+        #expect(row?.assetPrice == 100_000)
+        #expect(row?.subtitleExtra == "$48.80")
+    }
 }

--- a/ios/Packages/Store/Sources/Requests/PriceUsdRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/PriceUsdRequest.swift
@@ -1,0 +1,22 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import GRDB
+import Primitives
+
+public struct PriceUsdRequest: DatabaseQueryable {
+    public var assetId: AssetId
+
+    public init(assetId: AssetId) {
+        self.assetId = assetId
+    }
+
+    public func fetch(_ db: Database) throws -> Double? {
+        try PriceRecord
+            .filter(PriceRecord.Columns.assetId == assetId.identifier)
+            .fetchOne(db)?
+            .priceUsd
+    }
+}
+
+extension PriceUsdRequest: Equatable {}

--- a/ios/Packages/Store/Tests/StoreTests/Requests/PriceUsdRequestTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/Requests/PriceUsdRequestTests.swift
@@ -1,0 +1,29 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Primitives
+import PrimitivesTestKit
+import Store
+import StoreTestKit
+import Testing
+
+struct PriceUsdRequestTests {
+    @Test
+    func returnsUsdPriceIgnoringSelectedCurrency() throws {
+        let db = DB.mockAssets()
+        let fiatRateStore = FiatRateStore(db: db)
+        let priceStore = PriceStore(db: db)
+
+        try fiatRateStore.add([FiatRate(symbol: Currency.jpy.rawValue, rate: 150)])
+
+        let ethId = AssetId(chain: .ethereum)
+        try priceStore.updatePrice(
+            price: AssetPrice(assetId: ethId, price: 1100, priceChangePercentage24h: 0, updatedAt: .now),
+            currency: Currency.jpy.rawValue,
+        )
+
+        try db.dbQueue.read { db in
+            let result = try PriceUsdRequest(assetId: ethId).fetch(db)
+            #expect(result == 1100)
+        }
+    }
+}


### PR DESCRIPTION
Fiat providers now show fiat values in USD instead of the user’s selected currency, so amounts are correct for currencies like Japanese Yen. The crypto amount precision on Android is also aligned with iOS.

Closes #624

<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-07-08 at 18 17 52" src="https://github.com/user-attachments/assets/810245b3-53f7-4181-9f6c-725274d02e8a" />
<img width="320" alt="Screenshot_1783522382" src="https://github.com/user-attachments/assets/0343dd39-b0d2-497c-889a-5742b8e788d2" />
