### PR TITLE
Fix Auto Close layout

### DIFF
--- a/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/autoclose/AutocloseScene.kt
+++ b/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/autoclose/AutocloseScene.kt
@@ -1,38 +1,33 @@
 package com.gemwallet.android.features.perpetual.views.autoclose
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import com.gemwallet.android.features.perpetual.views.components.PerpetualPositionItem
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.PercentSuggestionsBar
 import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.components.perpetual.AutocloseInputSection
-import com.gemwallet.android.ui.components.perpetual.AutocloseSuggestionsBar
-import com.gemwallet.android.ui.icons.AppIcons
+import com.gemwallet.android.ui.components.screen.MainActionWidth
+import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.models.perpetual.autoclose.AutocloseUIModel
 import com.gemwallet.android.ui.theme.Spacer16
 import com.gemwallet.android.ui.theme.paddingDefault
+import com.gemwallet.android.ui.theme.paddingSmall
+import com.gemwallet.android.ui.theme.sceneContentPadding
 import com.wallet.core.primitives.TpslType
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun AutocloseScene(
     model: AutocloseUIModel,
@@ -53,82 +48,76 @@ internal fun AutocloseScene(
         TpslType.StopLoss -> stopLossText
         null -> ""
     }
+    val isPercentBarVisible = WindowInsets.isImeVisible && activeField != null && activeText.isEmpty()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .fillMaxHeight()
-            .imePadding(),
-    ) {
-        CenterAlignedTopAppBar(
-            title = {
-                Text(
-                    text = stringResource(R.string.perpetual_auto_close),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            },
-            navigationIcon = {
-                IconButton(onClick = { onAction(AutocloseAction.Close) }) {
-                    Icon(imageVector = AppIcons.Close, contentDescription = null)
-                }
-            },
-        )
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .padding(horizontal = paddingDefault),
-        ) {
-            PerpetualPositionItem(
-                data = model.position,
-                listPosition = ListPosition.Single,
-            )
-            Spacer16()
-            PropertyItem(
-                title = stringResource(R.string.perpetual_entry_price),
-                data = model.entryPriceText,
-                listPosition = ListPosition.First,
-            )
-            PropertyItem(
-                title = stringResource(R.string.perpetual_market_price),
-                data = model.marketPriceText,
-                listPosition = ListPosition.Last,
-            )
-            Spacer16()
-            AutocloseInputSection(
-                field = model.takeProfit,
-                text = takeProfitText,
-                onTextChanged = { onAction(AutocloseAction.TakeProfitChanged(it)) },
-                onFocusChanged = { focused ->
-                    if (focused) focusedField = TpslType.TakeProfit
-                    else if (focusedField == TpslType.TakeProfit) focusedField = null
-                },
-            )
-            Spacer16()
-            AutocloseInputSection(
-                field = model.stopLoss,
-                text = stopLossText,
-                onTextChanged = { onAction(AutocloseAction.StopLossChanged(it)) },
-                onFocusChanged = { focused ->
-                    if (focused) focusedField = TpslType.StopLoss
-                    else if (focusedField == TpslType.StopLoss) focusedField = null
-                },
-            )
-            Spacer(Modifier.weight(1f))
-            if (activeField != null && activeText.isEmpty()) {
-                AutocloseSuggestionsBar(
+    Scene(
+        title = stringResource(R.string.perpetual_auto_close),
+        onClose = { onAction(AutocloseAction.Close) },
+        closeIcon = true,
+        mainActionWidth = if (isPercentBarVisible) MainActionWidth.FillWidth else MainActionWidth.Constrained,
+        mainActionPadding = PaddingValues(
+            horizontal = sceneContentPadding(),
+            vertical = if (isPercentBarVisible) paddingSmall else paddingDefault,
+        ),
+        mainAction = {
+            if (isPercentBarVisible && activeField != null) {
+                PercentSuggestionsBar(
                     suggestions = activeField.percentSuggestions,
                     onPercentSelected = { percent -> onAction(AutocloseAction.SelectPercent(activeField.type, percent)) },
                 )
+            } else {
+                MainActionButton(
+                    title = stringResource(R.string.transfer_confirm),
+                    enabled = model.confirmEnabled,
+                    onClick = { onAction(AutocloseAction.Confirm) },
+                )
+            }
+        },
+    ) {
+        LazyColumn {
+            item {
+                PerpetualPositionItem(
+                    data = model.position,
+                    listPosition = ListPosition.Single,
+                )
                 Spacer16()
             }
-            MainActionButton(
-                title = stringResource(R.string.transfer_confirm),
-                enabled = model.confirmEnabled,
-                onClick = { onAction(AutocloseAction.Confirm) },
-            )
-            Spacer16()
+            item {
+                PropertyItem(
+                    title = stringResource(R.string.perpetual_entry_price),
+                    data = model.entryPriceText,
+                    listPosition = ListPosition.First,
+                )
+                PropertyItem(
+                    title = stringResource(R.string.perpetual_market_price),
+                    data = model.marketPriceText,
+                    listPosition = ListPosition.Last,
+                )
+                Spacer16()
+            }
+            item {
+                AutocloseInputSection(
+                    field = model.takeProfit,
+                    text = takeProfitText,
+                    onTextChanged = { onAction(AutocloseAction.TakeProfitChanged(it)) },
+                    onFocusChanged = { focused ->
+                        if (focused) focusedField = TpslType.TakeProfit
+                        else if (focusedField == TpslType.TakeProfit) focusedField = null
+                    },
+                )
+                Spacer16()
+            }
+            item {
+                AutocloseInputSection(
+                    field = model.stopLoss,
+                    text = stopLossText,
+                    onTextChanged = { onAction(AutocloseAction.StopLossChanged(it)) },
+                    onFocusChanged = { focused ->
+                        if (focused) focusedField = TpslType.StopLoss
+                        else if (focusedField == TpslType.StopLoss) focusedField = null
+                    },
+                )
+            }
         }
     }
 }

--- a/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/dialogs/AmountAutocloseSheet.kt
+++ b/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/dialogs/AmountAutocloseSheet.kt
@@ -26,8 +26,8 @@ import com.gemwallet.android.model.NumericFormatter
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
+import com.gemwallet.android.ui.components.PercentSuggestionsBar
 import com.gemwallet.android.ui.components.perpetual.AutocloseInputSection
-import com.gemwallet.android.ui.components.perpetual.AutocloseSuggestionsBar
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.models.perpetual.autoclose.AutocloseUIModel
@@ -147,7 +147,7 @@ internal fun AmountAutocloseSheet(
             )
             Spacer(Modifier.weight(1f))
             if (activeField != null && activeText.isEmpty()) {
-                AutocloseSuggestionsBar(
+                PercentSuggestionsBar(
                     suggestions = activeField.percentSuggestions,
                     onPercentSelected = { percent ->
                         val target = estimator.targetPriceFromRoe(percent, activeField.type)
@@ -163,20 +163,20 @@ internal fun AmountAutocloseSheet(
                         }
                     },
                 )
-                Spacer16()
+            } else {
+                MainActionButton(
+                    title = stringResource(R.string.common_done),
+                    enabled = confirmEnabled,
+                    onClick = {
+                        submitAttempted = true
+                        if (isTakeProfitValid && isStopLossValid) {
+                            provider.setTakeProfit(takeProfitText.takeIf { it.isNotEmpty() })
+                            provider.setStopLoss(stopLossText.takeIf { it.isNotEmpty() })
+                            onDismiss()
+                        }
+                    },
+                )
             }
-            MainActionButton(
-                title = stringResource(R.string.common_done),
-                enabled = confirmEnabled,
-                onClick = {
-                    submitAttempted = true
-                    if (isTakeProfitValid && isStopLossValid) {
-                        provider.setTakeProfit(takeProfitText.takeIf { it.isNotEmpty() })
-                        provider.setStopLoss(stopLossText.takeIf { it.isNotEmpty() })
-                        onDismiss()
-                    }
-                },
-            )
             Spacer16()
         }
     }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/PercentSuggestionsBar.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/PercentSuggestionsBar.kt
@@ -1,4 +1,4 @@
-package com.gemwallet.android.ui.components.perpetual
+package com.gemwallet.android.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -9,16 +9,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
+import com.gemwallet.android.ui.theme.paddingSmall
 
 @Composable
-fun AutocloseSuggestionsBar(
+fun PercentSuggestionsBar(
     suggestions: List<Int>,
+    modifier: Modifier = Modifier,
     onPercentSelected: (Int) -> Unit,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(paddingSmall),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         suggestions.forEach { percent ->

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/Scene.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/Scene.kt
@@ -38,6 +38,11 @@ import com.gemwallet.android.ui.theme.isCompactDimension
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.sceneContentPadding
 
+enum class MainActionWidth {
+    Constrained,
+    FillWidth,
+}
+
 @Composable
 fun Scene(
     title: String,
@@ -57,6 +62,7 @@ fun Scene(
             bottom = paddingDefault
         )
     },
+    mainActionWidth: MainActionWidth = MainActionWidth.Constrained,
     snackbar: SnackbarHostState? = null,
     navigationBarPadding: Boolean = true,
     content: @Composable ColumnScope.(PaddingValues) -> Unit,
@@ -77,6 +83,7 @@ fun Scene(
         actions = actions,
         mainAction = mainAction,
         mainActionPadding = mainActionPadding,
+        mainActionWidth = mainActionWidth,
         snackbar = snackbar,
         navigationBarPadding = navigationBarPadding,
         content = content,
@@ -94,6 +101,7 @@ fun Scene(
     actions: @Composable RowScope.() -> Unit = {},
     mainAction: (@Composable () -> Unit)? = null,
     mainActionPadding: PaddingValues = PaddingValues(horizontal = sceneContentPadding(), vertical = paddingDefault),
+    mainActionWidth: MainActionWidth = MainActionWidth.Constrained,
     snackbar: SnackbarHostState? = null,
     navigationBarPadding: Boolean = true,
     progress: (() -> Float)? = null,
@@ -143,7 +151,12 @@ fun Scene(
                 ) {
                     Box(
                         modifier = Modifier
-                            .widthIn(max = SceneSizing.buttonMaxWidth)
+                            .then(
+                                when (mainActionWidth) {
+                                    MainActionWidth.FillWidth -> Modifier.fillMaxWidth()
+                                    MainActionWidth.Constrained -> Modifier.widthIn(max = SceneSizing.buttonMaxWidth)
+                                }
+                            )
                             .padding(mainActionPadding)
                     ) {
                         mainAction()

--- a/ios/Features/Perpetuals/Sources/Scenes/AutocloseScene.swift
+++ b/ios/Features/Perpetuals/Sources/Scenes/AutocloseScene.swift
@@ -46,11 +46,12 @@ public struct AutocloseScene: View {
                 focusedField: $focusedField,
             )
         }
+        .listSectionSpacing(.compact)
         .contentMargins(.top, .scene.top, for: .scrollContent)
         .scrollDismissesKeyboard(.interactively)
         .safeAreaView {
             InputAccessoryView(
-                isEditing: model.input.focused?.text.isEmpty == true,
+                isEditing: model.isEditing(field: focusedField),
                 suggestions: model.takeProfitModel.percentSuggestions,
                 onSelect: { model.onSelectPercent($0.value) },
                 onDone: { focusedField = nil },

--- a/ios/Features/Perpetuals/Sources/Types/AutocloseInput.swift
+++ b/ios/Features/Perpetuals/Sources/Types/AutocloseInput.swift
@@ -41,6 +41,13 @@ struct AutocloseInput {
         }
     }
 
+    func text(for field: AutocloseScene.Field) -> String {
+        switch field {
+        case .takeProfit: takeProfit.text
+        case .stopLoss: stopLoss.text
+        }
+    }
+
     func field(
         type: TpslType,
         price: Double?,

--- a/ios/Features/Perpetuals/Sources/ViewModels/AutocloseSceneViewModel.swift
+++ b/ios/Features/Perpetuals/Sources/ViewModels/AutocloseSceneViewModel.swift
@@ -73,6 +73,11 @@ public final class AutocloseSceneViewModel {
 // MARK: - Actions
 
 public extension AutocloseSceneViewModel {
+    func isEditing(field: AutocloseScene.Field?) -> Bool {
+        guard let field else { return false }
+        return input.text(for: field).isEmpty
+    }
+
     func onChangeFocusField(_ _: AutocloseScene.Field?, _ newField: AutocloseScene.Field?) {
         input.focusField = newField
     }

--- a/ios/Features/Perpetuals/Tests/AutocloseSceneViewModelTests.swift
+++ b/ios/Features/Perpetuals/Tests/AutocloseSceneViewModelTests.swift
@@ -1,0 +1,24 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+@testable import Perpetuals
+@testable import PerpetualsTestKit
+import Primitives
+import Testing
+
+@MainActor
+struct AutocloseSceneViewModelTests {
+    @Test
+    func isEditing() {
+        let model = AutocloseSceneViewModel(type: .mockOpen())
+        model.input.takeProfit.text = ""
+        model.input.stopLoss.text = ""
+
+        #expect(model.isEditing(field: nil) == false)
+        #expect(model.isEditing(field: .takeProfit) == true)
+        #expect(model.isEditing(field: .stopLoss) == true)
+
+        model.input.takeProfit.text = "100"
+        #expect(model.isEditing(field: .takeProfit) == false)
+        #expect(model.isEditing(field: .stopLoss) == true)
+    }
+}


### PR DESCRIPTION
Reworks the Auto Close screen on iOS and Android so it behaves like the swap input: percent shortcuts show while a field is empty, and the Confirm button shows once a price is entered. Fixes the oversized margins and the hidden percent buttons.

Closes #656