### PR TITLE
Android: match iOS stake and delegation duration formatting

### DIFF
--- a/android/features/earn/stake/presents/src/main/kotlin/com/gemwallet/android/features/stake/presents/StakeScene.kt
+++ b/android/features/earn/stake/presents/src/main/kotlin/com/gemwallet/android/features/stake/presents/StakeScene.kt
@@ -2,6 +2,8 @@
 
 package com.gemwallet.android.features.stake.presents
 
+import android.icu.util.Measure
+import android.icu.util.MeasureUnit
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -24,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.asset.getIconUrl
 import com.gemwallet.android.domains.asset.lockTime
+import com.gemwallet.android.domains.duration.formatDuration
 import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
 import com.gemwallet.android.domains.percentage.formatAsPercentage
 import com.gemwallet.android.ext.asset
@@ -166,7 +169,7 @@ private fun LazyListScope.stakeInfoSection(assetInfo: AssetInfo) {
             )
             is StakeInfoRow.LockTime -> PropertyItem(
                 title = stringResource(id = R.string.stake_lock_time),
-                data = "${row.days} days",
+                data = formatDuration(Measure(row.days, MeasureUnit.DAY)),
                 info = InfoSheetEntity.StakeLockTimeInfo(icon = row.iconUrl),
                 listPosition = position,
             )

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/duration/DurationFormatter.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/duration/DurationFormatter.kt
@@ -1,0 +1,21 @@
+package com.gemwallet.android.domains.duration
+
+import android.icu.text.MeasureFormat
+import android.icu.util.Measure
+import android.icu.util.MeasureUnit
+import java.util.Locale
+
+fun formatDuration(vararg measures: Measure, locale: Locale = Locale.getDefault()): String =
+    MeasureFormat.getInstance(locale, MeasureFormat.FormatWidth.WIDE).formatMeasures(*measures)
+
+fun formatAvailableIn(millis: Long, locale: Locale = Locale.getDefault()): String {
+    val measures = availableInParts(millis).map { Measure(it.first, it.second.measureUnit) }
+    return if (measures.isEmpty()) "" else formatDuration(*measures.toTypedArray(), locale = locale)
+}
+
+private val DurationUnit.measureUnit: MeasureUnit
+    get() = when (this) {
+        DurationUnit.DAY -> MeasureUnit.DAY
+        DurationUnit.HOUR -> MeasureUnit.HOUR
+        DurationUnit.MINUTE -> MeasureUnit.MINUTE
+    }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/duration/DurationParts.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/duration/DurationParts.kt
@@ -1,0 +1,23 @@
+package com.gemwallet.android.domains.duration
+
+private const val MINUTE_MS = 60_000L
+private const val HOUR_MS = 60 * MINUTE_MS
+private const val DAY_MS = 24 * HOUR_MS
+
+internal enum class DurationUnit { DAY, HOUR, MINUTE }
+
+internal fun availableInParts(millis: Long): List<Pair<Long, DurationUnit>> {
+    if (millis < 0) return emptyList()
+    val parts = if (millis < DAY_MS) {
+        listOf(
+            millis / HOUR_MS to DurationUnit.HOUR,
+            (millis % HOUR_MS) / MINUTE_MS to DurationUnit.MINUTE,
+        )
+    } else {
+        listOf(
+            millis / DAY_MS to DurationUnit.DAY,
+            (millis % DAY_MS) / HOUR_MS to DurationUnit.HOUR,
+        )
+    }
+    return parts.dropWhile { it.first == 0L }.ifEmpty { parts.takeLast(1) }
+}

--- a/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/duration/DurationPartsTest.kt
+++ b/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/duration/DurationPartsTest.kt
@@ -1,0 +1,45 @@
+package com.gemwallet.android.domains.duration
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class DurationPartsTest {
+
+    @Test
+    fun over24Hours_showsDaysAndHours() {
+        assertEquals(
+            listOf(5L to DurationUnit.DAY, 3L to DurationUnit.HOUR),
+            availableInParts(TimeUnit.DAYS.toMillis(5) + TimeUnit.HOURS.toMillis(3)),
+        )
+    }
+
+    @Test
+    fun under24Hours_showsHoursAndMinutes() {
+        assertEquals(
+            listOf(23L to DurationUnit.HOUR, 59L to DurationUnit.MINUTE),
+            availableInParts(TimeUnit.HOURS.toMillis(23) + TimeUnit.MINUTES.toMillis(59)),
+        )
+    }
+
+    @Test
+    fun under1Hour_dropsLeadingZeroHour() {
+        assertEquals(
+            listOf(45L to DurationUnit.MINUTE),
+            availableInParts(TimeUnit.MINUTES.toMillis(45)),
+        )
+    }
+
+    @Test
+    fun subMinute_keepsMinutesNeverSeconds() {
+        assertEquals(
+            listOf(0L to DurationUnit.MINUTE),
+            availableInParts(TimeUnit.SECONDS.toMillis(30)),
+        )
+    }
+
+    @Test
+    fun negative_isEmpty() {
+        assertEquals(emptyList<Pair<Long, DurationUnit>>(), availableInParts(-1L))
+    }
+}

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/ValidatorItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/ValidatorItem.kt
@@ -1,6 +1,5 @@
 package com.gemwallet.android.ui.components.list_item
 
-import android.text.format.DateUtils
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.MaterialTheme
@@ -11,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.gemwallet.android.domains.asset.getIconUrl
+import com.gemwallet.android.domains.duration.formatAvailableIn
 import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
 import com.gemwallet.android.domains.percentage.formatAsPercentage
 import com.gemwallet.android.ext.currentTimestamp
@@ -81,19 +81,8 @@ private val DelegationValidator.placeholder: String
     get() = name.firstOrNull()?.toString() ?: id.firstOrNull()?.toString() ?: "V"
 
 fun availableIn(delegation: Delegation?): String {
-    val completionDate = ((delegation?.base?.completionDate ?: return "") - currentTimestamp()).secondsToMillis()
-    if (completionDate < 0) {
-        return ""
-    }
-    val days = completionDate / DateUtils.DAY_IN_MILLIS
-    val hours = (completionDate % DateUtils.DAY_IN_MILLIS) / DateUtils.HOUR_IN_MILLIS
-    val minutes = (completionDate % DateUtils.DAY_IN_MILLIS % DateUtils.HOUR_IN_MILLIS) / DateUtils.MINUTE_IN_MILLIS
-    val seconds = (completionDate % DateUtils.DAY_IN_MILLIS % DateUtils.HOUR_IN_MILLIS % DateUtils.MINUTE_IN_MILLIS) / DateUtils.SECOND_IN_MILLIS
-    return when {
-        days > 0 -> "$days days $hours hours"
-        hours > 0 -> "$hours hours $minutes minutes"
-        else -> "$minutes minutes $seconds seconds"
-    }
+    val remaining = ((delegation?.base?.completionDate ?: return "") - currentTimestamp()).secondsToMillis()
+    return formatAvailableIn(remaining)
 }
 
 @Composable


### PR DESCRIPTION
Stake lock-time and delegation "available in" rendered hardcoded English in every locale, and the countdown showed seconds where iOS shows none.

Format both with android.icu MeasureFormat (WIDE) - the same ICU/CLDR data iOS's DateComponentsFormatter uses - and mirror iOS's unit selection for the countdown: under 24h -> hours+minutes (bare minutes when under an hour), 24h and over -> days+hours, never seconds. Lock time shows days, like iOS.