### PR TITLE
Android: drop redundant XRP swap override

### DIFF
--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/Chain.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/Chain.kt
@@ -209,9 +209,6 @@ fun Chain.getNetworkId(): String {
 }
 
 fun Chain.isSwapSupport(): Boolean {
-    if (this == Chain.Xrp) { // TODO: Check and remove, looks like as legacy
-        return true
-    }
     return try {
         Config().getChainConfig(string).isSwapSupported
     } catch (_: Throwable) {


### PR DESCRIPTION
isSwapSupport() forced XRP to true, bypassing the shared chain config that already reports XRP swap as supported. Remove the legacy special case so swap support comes from a single source of truth, matching iOS.