### PR TITLE
Fix portfolio all-time high/low currency

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetPortfolioDataImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetPortfolioDataImpl.kt
@@ -59,8 +59,8 @@ class GetPortfolioDataImpl(
             .sortedBy { it.timestamp }
             .map { ChartDateValue(date = it.timestamp.toLong().secondsToMillis(), value = it.value * rate) }
         val statistics = listOfNotNull(
-            portfolio.allTimeHigh?.let { PortfolioStatistic.AllTimeHigh(it) },
-            portfolio.allTimeLow?.let { PortfolioStatistic.AllTimeLow(it) },
+            portfolio.allTimeHigh?.let { PortfolioStatistic.AllTimeHigh(it.copy(value = (it.value * rate).toFloat())) },
+            portfolio.allTimeLow?.let { PortfolioStatistic.AllTimeLow(it.copy(value = (it.value * rate).toFloat())) },
         )
         return PortfolioData(
             charts = listOf(PortfolioChartData(chartType = PortfolioChartType.Value, values = values)),

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/GetPortfolioDataImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/GetPortfolioDataImplTest.kt
@@ -43,13 +43,17 @@ class GetPortfolioDataImplTest {
         sessionRepository = sessionRepository,
     )
 
-    private fun portfolio(allTimeHigh: ChartValuePercentage? = null) = PortfolioAssets(
+    private fun portfolio(
+        allTimeHigh: ChartValuePercentage? = null,
+        allTimeLow: ChartValuePercentage? = null,
+    ) = PortfolioAssets(
         totalValue = 5.0f,
         values = listOf(
             ChartValue(timestamp = 2, value = 3.0f),
             ChartValue(timestamp = 1, value = 2.0f),
         ),
         allTimeHigh = allTimeHigh,
+        allTimeLow = allTimeLow,
         allocation = emptyList(),
     )
 
@@ -77,17 +81,25 @@ class GetPortfolioDataImplTest {
     }
 
     @Test
-    fun getPortfolioData_mapsAllTimeStatistics() = runTest {
+    fun getPortfolioData_convertsAllTimeStatisticsByRate() = runTest {
         val bitcoin = mockAsset()
         every { assetsRepository.getAssetsInfo() } returns
             flowOf(listOf(mockAssetInfo(asset = bitcoin, balance = AssetBalance.create(bitcoin, available = "1"))))
-        every { assetsRepository.getCurrencyRate(Currency.USD) } returns flowOf(FiatRate("USD", 1.0))
+        every { assetsRepository.getCurrencyRate(Currency.EUR) } returns flowOf(FiatRate("EUR", 2.0))
         val allTimeHigh = ChartValuePercentage(date = 10L, value = 99f, percentage = 5f)
-        coEvery { gemDeviceApiClient.getPortfolioAssets(any(), any()) } returns portfolio(allTimeHigh = allTimeHigh)
+        val allTimeLow = ChartValuePercentage(date = 20L, value = 10f, percentage = -3f)
+        coEvery { gemDeviceApiClient.getPortfolioAssets(any(), any()) } returns
+            portfolio(allTimeHigh = allTimeHigh, allTimeLow = allTimeLow)
 
-        val result = subject.getPortfolioData(PortfolioType.Wallet, period = ChartPeriod.Day, currency = Currency.USD)
+        val result = subject.getPortfolioData(PortfolioType.Wallet, period = ChartPeriod.Day, currency = Currency.EUR)
 
-        assertEquals(listOf(PortfolioStatistic.AllTimeHigh(allTimeHigh)), result.statistics)
+        assertEquals(
+            listOf(
+                PortfolioStatistic.AllTimeHigh(allTimeHigh.copy(value = 198f)),
+                PortfolioStatistic.AllTimeLow(allTimeLow.copy(value = 20f)),
+            ),
+            result.statistics,
+        )
     }
 
     @Test(expected = IllegalStateException::class)

--- a/ios/Features/WalletTab/Sources/Services/PortfolioDataService.swift
+++ b/ios/Features/WalletTab/Sources/Services/PortfolioDataService.swift
@@ -52,11 +52,19 @@ extension PortfolioDataService {
         let charts = [PortfolioChartData(chartType: .value, values: values)]
 
         let statistics: [PortfolioStatistic] = [
-            portfolio.allTimeHigh.map { .allTimeHigh($0) },
-            portfolio.allTimeLow.map { .allTimeLow($0) },
+            portfolio.allTimeHigh.map { .allTimeHigh(convert($0, rate: rate)) },
+            portfolio.allTimeLow.map { .allTimeLow(convert($0, rate: rate)) },
         ].compactMap(\.self)
 
         return PortfolioData(charts: charts, statistics: statistics, availablePeriods: [.day, .week, .month, .year, .all])
+    }
+
+    private func convert(_ chartValue: ChartValuePercentage, rate: Double) -> ChartValuePercentage {
+        ChartValuePercentage(
+            date: chartValue.date,
+            value: chartValue.value * Float(rate),
+            percentage: chartValue.percentage,
+        )
     }
 
     private func getPerpetualData(address: String, period: ChartPeriod) async throws -> PortfolioData {

--- a/ios/Features/WalletTab/Tests/PortfolioDataServiceTests.swift
+++ b/ios/Features/WalletTab/Tests/PortfolioDataServiceTests.swift
@@ -1,0 +1,39 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import PriceService
+import PriceServiceTestKit
+import Primitives
+import PrimitivesTestKit
+import Store
+import StoreTestKit
+import Testing
+@testable import WalletTab
+import WalletTabTestKit
+
+struct PortfolioDataServiceTests {
+    @Test
+    func walletAllTimeValuesConvertedByCurrencyRate() async throws {
+        let db = DB.mock()
+        let rate: Float = 3.67
+        let date = Date(timeIntervalSince1970: 0)
+        let currency = Currency.eur.rawValue
+        try FiatRateStore(db: db).add([FiatRate(symbol: currency, rate: Double(rate))])
+
+        let service = PortfolioDataService.mock(
+            portfolioService: .mock(apiService: GemAPIPortfolioServiceMock(
+                allTimeHigh: .mock(date: date, value: 100),
+                allTimeLow: .mock(date: date, value: 20),
+            )),
+            priceService: .mock(priceStore: .mock(db: db)),
+        )
+
+        let data = try await service.getPortfoliData(input: .wallet(walletId: .mock(), period: .all, currencyCode: currency))
+
+        let expected: [PortfolioStatistic] = [
+            .allTimeHigh(.mock(date: date, value: 100 * rate)),
+            .allTimeLow(.mock(date: date, value: 20 * rate)),
+        ]
+        #expect(data.statistics == expected)
+    }
+}

--- a/ios/Packages/FeatureServices/PriceService/TestKit/PortfolioService+TestKit.swift
+++ b/ios/Packages/FeatureServices/PriceService/TestKit/PortfolioService+TestKit.swift
@@ -4,21 +4,31 @@ import Foundation
 import GemAPI
 import PriceService
 import Primitives
+import Store
 import StoreTestKit
 
 public struct GemAPIPortfolioServiceMock: GemAPIPortfolioService {
-    public init() {}
+    private let allTimeHigh: ChartValuePercentage?
+    private let allTimeLow: ChartValuePercentage?
+
+    public init(allTimeHigh: ChartValuePercentage? = nil, allTimeLow: ChartValuePercentage? = nil) {
+        self.allTimeHigh = allTimeHigh
+        self.allTimeLow = allTimeLow
+    }
 
     public func getPortfolioAssets(period _: ChartPeriod, request _: PortfolioAssetsRequest) async throws -> PortfolioAssets {
-        PortfolioAssets(totalValue: 0, values: [], allTimeHigh: nil, allTimeLow: nil, allocation: [])
+        PortfolioAssets(totalValue: 0, values: [], allTimeHigh: allTimeHigh, allTimeLow: allTimeLow, allocation: [])
     }
 }
 
 public extension PortfolioService {
-    static func mock() -> PortfolioService {
+    static func mock(
+        apiService: any GemAPIPortfolioService = GemAPIPortfolioServiceMock(),
+        assetStore: AssetStore = .mock(),
+    ) -> PortfolioService {
         PortfolioService(
-            apiService: GemAPIPortfolioServiceMock(),
-            assetStore: .mock(),
+            apiService: apiService,
+            assetStore: assetStore,
         )
     }
 }


### PR DESCRIPTION
Portfolio all-time high/low values were shown in USD with the selected currency symbol. Now they are converted to the selected currency, like the chart.

Closes #619

<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-07-09 at 17 37 05" src="https://github.com/user-attachments/assets/ae87bef3-8a1e-45b9-9335-30fad6474c97" />
<img width="320" alt="Screenshot_1783605324" src="https://github.com/user-attachments/assets/b6492187-a360-40a4-a117-a0ebb536513e" />
