### PR TITLE
Extract chart pull-to-refresh into ChartRefreshController

### DIFF
--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/ChartRefreshController.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/ChartRefreshController.kt
@@ -1,0 +1,22 @@
+package com.gemwallet.android.features.asset.viewmodels.chart.viewmodels
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class ChartRefreshController {
+    private val refreshTrigger = MutableStateFlow(0L)
+    private val refreshState = MutableStateFlow(false)
+
+    val trigger: StateFlow<Long> = refreshTrigger.asStateFlow()
+    val isRefreshing: StateFlow<Boolean> = refreshState.asStateFlow()
+
+    fun startRefreshing() {
+        refreshState.value = true
+        refreshTrigger.value = refreshTrigger.value + 1
+    }
+
+    fun stopRefreshing() {
+        refreshState.value = false
+    }
+}

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/ChartViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/ChartViewModel.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
@@ -50,15 +49,14 @@ class ChartViewModel internal constructor(
         .map { it?.price }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
     private val selectedPeriod = MutableStateFlow(getChartPeriod())
-    private val refreshTrigger = MutableStateFlow(0L)
-    private val refreshState = MutableStateFlow(false)
+    private val refreshController = ChartRefreshController()
 
-    val isRefreshing = refreshState.asStateFlow()
+    val isRefreshing = refreshController.isRefreshing
 
     private val chartPrices = combine(
         selectedPeriod,
         getCurrentCurrency.getCurrency().distinctUntilChanged(),
-        refreshTrigger,
+        refreshController.trigger,
     ) { period, currency, _ -> AssetChartState(period, currency) }
         .transformLatest { state ->
             emit(state)
@@ -68,7 +66,7 @@ class ChartViewModel internal constructor(
                 currentCoroutineContext().ensureActive()
                 null
             }
-            refreshState.value = false
+            refreshController.stopRefreshing()
             val chartPrices = when {
                 prices == null -> StateViewType.Error
                 prices.size < MinChartPoints -> StateViewType.NoData
@@ -105,8 +103,7 @@ class ChartViewModel internal constructor(
     }
 
     fun refresh() {
-        refreshState.value = true
-        refreshTrigger.value = refreshTrigger.value + 1
+        refreshController.startRefreshing()
     }
 
     @Inject

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/PortfolioChartViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/PortfolioChartViewModel.kt
@@ -51,20 +51,19 @@ class PortfolioChartViewModel internal constructor(
     val selectedChartType = _selectedChartType.asStateFlow()
 
     private val selectedPeriod = MutableStateFlow(ChartPeriod.All)
-    private val refreshTrigger = MutableStateFlow(0L)
-    private val refreshState = MutableStateFlow(false)
+    private val refreshController = ChartRefreshController()
 
     val showSegmentedControl = observePerpetualWallet()
         .map { it != null }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(StopTimeoutMillis), false)
 
-    val isRefreshing = refreshState.asStateFlow()
+    val isRefreshing = refreshController.isRefreshing
 
     private val portfolio = combine(
         selectedType,
         selectedPeriod,
         getCurrentCurrency.getCurrency().distinctUntilChanged(),
-        refreshTrigger,
+        refreshController.trigger,
     ) { type, period, currency, _ -> PortfolioState(type, period, currency) }
         .transformLatest { state ->
             emit(state)
@@ -74,7 +73,7 @@ class PortfolioChartViewModel internal constructor(
                 currentCoroutineContext().ensureActive()
                 null
             }
-            refreshState.value = false
+            refreshController.stopRefreshing()
             val periods = data?.availablePeriods.orEmpty()
             when {
                 data == null -> emit(state.copy(data = StateViewType.Error))
@@ -136,8 +135,7 @@ class PortfolioChartViewModel internal constructor(
     }
 
     fun refresh() {
-        refreshState.value = true
-        refreshTrigger.value = refreshTrigger.value + 1
+        refreshController.startRefreshing()
     }
 
     @Inject


### PR DESCRIPTION
Removes the duplicated pull-to-refresh state that was copied across the two chart view models by moving it into a single shared `ChartRefreshController`. No behavior change.