### PR TITLE
Unify main action button state on Android

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/features/onboarding/AcceptTermsScreen.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/onboarding/AcceptTermsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.gemwallet.android.AppUrl
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.buttonState
 import com.gemwallet.android.ui.components.list_item.SelectionIndicator
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.icons.AppIcons
@@ -63,7 +64,7 @@ fun AcceptTermsScreen(
         mainAction = {
             MainActionButton(
                 title = stringResource(R.string.onboarding_accept_terms_continue),
-                enabled = isUnderstand1 && isUnderstand2 && isUnderstand3,
+                state = buttonState(enabled = isUnderstand1 && isUnderstand2 && isUnderstand3),
                 onClick = { onAccept() }
             )
         },

--- a/android/features/add_asset/presents/src/main/kotlin/com/gemwallet/android/features/add_asset/views/AddAssetScene.kt
+++ b/android/features/add_asset/presents/src/main/kotlin/com/gemwallet/android/features/add_asset/views/AddAssetScene.kt
@@ -31,6 +31,7 @@ import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.open
 import com.gemwallet.android.ui.components.DocsInfoButton
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.components.list_item.ChainItem
 import com.gemwallet.android.ui.components.list_item.SubheaderItem
 import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
@@ -60,7 +61,7 @@ internal fun AddAssetScene(
     network: Asset,
     token: Asset?,
     explorerLink: BlockExplorerLink?,
-    isLoading: Boolean,
+    buttonState: ButtonState,
     canSelectChain: Boolean,
     onAction: (AddAssetAction) -> Unit,
 ) {
@@ -75,8 +76,7 @@ internal fun AddAssetScene(
         mainAction = {
             MainActionButton(
                 title = stringResource(id = R.string.wallet_import_action),
-                enabled = searchState is TokenSearchState.Idle && token != null,
-                loading = isLoading,
+                state = buttonState,
                 onClick = { onAction(AddAssetAction.Add) },
             )
         },

--- a/android/features/add_asset/presents/src/main/kotlin/com/gemwallet/android/features/add_asset/views/AddAssetScreen.kt
+++ b/android/features/add_asset/presents/src/main/kotlin/com/gemwallet/android/features/add_asset/views/AddAssetScreen.kt
@@ -26,6 +26,7 @@ fun AddAssetScreen(
     val token by viewModel.token.collectAsStateWithLifecycle()
     val searchState by viewModel.searchState.collectAsStateWithLifecycle()
     val explorerLink by viewModel.explorerLink.collectAsStateWithLifecycle()
+    val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
 
     BackHandler(uiState.scene != AddAssetUIState.Scene.Form) {
         viewModel.cancelSelectChain()
@@ -53,7 +54,7 @@ fun AddAssetScreen(
                 network = network.asset(),
                 token = token,
                 explorerLink = explorerLink,
-                isLoading = uiState.isLoading,
+                buttonState = buttonState,
                 canSelectChain = (availableChains?.size ?: 0) > 1,
                 onAction = { action ->
                     when (action) {

--- a/android/features/add_asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/add_asset/viewmodels/AddAssetViewModel.kt
+++ b/android/features/add_asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/add_asset/viewmodels/AddAssetViewModel.kt
@@ -14,6 +14,8 @@ import com.gemwallet.android.ext.checksumAddress
 import com.gemwallet.android.ext.filter
 import com.gemwallet.android.features.add_asset.viewmodels.models.AddAssetUIState
 import com.gemwallet.android.features.add_asset.viewmodels.models.TokenSearchState
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.BlockExplorerLink
 import com.wallet.core.primitives.Chain
@@ -102,6 +104,13 @@ class AddAssetViewModel @Inject constructor(
     }
     .flowOn(Dispatchers.IO)
     .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val buttonState = combine(searchState, token, uiState) { searchState, token, uiState ->
+        buttonState(
+            enabled = searchState is TokenSearchState.Idle && token != null,
+            loading = uiState.isLoading,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ButtonState.Disabled)
 
     val explorerLink = token.combine(selectedChain) { token, chain ->
         val tokenId = token?.id?.tokenId ?: return@combine null

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/AuthRequestScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/AuthRequestScene.kt
@@ -23,6 +23,7 @@ import com.gemwallet.android.data.repositories.bridge.WalletConnectAuthenticatio
 import com.gemwallet.android.data.repositories.bridge.WalletConnectVerifyContext
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.components.list_head.CenteredListHead
 import com.gemwallet.android.ui.components.list_head.CenteredListHeadSubtitleLayout
 import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
@@ -47,6 +48,7 @@ fun AuthRequestScene(
     val context = LocalContext.current
     val viewModel: WCAuthViewModel = hiltViewModel()
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
 
     LaunchedEffect(request.id) {
         viewModel.onRequest(request, verifyContext)
@@ -81,6 +83,7 @@ fun AuthRequestScene(
         )
         is AuthSceneState.Content -> AuthRequestContent(
             state = currentState,
+            buttonState = buttonState,
             onApprove = viewModel::onApprove,
             onReject = viewModel::onReject,
             onWalletSelected = viewModel::onWalletSelected,
@@ -91,6 +94,7 @@ fun AuthRequestScene(
 @Composable
 private fun AuthRequestContent(
     state: AuthSceneState.Content,
+    buttonState: ButtonState,
     onApprove: () -> Unit,
     onReject: () -> Unit,
     onWalletSelected: (com.wallet.core.primitives.WalletId) -> Unit,
@@ -107,7 +111,7 @@ private fun AuthRequestContent(
         mainAction = {
             MainActionButton(
                 title = stringResource(id = R.string.transfer_confirm),
-                loading = state is AuthSceneState.Approving,
+                state = buttonState,
             ) {
                 context.requestAuth(AuthRequest.Confirmation) {
                     onApprove()

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/ProposalScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/ProposalScene.kt
@@ -29,6 +29,7 @@ import com.gemwallet.android.features.bridge.viewmodels.ProposalSceneViewModel
 import com.gemwallet.android.features.bridge.viewmodels.model.SessionUI
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.components.list_head.CenteredListHead
 import com.gemwallet.android.ui.components.list_head.CenteredListHeadSubtitleLayout
 import com.gemwallet.android.ui.components.list_item.ListItem
@@ -63,6 +64,7 @@ fun ProposalScene(
     val peer by viewModel.proposal.collectAsStateWithLifecycle()
     val selectedWallet by viewModel.selectedWallet.collectAsStateWithLifecycle()
     val availableWallets by viewModel.availableWallets.collectAsStateWithLifecycle()
+    val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
 
     LaunchedEffect(proposal) {
         viewModel.onProposal(proposal, verifyContext)
@@ -104,6 +106,7 @@ fun ProposalScene(
             state = contentState,
             selectedWallet = selectedWallet,
             availableWallets = availableWallets,
+            buttonState = buttonState,
             onReject = viewModel::onReject,
             onApprove = viewModel::onApprove,
             onWalletSelected = viewModel::onWalletSelected
@@ -117,6 +120,7 @@ private fun Proposal(
     state: ProposalSceneState.Content,
     selectedWallet: com.wallet.core.primitives.Wallet?,
     availableWallets: List<com.wallet.core.primitives.Wallet>,
+    buttonState: ButtonState,
     onReject: () -> Unit,
     onApprove: () -> Unit,
     onWalletSelected: (WalletId) -> Unit,
@@ -129,9 +133,8 @@ private fun Proposal(
         closeIcon = true,
         mainAction = {
             MainActionButton(
-                enabled = selectedWallet != null,
                 title = stringResource(id = R.string.transfer_confirm),
-                loading = state is ProposalSceneState.Approving,
+                state = buttonState,
                 onClick = onApprove
             )
         },

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
@@ -25,6 +25,7 @@ import com.gemwallet.android.features.confirm.presents.ConfirmScreen
 import com.gemwallet.android.model.AuthRequest
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.components.list_head.CenteredListHead
 import com.gemwallet.android.ui.components.list_head.CenteredListHeadSubtitleLayout
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
@@ -34,7 +35,6 @@ import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.components.simulation.simulationPayloadFieldsContent
 import com.gemwallet.android.ui.components.simulation.simulationWarningsContent
 import com.gemwallet.android.ui.models.ListPosition
-import com.gemwallet.android.ui.models.hasCriticalWarning
 import com.gemwallet.android.ui.requestAuth
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.features.confirm.presents.GetNetworkFeeAssetAction
@@ -72,6 +72,7 @@ fun RequestScene(
     }
 
     val sceneState by viewModel.sceneState.collectAsStateWithLifecycle()
+    val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
 
     when (sceneState) {
         RequestSceneState.Loading -> LoadingScene(
@@ -85,6 +86,7 @@ fun RequestScene(
                 is WCRequest.SignMessage -> SignMessageScene(
                     state = sceneState,
                     request = request,
+                    buttonState = buttonState,
                     onApprove = { viewModel.onSign(onError) },
                     onReject = viewModel::onReject,
                 )
@@ -106,6 +108,7 @@ fun RequestScene(
 private fun SignMessageScene(
     state: RequestSceneState.Content,
     request: WCRequest.SignMessage,
+    buttonState: ButtonState,
     onApprove: () -> Unit,
     onReject: () -> Unit,
 ) {
@@ -119,8 +122,7 @@ private fun SignMessageScene(
         mainAction = {
             MainActionButton(
                 title = stringResource(id = R.string.transfer_confirm),
-                enabled = !request.simulation.warnings.hasCriticalWarning(),
-                loading = state is RequestSceneState.Responding,
+                state = buttonState,
             ) {
                 context.requestAuth(AuthRequest.Confirmation) {
                     onApprove()

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/ProposalSceneViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/ProposalSceneViewModel.kt
@@ -11,6 +11,8 @@ import com.gemwallet.android.ext.walletConnectAppName
 import com.gemwallet.android.ext.walletConnectIcon
 import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectOriginVerifier
 import com.gemwallet.android.features.bridge.viewmodels.model.toSessionUI
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import com.wallet.core.primitives.WalletConnectionSessionAppMetadata
 import com.wallet.core.primitives.WalletId
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -73,6 +75,10 @@ class ProposalSceneViewModel @Inject constructor(
         wallet ?: availableWallets.firstOrNull { current?.id == it.id } ?: availableWallets.firstOrNull()
     }
     .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val buttonState = combine(selectedWallet, state) { wallet, sceneState ->
+        buttonState(enabled = wallet != null, loading = sceneState is ProposalSceneState.Approving)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ButtonState.Disabled)
 
     fun onProposal(
         proposal: WalletConnectSessionProposal,

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCAuthViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCAuthViewModel.kt
@@ -19,7 +19,9 @@ import com.gemwallet.android.ext.walletConnectAppName
 import com.gemwallet.android.features.bridge.viewmodels.model.SessionUI
 import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectOriginVerifier
 import com.gemwallet.android.features.bridge.viewmodels.model.toSessionUI
+import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.models.PayloadField
+import com.gemwallet.android.ui.models.buttonState
 import com.wallet.core.primitives.Account
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.ChainType
@@ -30,9 +32,12 @@ import com.wallet.core.primitives.WalletType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import uniffi.gemstone.MessageSigner
@@ -55,6 +60,10 @@ class WCAuthViewModel @Inject constructor(
 
     private val _state = MutableStateFlow<AuthSceneState>(AuthSceneState.Loading)
     val state: StateFlow<AuthSceneState> = _state.asStateFlow()
+
+    val buttonState: StateFlow<ButtonState> = state
+        .map { buttonState(loading = it is AuthSceneState.Approving) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ButtonState.Enabled)
 
     fun onRequest(
         request: WalletConnectAuthenticationRequest,

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
@@ -19,6 +19,9 @@ import com.gemwallet.android.features.bridge.viewmodels.model.BridgeRequestError
 import com.gemwallet.android.features.bridge.viewmodels.model.WCRequest
 import com.gemwallet.android.features.bridge.viewmodels.model.payload
 import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectOriginVerifier
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
+import com.gemwallet.android.ui.models.hasCriticalWarning
 import com.wallet.core.primitives.Account
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.WalletConnection
@@ -56,6 +59,14 @@ class WCRequestViewModel @Inject constructor(
     private val state = MutableStateFlow(RequestViewModelState())
     private var requestJob: Job? = null
     val sceneState = state.map { it.toSceneState() }.stateIn(viewModelScope, SharingStarted.Eagerly, RequestSceneState.Loading)
+
+    val buttonState = sceneState.map { scene ->
+        val request = (scene as? RequestSceneState.Content)?.request as? WCRequest.SignMessage
+        buttonState(
+            enabled = request?.simulation?.warnings?.hasCriticalWarning() != true,
+            loading = scene is RequestSceneState.Responding,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ButtonState.Enabled)
 
     fun onRequest(
         sessionRequest: WalletConnectSessionRequest,

--- a/android/features/buy/presents/src/main/kotlin/com/gemwallet/android/features/buy/views/FiatNavScreen.kt
+++ b/android/features/buy/presents/src/main/kotlin/com/gemwallet/android/features/buy/views/FiatNavScreen.kt
@@ -28,6 +28,7 @@ import com.gemwallet.android.features.buy.viewmodels.models.FiatSuggestion
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.TabsBar
 import com.gemwallet.android.ui.components.clickable
+import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.models.actions.CancelAction
 import com.gemwallet.android.ui.open
 import com.gemwallet.android.ui.theme.iconSize
@@ -52,6 +53,8 @@ fun FiatNavScreen(
     val providers by viewModel.providers.collectAsStateWithLifecycle()
     val selectedProvider by viewModel.selectedProvider.collectAsStateWithLifecycle()
     val showFiatTypePicker by viewModel.showFiatTypePicker.collectAsStateWithLifecycle()
+    val quoteButtonState by viewModel.buttonState.collectAsStateWithLifecycle()
+    val buttonState = if (urlLoading.value) ButtonState.Loading else quoteButtonState
 
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
@@ -68,7 +71,7 @@ fun FiatNavScreen(
         cancelAction = cancelAction,
         fiatAmount = amount,
         suggestedAmounts = suggestedAmounts,
-        urlLoading = urlLoading,
+        buttonState = buttonState,
         titleContent = {
             FiatTitle(
                 asset = currentAsset,

--- a/android/features/buy/presents/src/main/kotlin/com/gemwallet/android/features/buy/views/FiatScene.kt
+++ b/android/features/buy/presents/src/main/kotlin/com/gemwallet/android/features/buy/views/FiatScene.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -28,6 +27,7 @@ import com.gemwallet.android.features.buy.viewmodels.models.FiatSceneState
 import com.gemwallet.android.features.buy.viewmodels.models.FiatSuggestion
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.components.buttons.RandomGradientButton
 import com.gemwallet.android.ui.components.fields.AmountField
 import com.gemwallet.android.ui.components.image.AsyncImage
@@ -64,7 +64,7 @@ fun BuyScene(
     selectedProvider: BuyFiatProviderUIModel?,
     fiatAmount: String,
     suggestedAmounts: List<FiatSuggestion>,
-    urlLoading: State<Boolean>,
+    buttonState: ButtonState,
     cancelAction: CancelAction,
     titleContent: @Composable () -> Unit,
     onLotSelect: (FiatSuggestion) -> Unit,
@@ -93,8 +93,7 @@ fun BuyScene(
         mainAction = {
             MainActionButton(
                 title = stringResource(R.string.common_continue),
-                enabled = state == FiatSceneState.Ready && selectedProvider != null,
-                loading = urlLoading.value,
+                state = buttonState,
                 onClick = onBuy,
             )
         }

--- a/android/features/buy/viewmodels/src/main/kotlin/com/gemwallet/android/features/buy/viewmodels/FiatViewModel.kt
+++ b/android/features/buy/viewmodels/src/main/kotlin/com/gemwallet/android/features/buy/viewmodels/FiatViewModel.kt
@@ -21,6 +21,8 @@ import com.gemwallet.android.model.CryptoFiatConverter
 import com.gemwallet.android.model.Fiat
 import com.gemwallet.android.model.hasAvailable
 import com.gemwallet.android.ui.components.list_item.AssetInfoUIModel
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import com.gemwallet.android.ui.models.navigation.RouteArgument
 import com.gemwallet.android.ui.models.navigation.requireAssetId
 import com.wallet.core.primitives.Currency
@@ -224,6 +226,10 @@ class FiatViewModel @Inject constructor(
     val selectedProvider = combine(assetInfoUIModel, currentSelectedQuote) { asset, quote ->
         return@combine asset?.let { quote?.toProviderUIModel(asset.asset, currency) }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val buttonState = combine(state, selectedProvider) { state, provider ->
+        buttonState(enabled = state == FiatSceneState.Ready && provider != null)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ButtonState.Disabled)
 
     fun updateAmount(newAmount: String) {
         currentOperation().updateAmount(newAmount)

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -72,7 +72,6 @@ import com.gemwallet.android.ui.localizedDescription
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.models.actions.CancelAction
 import com.gemwallet.android.ui.models.actions.FinishConfirmAction
-import com.gemwallet.android.ui.models.hasCriticalWarning
 import com.gemwallet.android.ui.requestAuth
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.features.confirm.presents.components.confirmBalanceChangesContent
@@ -100,6 +99,7 @@ fun ConfirmScreen(
     val feeAssetInfo by viewModel.feeAssetInfo.collectAsStateWithLifecycle()
     val simulation by viewModel.simulation.collectAsStateWithLifecycle()
     val detailElements by viewModel.detailElements.collectAsStateWithLifecycle()
+    val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
     val isWalletConnect = params is ConfirmParams.TransferParams.Generic
     val displayTxProperties = if (isWalletConnect) txProperties.reorderWalletConnectProperties() else txProperties
 
@@ -131,10 +131,7 @@ fun ConfirmScreen(
         mainAction = {
             MainActionButton(
                 title = state.buttonLabel(),
-                enabled = state !is ConfirmState.Prepare
-                    && state !is ConfirmState.Sending
-                    && !simulation.warnings.hasCriticalWarning(),
-                loading = state is ConfirmState.Sending || state is ConfirmState.Prepare || state is ConfirmState.Result,
+                state = buttonState,
                 onClick = {
                     context.requestAuth(AuthRequest.Confirmation) {
                         viewModel.send(finishAction)

--- a/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
+++ b/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
@@ -25,6 +25,9 @@ import com.gemwallet.android.ui.models.swap.SwapDetailsUIModelFactory
 import com.gemwallet.android.ui.models.swap.SwapDetailsUIModelInput
 import com.gemwallet.android.ui.models.swap.SwapProviderUIModelFactory
 import com.gemwallet.android.ui.models.actions.FinishConfirmAction
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
+import com.gemwallet.android.ui.models.hasCriticalWarning
 import com.gemwallet.android.domains.confirm.AmountUIModel
 import com.gemwallet.android.features.confirm.models.ConfirmDetailElement
 import com.gemwallet.android.features.confirm.models.PerpetualModifyAutocloseFactory
@@ -111,6 +114,15 @@ class ConfirmViewModel @Inject constructor(
         }
         simulation.copy(headerAsset = asset)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, Simulation())
+
+    val buttonState = combine(state, simulation) { state, simulation ->
+        buttonState(
+            enabled = state !is ConfirmState.Prepare
+                && state !is ConfirmState.Sending
+                && !simulation.warnings.hasCriticalWarning(),
+            loading = state is ConfirmState.Sending || state is ConfirmState.Prepare || state is ConfirmState.Result,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ButtonState.Loading)
 
     private val assetsInfo = request.filterNotNull().mapNotNull {
         if (it is ConfirmParams.SwapParams) {

--- a/android/features/create_wallet/presents/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/CheckPhrase.kt
+++ b/android/features/create_wallet/presents/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/CheckPhrase.kt
@@ -25,6 +25,7 @@ import com.gemwallet.android.ui.DisableScreenShooting
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.CenteredDescriptionText
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.buttonState
 import com.gemwallet.android.ui.components.screen.PhraseLayout
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.theme.SceneSizing
@@ -44,6 +45,7 @@ private const val verifyGroupCount = 3
 @Composable
 internal fun CheckPhrase(
     words: List<String>,
+    loading: Boolean,
     onDone: () -> Unit,
     onCancel: () -> Unit,
 ) {
@@ -94,7 +96,7 @@ internal fun CheckPhrase(
         mainAction = {
             MainActionButton(
                 title = stringResource(id = R.string.common_continue),
-                enabled = isDone,
+                state = buttonState(enabled = isDone, loading = loading),
             ) {
                 onDone()
             }

--- a/android/features/create_wallet/presents/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/CreateWalletScreen.kt
+++ b/android/features/create_wallet/presents/src/main/kotlin/com/gemwallet/android/features/create_wallet/views/CreateWalletScreen.kt
@@ -72,6 +72,7 @@ fun CreateWalletScreen(
         when (state) {
             true -> CheckPhrase(
                 words = uiState.data,
+                loading = uiState.loading,
                 onDone = { viewModel.handleCreate(onCreated) },
                 onCancel = viewModel::handleCreateDismiss,
             )

--- a/android/features/create_wallet/viewmodels/src/main/kotlin/com/gemwallet/android/features/create_wallet/viewmodels/CreateWalletViewModel.kt
+++ b/android/features/create_wallet/viewmodels/src/main/kotlin/com/gemwallet/android/features/create_wallet/viewmodels/CreateWalletViewModel.kt
@@ -58,6 +58,9 @@ class CreateWalletViewModel @Inject constructor(
     }
 
     fun handleCreate(onCreated: (walletId: WalletId?) -> Unit) {
+        if (state.value.loading) {
+            return
+        }
         state.update { it.copy(isShowSafeMessage = true, loading = true) }
         viewModelScope.launch(Dispatchers.IO) {
             val phrase = state.value.data.joinToString(" ")

--- a/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/views/ImportScreen.kt
+++ b/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/views/ImportScreen.kt
@@ -56,6 +56,8 @@ import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.InfoBottomSheet
 import com.gemwallet.android.ui.components.InfoSheetEntity
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import com.gemwallet.android.ui.components.list_item.listItem
 import com.gemwallet.android.ui.components.parseMarkdownToAnnotatedString
 import com.gemwallet.android.ui.components.screen.Scene
@@ -111,6 +113,7 @@ fun ImportScreen(
         chainName = uiState.chainName,
         nameRecord = uiState.nameRecord,
         dataError = uiState.dataError,
+        buttonState = buttonState(loading = uiState.loading),
         onImport = { generatedName, value, nameRecord ->
             viewModel.import(generatedName, value, nameRecord, onImported)
         },
@@ -163,6 +166,7 @@ private fun ImportScene(
     chainName: String,
     nameRecord: NameRecord?,
     dataError: ImportError?,
+    buttonState: ButtonState,
     onImport: (generatedName: String, value: String, nameRecord: NameRecord?) -> Unit,
     onTypeChange: (WalletType) -> Unit,
     onCancel: () -> Unit
@@ -189,6 +193,7 @@ private fun ImportScene(
         mainAction = {
             MainActionButton(
                 title = stringResource(id = R.string.wallet_import_action),
+                state = buttonState,
                 onClick = {
                     onImport(generatedName, inputState.value.text, nameRecordState.value)
                 },
@@ -359,6 +364,7 @@ fun PreviewImportAddress() {
                 chainName = "Ethereum",
                 nameRecord = null,
                 dataError = null,
+                buttonState = ButtonState.Enabled,
                 onImport = {_, _, _ -> },
                 onTypeChange = {},
                 onCancel = {},

--- a/android/features/import_wallet/viewmodels/src/main/kotlin/com/gemwallet/android/features/import_wallet/viewmodels/ImportViewModel.kt
+++ b/android/features/import_wallet/viewmodels/src/main/kotlin/com/gemwallet/android/features/import_wallet/viewmodels/ImportViewModel.kt
@@ -59,29 +59,34 @@ class ImportViewModel @Inject constructor(
         data: String,
         nameRecord: NameRecord?,
         onImported: (WalletImportResult) -> Unit
-    ) = viewModelScope.launch(Dispatchers.IO) {
+    ) {
+        if (state.value.loading) {
+            return
+        }
         state.update { it.copy(loading = true) }
 
-        try {
-            val result = importWalletService.importWallet(
-                importType = state.value.importType,
-                walletName = nameRecord?.name?.takeIf { it.isNotBlank() } ?: generatedName,
-                data = if (nameRecord?.address.isNullOrEmpty()) data.trim() else nameRecord.address,
-            )
-            state.update { it.copy(dataError = null, loading = false) }
-            withContext(Dispatchers.Main) {
-                when (result) {
-                    is WalletImportResult.New -> onImported(result)
-                    is WalletImportResult.Existing -> {
-                        setCurrentWallet.setCurrentWallet(result.wallet.id)
-                        state.update {
-                            it.copy(existingWalletResult = result, loading = false)
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val result = importWalletService.importWallet(
+                    importType = state.value.importType,
+                    walletName = nameRecord?.name?.takeIf { it.isNotBlank() } ?: generatedName,
+                    data = if (nameRecord?.address.isNullOrEmpty()) data.trim() else nameRecord.address,
+                )
+                state.update { it.copy(dataError = null, loading = false) }
+                withContext(Dispatchers.Main) {
+                    when (result) {
+                        is WalletImportResult.New -> onImported(result)
+                        is WalletImportResult.Existing -> {
+                            setCurrentWallet.setCurrentWallet(result.wallet.id)
+                            state.update {
+                                it.copy(existingWalletResult = result, loading = false)
+                            }
                         }
                     }
                 }
+            } catch (err: Throwable) {
+                state.update { it.copy(dataError = (err as? ImportError) ?: ImportError.CreateError("Unknown error"), loading = false) }
             }
-        } catch (err: Throwable) {
-            state.update { it.copy(dataError = (err as? ImportError) ?: ImportError.CreateError("Unknown error"), loading = false) }
         }
     }
 

--- a/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/autoclose/AutocloseScene.kt
+++ b/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/autoclose/AutocloseScene.kt
@@ -68,7 +68,7 @@ internal fun AutocloseScene(
             } else {
                 MainActionButton(
                     title = stringResource(R.string.transfer_confirm),
-                    enabled = model.confirmEnabled,
+                    state = model.buttonState,
                     onClick = { onAction(AutocloseAction.Confirm) },
                 )
             }

--- a/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/RecipientScreen.kt
+++ b/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/RecipientScreen.kt
@@ -34,6 +34,7 @@ import com.gemwallet.android.model.DestinationAddress
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.QrCodeScannerModal
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.components.keyboardAsState
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.actions.AmountTransactionAction
@@ -56,6 +57,7 @@ fun RecipientScreen(
     val addressError by viewModel.addressError.collectAsStateWithLifecycle()
     val memoError by viewModel.memoErrorState.collectAsStateWithLifecycle()
     val address by viewModel.address.collectAsStateWithLifecycle()
+    val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
     val memo by viewModel.memo.collectAsStateWithLifecycle()
 
     var scan by remember { mutableStateOf(QrScanField.None) }
@@ -72,6 +74,7 @@ fun RecipientScreen(
                 memoError = memoError,
                 wallets = wallets,
                 contacts = contacts,
+                buttonState = buttonState,
                 onAction = { action ->
                     when (action) {
                         is RecipientAction.SetAddress -> viewModel.onAddress(action.address, action.nameRecord)
@@ -106,6 +109,7 @@ internal fun RecipientScreen(
     memoError: RecipientError,
     wallets: List<Wallet>,
     contacts: List<ContactRecipient>,
+    buttonState: ButtonState,
     onAction: (RecipientAction) -> Unit,
 ) {
     val isKeyBoardOpen by keyboardAsState()
@@ -121,12 +125,14 @@ internal fun RecipientScreen(
             if (!isKeyBoardOpen || !isSmallScreen) {
                 MainActionButton(
                     title = stringResource(id = R.string.common_continue),
+                    state = buttonState,
                     onClick = { onAction(RecipientAction.Next) },
                 )
             }
         },
         actions = {
             TextButton(onClick = { onAction(RecipientAction.Next) },
+                enabled = buttonState == ButtonState.Enabled,
                 colors = ButtonDefaults.textButtonColors()
                     .copy(contentColor = MaterialTheme.colorScheme.primary)
             ) {

--- a/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/RecipientViewModel.kt
+++ b/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/RecipientViewModel.kt
@@ -24,6 +24,8 @@ import com.gemwallet.android.features.recipient.viewmodel.models.RecipientType
 import com.gemwallet.android.model.AmountParams
 import com.gemwallet.android.model.ConfirmParams
 import com.gemwallet.android.model.DestinationAddress
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import com.gemwallet.android.ui.models.actions.AmountTransactionAction
 import com.gemwallet.android.ui.models.actions.ConfirmTransactionAction
 import com.gemwallet.android.ui.models.navigation.RouteArgument
@@ -139,6 +141,19 @@ class RecipientViewModel @Inject constructor(
     }.mutableStateIn(viewModelScope, RecipientError.None)
 
     val memoErrorState = MutableStateFlow<RecipientError>(RecipientError.None)
+
+    val buttonState: StateFlow<ButtonState> = combine(
+        address,
+        nameRecord,
+        addressError,
+    ) { address, record, error ->
+        val valid = when {
+            record != null -> true
+            resolveName.canResolveName(address) -> false
+            else -> address.isNotBlank() && error == RecipientError.None
+        }
+        buttonState(enabled = valid)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ButtonState.Disabled)
 
     val hasMemo: StateFlow<Boolean> = state
         .map {

--- a/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/ReferralScene.kt
+++ b/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/ReferralScene.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -36,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.components.buttons.mainActionButtonColors
 import com.gemwallet.android.ui.components.clickable
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.icons.AppIcons
@@ -167,8 +167,10 @@ fun ReferralScene(
                         Box(modifier = Modifier.padding(horizontal = sceneContentPadding())) {
                             MainActionButton(
                                 title = stringResource(R.string.rewards_activate_referral_code_title),
-                                colors = ButtonDefaults.buttonColors()
-                                    .copy(containerColor = Color.White, contentColor = Color.Black)
+                                colors = mainActionButtonColors(
+                                    containerColor = Color.White,
+                                    contentColor = Color.Black,
+                                ),
                             ) { codeDialogShow = true }
                         }
                         Spacer8()

--- a/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/components/ReferralConfirm.kt
+++ b/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/components/ReferralConfirm.kt
@@ -63,7 +63,7 @@ internal fun LazyListScope.referralConfirmCode(rewards: Rewards, uiState: Reward
             HorizontalDivider(modifier = Modifier.padding(vertical = paddingSmall), thickness = 0.5.dp)
             MainActionButton(
                 title = stringResource(R.string.transfer_confirm),
-                enabled = uiState.canActivatePendingReferral
+                state = uiState.buttonState
             ) {
                 onConfirm(code)
             }

--- a/android/features/referral/viewmodels/src/main/kotlin/com/gemwallet/android/features/referral/viewmodels/RewardsUIState.kt
+++ b/android/features/referral/viewmodels/src/main/kotlin/com/gemwallet/android/features/referral/viewmodels/RewardsUIState.kt
@@ -1,5 +1,7 @@
 package com.gemwallet.android.features.referral.viewmodels
 
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import com.wallet.core.primitives.RewardStatus
 import com.wallet.core.primitives.Rewards
 
@@ -9,6 +11,9 @@ data class RewardsUIState(
     val hasPendingReferral: Boolean,
     val canActivatePendingReferral: Boolean,
 ) {
+    val buttonState: ButtonState
+        get() = buttonState(enabled = canActivatePendingReferral)
+
     companion object {
         fun from(rewards: Rewards?): RewardsUIState {
             if (rewards == null) {

--- a/android/features/referral/viewmodels/src/test/kotlin/com/gemwallet/android/features/referral/viewmodels/RewardsUIStateTest.kt
+++ b/android/features/referral/viewmodels/src/test/kotlin/com/gemwallet/android/features/referral/viewmodels/RewardsUIStateTest.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.referral.viewmodels
 
+import com.gemwallet.android.ui.models.ButtonState
 import com.wallet.core.primitives.RewardStatus
 import com.wallet.core.primitives.Rewards
 import org.junit.Assert.assertEquals
@@ -51,6 +52,7 @@ class RewardsUIStateTest {
         assertEquals(false, state.isUnverified)
         assertEquals(true, state.hasPendingReferral)
         assertEquals(false, state.canActivatePendingReferral)
+        assertEquals(ButtonState.Disabled, state.buttonState)
     }
 
     @Test
@@ -59,6 +61,7 @@ class RewardsUIStateTest {
         val state = RewardsUIState.from(rewards(status = RewardStatus.Pending, verifyAfter = past, usedReferralCode = "ref1"))
         assertEquals(true, state.hasPendingReferral)
         assertEquals(true, state.canActivatePendingReferral)
+        assertEquals(ButtonState.Enabled, state.buttonState)
     }
 
     @Test

--- a/android/features/settings/networks/presents/src/main/kotlin/com/gemwallet/android/features/settings/networks/presents/AddNodeScene.kt
+++ b/android/features/settings/networks/presents/src/main/kotlin/com/gemwallet/android/features/settings/networks/presents/AddNodeScene.kt
@@ -63,8 +63,7 @@ fun AddNodeScene(chain: Chain, onCancel: () -> Unit) {
         mainAction = {
             MainActionButton(
                 title = stringResource(id = R.string.wallet_import_action),
-                enabled = uiModel.canImport,
-                loading = uiModel.checking,
+                state = uiModel.buttonState,
             ) {
                 viewModel.addUrl()
                 onCancel()

--- a/android/features/settings/networks/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/networks/viewmodels/models/AddNodeUIModel.kt
+++ b/android/features/settings/networks/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/networks/viewmodels/models/AddNodeUIModel.kt
@@ -1,6 +1,8 @@
 package com.gemwallet.android.features.settings.networks.viewmodels.models
 
 import com.gemwallet.android.model.NodeStatus
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import com.wallet.core.primitives.Chain
 
 data class AddNodeUIModel(
@@ -11,4 +13,7 @@ data class AddNodeUIModel(
 ) {
     val canImport: Boolean
         get() = status != null && errorResId == null && !checking
+
+    val buttonState: ButtonState
+        get() = buttonState(enabled = canImport, loading = checking)
 }

--- a/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertTargetNavScreen.kt
+++ b/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertTargetNavScreen.kt
@@ -29,6 +29,7 @@ fun PriceAlertTargetNavScreen(
     val asset by viewModel.asset.collectAsStateWithLifecycle()
     val priceChangeFormatted by viewModel.priceChangeFormatted.collectAsStateWithLifecycle()
     val priceState by viewModel.priceState.collectAsStateWithLifecycle()
+    val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
 
     PriceAlertTargetScene(
         value = viewModel.value,
@@ -44,6 +45,7 @@ fun PriceAlertTargetNavScreen(
         assetPriceChangeFormatted = priceChangeFormatted,
         assetValueDirection = priceState,
         error = error,
+        buttonState = buttonState,
         onType = viewModel::onType,
         onDirection = viewModel::onDirection,
         onConfirm = {

--- a/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertTargetScene.kt
+++ b/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertTargetScene.kt
@@ -37,6 +37,7 @@ import com.gemwallet.android.domains.price.ValueDirection
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.TabsBar
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.components.clickable
 import com.gemwallet.android.ui.components.image.AssetIcon
 import com.gemwallet.android.ui.components.list_item.Badge
@@ -78,6 +79,7 @@ fun PriceAlertTargetScene(
     assetPriceChangeFormatted: String = "",
     assetValueDirection: ValueDirection = ValueDirection.None,
     error: PriceAlertTargetError?,
+    buttonState: ButtonState,
     onType: (PriceAlertNotificationType) -> Unit,
     onDirection: (PriceAlertDirection) -> Unit,
     onConfirm: () -> Unit,
@@ -135,7 +137,7 @@ fun PriceAlertTargetScene(
             } else {
                 MainActionButton(
                     title = stringResource(R.string.transfer_confirm),
-                    enabled = error == null,
+                    state = buttonState,
                     onClick = onConfirm,
                 )
             }
@@ -278,6 +280,7 @@ fun PriceAlertTargetScenePricePreview() {
             priceSuggestions = listOf("$850" to "850", "$950" to "950"),
             percentageSuggestions = listOf(3, 6, 9),
             error = null,
+            buttonState = ButtonState.Enabled,
             onType = {},
             onDirection = {},
             onConfirm = {},
@@ -300,6 +303,7 @@ fun PriceAlertTargetScenePercentagePreview() {
             priceSuggestions = listOf("$850" to "850", "$950" to "950"),
             percentageSuggestions = listOf(3, 6, 9),
             error = null,
+            buttonState = ButtonState.Enabled,
             onType = {},
             onDirection = {},
             onConfirm = {},

--- a/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/PriceAlertTargetViewModel.kt
+++ b/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/PriceAlertTargetViewModel.kt
@@ -15,6 +15,8 @@ import com.gemwallet.android.domains.price.toValueDirection
 import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.features.settings.price_alerts.viewmodels.models.PriceAlertConfirmResult
 import com.gemwallet.android.features.settings.price_alerts.viewmodels.models.PriceAlertTargetError
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import com.gemwallet.android.ui.models.navigation.RouteArgument
 import com.gemwallet.android.ui.models.navigation.requireAssetId
 import com.wallet.core.primitives.Asset
@@ -90,6 +92,10 @@ class PriceAlertTargetViewModel @Inject constructor(
         }
     }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val buttonState: StateFlow<ButtonState> = error
+        .map { buttonState(enabled = it == null) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, buttonState(enabled = error.value == null))
 
     private val _direction = MutableStateFlow(PriceAlertDirection.Up)
     val direction: StateFlow<PriceAlertDirection> = _direction

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/components/SwapAction.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/components/SwapAction.kt
@@ -1,9 +1,6 @@
 package com.gemwallet.android.features.swap.views.components
 
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -11,8 +8,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.progress.CircularProgressIndicator20
-import com.gemwallet.android.ui.theme.mainActionHeight
 import com.gemwallet.android.ui.theme.paddingHalfSmall
 import com.gemwallet.android.features.swap.viewmodels.models.SwapActionState
 import com.gemwallet.android.features.swap.viewmodels.models.SwapError
@@ -24,19 +21,9 @@ internal fun SwapAction(
     onSwap: () -> Unit,
 ) {
     val action = swapState.action
-    Button(
-        modifier = Modifier
-            .fillMaxWidth()
-            .heightIn(mainActionHeight),
+    MainActionButton(
+        state = swapState.buttonState,
         onClick = onSwap,
-        enabled = when (action) {
-            SwapActionState.Ready,
-            is SwapActionState.TransferError -> true
-            is SwapActionState.QuoteError -> action.error !is SwapError.InsufficientBalance
-            SwapActionState.None,
-            SwapActionState.QuoteLoading,
-            SwapActionState.TransferLoading -> false
-        }
     ) {
         when (action) {
             SwapActionState.None,

--- a/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/models/SwapUiState.kt
+++ b/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/models/SwapUiState.kt
@@ -3,6 +3,8 @@ package com.gemwallet.android.features.swap.viewmodels.models
 import com.gemwallet.android.application.swap.coordinators.SwapQuoteRequestKey
 import com.gemwallet.android.application.swap.coordinators.SwapQuotesResult
 import com.gemwallet.android.application.swap.coordinators.getQuote
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import uniffi.gemstone.SwapperProvider
 
 sealed interface SwapActionState {
@@ -48,6 +50,16 @@ data class SwapUiState(
             SwapActionState.QuoteLoading,
             SwapActionState.Ready,
             SwapActionState.TransferLoading -> null
+        }
+
+    val buttonState: ButtonState
+        get() = when (val currentAction = action) {
+            SwapActionState.Ready,
+            is SwapActionState.TransferError -> ButtonState.Enabled
+            is SwapActionState.QuoteError -> buttonState(enabled = currentAction.error !is SwapError.InsufficientBalance)
+            SwapActionState.QuoteLoading,
+            SwapActionState.TransferLoading -> ButtonState.Loading
+            SwapActionState.None -> ButtonState.Disabled
         }
 
     val isReceiveLoading: Boolean

--- a/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/AmountScene.kt
+++ b/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/AmountScene.kt
@@ -40,6 +40,7 @@ import com.gemwallet.android.ui.components.list_item.property.PropertyAssetInfoI
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.models.AmountInputType
+import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.theme.Spacer16
 import com.gemwallet.android.ui.theme.secondaryFaded
 import com.gemwallet.android.ui.theme.paddingMiddle
@@ -61,6 +62,7 @@ internal fun AmountScene(
     equivalent: String,
     availableBalance: String,
     reserveForFee: String? = null,
+    buttonState: ButtonState,
     onAction: (AmountAction) -> Unit,
     additionParams: (@Composable () -> Unit)? = null,
 ) {
@@ -78,6 +80,7 @@ internal fun AmountScene(
             if (!isKeyBoardOpen || !isSmallScreen) {
                 MainActionButton(
                     title = stringResource(id = R.string.common_continue),
+                    state = buttonState,
                     onClick = { onAction(AmountAction.Next) },
                 )
             }
@@ -85,6 +88,7 @@ internal fun AmountScene(
         actions = {
             TextButton(
                 onClick = { onAction(AmountAction.Next) },
+                enabled = buttonState == ButtonState.Enabled,
                 colors = ButtonDefaults.textButtonColors().copy(contentColor = MaterialTheme.colorScheme.primary),
             ) { Text(stringResource(R.string.common_continue).uppercase()) }
         },

--- a/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/AmountScreen.kt
+++ b/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/AmountScreen.kt
@@ -40,6 +40,7 @@ fun AmountScreen(
     val available by viewModel.availableBalanceFormatted.collectAsStateWithLifecycle()
     val reserve by viewModel.reserveForFeeFormatted.collectAsStateWithLifecycle()
     val currency by viewModel.currency.collectAsStateWithLifecycle()
+    val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
 
     AnimatedContent(
         isSelectValidator && canPickValidator,
@@ -74,6 +75,7 @@ fun AmountScreen(
                 equivalent = equivalent,
                 availableBalance = available,
                 reserveForFee = reserve,
+                buttonState = buttonState,
                 onAction = { action ->
                     when (action) {
                         AmountAction.Next -> viewModel.onNext(onConfirm)

--- a/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/dialogs/AmountAutocloseSheet.kt
+++ b/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/dialogs/AmountAutocloseSheet.kt
@@ -25,6 +25,7 @@ import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.NumericFormatter
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.models.buttonState
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.components.PercentSuggestionsBar
 import com.gemwallet.android.ui.components.perpetual.AutocloseInputSection
@@ -166,7 +167,7 @@ internal fun AmountAutocloseSheet(
             } else {
                 MainActionButton(
                     title = stringResource(R.string.common_done),
-                    enabled = confirmEnabled,
+                    state = buttonState(enabled = confirmEnabled),
                     onClick = {
                         submitAttempted = true
                         if (isTakeProfitValid && isStopLossValid) {

--- a/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountViewModel.kt
+++ b/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountViewModel.kt
@@ -20,6 +20,8 @@ import com.gemwallet.android.model.ValueConverter
 import com.gemwallet.android.model.ValueFormatter
 import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.ui.models.AmountInputType
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.Currency
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -84,6 +86,14 @@ class AmountViewModel @Inject constructor(
     val currency: StateFlow<Currency> = provider.assetInfo
         .mapLatest { it?.price?.currency ?: Currency.USD }
         .stateIn(viewModelScope, SharingStarted.Eagerly, Currency.USD)
+
+    val buttonState: StateFlow<ButtonState> = combine(
+        snapshotFlow { amount },
+        amountError,
+    ) { input, error ->
+        val valid = (input.parseNumberOrNull()?.signum() ?: 0) > 0 && error is AmountError.None
+        buttonState(enabled = valid)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ButtonState.Disabled)
 
     init {
         combine(

--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/ButtonState.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/ButtonState.kt
@@ -1,0 +1,13 @@
+package com.gemwallet.android.ui.models
+
+enum class ButtonState {
+    Enabled,
+    Loading,
+    Disabled,
+}
+
+fun buttonState(enabled: Boolean = true, loading: Boolean = false): ButtonState = when {
+    loading -> ButtonState.Loading
+    enabled -> ButtonState.Enabled
+    else -> ButtonState.Disabled
+}

--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/perpetual/autoclose/AutocloseUIModel.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/perpetual/autoclose/AutocloseUIModel.kt
@@ -3,6 +3,8 @@ package com.gemwallet.android.ui.models.perpetual.autoclose
 import com.gemwallet.android.domains.perpetual.aggregates.PerpetualPositionDataAggregate
 import com.gemwallet.android.domains.perpetual.autoclose.AutocloseError
 import com.gemwallet.android.domains.price.ValueDirection
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.buttonState
 import com.wallet.core.primitives.TpslType
 
 data class AutocloseUIModel(
@@ -13,6 +15,9 @@ data class AutocloseUIModel(
     val stopLoss: Field,
     val confirmEnabled: Boolean,
 ) {
+    val buttonState: ButtonState
+        get() = buttonState(enabled = confirmEnabled)
+
     data class Field(
         val type: TpslType,
         val isProfit: Boolean,

--- a/android/ui-models/src/test/kotlin/com/gemwallet/android/ui/models/ButtonStateTest.kt
+++ b/android/ui-models/src/test/kotlin/com/gemwallet/android/ui/models/ButtonStateTest.kt
@@ -1,0 +1,34 @@
+package com.gemwallet.android.ui.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ButtonStateTest {
+
+    @Test
+    fun loadingTakesPrecedenceOverEnabledAndDisabled() {
+        assertEquals(ButtonState.Loading, buttonState(enabled = true, loading = true))
+        assertEquals(ButtonState.Loading, buttonState(enabled = false, loading = true))
+    }
+
+    @Test
+    fun enabledOnlyWhenEnabledAndNotLoading() {
+        assertEquals(ButtonState.Enabled, buttonState(enabled = true, loading = false))
+        assertEquals(ButtonState.Disabled, buttonState(enabled = false, loading = false))
+    }
+
+    @Test
+    fun defaultsToEnabled() {
+        assertEquals(ButtonState.Enabled, buttonState())
+    }
+
+    @Test
+    fun onlyEnabledStateIsInteractive() {
+        for (enabled in listOf(true, false)) {
+            for (loading in listOf(true, false)) {
+                val interactive = buttonState(enabled = enabled, loading = loading) == ButtonState.Enabled
+                assertEquals(enabled && !loading, interactive)
+            }
+        }
+    }
+}

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/buttons/MainActionButton.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/buttons/MainActionButton.kt
@@ -11,24 +11,26 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.gemwallet.android.ui.components.progress.CircularProgressIndicator20
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.theme.alpha50
 import com.gemwallet.android.ui.theme.mainActionHeight
 
 @Composable
 fun MainActionButton(
     title: String,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    loading: Boolean = false,
-    colors: ButtonColors = ButtonDefaults.buttonColors(),
+    state: ButtonState = ButtonState.Enabled,
+    colors: ButtonColors = mainActionButtonColors(),
     onClick: () -> Unit,
 ) {
-    MainActionButton(modifier, enabled && !loading, colors, onClick) {
-        if (loading) {
-            CircularProgressIndicator20(color = MaterialTheme.colorScheme.onPrimary)
+    MainActionButton(modifier, state, colors, onClick) {
+        if (state == ButtonState.Loading) {
+            CircularProgressIndicator20(color = colors.contentColor)
         } else {
             Text(
                 modifier = Modifier.padding(4.dp),
@@ -42,8 +44,8 @@ fun MainActionButton(
 @Composable
 fun MainActionButton(
     modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    colors: ButtonColors = ButtonDefaults.buttonColors(),
+    state: ButtonState = ButtonState.Enabled,
+    colors: ButtonColors = mainActionButtonColors(),
     onClick: () -> Unit,
     content: @Composable RowScope.() -> Unit
 ) {
@@ -53,17 +55,34 @@ fun MainActionButton(
             .heightIn(min = mainActionHeight)
             .testTag("main_action"),
         onClick = onClick,
-        enabled = enabled,
-        colors = colors,
+        enabled = state == ButtonState.Enabled,
+        colors = colors.forState(state),
     ) {
         content()
     }
 }
 
-@Composable
-fun secondaryActionButtonColors(): ButtonColors {
-    return ButtonDefaults.buttonColors().copy(
-        containerColor = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.onSurface,
+private fun ButtonColors.forState(state: ButtonState): ButtonColors = when (state) {
+    ButtonState.Loading -> copy(
+        disabledContainerColor = containerColor,
+        disabledContentColor = contentColor,
     )
+    else -> this
 }
+
+@Composable
+fun mainActionButtonColors(
+    containerColor: Color = MaterialTheme.colorScheme.primary,
+    contentColor: Color = MaterialTheme.colorScheme.onPrimary,
+): ButtonColors = ButtonDefaults.buttonColors(
+    containerColor = containerColor,
+    contentColor = contentColor,
+    disabledContainerColor = containerColor.copy(alpha = alpha50),
+    disabledContentColor = contentColor,
+)
+
+@Composable
+fun secondaryActionButtonColors(): ButtonColors = mainActionButtonColors(
+    containerColor = MaterialTheme.colorScheme.surface,
+    contentColor = MaterialTheme.colorScheme.onSurface,
+)


### PR DESCRIPTION
The main button now has one state instead of two separate flags, so every screen behaves the same.

A disabled button is clearly faded and cannot be tapped. While loading it keeps its normal colour and shows a spinner, like on iOS.

On the Amount screen the continue button stays disabled until a valid amount is entered.

Closes #317