### PR TITLE
Add swap slippage percent suggestions and info

### DIFF
--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScreen.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScreen.kt
@@ -34,6 +34,7 @@ fun SwapScreen(
     val toEquivalent by viewModel.toEquivalentFormatted.collectAsStateWithLifecycle()
     val swapState by viewModel.uiState.collectAsStateWithLifecycle()
     val swapDetails by viewModel.swapDetails.collectAsStateWithLifecycle()
+    val selectedSlippage by viewModel.selectedSlippage.collectAsStateWithLifecycle()
 
     var isShowPriceImpactAlert by remember { mutableStateOf(false) }
     var isShowDetails by remember { mutableStateOf(false) }
@@ -72,7 +73,7 @@ fun SwapScreen(
                 SwapSceneAction.SwitchAssets -> viewModel.switchSwap()
                 SwapSceneAction.ShowDetails -> isShowDetails = true
                 SwapSceneAction.Slippage -> if (swapState.isQuoteInteractionEnabled) {
-                    slippageSeedBps = swapDetails?.selectedSlippage
+                    slippageSeedBps = selectedSlippage
                     isShowSlippage = true
                 }
                 SwapSceneAction.Swap -> viewModel.onPrimaryAction(

--- a/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModel.kt
+++ b/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModel.kt
@@ -55,6 +55,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.firstOrNull
@@ -99,6 +101,7 @@ class SwapViewModel @Inject constructor(
 
     val selectedProvider = MutableStateFlow<SwapperProvider?>(null)
     private val selectedSlippageBps = MutableStateFlow<UInt?>(null)
+    val selectedSlippage: StateFlow<UInt?> = selectedSlippageBps.asStateFlow()
 
     val slippageWarningThresholdBps: UInt by lazy { Config().getSwapConfig().highSlippageWarningBps }
 

--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/swap/SwapSlippage.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/swap/SwapSlippage.kt
@@ -6,6 +6,7 @@ import java.math.BigDecimal
 
 object SwapSlippage {
     val defaultBps: UInt = 100u
+    val suggestionsBps: List<UInt> = listOf(30u, 50u, 300u)
     const val maxPercent: Int = 20
     private val minPercent: BigDecimal = BigDecimal("0.1")
 

--- a/android/ui-models/src/test/kotlin/com/gemwallet/android/ui/models/swap/SwapSlippageTest.kt
+++ b/android/ui-models/src/test/kotlin/com/gemwallet/android/ui/models/swap/SwapSlippageTest.kt
@@ -50,6 +50,12 @@ class SwapSlippageTest {
     }
 
     @Test
+    fun suggestions_formatToExpectedLabels() {
+        assertEquals(listOf(30u, 50u, 300u), SwapSlippage.suggestionsBps)
+        assertEquals(listOf("0.3", "0.5", "3"), SwapSlippage.suggestionsBps.map { SwapSlippage.format(it) })
+    }
+
+    @Test
     fun sanitize_limitsFractionAndIntegerDigits() {
         assertEquals("0.11", SwapSlippage.sanitize("0.111111"))
         assertEquals("33", SwapSlippage.sanitize("33333312312"))

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/PercentSuggestionsBar.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/PercentSuggestionsBar.kt
@@ -17,18 +17,31 @@ fun PercentSuggestionsBar(
     modifier: Modifier = Modifier,
     onPercentSelected: (Int) -> Unit,
 ) {
+    SuggestionsBar(
+        labels = suggestions.map { "$it%" },
+        modifier = modifier,
+        onSelected = { index -> onPercentSelected(suggestions[index]) },
+    )
+}
+
+@Composable
+fun SuggestionsBar(
+    labels: List<String>,
+    modifier: Modifier = Modifier,
+    onSelected: (Int) -> Unit,
+) {
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(paddingSmall),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        suggestions.forEach { percent ->
+        labels.forEachIndexed { index, label ->
             SuggestionChip(
                 modifier = Modifier.weight(1f),
-                onClick = { onPercentSelected(percent) },
+                onClick = { onSelected(index) },
                 label = {
                     Text(
-                        text = "$percent%",
+                        text = label,
                         modifier = Modifier.fillMaxWidth(),
                         textAlign = TextAlign.Center,
                     )

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapSlippageBottomSheet.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapSlippageBottomSheet.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.ui.components.swap
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -25,7 +26,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.InfoSheetEntity
 import com.gemwallet.android.ui.components.SuffixTextField
+import com.gemwallet.android.ui.components.SuggestionsBar
 import com.gemwallet.android.ui.components.list_item.SwitchProperty
 import com.gemwallet.android.ui.components.list_item.listItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyTitleText
@@ -71,7 +74,11 @@ fun SwapSlippageBottomSheet(
             onDispose { commit() }
         }
 
-        Column(modifier = Modifier.height(SlippageSheetHeight)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(SlippageSheetHeight),
+        ) {
             SwitchProperty(
                 text = stringResource(R.string.swap_slippage_auto),
                 checked = isAuto,
@@ -90,7 +97,10 @@ fun SwapSlippageBottomSheet(
                         .padding(paddingDefault),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    PropertyTitleText(stringResource(R.string.swap_slippage))
+                    PropertyTitleText(
+                        stringResource(R.string.swap_slippage),
+                        info = InfoSheetEntity.Slippage,
+                    )
                     SuffixTextField(
                         modifier = Modifier
                             .weight(1f)
@@ -116,6 +126,12 @@ fun SwapSlippageBottomSheet(
                         color = MaterialTheme.colorScheme.error,
                     )
                 }
+                Spacer(modifier = Modifier.weight(1f))
+                SuggestionsBar(
+                    labels = SwapSlippage.suggestionsBps.map { "${SwapSlippage.format(it)}%" },
+                    modifier = Modifier.padding(horizontal = paddingDefault, vertical = paddingSmall),
+                    onSelected = { index -> input = SwapSlippage.format(SwapSlippage.suggestionsBps[index]) },
+                )
             }
         }
 

--- a/ios/Features/Swap/Sources/Types/SlippageSuggestion.swift
+++ b/ios/Features/Swap/Sources/Types/SlippageSuggestion.swift
@@ -1,0 +1,22 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import PrimitivesComponents
+
+public struct SlippageSuggestion: SuggestionViewable {
+    public let id: UInt32
+    private let percentText: String
+
+    public var title: String {
+        "\(percentText)%"
+    }
+
+    public var inputValue: String {
+        percentText
+    }
+
+    public init(bps: UInt32, percentText: String) {
+        id = bps
+        self.percentText = percentText
+    }
+}

--- a/ios/Features/Swap/Sources/ViewModels/SwapSlippageViewModel.swift
+++ b/ios/Features/Swap/Sources/ViewModels/SwapSlippageViewModel.swift
@@ -3,6 +3,7 @@
 import Formatters
 import Foundation
 import GemstonePrimitives
+import InfoSheet
 import Localization
 import Primitives
 import PrimitivesComponents
@@ -12,6 +13,7 @@ import Validators
 @Observable
 public final class SwapSlippageViewModel {
     private static let defaultBps: UInt32 = 100
+    private static let suggestionsBps: [UInt32] = [30, 50, 300]
     static let minPercent: Double = 0.1
     static let maxPercent: Double = 20
     private static let maxFractionDigits: Int = 2
@@ -23,6 +25,7 @@ public final class SwapSlippageViewModel {
 
     var isAuto: Bool
     var inputModel: InputValidationViewModel
+    var infoSheet: InfoSheetType?
 
     public init(slippage: SwapSlippage, onSelect: @escaping (SwapSlippage) -> Void) {
         self.onSelect = onSelect
@@ -70,6 +73,18 @@ public final class SwapSlippageViewModel {
     var warningText: String? {
         guard inputModel.isValid, selectedBps >= highWarningBps else { return nil }
         return Localized.Swap.slippageWarning
+    }
+
+    var suggestions: [SlippageSuggestion] {
+        Self.suggestionsBps.map { SlippageSuggestion(bps: $0, percentText: Self.format(bps: $0)) }
+    }
+
+    func onSelect(suggestion: SlippageSuggestion) {
+        inputModel.text = suggestion.inputValue
+    }
+
+    func onSelectInfo() {
+        infoSheet = .slippage
     }
 
     func sanitize(_ text: String) -> String {

--- a/ios/Features/Swap/Sources/Views/SwapSlippageScene.swift
+++ b/ios/Features/Swap/Sources/Views/SwapSlippageScene.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Components
+import InfoSheet
 import PrimitivesComponents
 import Style
 import SwiftUI
@@ -35,6 +36,7 @@ public struct SwapSlippageScene: View {
                             Text(model.title)
                                 .lineLimit(1)
                                 .fixedSize(horizontal: true, vertical: false)
+                            InfoButton { model.onSelectInfo() }
                             SuffixTextField(
                                 suffix: "%",
                                 sanitizer: model.sanitize,
@@ -58,6 +60,16 @@ public struct SwapSlippageScene: View {
             .navigationBarTitleDisplayMode(.inline)
             .listSectionSpacing(.compact)
             .contentMargins([.top], .small, for: .scrollContent)
+            .safeAreaView {
+                if focusedField == .slippage {
+                    SuggestionsAccessoryView(
+                        suggestions: model.suggestions,
+                        onSelect: { model.onSelect(suggestion: $0) },
+                        onDone: { focusedField = nil },
+                    )
+                    .padding(.small)
+                }
+            }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("", systemImage: SystemImage.checkmark) {
@@ -74,6 +86,9 @@ public struct SwapSlippageScene: View {
                 if !model.isAuto {
                     focusedField = .slippage
                 }
+            }
+            .sheet(item: $model.infoSheet) {
+                InfoSheetScene(type: $0)
             }
         }
     }

--- a/ios/Features/Swap/Tests/SwapTests/SwapSlippageViewModelTests.swift
+++ b/ios/Features/Swap/Tests/SwapTests/SwapSlippageViewModelTests.swift
@@ -99,6 +99,24 @@ struct SwapSlippageViewModelTests {
     }
 
     @Test
+    func suggestionsProvideExpectedValues() {
+        let model = SwapSlippageViewModel(slippage: .auto) { _ in }
+
+        #expect(model.suggestions.map(\.title) == ["0.3%", "0.5%", "3%"])
+        #expect(model.suggestions.map(\.inputValue) == ["0.3", "0.5", "3"])
+    }
+
+    @Test
+    func onSelectSuggestionUpdatesInput() {
+        let model = SwapSlippageViewModel(slippage: .auto) { _ in }
+        model.isAuto = false
+        model.onSelect(suggestion: model.suggestions[2])
+
+        #expect(model.inputModel.text == "3")
+        #expect(model.selectedBps == 300)
+    }
+
+    @Test
     func maximumBoundaryIsValid() {
         let model = SwapSlippageViewModel(slippage: .auto) { _ in }
         model.isAuto = false


### PR DESCRIPTION
Adds quick percent suggestions (0.3%, 0.5%, 3%) above the keyboard in the swap slippage input, plus an info button explaining slippage.

On Android, a custom slippage now stays set after reopening the sheet.

<img width="320" alt="Screenshot_1783715537" src="https://github.com/user-attachments/assets/9ef8013d-0eec-4485-b195-12ae572df7c1" />
<img width="320" alt="Simulator Screenshot - wt1 - 2026-07-11 at 00 21 43" src="https://github.com/user-attachments/assets/ee0e6355-4928-4ef7-a833-651c70d59db3" />
