### PR TITLE
Deduplicate Resource title mapping on Android

### DIFF
--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsScene.kt
@@ -28,11 +28,11 @@ import com.gemwallet.android.ui.components.list_item.color
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
 import com.gemwallet.android.ui.components.list_item.transaction.getTitle
 import com.gemwallet.android.ui.components.screen.Scene
+import com.gemwallet.android.ui.components.titleRes
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.theme.padding16
 import com.gemwallet.android.ui.theme.paddingSmall
 import com.wallet.core.primitives.Asset
-import com.wallet.core.primitives.Resource
 import com.wallet.core.primitives.TransactionType
 
 @Composable
@@ -99,7 +99,7 @@ internal fun TransactionDetailsScene(
                         is TransactionDetailsValue.Memo -> PropertyItem(R.string.transfer_memo, item.data, listPosition = position)
                         is TransactionDetailsValue.ResourceType -> PropertyItem(
                             R.string.stake_resource,
-                            item.data.resourceTitle(),
+                            stringResource(item.data.titleRes()),
                             listPosition = position,
                         )
                         is TransactionDetailsValue.Network -> PropertyNetworkItem(item.data.chain, listPosition = position)
@@ -148,10 +148,4 @@ private fun TransactionDetailsAggregate.amountAction(asset: Asset): TransactionD
         TransactionType.EarnDeposit,
         TransactionType.EarnWithdraw -> null
     }
-}
-
-@Composable
-private fun Resource.resourceTitle(): String = when (this) {
-    Resource.Bandwidth -> stringResource(R.string.stake_resource_bandwidth)
-    Resource.Energy -> stringResource(R.string.stake_resource_energy)
 }

--- a/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/ProviderExtras.kt
+++ b/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/ProviderExtras.kt
@@ -23,6 +23,7 @@ import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.InfoSheetEntity
 import com.gemwallet.android.ui.components.TabsBar
+import com.gemwallet.android.ui.components.titleRes
 import com.gemwallet.android.ui.components.clickable
 import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.ui.components.list_item.SubheaderItem
@@ -90,10 +91,7 @@ private fun StakeResourceSection(provider: AmountStakeProvider) {
         selected = resource,
         onSelect = provider::setResource,
     ) { item ->
-        Text(stringResource(when (item) {
-            Resource.Bandwidth -> R.string.stake_resource_bandwidth
-            Resource.Energy -> R.string.stake_resource_energy
-        }))
+        Text(stringResource(item.titleRes()))
     }
 }
 

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/ResourceExt.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/ResourceExt.kt
@@ -1,0 +1,11 @@
+package com.gemwallet.android.ui.components
+
+import androidx.annotation.StringRes
+import com.gemwallet.android.ui.R
+import com.wallet.core.primitives.Resource
+
+@StringRes
+fun Resource.titleRes(): Int = when (this) {
+    Resource.Bandwidth -> R.string.stake_resource_bandwidth
+    Resource.Energy -> R.string.stake_resource_energy
+}

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/transaction/TransactionDataAggregateExt.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/transaction/TransactionDataAggregateExt.kt
@@ -10,10 +10,10 @@ import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.showsStatusBadge
 import com.gemwallet.android.ui.components.statusColor
 import com.gemwallet.android.ui.components.statusLabelRes
+import com.gemwallet.android.ui.components.titleRes
 import com.gemwallet.android.model.CurrencyFormatter
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.PerpetualDirection
-import com.wallet.core.primitives.Resource
 import com.wallet.core.primitives.TransactionDirection
 import com.wallet.core.primitives.TransactionState
 import com.wallet.core.primitives.TransactionType
@@ -75,22 +75,16 @@ fun TransactionDataAggregate.formatAddress(): String? = when (type) {
         "${stringResource(R.string.asset_price)}: ${CurrencyFormatter(type = CurrencyFormatter.Type.Fiat, currency = Currency.USD).string(it)}"
     }
     TransactionType.StakeFreeze -> resourceType?.let {
-        "${stringResource(id = R.string.transfer_to)} ${it.resourceTitle()}"
+        "${stringResource(id = R.string.transfer_to)} ${stringResource(it.titleRes())}"
     }
     TransactionType.StakeUnfreeze -> resourceType?.let {
-        "${stringResource(id = R.string.transfer_from)} ${it.resourceTitle()}"
+        "${stringResource(id = R.string.transfer_from)} ${stringResource(it.titleRes())}"
     }
     TransactionType.Swap,
     TransactionType.StakeWithdraw,
     TransactionType.AssetActivation,
     TransactionType.StakeRewards,
         -> null
-}
-
-@Composable
-private fun Resource.resourceTitle(): String = when (this) {
-    Resource.Bandwidth -> stringResource(R.string.stake_resource_bandwidth)
-    Resource.Energy -> stringResource(R.string.stake_resource_energy)
 }
 
 @Composable


### PR DESCRIPTION
Move the Bandwidth/Energy title mapping into a single shared `Resource.titleRes()` extension and use it everywhere instead of three copies.