### PR TITLE
Deduplicate DelegationState label and color mapping

### DIFF
--- a/android/features/earn/delegation/presents/src/main/kotlin/com/gemwallet/android/features/earn/delegation/presents/components/TransactionStatus.kt
+++ b/android/features/earn/delegation/presents/src/main/kotlin/com/gemwallet/android/features/earn/delegation/presents/components/TransactionStatus.kt
@@ -1,37 +1,19 @@
 package com.gemwallet.android.features.earn.delegation.presents.components
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
+import com.gemwallet.android.ui.components.list_item.stateColor
+import com.gemwallet.android.ui.components.list_item.stateText
 import com.gemwallet.android.ui.models.ListPosition
-import com.gemwallet.android.ui.theme.pendingColor
 import com.wallet.core.primitives.DelegationState
 
 @Composable
 internal fun TransactionStatus(state: DelegationState, active: Boolean, listPosition: ListPosition) {
     PropertyItem(
         title = R.string.transaction_status,
-        data = when (state) {
-            DelegationState.Active -> when (active) {
-                true -> R.string.stake_active
-                false -> R.string.stake_inactive
-            }
-
-            DelegationState.Pending -> R.string.stake_pending
-            DelegationState.Inactive -> R.string.stake_inactive
-            DelegationState.Activating -> R.string.stake_activating
-            DelegationState.Deactivating -> R.string.stake_deactivating
-            DelegationState.AwaitingWithdrawal -> R.string.stake_awaiting_withdrawal
-        },
-        dataColor = when (state) {
-            DelegationState.Active -> MaterialTheme.colorScheme.tertiary
-            DelegationState.Activating,
-            DelegationState.Deactivating,
-            DelegationState.Pending -> pendingColor
-            DelegationState.AwaitingWithdrawal,
-            DelegationState.Inactive -> MaterialTheme.colorScheme.error
-        },
+        data = state.stateText(active),
+        dataColor = state.stateColor(),
         listPosition = listPosition
     )
 }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/DelegationItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/DelegationItem.kt
@@ -2,27 +2,16 @@ package com.gemwallet.android.ui.components.list_item
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import com.gemwallet.android.domains.asset.getIconUrl
 import com.gemwallet.android.model.AssetInfo
-import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.image.IconWithBadge
 import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
 import com.gemwallet.android.ui.models.DelegationBalanceInfoUIModel
 import com.gemwallet.android.ui.models.ListPosition
-import com.gemwallet.android.ui.theme.pendingColor
 import com.wallet.core.primitives.Delegation
-import com.wallet.core.primitives.DelegationState
-import com.wallet.core.primitives.DelegationState.Activating
-import com.wallet.core.primitives.DelegationState.Active
-import com.wallet.core.primitives.DelegationState.AwaitingWithdrawal
-import com.wallet.core.primitives.DelegationState.Deactivating
-import com.wallet.core.primitives.DelegationState.Inactive
-import com.wallet.core.primitives.DelegationState.Pending
 
 @Composable
 fun DelegationItem(
@@ -44,7 +33,10 @@ fun DelegationItem(
             ListItemTitleText(text = delegation.validator.name)
         },
         subtitle = {
-            ListItemSupportText(delegation.stateText(), color = delegation.base.state.color())
+            ListItemSupportText(
+                delegation.base.state.stateText(delegation.validator.isActive),
+                color = delegation.base.state.stateColor(),
+            )
         },
         trailing = {
             val balance = DelegationBalanceInfoUIModel(
@@ -58,25 +50,3 @@ fun DelegationItem(
         }
     )
 }
-
-@Composable
-private fun DelegationState.color() = when (this) {
-    Active -> MaterialTheme.colorScheme.tertiary
-    Pending,
-    Activating,
-    Deactivating -> pendingColor
-    AwaitingWithdrawal,
-    Inactive -> MaterialTheme.colorScheme.error
-}
-
-@Composable
-private fun Delegation.stateText(): String = stringResource(
-    when (base.state) {
-        Active -> if (validator.isActive) R.string.stake_active else R.string.stake_inactive
-        Pending -> R.string.stake_pending
-        Inactive -> R.string.stake_inactive
-        Activating -> R.string.stake_activating
-        Deactivating -> R.string.stake_deactivating
-        AwaitingWithdrawal -> R.string.stake_awaiting_withdrawal
-    }
-)

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/DelegationStatePresentation.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/DelegationStatePresentation.kt
@@ -1,0 +1,37 @@
+package com.gemwallet.android.ui.components.list_item
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.theme.pendingColor
+import com.wallet.core.primitives.DelegationState
+import com.wallet.core.primitives.DelegationState.Activating
+import com.wallet.core.primitives.DelegationState.Active
+import com.wallet.core.primitives.DelegationState.AwaitingWithdrawal
+import com.wallet.core.primitives.DelegationState.Deactivating
+import com.wallet.core.primitives.DelegationState.Inactive
+import com.wallet.core.primitives.DelegationState.Pending
+
+@Composable
+fun DelegationState.stateText(active: Boolean): String = stringResource(
+    when (this) {
+        Active -> if (active) R.string.stake_active else R.string.stake_inactive
+        Pending -> R.string.stake_pending
+        Inactive -> R.string.stake_inactive
+        Activating -> R.string.stake_activating
+        Deactivating -> R.string.stake_deactivating
+        AwaitingWithdrawal -> R.string.stake_awaiting_withdrawal
+    }
+)
+
+@Composable
+fun DelegationState.stateColor(): Color = when (this) {
+    Active -> MaterialTheme.colorScheme.tertiary
+    Pending,
+    Activating,
+    Deactivating -> pendingColor
+    AwaitingWithdrawal,
+    Inactive -> MaterialTheme.colorScheme.error
+}


### PR DESCRIPTION
The staking status label and color mapping for delegations was hand-written in two separate modules. This moves it into one shared pair in the `:ui` module so both the staking list and the delegation detail screen use the same source.

No behavior change.