### PR TITLE
Do not show error when user cancels biometric auth in confirm

### DIFF
--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
@@ -28,18 +28,7 @@ public final class ConfirmTransferSceneViewModel {
         }
     }
 
-    var confirmingState: StateViewType<Bool> = .noData {
-        didSet {
-            if case let .error(error) = confirmingState {
-                isPresentingAlertMessage = AlertMessage(
-                    title: Localized.Errors.transferError,
-                    message: error.localizedDescription,
-                )
-            } else {
-                isPresentingAlertMessage = nil
-            }
-        }
-    }
+    var confirmingState: StateViewType<Bool> = .noData
 
     public var isPresentingSheet: ConfirmTransferSheetType?
     public var isPresentingAlertMessage: AlertMessage?
@@ -500,7 +489,19 @@ extension ConfirmTransferSceneViewModel {
             }
             confirmingState = .data(true)
         } catch {
+            handleError(error)
+        }
+    }
+
+    private func handleError(_ error: Error) {
+        if error.isAuthenticationCancelled {
+            confirmingState = .noData
+        } else {
             confirmingState = .error(error)
+            isPresentingAlertMessage = AlertMessage(
+                title: Localized.Errors.transferError,
+                message: error.localizedDescription,
+            )
             debugLog("confirm transaction error: \(error)")
         }
     }

--- a/ios/Packages/Primitives/Sources/Extensions/Error+Primitives.swift
+++ b/ios/Packages/Primitives/Sources/Extensions/Error+Primitives.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
+import Security
 
 public extension Error {
     var isCancelled: Bool {
@@ -12,5 +13,9 @@ public extension Error {
         default:
             false
         }
+    }
+
+    var isAuthenticationCancelled: Bool {
+        (self as NSError).code == Int(errSecUserCanceled)
     }
 }

--- a/ios/Packages/Primitives/Tests/PrimitivesTests/Error+PrimitivesTests.swift
+++ b/ios/Packages/Primitives/Tests/PrimitivesTests/Error+PrimitivesTests.swift
@@ -1,0 +1,16 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import Security
+import Testing
+
+struct ErrorPrimitivesTests {
+    @Test
+    func isAuthenticationCancelled() {
+        #expect(NSError(domain: NSOSStatusErrorDomain, code: Int(errSecUserCanceled)).isAuthenticationCancelled)
+
+        #expect(!NSError(domain: NSOSStatusErrorDomain, code: Int(errSecAuthFailed)).isAuthenticationCancelled)
+        #expect(!NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled).isAuthenticationCancelled)
+    }
+}


### PR DESCRIPTION
When a user declines Face ID or cancels the PIN prompt during a transfer, the app no longer shows a "Transfer error" alert.

Closes #564