### PR TITLE
Add migration guide link to wallet import screen

### DIFF
--- a/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/views/SelectImportTypeScreen.kt
+++ b/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/views/SelectImportTypeScreen.kt
@@ -14,16 +14,19 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gemwallet.android.AppUrl
 import com.gemwallet.android.features.import_wallet.viewmodels.ChainUIState
 import com.gemwallet.android.features.import_wallet.viewmodels.SelectImportTypeViewModel
 import com.gemwallet.android.model.ImportType
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.DocsInfoButton
 import com.gemwallet.android.ui.components.SearchBar
 import com.gemwallet.android.ui.components.list_item.ChainItem
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.ListPosition
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.WalletType
+import uniffi.gemstone.DocsUrl
 
 @Composable
 fun SelectImportTypeScreen(
@@ -51,6 +54,9 @@ private fun SelectImportTypeScene(
 
     Scene(
         title = stringResource(id = R.string.wallet_import_title),
+        actions = {
+            DocsInfoButton(AppUrl.docs(DocsUrl.MigrateWallet))
+        },
         onClose = onClose,
     ) {
         LazyColumn(modifier = Modifier) {

--- a/core/gemstone/src/config/docs.rs
+++ b/core/gemstone/src/config/docs.rs
@@ -34,6 +34,7 @@ pub enum DocsUrl {
     PerpetualsFundingPayments,
     PerpetualsAutoclose,
     Dust,
+    MigrateWallet,
 }
 const DOCS_URL: &str = "https://docs.gemwallet.com";
 
@@ -70,6 +71,7 @@ pub fn get_docs_url(item: DocsUrl) -> String {
         DocsUrl::PerpetualsFundingPayments => "/defi/perps/funding-payment/",
         DocsUrl::PerpetualsAutoclose => "/defi/perps/auto-close/",
         DocsUrl::Dust => "/blockchains/bitcoin/dust/",
+        DocsUrl::MigrateWallet => "/guides/migrate-wallet/",
     };
     format!("{DOCS_URL}{path}")
 }

--- a/ios/Features/Onboarding/Sources/Scenes/ImportWalletTypeScene.swift
+++ b/ios/Features/Onboarding/Sources/Scenes/ImportWalletTypeScene.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Components
+import GemstonePrimitives
 import Localization
 import Primitives
 import PrimitivesComponents
@@ -46,6 +47,7 @@ struct ImportWalletTypeScene: View {
         .contentMargins(.top, .scene.top, for: .scrollContent)
         .navigationBarTitle(model.title)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarInfoButton(url: AppUrl.docs(.migrateWallet))
         .searchable(
             text: $searchQuery,
             placement: .navigationBarDrawer(displayMode: .always),


### PR DESCRIPTION
Adds an info button on the wallet import type screen (Multi-Coin / networks) linking to the migration guide.

Closes #367