### PR TITLE
Extract shared shareText helper for Android share intents

### DIFF
--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsNavScreen.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsNavScreen.kt
@@ -1,6 +1,5 @@
 package com.gemwallet.android.features.activities.presents.details
 
-import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -11,6 +10,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.features.activities.viewmodels.TransactionDetailsViewModel
 import com.gemwallet.android.ui.components.screen.LoadingScene
+import com.gemwallet.android.ui.shareText
 
 @Composable
 fun TransactionDetailsNavScreen(
@@ -22,14 +22,7 @@ fun TransactionDetailsNavScreen(
     val context = LocalContext.current
 
     fun onShare(url: String, name: String) {
-        val type = "text/plain"
-
-        val intent = Intent(Intent.ACTION_SEND)
-        intent.type = type
-        intent.putExtra(Intent.EXTRA_SUBJECT, url)
-        intent.putExtra(Intent.EXTRA_TEXT, url)
-
-        context.startActivity(Intent.createChooser(intent, name))
+        context.shareText(subject = url, text = url, chooserTitle = name)
     }
 
     val model = transaction

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/components/AssetDetailsMenu.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/components/AssetDetailsMenu.kt
@@ -1,6 +1,5 @@
 package com.gemwallet.android.features.asset.presents.details.components
 
-import android.content.Intent
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -22,6 +21,7 @@ import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.screen.showSnackbar
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.open
+import com.gemwallet.android.ui.shareText
 import com.gemwallet.android.features.asset.viewmodels.details.models.AssetInfoUIModel
 import com.gemwallet.android.ext.toIdentifier
 import com.wallet.core.primitives.AssetId
@@ -46,17 +46,11 @@ fun RowScope.AssetDetailsMenu(
     val shareTitle = stringResource(id = R.string.common_share)
 
     val onShare = fun () {
-        val type = "text/plain"
         val subject = "${uiState.assetInfo.owner?.chain}\n${uiState.assetInfo.asset.symbol}"
         val assetId = uiState.asset.id
         val shareUrl = deeplinkBuildUrl(Deeplink.Asset(assetId = assetId.toIdentifier()))
 
-        val intent = Intent(Intent.ACTION_SEND)
-        intent.type = type
-        intent.putExtra(Intent.EXTRA_SUBJECT, subject)
-        intent.putExtra(Intent.EXTRA_TEXT, shareUrl)
-
-        context.startActivity(Intent.createChooser(intent, shareTitle))
+        context.shareText(subject = subject, text = shareUrl, chooserTitle = shareTitle)
     }
 
     IconButton(

--- a/android/features/receive/presents/src/main/kotlin/com/gemwallet/android/features/receive/presents/ReceiveScreen.kt
+++ b/android/features/receive/presents/src/main/kotlin/com/gemwallet/android/features/receive/presents/ReceiveScreen.kt
@@ -1,6 +1,5 @@
 package com.gemwallet.android.features.receive.presents
 
-import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -50,6 +49,7 @@ import com.gemwallet.android.ui.components.list_head.HeaderIcon
 import com.gemwallet.android.ui.components.parseMarkdownToAnnotatedString
 import com.gemwallet.android.ui.components.screen.LoadingScene
 import com.gemwallet.android.ui.components.screen.Scene
+import com.gemwallet.android.ui.shareText
 import com.gemwallet.android.ui.theme.WindowDimension
 import com.gemwallet.android.ui.theme.isCompactDimension
 import com.gemwallet.android.ui.theme.paddingDefault
@@ -89,15 +89,8 @@ private fun ReceiveScene(
     val imagePadding = if (isCompactHeight) paddingSmall else paddingDefault
 
     val onShare = fun () {
-        val type = "text/plain"
         val subject = "${assetInfo.owner?.chain}\n${assetInfo.asset.symbol}"
-
-        val intent = Intent(Intent.ACTION_SEND)
-        intent.type = type
-        intent.putExtra(Intent.EXTRA_SUBJECT, subject)
-        intent.putExtra(Intent.EXTRA_TEXT, assetInfo.owner?.address)
-
-        context.startActivity(Intent.createChooser(intent, shareTitle))
+        context.shareText(subject = subject, text = assetInfo.owner?.address, chooserTitle = shareTitle)
     }
 
     val onCopyClick = fun () {

--- a/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/ReferralScene.kt
+++ b/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/ReferralScene.kt
@@ -1,6 +1,5 @@
 package com.gemwallet.android.features.referral.views
 
-import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -40,6 +39,7 @@ import com.gemwallet.android.ui.components.buttons.mainActionButtonColors
 import com.gemwallet.android.ui.components.clickable
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.components.screen.showSnackbar
+import com.gemwallet.android.ui.shareText
 import kotlinx.coroutines.launch
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.theme.Spacer8
@@ -98,13 +98,7 @@ fun ReferralScene(
     val scope = rememberCoroutineScope()
 
     val onShare = fun () {
-        val type = "text/plain"
-        val intent = Intent(Intent.ACTION_SEND)
-        intent.type = type
-        intent.putExtra(Intent.EXTRA_SUBJECT, link)
-        intent.putExtra(Intent.EXTRA_TEXT, joinText)
-
-        context.startActivity(Intent.createChooser(intent, shareTitle))
+        context.shareText(subject = link, text = joinText, chooserTitle = shareTitle)
     }
 
     Scene(

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/ContextExts.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/ContextExts.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.ui
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.Intent
 import android.view.WindowManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -22,6 +23,15 @@ fun Context.findActivity(): Activity? {
 
 fun Context.requestAuth(auth: AuthRequest, onSuccess: () -> Unit) {
     (findActivity() as? AuthRequester)?.requestAuth(auth, onSuccess)
+}
+
+fun Context.shareText(subject: String?, text: String?, chooserTitle: String) {
+    val intent = Intent(Intent.ACTION_SEND)
+    intent.type = "text/plain"
+    intent.putExtra(Intent.EXTRA_SUBJECT, subject)
+    intent.putExtra(Intent.EXTRA_TEXT, text)
+
+    startActivity(Intent.createChooser(intent, chooserTitle))
 }
 
 @Composable


### PR DESCRIPTION
Deduplicates the identical share-intent code across the transaction, asset, receive, and referral screens into a single `shareText` helper.