### PR TITLE
Fix balance chain filter in BalanceService

### DIFF
--- a/ios/GemTests/unit_frameworks.xctestplan
+++ b/ios/GemTests/unit_frameworks.xctestplan
@@ -241,6 +241,13 @@
     {
       "target" : {
         "containerPath" : "container:Packages\/FeatureServices",
+        "identifier" : "BalanceServiceTests",
+        "name" : "BalanceServiceTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/FeatureServices",
         "identifier" : "PriceAlertServiceTests",
         "name" : "PriceAlertServiceTests"
       }

--- a/ios/Packages/FeatureServices/BalanceService/BalanceService.swift
+++ b/ios/Packages/FeatureServices/BalanceService/BalanceService.swift
@@ -47,8 +47,8 @@ extension BalanceService: BalanceUpdater {
             for account in wallet.accounts {
                 let chain = account.chain
                 let address = account.address
-                let ids = assetIds.filter { $0.identifier.hasPrefix(chain.rawValue) }
-                let tokenIds = ids.filter { $0.identifier != chain.id }
+                let ids = assetIds.filter { $0.chain == chain }
+                let tokenIds = ids.filter { $0.type == .token }
 
                 guard !ids.isEmpty else { continue }
 

--- a/ios/Packages/FeatureServices/BalanceService/Tests/BalanceServiceTests.swift
+++ b/ios/Packages/FeatureServices/BalanceService/Tests/BalanceServiceTests.swift
@@ -1,0 +1,44 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import AssetsServiceTestKit
+import BalanceService
+import BalanceServiceTestKit
+import BlockchainTestKit
+import ChainServiceTestKit
+import Foundation
+import Primitives
+import PrimitivesTestKit
+import Store
+import StoreTestKit
+import Testing
+
+struct BalanceServiceTests {
+    // `seievm` (Chain.seiEvm) has `sei` (Chain.sei) as a rawValue prefix, so a
+    // string-prefix asset match pulls a Sei-EVM token into the Sei account's
+    // token fetch. Matching by typed chain must skip it. Real colliding pairs in
+    // the current chain set: bitcoin/bitcoincash and sei/seievm.
+    @Test
+    func updateBalanceSkipsPrefixCollidingChainToken() async throws {
+        let sei = Chain.sei.assetId
+        let seiEvmToken = AssetId(chain: .seiEvm, tokenId: "0xtoken")
+
+        let db = DB.mockWithChains([.sei, .seiEvm])
+        try AssetStore(db: db).add(assets: [.mock(asset: .mock(id: seiEvmToken))])
+        let wallet = Wallet.mock(accounts: [.mock(chain: .sei, address: "sei-address")])
+        try WalletStore(db: db).addWallet(wallet)
+        let balanceStore = BalanceStore.mock(db: db)
+        let chainService = ChainServiceMock()
+        chainService.coinBalances["sei-address"] = AssetBalance(assetId: sei, balance: .mock(available: 100))
+        chainService.tokenBalances["sei-address"] = [AssetBalance(assetId: seiEvmToken, balance: .mock(available: 50))]
+        let service = BalanceService.mock(
+            balanceStore: balanceStore,
+            assetsService: .mock(assetStore: .mock(db: db), balanceStore: balanceStore),
+            chainServiceFactory: ChainServiceFactoryMock(chainService: chainService),
+        )
+
+        await service.updateBalance(for: wallet, assetIds: [sei, seiEvmToken])
+
+        #expect(try balanceStore.getBalance(walletId: wallet.id, assetId: sei)?.available == 100)
+        #expect(try balanceStore.getBalance(walletId: wallet.id, assetId: seiEvmToken) == nil)
+    }
+}

--- a/ios/Packages/FeatureServices/Package.swift
+++ b/ios/Packages/FeatureServices/Package.swift
@@ -112,7 +112,7 @@ let package = Package(
                 "Formatters",
             ],
             path: "BalanceService",
-            exclude: ["TestKit"],
+            exclude: ["TestKit", "Tests"],
         ),
         .target(
             name: "BalanceServiceTestKit",
@@ -712,6 +712,19 @@ let package = Package(
                 .product(name: "PrimitivesTestKit", package: "Primitives"),
             ],
             path: "DiscoverAssetsService/Tests",
+        ),
+        .testTarget(
+            name: "BalanceServiceTests",
+            dependencies: [
+                "BalanceService",
+                "BalanceServiceTestKit",
+                "AssetsServiceTestKit",
+                .product(name: "BlockchainTestKit", package: "Blockchain"),
+                .product(name: "ChainServiceTestKit", package: "ChainServices"),
+                .product(name: "PrimitivesTestKit", package: "Primitives"),
+                .product(name: "StoreTestKit", package: "Store"),
+            ],
+            path: "BalanceService/Tests",
         ),
         .testTarget(
             name: "PriceAlertServiceTests",


### PR DESCRIPTION
Matching assets to an account's chain used a string prefix on the asset id, so chains whose id prefixes another (`bitcoin`/`bitcoincash`, `sei`/`seievm`) pulled the other chain's tokens into the wrong account's balance update. Match by typed chain instead.