### PR TITLE
Fix slippage calculation in swap minimum receive

### DIFF
--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModelFactory.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModelFactory.kt
@@ -11,6 +11,7 @@ import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.ValueFormatter
 import java.math.BigDecimal
+import java.math.BigInteger
 import uniffi.gemstone.SwapPriceImpact
 import uniffi.gemstone.SwapperProvider
 import uniffi.gemstone.SwapperProviderType
@@ -64,6 +65,8 @@ data class SwapDetailsUIModelInput(
 )
 
 object SwapDetailsUIModelFactory {
+    private const val BPS_SCALE = 10_000
+
     private val rateFormatter = AssetRateFormatter()
 
     fun create(input: SwapDetailsUIModelInput): SwapDetailsUIModel? {
@@ -95,9 +98,7 @@ object SwapDetailsUIModelFactory {
         }
 
         val toAmount = Crypto(input.toValue)
-        val minReceiveAtomic = toAmount.atomicValue.toBigDecimal().let { amount ->
-            amount - (amount * BigDecimal.valueOf(slippagePercent / 100.0))
-        }.toBigInteger()
+        val minReceiveAtomic = minimumReceiveAtomic(toAmount.atomicValue, input.slippageBps)
 
         return SwapDetailsUIModel(
             provider = input.provider,
@@ -113,6 +114,9 @@ object SwapDetailsUIModelFactory {
             isProviderSelectable = input.isProviderSelectable,
         )
     }
+
+    internal fun minimumReceiveAtomic(atomicValue: BigInteger, slippageBps: UInt): BigInteger =
+        atomicValue * (BPS_SCALE - slippageBps.toInt()).toBigInteger() / BPS_SCALE.toBigInteger()
 
     private fun estimateSwapRate(
         payAsset: AssetInfo,

--- a/android/ui-models/src/test/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModelFactoryTest.kt
+++ b/android/ui-models/src/test/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModelFactoryTest.kt
@@ -150,6 +150,16 @@ class SwapDetailsUIModelFactoryTest {
     }
 
     @Test
+    fun `minimum receive applies sub percent slippage`() {
+        val result = swapDetails(
+            toValue = DEFAULT_TO_VALUE,
+            slippageBps = 50u,
+        )
+
+        assertEquals(formattedReceiveAmount("995000000000000000"), result!!.minimumReceive)
+    }
+
+    @Test
     fun `minimum receive floors to zero for a single atomic unit`() {
         val result = swapDetails(
             toValue = "1",

--- a/ios/Features/Swap/Sources/ViewModels/SwapDetailsViewModel.swift
+++ b/ios/Features/Swap/Sources/ViewModels/SwapDetailsViewModel.swift
@@ -138,10 +138,6 @@ public final class SwapDetailsViewModel {
 
     // MARK: - Slippage
 
-    var slippageValue: UInt32 {
-        selectedQuote.slippageBps / 100
-    }
-
     var slippageField: ListItemField {
         let value: String = switch slippage {
         case .auto: Localized.Swap.slippageAuto
@@ -155,7 +151,7 @@ public final class SwapDetailsViewModel {
     var minReceiveField: ListItemField {
         ListItemField(
             title: Localized.Swap.minReceive,
-            value: valueFormatter.string(selectedQuote.toValueBigInt.decrease(byPercent: Int(slippageValue)), asset: toAssetPrice.asset),
+            value: valueFormatter.string(selectedQuote.toValueBigInt.decrease(byBasisPoints: Int(selectedQuote.slippageBps)), asset: toAssetPrice.asset),
         )
     }
 

--- a/ios/Features/Swap/Tests/SwapTests/SwapDetailsViewModelTests.swift
+++ b/ios/Features/Swap/Tests/SwapTests/SwapDetailsViewModelTests.swift
@@ -32,6 +32,13 @@ struct SwapDetailsViewModelTests {
         model.switchRateDirection()
         #expect(model.rateText == "1 USDT ≈ 0.000004 ETH")
     }
+
+    @Test
+    func minReceiveAppliesSlippageBasisPoints() throws {
+        let model = try SwapDetailsViewModel.mock(selectedQuote: SwapperQuote.mock(toValue: "250000000000").map())
+
+        #expect(model.minReceiveField.value.text == "248,750 USDT")
+    }
 }
 
 extension SwapDetailsViewModel {

--- a/ios/Packages/Primitives/Sources/Extensions/BigInt+Primitives.swift
+++ b/ios/Packages/Primitives/Sources/Extensions/BigInt+Primitives.swift
@@ -32,6 +32,11 @@ public extension BigInt {
         return self * BigInt(multiplier) / 100
     }
 
+    func decrease(byBasisPoints basisPoints: Int) -> BigInt {
+        let multiplier = 10000 - basisPoints
+        return self * BigInt(multiplier) / 10000
+    }
+
     func multiply(byPercent percent: Int) -> BigInt {
         self * BigInt(percent) / 100
     }

--- a/ios/Packages/Primitives/Tests/PrimitivesTests/Extensions/BigInt+PrimitivesTests.swift
+++ b/ios/Packages/Primitives/Tests/PrimitivesTests/Extensions/BigInt+PrimitivesTests.swift
@@ -26,6 +26,15 @@ struct BigInt_PrimitivesTests {
     }
 
     @Test
+    func decreaseByBasisPoints() {
+        #expect(BigInt(1_000_000).decrease(byBasisPoints: 30) == BigInt(997_000))
+        #expect(BigInt(1_000_000).decrease(byBasisPoints: 50) == BigInt(995_000))
+        #expect(BigInt(1_000_000).decrease(byBasisPoints: 100) == BigInt(990_000))
+        #expect(BigInt(1_000_000).decrease(byBasisPoints: 300) == BigInt(970_000))
+        #expect(BigInt(1_000_000).decrease(byBasisPoints: 0) == BigInt(1_000_000))
+    }
+
+    @Test
     func multiplyByPercent() {
         #expect(BigInt(100).multiply(byPercent: 10) == BigInt(10))
         #expect(BigInt(100).multiply(byPercent: 5) == BigInt(5))


### PR DESCRIPTION
The swap minimum receive divided slippage bps into whole percents, so fractional slippage (0.5% = 50 bps) truncated to 0% and displayed a higher minimum receive than the quote guarantees. Apply the basis points directly, on iOS and Android.