### PR TITLE
Collapse ChainServiceable protocol composition into one protocol

### DIFF
--- a/ios/Packages/Blockchain/Sources/Gateway/GatewayChainService.swift
+++ b/ios/Packages/Blockchain/Sources/Gateway/GatewayChainService.swift
@@ -19,9 +19,7 @@ struct GatewayChainService {
     }
 }
 
-// MARK: - ChainBalanceable
-
-extension GatewayChainService: ChainBalanceable {
+extension GatewayChainService: ChainServiceable {
     func coinBalance(for address: String) async throws -> AssetBalance {
         try await gateway.coinBalance(chain: chain, address: address)
     }
@@ -37,79 +35,39 @@ extension GatewayChainService: ChainBalanceable {
     func getEarnBalance(for address: String, tokenIds: [AssetId]) async throws -> [AssetBalance] {
         try await gateway.getEarnBalance(chain: chain, address: address, tokenIds: tokenIds)
     }
-}
 
-// MARK: - ChainFeeRateFetchable
-
-extension GatewayChainService: ChainFeeRateFetchable {
     func feeRates(type: TransferDataType) async throws -> [FeeRate] {
         try await gateway.feeRates(chain: chain, input: type)
     }
-}
 
-// MARK: - ChainBroadcastable
-
-extension GatewayChainService: ChainBroadcastable {
-    func broadcast(data: String, options: BroadcastOptions) async throws -> String {
-        try await gateway.transactionBroadcast(chain: chain, data: data, options: options)
-    }
-}
-
-// MARK: - ChainTransactionStateFetchable
-
-extension GatewayChainService: ChainTransactionStateFetchable {
-    func transactionState(for request: TransactionStateRequest) async throws -> TransactionChanges {
-        try await gateway.transactionStatus(chain: chain, request: request)
-    }
-}
-
-// MARK: - ChainTokenable
-
-extension GatewayChainService: ChainTokenable {
-    func getTokenData(tokenId: String) async throws -> Asset {
-        try await gateway.tokenData(chain: chain, tokenId: tokenId)
-    }
-
-    func getIsTokenAddress(tokenId: String) async throws -> Bool {
-        try await gateway.isTokenAddress(chain: chain, tokenId: tokenId)
-    }
-}
-
-// MARK: - ChainIDFetchable
-
-extension GatewayChainService: ChainIDFetchable {
-    func getChainID() async throws -> String {
-        try await gateway.chainId(chain: chain)
-    }
-}
-
-// MARK: - ChainLatestBlockFetchable
-
-extension GatewayChainService: ChainLatestBlockFetchable {
-    func getLatestBlock() async throws -> BigInt {
-        try await BigInt(gateway.latestBlock(chain: chain))
-    }
-}
-
-// MARK: - ChainTransactionPreloadable
-
-extension GatewayChainService: ChainTransactionPreloadable {
     func preload(input: TransactionPreloadInput) async throws -> TransactionLoadMetadata {
         try await gateway.transactionPreload(chain: chain, input: input)
     }
-}
 
-// MARK: - ChainTransactionDataLoadable
-
-extension GatewayChainService: ChainTransactionDataLoadable {
     func load(input: TransactionInput) async throws -> TransactionData {
         try await gateway.transactionLoad(chain: chain, input: input.map())
     }
-}
 
-// MARK: - ChainStakable
+    func broadcast(data: String, options: BroadcastOptions) async throws -> String {
+        try await gateway.transactionBroadcast(chain: chain, data: data, options: options)
+    }
 
-extension GatewayChainService: ChainStakable {
+    func transactionState(for request: TransactionStateRequest) async throws -> TransactionChanges {
+        try await gateway.transactionStatus(chain: chain, request: request)
+    }
+
+    func getChainID() async throws -> String {
+        try await gateway.chainId(chain: chain)
+    }
+
+    func getLatestBlock() async throws -> BigInt {
+        try await BigInt(gateway.latestBlock(chain: chain))
+    }
+
+    func getNodeStatus(url: String) async throws -> NodeStatus {
+        try await gateway.nodeStatus(chain: chain, url: url)
+    }
+
     func getValidators(apr: Double) async throws -> [DelegationValidator] {
         try await gateway.validators(chain: chain, apy: apr)
     }
@@ -121,12 +79,12 @@ extension GatewayChainService: ChainStakable {
     func getStakeDelegations(address: String) async throws -> [DelegationBase] {
         try await gateway.delegations(chain: chain, address: address)
     }
-}
 
-// MARK: - ChainNodeStatusFetchable
+    func getTokenData(tokenId: String) async throws -> Asset {
+        try await gateway.tokenData(chain: chain, tokenId: tokenId)
+    }
 
-extension GatewayChainService: ChainNodeStatusFetchable {
-    func getNodeStatus(url: String) async throws -> NodeStatus {
-        try await gateway.nodeStatus(chain: chain, url: url)
+    func getIsTokenAddress(tokenId: String) async throws -> Bool {
+        try await gateway.isTokenAddress(chain: chain, tokenId: tokenId)
     }
 }

--- a/ios/Packages/Blockchain/Sources/Protocols/ChainServiceable.swift
+++ b/ios/Packages/Blockchain/Sources/Protocols/ChainServiceable.swift
@@ -2,78 +2,32 @@ import BigInt
 import Foundation
 import Primitives
 
-public typealias ChainServiceable =
-    ChainBalanceable &
-    ChainBroadcastable &
-    ChainFeeRateFetchable &
-    ChainIDFetchable &
-    ChainLatestBlockFetchable &
-    ChainNodeStatusFetchable &
-    ChainStakable &
-    ChainTokenable &
-    ChainTransactionDataLoadable &
-    ChainTransactionPreloadable &
-    ChainTransactionStateFetchable
-
-// MARK: - Protocols
-
-public protocol ChainBalanceable: Sendable {
-    func coinBalance(for address: String) async throws -> AssetBalance
-    func tokenBalance(for address: String, tokenIds: [AssetId]) async throws -> [AssetBalance]
-    func getStakeBalance(for address: String) async throws -> AssetBalance?
-    func getEarnBalance(for address: String, tokenIds: [AssetId]) async throws -> [AssetBalance]
-}
-
 public protocol ChainFeeRateFetchable: Sendable {
     func feeRates(type: TransferDataType) async throws -> [FeeRate]
     func defaultPriority(for type: TransferDataType) -> FeePriority
 }
 
-public protocol ChainTransactionPreloadable: Sendable {
+public protocol ChainServiceable: ChainFeeRateFetchable {
+    func coinBalance(for address: String) async throws -> AssetBalance
+    func tokenBalance(for address: String, tokenIds: [AssetId]) async throws -> [AssetBalance]
+    func getStakeBalance(for address: String) async throws -> AssetBalance?
+    func getEarnBalance(for address: String, tokenIds: [AssetId]) async throws -> [AssetBalance]
+
     func preload(input: TransactionPreloadInput) async throws -> TransactionLoadMetadata
-}
-
-public protocol ChainTransactionDataLoadable: Sendable {
     func load(input: TransactionInput) async throws -> TransactionData
-}
-
-public protocol ChainBroadcastable: Sendable {
     func broadcast(data: String, options: BroadcastOptions) async throws -> String
-}
-
-public protocol ChainTransactionStateFetchable: Sendable {
     func transactionState(for request: TransactionStateRequest) async throws -> TransactionChanges
-}
 
-public protocol ChainIDFetchable: Sendable {
     func getChainID() async throws -> String
-}
+    func getLatestBlock() async throws -> BigInt
+    func getNodeStatus(url: String) async throws -> NodeStatus
 
-public protocol ChainStakable: Sendable {
     func getValidators(apr: Double) async throws -> [DelegationValidator]
     func getDelegationValidators(address: String) async throws -> [DelegationValidator]
     func getStakeDelegations(address: String) async throws -> [DelegationBase]
-}
 
-public protocol ChainTokenable: Sendable {
     func getTokenData(tokenId: String) async throws -> Asset
     func getIsTokenAddress(tokenId: String) async throws -> Bool
-}
-
-public protocol ChainLatestBlockFetchable: Sendable {
-    func getLatestBlock() async throws -> BigInt
-}
-
-public protocol ChainNodeStatusFetchable: Sendable {
-    func getNodeStatus(url: String) async throws -> NodeStatus
-}
-
-protocol ChainFeePriorityPreference: Sendable {}
-
-public extension ChainBalanceable {
-    func getEarnBalance(for _: String, tokenIds _: [AssetId]) async throws -> [AssetBalance] {
-        []
-    }
 }
 
 public extension ChainFeeRateFetchable {
@@ -85,7 +39,11 @@ public extension ChainFeeRateFetchable {
     }
 }
 
-public extension ChainStakable {
+public extension ChainServiceable {
+    func getEarnBalance(for _: String, tokenIds _: [AssetId]) async throws -> [AssetBalance] {
+        []
+    }
+
     func getValidators(apr _: Double) async throws -> [DelegationValidator] {
         []
     }
@@ -97,9 +55,7 @@ public extension ChainStakable {
     func getStakeDelegations(address _: String) async throws -> [DelegationBase] {
         []
     }
-}
 
-public extension ChainTokenable {
     func getTokenData(tokenId _: String) async throws -> Asset {
         throw AnyError("Not Implemented")
     }


### PR DESCRIPTION
ChainServiceable was a typealias gluing together 11 separate protocols, but only one type actually implements it, and it implements all of them. Ten of the eleven were never referenced anywhere else, so the split wasn't buying anything.

Collapsed them into a single protocol. ChainFeeRateFetchable stays separate because FeeRateService genuinely uses just that part. Nothing changes at any call site.