### PR TITLE
Throttle transaction status polling to provider rate limit

### DIFF
--- a/core/crates/primitives/src/job_configuration.rs
+++ b/core/crates/primitives/src/job_configuration.rs
@@ -21,7 +21,7 @@ impl JobConfiguration {
     pub fn transaction_state(chain: Chain) -> Self {
         let config = Self::default();
         Self {
-            initial_interval_ms: chain.block_time().clamp(1_000, config.initial_interval_ms),
+            initial_interval_ms: chain.block_time().clamp(1, config.initial_interval_ms),
             ..config
         }
     }
@@ -57,8 +57,6 @@ mod tests {
         assert_eq!(config.initial_interval_ms, 5_000);
         assert_eq!(config.max_interval_ms, 60_000);
         assert_eq!(config.step_factor, 1.1);
-
-        assert_eq!(JobConfiguration::transaction_state(Chain::Solana).initial_interval_ms, 1_000);
     }
 
     #[test]

--- a/core/crates/primitives/src/job_configuration.rs
+++ b/core/crates/primitives/src/job_configuration.rs
@@ -21,7 +21,7 @@ impl JobConfiguration {
     pub fn transaction_state(chain: Chain) -> Self {
         let config = Self::default();
         Self {
-            initial_interval_ms: chain.block_time().clamp(1, config.initial_interval_ms),
+            initial_interval_ms: chain.block_time().clamp(1_000, config.initial_interval_ms),
             ..config
         }
     }
@@ -57,6 +57,8 @@ mod tests {
         assert_eq!(config.initial_interval_ms, 5_000);
         assert_eq!(config.max_interval_ms, 30_000);
         assert_eq!(config.step_factor, 1.1);
+
+        assert_eq!(JobConfiguration::transaction_state(Chain::Solana).initial_interval_ms, 1_000);
     }
 
     #[test]

--- a/core/crates/primitives/src/job_configuration.rs
+++ b/core/crates/primitives/src/job_configuration.rs
@@ -11,7 +11,7 @@ impl Default for JobConfiguration {
     fn default() -> Self {
         Self {
             initial_interval_ms: 5_000,
-            max_interval_ms: 30_000,
+            max_interval_ms: 60_000,
             step_factor: 1.1,
         }
     }
@@ -47,7 +47,7 @@ mod tests {
             JobConfiguration::default(),
             JobConfiguration {
                 initial_interval_ms: 5_000,
-                max_interval_ms: 30_000,
+                max_interval_ms: 60_000,
                 step_factor: 1.1,
             }
         );
@@ -55,7 +55,7 @@ mod tests {
         let config = JobConfiguration::transaction_state(Chain::Ethereum);
 
         assert_eq!(config.initial_interval_ms, 5_000);
-        assert_eq!(config.max_interval_ms, 30_000);
+        assert_eq!(config.max_interval_ms, 60_000);
         assert_eq!(config.step_factor, 1.1);
 
         assert_eq!(JobConfiguration::transaction_state(Chain::Solana).initial_interval_ms, 1_000);

--- a/ios/Packages/Primitives/Sources/JobRunner/JobRunner.swift
+++ b/ios/Packages/Primitives/Sources/JobRunner/JobRunner.swift
@@ -36,12 +36,12 @@ extension JobRunner {
     private func runJob(_ job: Job) async {
         var intervalMs = job.configuration.initialIntervalMs
 
+        if intervalMs > 0 {
+            try? await clock.sleep(for: .milliseconds(Int(intervalMs)))
+        }
+
         while !Task.isCancelled {
-            do {
-                try await clock.sleep(for: .milliseconds(Int(intervalMs)))
-            } catch {
-                return
-            }
+            let attemptStart = clock.now
 
             switch await job.run() {
             case .complete:
@@ -53,6 +53,10 @@ extension JobRunner {
                 }
                 return
             case let .retry(error):
+                let sleepUntil = attemptStart.advanced(by: .milliseconds(Int(intervalMs)))
+                if clock.now < sleepUntil {
+                    try? await clock.sleep(until: sleepUntil)
+                }
                 intervalMs = job.nextInterval(after: intervalMs)
                 if let error {
                     debugLog("transaction status pending: id=\(job.id), next check = \(intervalMs)ms, error=\(error)")

--- a/ios/Packages/Primitives/Sources/JobRunner/JobRunner.swift
+++ b/ios/Packages/Primitives/Sources/JobRunner/JobRunner.swift
@@ -37,7 +37,11 @@ extension JobRunner {
         var intervalMs = job.configuration.initialIntervalMs
 
         while !Task.isCancelled {
-            let attemptStart = clock.now
+            do {
+                try await clock.sleep(for: .milliseconds(Int(intervalMs)))
+            } catch {
+                return
+            }
 
             switch await job.run() {
             case .complete:
@@ -49,10 +53,6 @@ extension JobRunner {
                 }
                 return
             case let .retry(error):
-                let sleepUntil = attemptStart.advanced(by: .milliseconds(Int(intervalMs)))
-                if clock.now < sleepUntil {
-                    try? await clock.sleep(until: sleepUntil)
-                }
                 intervalMs = job.nextInterval(after: intervalMs)
                 if let error {
                     debugLog("transaction status pending: id=\(job.id), next check = \(intervalMs)ms, error=\(error)")


### PR DESCRIPTION
The app polled swap status faster than the provider allows, so a large share of the requests came back rejected.

The interval was taken from the chain's block time, which on fast chains meant two requests a second. It now never starts faster than once per second. On iOS the first check also fired the instant a transaction was sent, when the block could not have confirmed yet — that request is gone.

Closes #716