### PR TITLE
Carry secret phrase in the create wallet route

### DIFF
--- a/ios/Features/Onboarding/Sources/Navigation/CreateWalletNavigationStack.swift
+++ b/ios/Features/Onboarding/Sources/Navigation/CreateWalletNavigationStack.swift
@@ -38,10 +38,10 @@ public struct CreateWalletNavigationStack: View {
                     .navigationBarBackButtonHidden()
                     .interactiveDismissDisabled()
                 }
-                .navigationDestination(for: Scenes.CreateWallet.self) { _ in
+                .navigationDestination(for: Scenes.CreateWallet.self) {
                     ShowSecretDataScene(
                         model: NewSecretPhraseViewModel(
-                            walletService: model.walletService,
+                            words: $0.words,
                             onCreateWallet: { navigate(to: .verifyPhrase(words: $0)) },
                         ),
                     )
@@ -89,7 +89,8 @@ extension CreateWalletNavigationStack {
     func navigate(to route: CreateWalletRoute) {
         switch route {
         case .securityReminder: navigationPath.append(Scenes.SecurityReminder())
-        case .createWallet: navigationPath.append(Scenes.CreateWallet())
+        case .createWallet:
+            navigationPath.append(Scenes.CreateWallet(words: model.generateSecretPhrase()))
         case let .verifyPhrase(words): navigationPath.append(Scenes.VerifyPhrase(words: words))
         case let .walletProfile(wallet): navigationPath.append(Scenes.WalletProfile(wallet: wallet))
         }

--- a/ios/Features/Onboarding/Sources/ViewModels/CreateWalletModel.swift
+++ b/ios/Features/Onboarding/Sources/ViewModels/CreateWalletModel.swift
@@ -45,6 +45,14 @@ extension CreateWalletModel {
         isPresentingSelectImageWallet = wallet
     }
 
+    func generateSecretPhrase() -> [String] {
+        do {
+            return try walletService.createWallet()
+        } catch {
+            fatalError("Unable to create wallet")
+        }
+    }
+
     func createWallet(words: [String]) async throws -> Wallet {
         let result = try await walletService.loadOrCreateWallet(
             name: WalletNameGenerator(type: .multicoin, walletService: walletService).name,

--- a/ios/Features/Onboarding/Sources/ViewModels/NewSecretPhraseViewModel.swift
+++ b/ios/Features/Onboarding/Sources/ViewModels/NewSecretPhraseViewModel.swift
@@ -6,7 +6,6 @@ import Primitives
 import PrimitivesComponents
 import Style
 import SwiftUI
-import WalletService
 
 struct NewSecretPhraseViewModel: SecretPhraseViewableModel {
     private let onCreateWallet: ([String]) -> Void
@@ -21,15 +20,11 @@ struct NewSecretPhraseViewModel: SecretPhraseViewableModel {
     }
 
     init(
-        walletService: WalletService,
+        words: [String],
         onCreateWallet: @escaping (([String]) -> Void),
     ) {
+        self.words = words
         self.onCreateWallet = onCreateWallet
-        do {
-            words = try walletService.createWallet()
-        } catch {
-            fatalError("Unable to create wallet")
-        }
     }
 
     var title: String {

--- a/ios/Features/Onboarding/Tests/CreateWalletModelTests.swift
+++ b/ios/Features/Onboarding/Tests/CreateWalletModelTests.swift
@@ -28,4 +28,18 @@ struct CreateWalletModelTests {
 
         preferences.clear()
     }
+
+    @Test
+    func generateSecretPhraseReturnsGeneratedWords() {
+        let model = CreateWalletModel(
+            walletService: .mock(keystore: KeystoreMock()),
+            avatarService: .init(store: .mock()),
+            onComplete: nil,
+        )
+
+        let words = model.generateSecretPhrase()
+
+        #expect(words.isNotEmpty)
+        #expect(words == LocalKeystore.words)
+    }
 }

--- a/ios/Packages/Primitives/Sources/Scenes.swift
+++ b/ios/Packages/Primitives/Sources/Scenes.swift
@@ -4,7 +4,11 @@ import Foundation
 
 public enum Scenes {
     public struct CreateWallet: Hashable, Codable {
-        public init() {}
+        public let words: [String]
+
+        public init(words: [String]) {
+            self.words = words
+        }
     }
 
     public struct ImportWallet: Hashable, Codable {


### PR DESCRIPTION
The secret phrase now travels with the create wallet route, the same way the verify phrase step already does.