### PR TITLE
Sort held-balance assets first in search

### DIFF
--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
@@ -331,7 +331,7 @@ interface AssetsDao {
             (chain IN (:byChains) OR asset_info.id IN (:byAssets) )
             AND assetRank > 0
             AND search.`query` = :query
-            ORDER BY search.priority ASC, assetRank DESC
+            ORDER BY balanceFiatTotalAmount DESC, search.priority ASC, assetRank DESC
         """)
     fun swapSearchWithPriority(walletId: String, query: String, byChains: List<Chain>, byAssets: List<String>): Flow<List<DbAssetInfo>>
 

--- a/ios/Packages/Store/Sources/Requests/AssetsRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/AssetsRequest.swift
@@ -73,9 +73,12 @@ extension AssetsRequest {
         switch filter {
         case let .search(query, hasPriorityAssets):
             if hasPriorityAssets {
+                let totalValue = (TableAlias(name: BalanceRecord.databaseTableName)[BalanceRecord.Columns.totalAmount] * (TableAlias(name: PriceRecord.databaseTableName)[PriceRecord.Columns.price] ?? 0))
                 return request.joining(required: AssetRecord.search
                     .filter(SearchRecord.Columns.query == query))
                     .order(
+                        totalValue.desc,
+                        (totalValue == 0).desc,
                         TableAlias(name: SearchRecord.databaseTableName)[SearchRecord.Columns.priority].ascNullsLast,
                         TableAlias(name: AssetRecord.databaseTableName)[AssetRecord.Columns.rank].desc,
                     )

--- a/ios/Packages/Store/Tests/StoreTests/Requests/AssetsRequestTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/Requests/AssetsRequestTests.swift
@@ -141,6 +141,32 @@ struct AssetsRequestTests {
         }
     }
 
+    @Test func searchPrioritySortsHeldBalanceFirst() throws {
+        let db = DB.mockAssets()
+        let searchStore = SearchStore(db: db)
+        let priceStore = PriceStore(db: db)
+        let fiatRateStore = FiatRateStore(db: db)
+
+        try fiatRateStore.add([FiatRate(symbol: Currency.usd.rawValue, rate: 1)])
+
+        let assets = [AssetBasic].mock()
+        try priceStore.updatePrices(
+            prices: assets.map {
+                .mock(assetId: $0.asset.id, price: 1, priceChangePercentage24h: 0)
+            },
+            currency: Currency.usd.rawValue,
+        )
+
+        let query = "usdt"
+        try searchStore.add(type: .asset, query: query, ids: assets.map(\.asset.id.identifier))
+
+        try db.dbQueue.read { db in
+            let result = try AssetsRequest.mock(filters: [.search(query, hasPriorityAssets: true)]).fetch(db)
+
+            #expect(result.map(\.asset.id) == assets.reversed().map(\.asset.id))
+        }
+    }
+
     @Test func searchNativeAssetByChainDoesNotMatchChainTokens() throws {
         let db = DB.mockAssets(assets: [
             .mock(asset: .mock(id: AssetId(chain: .ton), name: "Gram", symbol: "GRAM", decimals: 9, type: .native)),


### PR DESCRIPTION
When searching for an asset (e.g. USDT while swapping), chains where you already hold a balance were sorted below chains with no balance. So USDT on BNB Chain with a real balance showed up under USDT on Aptos with zero.

Now assets with a balance appear at the top, ordered by their value, and the backend order is kept for everything below. Fixed on both iOS and Android.

Close: https://github.com/gemwalletcom/wallet/issues/714

<img width="320" alt="Screenshot_1784314659" src="https://github.com/user-attachments/assets/797c7f55-00e7-4076-ba39-2c203dc94b2a" />
<img width="320" alt="Simulator Screenshot - iPhone Air - 2026-07-17 at 22 21 57" src="https://github.com/user-attachments/assets/c6c5c5a6-53ec-4707-ad18-d490bb89ae3b" />

