### PR TITLE
Dedupe crypto-to-fiat string formatting

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionDetailsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionDetailsImpl.kt
@@ -145,7 +145,7 @@ class TransactionDetailsAggregateImpl(
                 else -> {
                     val value = Crypto(data.transaction.value.toBigInteger())
                     val fiat = data.price?.price?.let {
-                        CurrencyFormatter(currency = currency).string(CryptoFiatConverter.toFiat(value, asset.decimals, it).atomicValue)
+                        CryptoFiatConverter.toFiatString(value, asset.decimals, it, currency)
                     } ?: ""
 
                     val formatter = ValueFormatter(style = ValueFormatter.Style.Full)
@@ -184,7 +184,7 @@ class TransactionDetailsAggregateImpl(
             val feeCrypto = ValueFormatter(style = ValueFormatter.Style.Full)
                 .string(fee.atomicValue, data.feeAsset)
             val feeFiat = data.feePrice?.price?.let {
-                CurrencyFormatter(currency = currency).string(CryptoFiatConverter.toFiat(fee, data.feeAsset.decimals, it).atomicValue)
+                CryptoFiatConverter.toFiatString(fee, data.feeAsset.decimals, it, currency)
             } ?: ""
             return TransactionDetailsValue.Fee(data.feeAsset, feeCrypto, feeFiat)
         }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/AmountUIModel.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/AmountUIModel.kt
@@ -3,7 +3,6 @@ package com.gemwallet.android.domains.confirm
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.CryptoFiatConverter
-import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.ValueFormatter
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.NFTAsset
@@ -29,7 +28,6 @@ class AmountUIModel(
 
     val amountEquivalent: String by lazy {
         if (price == null) ""
-        else CurrencyFormatter(currency = currency)
-            .string(CryptoFiatConverter.toFiat(Crypto(amount), asset.asset.decimals, price).atomicValue)
+        else CryptoFiatConverter.toFiatString(Crypto(amount), asset.asset.decimals, price, currency)
     }
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeUIModel.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeUIModel.kt
@@ -2,7 +2,6 @@ package com.gemwallet.android.domains.confirm
 
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.CryptoFiatConverter
-import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.ValueFormatter
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.Currency
@@ -25,8 +24,7 @@ sealed interface FeeUIModel {
 
         val fiatAmount: String by lazy {
             if (price == null) ""
-            else CurrencyFormatter(currency = currency)
-                .string(CryptoFiatConverter.toFiat(Crypto(amount), feeAsset.decimals, price).atomicValue)
+            else CryptoFiatConverter.toFiatString(Crypto(amount), feeAsset.decimals, price, currency)
         }
 
         val cryptoAmountWithFiat: String by lazy {

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/CryptoFiatConverter.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/CryptoFiatConverter.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.model
 
+import com.wallet.core.primitives.Currency
 import java.math.BigDecimal
 import java.math.MathContext
 
@@ -10,6 +11,9 @@ object CryptoFiatConverter {
             .multiply(price.toBigDecimal())
         return Fiat(result)
     }
+
+    fun toFiatString(crypto: Crypto, decimals: Int, price: Double, currency: Currency): String =
+        CurrencyFormatter(currency = currency).string(toFiat(crypto, decimals, price).atomicValue)
 
     fun toCrypto(fiat: Fiat, decimals: Int, price: Double): Crypto =
         Crypto(cryptoValue(fiat, price), decimals)

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_head/SwapListHead.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_head/SwapListHead.kt
@@ -19,7 +19,6 @@ import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.CryptoFiatConverter
 import com.gemwallet.android.model.ValueFormatter
-import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.ui.components.list_item.ListItemDefaults
 import com.gemwallet.android.ui.components.list_item.listItem
 import com.gemwallet.android.ui.icons.AppIcons
@@ -116,8 +115,8 @@ private fun SwapItem(
             )
             if (currency != null) {
                 Text(
-                    text = CurrencyFormatter(currency = currency).string(
-                        CryptoFiatConverter.toFiat(Crypto(value), decimals, assetInfo.price?.price?.price ?: 0.0).atomicValue
+                    text = CryptoFiatConverter.toFiatString(
+                        Crypto(value), decimals, assetInfo.price?.price?.price ?: 0.0, currency
                     ),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.secondary,


### PR DESCRIPTION
The same crypto-to-fiat formatting was copied across five places on Android. Moved it into a single `CryptoFiatConverter.toFiatString` helper and updated the call sites. No behavior change.