### PR TITLE
Advance per-asset transactions timestamp on empty responses

### DIFF
--- a/ios/GemTests/unit_frameworks.xctestplan
+++ b/ios/GemTests/unit_frameworks.xctestplan
@@ -345,6 +345,13 @@
         "identifier" : "DiscoverAssetsServiceTests",
         "name" : "DiscoverAssetsServiceTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/FeatureServices",
+        "identifier" : "TransactionsServiceTests",
+        "name" : "TransactionsServiceTests"
+      }
     }
   ],
   "version" : 1

--- a/ios/Packages/FeatureServices/Package.swift
+++ b/ios/Packages/FeatureServices/Package.swift
@@ -302,7 +302,7 @@ let package = Package(
                 "AssetsService",
             ],
             path: "TransactionsService",
-            exclude: ["TestKit"],
+            exclude: ["TestKit", "Tests"],
         ),
         .target(
             name: "TransactionsServiceTestKit",
@@ -714,6 +714,16 @@ let package = Package(
                 .product(name: "PrimitivesTestKit", package: "Primitives"),
             ],
             path: "DiscoverAssetsService/Tests",
+        ),
+        .testTarget(
+            name: "TransactionsServiceTests",
+            dependencies: [
+                "TransactionsService",
+                "TransactionsServiceTestKit",
+                .product(name: "GemAPITestKit", package: "GemAPI"),
+                .product(name: "PrimitivesTestKit", package: "Primitives"),
+            ],
+            path: "TransactionsService/Tests",
         ),
         .testTarget(
             name: "BalanceServiceTests",

--- a/ios/Packages/FeatureServices/TransactionsService/Tests/TransactionsServiceTests.swift
+++ b/ios/Packages/FeatureServices/TransactionsService/Tests/TransactionsServiceTests.swift
@@ -1,0 +1,22 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Preferences
+import Primitives
+import PrimitivesTestKit
+import Testing
+import TransactionsService
+import TransactionsServiceTestKit
+
+struct TransactionsServiceTests {
+    @Test
+    func updateForAssetAdvancesTimestampOnEmptyResponse() async throws {
+        let walletId = WalletId.mock()
+        let assetId = AssetId.mockEthereum()
+        let preferences = WalletPreferences(walletId: walletId)
+        preferences.clear()
+
+        try await TransactionsService.mock().updateForAsset(walletId: walletId, assetId: assetId)
+
+        #expect(preferences.transactionsForAssetTimestamp(assetId: assetId.identifier) > 0)
+    }
+}

--- a/ios/Packages/FeatureServices/TransactionsService/TransactionsService.swift
+++ b/ios/Packages/FeatureServices/TransactionsService/TransactionsService.swift
@@ -49,9 +49,6 @@ public final class TransactionsService: Sendable {
             asset: assetId,
             fromTimestamp: store.transactionsForAssetTimestamp(assetId: assetId.identifier),
         )
-        if response.transactions.isEmpty {
-            return
-        }
 
         try await prefetchAssets(walletId: walletId, transactions: response.transactions)
         try transactionStore.addTransactions(walletId: walletId, transactions: response.transactions)


### PR DESCRIPTION
Fix per-asset transactions cursor never advancing. updateForAsset returns early on an empty response before setTransactionsForAssetTimestamp, so for assets with no new activity every asset screen open re-queries from the last transaction date forever. Removed the early return — updateAll and Android (SyncTransactionsImpl) already advance the cursor unconditionally.
