### PR TITLE
Skip Sui staking reward simulations when there are no staked objects

### DIFF
--- a/core/crates/gem_sui/src/rpc/staking.rs
+++ b/core/crates/gem_sui/src/rpc/staking.rs
@@ -151,10 +151,12 @@ impl SuiClient {
                     .map_err(|error| error.into())
             })
             .collect::<Result<Vec<_>, Box<dyn Error + Send + Sync>>>()?;
+        if staked_sui.is_empty() {
+            return Ok(Vec::new());
+        }
         let ids = staked_sui.iter().map(|stake| stake.id).collect::<Vec<_>>();
         let pool_ids = staked_sui.iter().map(|stake| stake.pool_id).collect::<Vec<_>>();
-        let rewards = self.calculate_rewards(&ids).await?;
-        let validator_addresses = self.get_validator_address_by_pool_id(&pool_ids).await?;
+        let (rewards, validator_addresses) = futures::try_join!(self.calculate_rewards(&ids), self.get_validator_address_by_pool_id(&pool_ids))?;
 
         Ok(staked_sui
             .into_iter()


### PR DESCRIPTION
create_delegated_stakes ran two SimulateTransaction calls even with no staked objects, on every Sui balance refresh. Return early on empty and join the two simulations for wallets that do stake.