### PR TITLE
Skip swap balance update when pair assets are unchanged

### DIFF
--- a/ios/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
+++ b/ios/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
@@ -152,8 +152,8 @@ public final class SwapSceneViewModel {
         isQuoteLoading
     }
 
-    var assetIds: [AssetId] {
-        [fromAsset?.asset.id, toAsset?.asset.id].compactMap(\.self)
+    var assetIds: Set<AssetId> {
+        Set([fromAsset?.asset.id, toAsset?.asset.id].compactMap(\.self))
     }
 
     var errorInfoAction: VoidAction {
@@ -260,8 +260,8 @@ extension SwapSceneViewModel {
         swap()
     }
 
-    func onAssetIdsChange(assetIds: [AssetId]) async {
-        await performUpdate(for: assetIds)
+    func onAssetIdsChange(assetIds: Set<AssetId>) async {
+        await performUpdate(for: Array(assetIds))
     }
 
     func onSelectPriceImpactInfo() {

--- a/ios/Features/Swap/Tests/SwapTests/SwapSceneViewModelTests.swift
+++ b/ios/Features/Swap/Tests/SwapTests/SwapSceneViewModelTests.swift
@@ -22,6 +22,18 @@ import Testing
 @MainActor
 struct SwapSceneViewModelTests {
     @Test
+    func assetIdsIgnoresPairOrder() {
+        let model = SwapSceneViewModel.mock()
+        let assetIds = model.assetIds
+
+        model.fromAssetQuery.value = .mock(asset: .mockEthereumUSDT())
+        model.toAssetQuery.value = .mock(asset: .mockEthereum(), balance: .mock())
+
+        #expect(model.assetIds == assetIds)
+        #expect(model.assetIds == [AssetId.mockEthereum(), AssetId.mockEthereumUSDT()])
+    }
+
+    @Test
     func toValue() async {
         #expect(await model().toValue == "250,000")
         #expect(await model(toValueMock: "1000000").toValue == "1")


### PR DESCRIPTION
 Make assetIds a Set so balance updates only run when the assets actually change. Before multiple unneeded requests on same assets swap