### PR TITLE
Parse machine-generated amounts independent of locale

### DIFF
--- a/ios/Features/Transfer/Sources/ViewModels/RecipientSceneViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/RecipientSceneViewModel.swift
@@ -29,7 +29,6 @@ public final class RecipientSceneViewModel {
 
     private let walletService: WalletService
     private let onRecipientDataAction: RecipientDataAction
-    private let formatter = ValueFormatter(style: .full)
     private let assetImageFormatter: AssetImageFormatter
 
     public var isPresentingScanner: RecipientScene.Field?
@@ -204,7 +203,7 @@ extension RecipientSceneViewModel {
             case let .nft(asset): .transferNft(asset)
             }
 
-            let value = try formatter.inputNumber(from: amount, decimals: asset.decimals.asInt)
+            let value = try BigNumberFormatter.standard.number(from: amount, decimals: asset.decimals.asInt)
             let recipientData = RecipientData(
                 recipient: Recipient(
                     name: .none,

--- a/ios/Features/Transfer/Tests/RecipientSceneViewModelTests.swift
+++ b/ios/Features/Transfer/Tests/RecipientSceneViewModelTests.swift
@@ -1,5 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
+import BigInt
 import Components
 import Formatters
 import NameServiceTestKit
@@ -100,23 +101,19 @@ struct RecipientSceneViewModelTests {
 
         let payment = PaymentScanResult(
             address: " \n\(address)\r ",
-            amount: "1",
+            amount: "1.234",
             memo: nil,
         )
 
-        do {
-            let result = try model.getRecipientScanResult(payment: payment)
+        let result = try model.getRecipientScanResult(payment: payment)
 
-            switch result {
-            case let .transferData(data):
-                #expect(data.recipientData.recipient.address == checksummed)
-                #expect(data.canChangeValue == false)
-            case .recipient:
-                Issue.record("Expected transferData but got recipient")
-            }
-        } catch {
-            // If the formatter throws an error, we can still test the recipient case
-            Issue.record("Formatter threw error: \(error)")
+        switch result {
+        case let .transferData(data):
+            #expect(data.recipientData.recipient.address == checksummed)
+            #expect(data.canChangeValue == false)
+            #expect(data.value == BigInt("1234000000000000000"))
+        case .recipient:
+            Issue.record("Expected transferData but got recipient")
         }
     }
 

--- a/ios/Packages/FeatureServices/PerpetualService/PerpetualService.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/PerpetualService.swift
@@ -111,7 +111,7 @@ public struct PerpetualService: PerpetualServiceable {
 
     private func perpetualBalanceValue(_ amount: Double) throws -> UpdateBalanceValue {
         try UpdateBalanceValue(
-            value: ValueFormatter.full.inputNumber(from: amount.description, decimals: 6).description,
+            value: BigNumberFormatter.standard.number(from: amount.description, decimals: 6).description,
             amount: amount,
         )
     }


### PR DESCRIPTION
On locales that group thousands with a dot, amounts the app read from QR payment links or the perpetuals exchange could come out 1000x too high. These values were parsed as if a person had typed them.

Now machine-generated amounts are parsed the same way everywhere, regardless of the phone's locale.

Closes #727