### PR TITLE
Deduplicate selectable list onSelect handler

### DIFF
--- a/ios/Packages/Components/Sources/ListViews/Protocols/SelectableListAdoptable.swift
+++ b/ios/Packages/Components/Sources/ListViews/Protocols/SelectableListAdoptable.swift
@@ -54,4 +54,13 @@ public extension SelectableListAdoptable {
     mutating func reset() {
         selectedItems = []
     }
+
+    mutating func select(item: Item) -> [Item]? {
+        toggle(item: item)
+
+        return switch selectionType {
+        case .multiSelection: nil
+        case .navigationLink, .checkmark: Array(selectedItems)
+        }
+    }
 }

--- a/ios/Packages/Components/Sources/ListViews/SearchableSelectableListView.swift
+++ b/ios/Packages/Components/Sources/ListViews/SearchableSelectableListView.swift
@@ -51,13 +51,8 @@ public struct SearchableSelectableListView<ViewModel: SelectableListAdoptable & 
     }
 
     private func onSelect(item: ViewModel.Item) {
-        model.toggle(item: item)
-
-        switch model.selectionType {
-        case .multiSelection:
-            break
-        case .navigationLink, .checkmark:
-            onFinishSelection?(Array(model.selectedItems))
+        if let selected = model.select(item: item) {
+            onFinishSelection?(selected)
         }
     }
 }

--- a/ios/Packages/Components/Sources/ListViews/SelectableListView.swift
+++ b/ios/Packages/Components/Sources/ListViews/SelectableListView.swift
@@ -67,13 +67,8 @@ public struct SelectableListView<ViewModel: SelectableListAdoptable, Content: Vi
     }
 
     private func onSelect(item: ViewModel.Item) {
-        model.toggle(item: item)
-
-        switch model.selectionType {
-        case .multiSelection:
-            break
-        case .navigationLink, .checkmark:
-            onFinishSelection?(Array(model.selectedItems))
+        if let selected = model.select(item: item) {
+            onFinishSelection?(selected)
         }
     }
 }


### PR DESCRIPTION
The two selectable list views carried a byte-for-byte copy of the same selection handler. This moves that shared logic into a single method on the list protocol so both views use one implementation and can't drift apart.

No behavior change.