### PR TITLE
Clear import validation error when switching tabs

### DIFF
--- a/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/components/ImportInput.kt
+++ b/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/components/ImportInput.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -91,6 +92,10 @@ internal fun ImportInput(
         viewModel.onResolved(onResolved)
 
         onDispose {}
+    }
+
+    LaunchedEffect(importType.walletType) {
+        viewModel.reset()
     }
 
     val errorColor = MaterialTheme.colorScheme.error

--- a/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/views/ImportScreen.kt
+++ b/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/views/ImportScreen.kt
@@ -215,6 +215,7 @@ private fun ImportScene(
                     TypeSelection(importType) { walletType ->
                         onTypeChange(walletType)
                         inputState.value = TextFieldValue()
+                        nameRecordState.value = null
                     }
                     DataInput(importType, inputState, nameRecordState) {
                         dataErrorState = null

--- a/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/AddressChainViewModel.kt
+++ b/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/AddressChainViewModel.kt
@@ -22,6 +22,8 @@ class AddressChainViewModel @Inject constructor(
 
     fun onInput(input: String, chain: Chain?) = resolver.onInput(input, chain)
 
+    fun reset() = resolver.reset()
+
     fun onResolved(onResolved: (NameRecord?) -> Unit) {
         resolver.onResolved = onResolved
     }


### PR DESCRIPTION
On the wallet import screen, switching between the Address and Phrase tabs left a stale validation error on the now-empty field. Switching tabs now clears the field and its error, matching iOS.

Closes #715