### PR TITLE
Allow fractional custom fee rate on Bitcoin

### DIFF
--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
@@ -35,8 +35,8 @@ import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.confirm.CustomFee
 import com.gemwallet.android.domains.confirm.FeeRateUIModel
 import com.gemwallet.android.domains.confirm.FeeUIModel
+import com.gemwallet.android.ext.feeRateDecimals
 import com.gemwallet.android.ext.feeUnitType
-import com.gemwallet.android.ext.gasPriceDecimals
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.FeeSelection
 import com.gemwallet.android.ui.R
@@ -84,13 +84,14 @@ fun FeeDetails(
     val unitSymbol = unitSuffix.trim()
     val feeConfig = remember(chain) { Config().getFeeConfig(chain.string) }
     val supportsCustomFee = feeConfig.customFeeEnabled && feeRates.size > 1
-    val decimals = feeUnitType?.gasPriceDecimals ?: feeAssetInfo.asset.decimals
+    val decimals = feeRateDecimals(feeUnitType, feeConfig, feeAssetInfo.asset.decimals)
     val maxMultiplier = feeConfig.maxMultiplier.toInt()
+    val minimumCustomFeeRate = feeConfig.minimumCustomFeeRate?.toLong()?.toBigInteger()
 
     val selectedCustomRate = (selection as? FeeSelection.Custom)?.gasPrice
     var showCustom by remember(isVisible) { mutableStateOf(false) }
     val customModel = remember(showCustom) {
-        NetworkFeeCustomViewModel(currentFee, feeRates, selection, decimals, maxMultiplier, selectedCustomRate)
+        NetworkFeeCustomViewModel(currentFee, feeRates, selection, decimals, maxMultiplier, minimumCustomFeeRate, selectedCustomRate)
     }
 
     ModalBottomSheet(
@@ -126,6 +127,7 @@ fun FeeDetails(
                 feeRates = feeRates,
                 feeAssetInfo = feeAssetInfo,
                 feeUnitType = feeUnitType,
+                decimals = decimals,
                 unitSymbol = unitSymbol,
                 supportsCustomFee = supportsCustomFee,
                 customRateText = selectedCustomRate?.let { CustomFee.formatRate(it, decimals, unitSymbol) },
@@ -144,6 +146,7 @@ private fun FeeRates(
     feeRates: List<GemFeeRate>,
     feeAssetInfo: AssetInfo,
     feeUnitType: FeeUnitType?,
+    decimals: Int,
     unitSymbol: String,
     supportsCustomFee: Boolean,
     customRateText: String?,
@@ -156,7 +159,7 @@ private fun FeeRates(
         if (feeRates.size > 1) {
             val totalCount = feeRates.size + if (supportsCustomFee) 1 else 0
             itemsPositioned(feeRates, totalCount = totalCount) { position, item ->
-                val feeRate = FeeRateUIModel(item, feeAssetInfo, feeUnitType, selectedRate, currentFee.amount, unitSymbol)
+                val feeRate = FeeRateUIModel(item, feeAssetInfo, feeUnitType, decimals, selectedRate, currentFee.amount, unitSymbol)
                 FeeRow(
                     emoji = feeRate.emoji,
                     title = feeRate.priority.title(),
@@ -225,10 +228,10 @@ private fun ColumnScope.CustomFeeInput(
     }
     Text(
         modifier = Modifier.padding(horizontal = paddingLarge, vertical = paddingHalfSmall),
-        text = if (model.isOverMax) {
-            stringResource(R.string.common_maximum_value, "${model.maxRateText} $unitSymbol")
-        } else {
-            ""
+        text = when {
+            model.isOverMax -> stringResource(R.string.common_maximum_value, "${model.maxRateText} $unitSymbol")
+            model.isBelowMinimum -> stringResource(R.string.common_minimum_value, "${model.minRateText} $unitSymbol")
+            else -> ""
         },
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.error,

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/NetworkFeeCustomViewModel.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/NetworkFeeCustomViewModel.kt
@@ -17,19 +17,22 @@ class NetworkFeeCustomViewModel(
     private val selection: FeeSelection,
     private val decimals: Int,
     private val maxMultiplier: Int,
+    private val minimumCustomFeeRate: BigInteger?,
     initialRate: BigInteger?,
 ) {
     var input by mutableStateOf(initialRate?.let { CustomFee.format(it, decimals) } ?: "")
         private set
 
     private val custom by derivedStateOf {
-        CustomFee.from(input, currentFee, feeRates, selection, decimals, maxMultiplier)
+        CustomFee.from(input, currentFee, feeRates, selection, decimals, maxMultiplier, minimumCustomFeeRate)
     }
 
     val placeholder: String get() = custom.placeholder
     val networkFee: FeeUIModel.FeeInfo get() = custom.networkFee
     val isOverMax: Boolean get() = custom.isOverMax
     val maxRateText: String get() = custom.maxRateText
+    val isBelowMinimum: Boolean get() = custom.isBelowMinimum
+    val minRateText: String get() = custom.minRateText
     val isConfirmEnabled: Boolean get() = custom.isConfirmEnabled
     val rate: BigInteger? get() = custom.rate
 

--- a/android/features/confirm/viewmodels/src/test/kotlin/com/gemwallet/android/features/confirm/models/CustomFeeTest.kt
+++ b/android/features/confirm/viewmodels/src/test/kotlin/com/gemwallet/android/features/confirm/models/CustomFeeTest.kt
@@ -27,25 +27,33 @@ class CustomFeeTest {
         priority = FeePriority.Normal,
     )
 
-    private fun custom(input: String, selection: FeeSelection) =
-        CustomFee.from(input, currentFee, feeRates, selection, decimals = 0, maxMultiplier = 10)
+    private fun custom(input: String, decimals: Int = 0, minimumCustomFeeRate: BigInteger? = null, selection: FeeSelection = FeeSelection.Preset(FeePriority.Normal)) =
+        CustomFee.from(input, currentFee, feeRates, selection, decimals, maxMultiplier = 10, minimumCustomFeeRate)
 
     @Test
-    fun customFeeComputesRateScalingAndMax() {
-        val valid = custom("4", FeeSelection.Preset(FeePriority.Normal))
-
+    fun customFeeFrom() {
+        val valid = custom("4")
         assertEquals(BigInteger("4"), valid.rate)
-        assertFalse(valid.isOverMax)
-        assertTrue(valid.isConfirmEnabled)
         assertEquals(BigInteger("2000"), valid.networkFee.amount)
+        assertTrue(valid.isConfirmEnabled)
 
-        val aboveMax = custom("21", FeeSelection.Preset(FeePriority.Normal))
+        val fractional = custom("0.1", decimals = 1, minimumCustomFeeRate = BigInteger.ONE)
+        assertEquals(BigInteger("1"), fractional.rate)
+        assertTrue(fractional.isConfirmEnabled)
 
-        assertTrue(aboveMax.isOverMax)
-        assertFalse(aboveMax.isConfirmEnabled)
+        val belowMinimum = custom("0.3", decimals = 1, minimumCustomFeeRate = BigInteger("5"))
+        assertTrue(belowMinimum.isBelowMinimum)
+        assertFalse(belowMinimum.isConfirmEnabled)
 
-        val anchoredToNormal = custom("21", FeeSelection.Custom(BigInteger("20")))
+        val atMinimum = custom("0.5", decimals = 1, minimumCustomFeeRate = BigInteger("5"))
+        assertFalse(atMinimum.isBelowMinimum)
+        assertTrue(atMinimum.isConfirmEnabled)
 
+        val overMax = custom("21")
+        assertTrue(overMax.isOverMax)
+        assertFalse(overMax.isConfirmEnabled)
+
+        val anchoredToNormal = custom("21", selection = FeeSelection.Custom(BigInteger("20")))
         assertTrue(anchoredToNormal.isOverMax)
     }
 }

--- a/android/features/confirm/viewmodels/src/test/kotlin/com/gemwallet/android/features/confirm/models/FeeRateUIModelTest.kt
+++ b/android/features/confirm/viewmodels/src/test/kotlin/com/gemwallet/android/features/confirm/models/FeeRateUIModelTest.kt
@@ -29,6 +29,7 @@ class FeeRateUIModelTest {
             ),
             feeAsset = assetInfo,
             feeUnitType = FeeUnitType.Gwei,
+            feeRateDecimals = 9,
             selectedRate = selectedRate,
             selectedFeeAmount = BigInteger("1000000000000000000"),
         )
@@ -48,6 +49,7 @@ class FeeRateUIModelTest {
             feeRate = GemFeeRate(priority = priority.string, gasPriceType = GemGasPriceType.Regular(gasPrice = gasPrice)),
             feeAsset = assetInfo,
             feeUnitType = FeeUnitType.Native,
+            feeRateDecimals = assetInfo.asset.decimals,
             selectedRate = selectedRate,
             selectedFeeAmount = BigInteger("110000"),
         )
@@ -65,6 +67,7 @@ class FeeRateUIModelTest {
             ),
             feeAsset = mockAssetInfo(asset = mockAssetEthereum()),
             feeUnitType = FeeUnitType.Native,
+            feeRateDecimals = mockAssetEthereum().decimals,
         )
 
         assertEquals("0.000000000000000001 ETH", model.price)

--- a/android/features/confirm/viewmodels/src/test/kotlin/com/gemwallet/android/features/confirm/models/GemGasPriceTypeTest.kt
+++ b/android/features/confirm/viewmodels/src/test/kotlin/com/gemwallet/android/features/confirm/models/GemGasPriceTypeTest.kt
@@ -1,10 +1,7 @@
 package com.gemwallet.android.domains.confirm
 
-import com.gemwallet.android.ext.gasPriceDecimals
 import com.gemwallet.android.ext.totalFee
-import com.wallet.core.primitives.FeeUnitType
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 import uniffi.gemstone.GemGasPriceType
 import java.math.BigInteger
@@ -19,12 +16,5 @@ class GemGasPriceTypeTest {
             BigInteger("9"),
             GemGasPriceType.Solana(gasPrice = "4", priorityFee = "5", unitPrice = "0").totalFee(),
         )
-    }
-
-    @Test
-    fun gasPriceDecimalsMapsByUnitType() {
-        assertEquals(0, FeeUnitType.SatVb.gasPriceDecimals)
-        assertEquals(9, FeeUnitType.Gwei.gasPriceDecimals)
-        assertNull(FeeUnitType.Native.gasPriceDecimals)
     }
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/CustomFee.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/CustomFee.kt
@@ -15,7 +15,9 @@ data class CustomFee(
     val placeholder: String,
     val networkFee: FeeUIModel.FeeInfo,
     val maxRateText: String,
+    val minRateText: String,
     val isOverMax: Boolean,
+    val isBelowMinimum: Boolean,
     val isConfirmEnabled: Boolean,
 ) {
     companion object {
@@ -26,10 +28,12 @@ data class CustomFee(
             selection: FeeSelection,
             decimals: Int,
             maxMultiplier: Int,
+            minimumCustomFeeRate: BigInteger?,
         ): CustomFee {
             val baseTotal = baseTotal(selection, feeRates, currentFee.priority)
             val normalTotal = normalTotal(feeRates) ?: baseTotal
             val rate = input.parseInputNumberOrNull()?.movePointRight(decimals)?.toBigInteger()?.takeIf { it > BigInteger.ZERO }
+            val isBelowMinimum = rate != null && minimumCustomFeeRate != null && rate < minimumCustomFeeRate
 
             val estimate = customFeeEstimate(
                 rate = rate?.toString(),
@@ -44,8 +48,10 @@ data class CustomFee(
                 placeholder = ValueFormatter(style = ValueFormatter.Style.Auto).string(baseTotal, decimals),
                 networkFee = FeeUIModel.FeeInfo(BigInteger(estimate.feeValue), currentFee.feeAsset, currentFee.price, currentFee.currency, currentFee.priority),
                 maxRateText = format(BigInteger(estimate.maxRate), decimals),
+                minRateText = minimumCustomFeeRate?.let { format(it, decimals) } ?: "",
                 isOverMax = estimate.isOverMax,
-                isConfirmEnabled = rate != null && !estimate.isOverMax,
+                isBelowMinimum = isBelowMinimum,
+                isConfirmEnabled = rate != null && !estimate.isOverMax && !isBelowMinimum,
             )
         }
 

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeRateUIModel.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/FeeRateUIModel.kt
@@ -6,7 +6,6 @@ import com.gemwallet.android.model.CryptoFiatConverter
 import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.ValueFormatter
 import com.wallet.core.primitives.FeePriority
-import com.gemwallet.android.ext.gasPriceDecimals
 import com.gemwallet.android.ext.totalFee
 import com.wallet.core.primitives.FeeUnitType
 import uniffi.gemstone.GemFeeRate
@@ -16,6 +15,7 @@ data class FeeRateUIModel(
     val feeRate: GemFeeRate,
     val feeAsset: AssetInfo,
     val feeUnitType: FeeUnitType?,
+    val feeRateDecimals: Int,
     val selectedRate: GemFeeRate? = null,
     val selectedFeeAmount: BigInteger? = null,
     val unitSymbol: String? = null,
@@ -56,11 +56,10 @@ data class FeeRateUIModel(
     }
 
     private fun gasPriceText(): String {
-        val unit = feeUnitType ?: return ""
-        val decimals = unit.gasPriceDecimals ?: return ""
+        feeUnitType ?: return ""
         val symbol = unitSymbol ?: return ""
         return ValueFormatter(style = ValueFormatter.Style.Auto)
-            .string(feeRate.gasPriceType.totalFee(), decimals, symbol)
+            .string(feeRate.gasPriceType.totalFee(), feeRateDecimals, symbol)
     }
 
     private fun nativeAmountText(): String {

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/GemGasPriceType.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/GemGasPriceType.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.ext
 
 import com.wallet.core.primitives.FeeUnitType
+import uniffi.gemstone.FeeConfig
 import uniffi.gemstone.GemGasPriceType
 import java.math.BigInteger
 
@@ -10,9 +11,8 @@ fun GemGasPriceType.totalFee(): BigInteger = when (this) {
     is GemGasPriceType.Solana -> gasPrice.toBigInteger() + priorityFee.toBigInteger()
 }
 
-val FeeUnitType.gasPriceDecimals: Int?
-    get() = when (this) {
-        FeeUnitType.SatVb -> 0
-        FeeUnitType.Gwei -> 9
-        FeeUnitType.Native -> null
+fun feeRateDecimals(feeUnitType: FeeUnitType?, feeConfig: FeeConfig, assetDecimals: Int): Int =
+    when (feeUnitType) {
+        FeeUnitType.SatVb, FeeUnitType.Gwei -> feeConfig.decimals.toInt()
+        FeeUnitType.Native, null -> assetDecimals
     }

--- a/core/crates/gem_bitcoin/src/provider/preload.rs
+++ b/core/crates/gem_bitcoin/src/provider/preload.rs
@@ -6,7 +6,8 @@ use std::error::Error;
 
 use gem_client::Client;
 use primitives::{
-    BitcoinChain, FeePriority, FeeRate, GasPriceType, TransactionInputType, TransactionLoadData, TransactionLoadInput, TransactionLoadMetadata, TransactionPreloadInput, UTXO,
+    BitcoinChain, FeePriority, FeeRate, FeeUnitType, GasPriceType, TransactionInputType, TransactionLoadData, TransactionLoadInput, TransactionLoadMetadata,
+    TransactionPreloadInput, UTXO,
 };
 
 use crate::models::Address;
@@ -44,7 +45,7 @@ impl<C: Client> ChainTransactionLoad for BitcoinClient<C> {
                 let (slow, normal, fast) = futures::try_join!(self.get_fee(priority.slow), self.get_fee(priority.normal), self.get_fee(priority.fast))?;
                 Ok(map_fee_rates(slow, normal, fast, self.chain))
             }
-            BitcoinChain::Zcash => Ok(vec![FeeRate::new(FeePriority::Normal, GasPriceType::regular(BigInt::from(1_000)))]),
+            BitcoinChain::Zcash => Ok(vec![FeeRate::new(FeePriority::Normal, GasPriceType::regular(BigInt::from(10_000)))]),
         }
     }
 
@@ -69,13 +70,14 @@ fn calculate_fee_rate(fee_sat_per_kb: &str, minimum_byte_fee: u32) -> Result<Big
 }
 
 fn map_fee_rates(slow: BigInt, normal: BigInt, fast: BigInt, chain: BitcoinChain) -> Vec<FeeRate> {
+    let scale = BigInt::from(FeeUnitType::SatVb.scale_factor());
     let min_fee = BigInt::from(chain.minimum_byte_fee());
     let normal = normal.max(&slow + &min_fee);
     let third: BigInt = &normal / 3;
     let fast = fast.max(&slow + &min_fee * 2).max(&normal + third);
     vec![
-        FeeRate::new(FeePriority::Normal, GasPriceType::regular(normal)),
-        FeeRate::new(FeePriority::Fast, GasPriceType::regular(fast)),
+        FeeRate::new(FeePriority::Normal, GasPriceType::regular(normal * &scale)),
+        FeeRate::new(FeePriority::Fast, GasPriceType::regular(fast * &scale)),
     ]
 }
 
@@ -101,27 +103,23 @@ mod tests {
 
     #[test]
     fn test_map_fee_rates_bitcoin() {
-        // all 1 sat → normal=2 (slow+1), fast=3 (slow+2)
         let rates = map_fee_rates(BigInt::from(1), BigInt::from(1), BigInt::from(1), BitcoinChain::Bitcoin);
-        assert_eq!(FeeRate::find(&rates, FeePriority::Normal).unwrap().gas_price_type.gas_price(), BigInt::from(2));
-        assert_eq!(FeeRate::find(&rates, FeePriority::Fast).unwrap().gas_price_type.gas_price(), BigInt::from(3));
+        assert_eq!(FeeRate::find(&rates, FeePriority::Normal).unwrap().gas_price_type.gas_price(), BigInt::from(20));
+        assert_eq!(FeeRate::find(&rates, FeePriority::Fast).unwrap().gas_price_type.gas_price(), BigInt::from(30));
 
-        // slow=1, normal=12, fast=12 → normal kept, fast=16 (12+12/3)
         let rates = map_fee_rates(BigInt::from(1), BigInt::from(12), BigInt::from(12), BitcoinChain::Bitcoin);
-        assert_eq!(FeeRate::find(&rates, FeePriority::Normal).unwrap().gas_price_type.gas_price(), BigInt::from(12));
-        assert_eq!(FeeRate::find(&rates, FeePriority::Fast).unwrap().gas_price_type.gas_price(), BigInt::from(16));
+        assert_eq!(FeeRate::find(&rates, FeePriority::Normal).unwrap().gas_price_type.gas_price(), BigInt::from(120));
+        assert_eq!(FeeRate::find(&rates, FeePriority::Fast).unwrap().gas_price_type.gas_price(), BigInt::from(160));
 
-        // fast already higher → kept
         let rates = map_fee_rates(BigInt::from(1), BigInt::from(12), BigInt::from(25), BitcoinChain::Bitcoin);
-        assert_eq!(FeeRate::find(&rates, FeePriority::Fast).unwrap().gas_price_type.gas_price(), BigInt::from(25));
+        assert_eq!(FeeRate::find(&rates, FeePriority::Fast).unwrap().gas_price_type.gas_price(), BigInt::from(250));
     }
 
     #[test]
     fn test_map_fee_rates_doge() {
-        // all 1000 → normal=2000 (1000+1000), fast=3000 (slow+2000)
         let rates = map_fee_rates(BigInt::from(1000), BigInt::from(1000), BigInt::from(1000), BitcoinChain::Doge);
-        assert_eq!(FeeRate::find(&rates, FeePriority::Normal).unwrap().gas_price_type.gas_price(), BigInt::from(2000));
-        assert_eq!(FeeRate::find(&rates, FeePriority::Fast).unwrap().gas_price_type.gas_price(), BigInt::from(3000));
+        assert_eq!(FeeRate::find(&rates, FeePriority::Normal).unwrap().gas_price_type.gas_price(), BigInt::from(20_000));
+        assert_eq!(FeeRate::find(&rates, FeePriority::Fast).unwrap().gas_price_type.gas_price(), BigInt::from(30_000));
     }
 
     #[tokio::test]

--- a/core/crates/gem_bitcoin/src/signer/planner/fee.rs
+++ b/core/crates/gem_bitcoin/src/signer/planner/fee.rs
@@ -1,4 +1,4 @@
-use primitives::BitcoinChain;
+use primitives::{BitcoinChain, FeeUnitType};
 
 use super::{PlanInput, PlanOutput};
 use crate::signer::{address::UnlockingScript, encoding::varint_len};
@@ -31,7 +31,8 @@ fn estimate_bitcoin_fee(inputs: &[PlanInput], outputs: &[PlanOutput], fee_rate: 
     let input_weight: u128 = inputs.iter().map(input_weight).sum();
     let output_weight: u128 = outputs.iter().map(|output| output.serialized_len() as u128 * WITNESS_SCALE_FACTOR).sum();
     let weight = transaction_base_weight(inputs.len(), outputs.len(), has_witness) + input_weight + output_weight;
-    weight.div_ceil(WITNESS_SCALE_FACTOR) * fee_rate as u128
+    let scale = FeeUnitType::SatVb.scale_factor() as u128;
+    (weight.div_ceil(WITNESS_SCALE_FACTOR) * fee_rate as u128).div_ceil(scale)
 }
 
 fn transaction_base_weight(input_count: usize, output_count: usize, has_witness: bool) -> u128 {
@@ -68,11 +69,14 @@ mod tests {
             PlanOutput::new(10_000, script_for_public_key_hash(UnlockingScript::P2pkh, [0u8; 20])),
             PlanOutput::new(20_000, script_for_public_key_hash(UnlockingScript::P2pkh, [0u8; 20])),
         ];
-        assert_eq!(estimate_fee(BitcoinChain::Bitcoin, &legacy_inputs, &legacy_outputs, 2), 452);
+        assert_eq!(estimate_fee(BitcoinChain::Bitcoin, &legacy_inputs, &legacy_outputs, 20), 452);
+        assert_eq!(estimate_fee(BitcoinChain::Bitcoin, &legacy_inputs, &legacy_outputs, 1), 23);
 
         let segwit_inputs = vec![PlanInput::mock_with_unlocking_script(UnlockingScript::P2wpkh)];
         let segwit_outputs = vec![PlanOutput::new(10_000, script_for_public_key_hash(UnlockingScript::P2wpkh, [0u8; 20]))];
-        assert_eq!(estimate_fee(BitcoinChain::Bitcoin, &segwit_inputs, &segwit_outputs, 3), 330);
+        assert_eq!(estimate_fee(BitcoinChain::Bitcoin, &segwit_inputs, &segwit_outputs, 30), 330);
+        assert_eq!(estimate_fee(BitcoinChain::Bitcoin, &segwit_inputs, &segwit_outputs, 5), 55);
+        assert_eq!(estimate_fee(BitcoinChain::Bitcoin, &segwit_inputs, &segwit_outputs, 1), 11);
 
         let zcash_outputs = vec![PlanOutput::new(10_000, script_for_public_key_hash(UnlockingScript::P2pkh, [0u8; 20]))];
         assert_eq!(estimate_fee(BitcoinChain::Zcash, &legacy_inputs, &zcash_outputs, 100), 10_000);

--- a/core/crates/gem_bitcoin/src/signer/planner/request.rs
+++ b/core/crates/gem_bitcoin/src/signer/planner/request.rs
@@ -57,8 +57,7 @@ impl SpendRequest {
 }
 
 fn spend_fee_rate(chain: BitcoinChain, input: &SignerInput) -> Result<u64, SignerError> {
-    let minimum_fee_rate = u64::try_from(chain.minimum_byte_fee()).map_err(|_| SignerError::invalid_input(format!("invalid {} minimum fee", chain.get_chain())))?;
-    Ok(input.fee.gas_price_u64()?.max(minimum_fee_rate))
+    Ok(input.fee.gas_price_u64()?.max(u64::from(chain.minimum_custom_fee_rate())))
 }
 
 fn validate_native_chain_asset(chain: BitcoinChain, asset: &Asset, message: &'static str) -> Result<(), SignerError> {

--- a/core/crates/gem_bitcoin/src/signer/planner/spend.rs
+++ b/core/crates/gem_bitcoin/src/signer/planner/spend.rs
@@ -151,6 +151,25 @@ mod tests {
         planner_mock::{mock_signer_input, mock_signer_input_with, mock_spend_utxos, sum_inputs},
         signer_mock::{TEST_UTXO_TXID, mock_transfer_input_with_utxos, mock_utxo_with},
     };
+    use num_bigint::BigInt;
+    use primitives::{GasPriceType, TransactionFee};
+
+    fn plan_with_fee_rate(value: &str, fee_rate: u64) -> SpendPlan {
+        let mut input = mock_signer_input(value, false);
+        input.input.gas_price = GasPriceType::regular(BigInt::from(fee_rate));
+        input.fee = TransactionFee::new_from_fee(BigInt::from(fee_rate));
+        UtxoPlanner::plan(SpendRequest::transfer(BitcoinChain::Bitcoin, &input).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn test_plan_applies_fractional_fee_rate_below_one_sat() {
+        let sub_one = plan_with_fee_rate("5000", 1);
+        let one_sat = plan_with_fee_rate("5000", 10);
+
+        assert!(sub_one.fee > 0);
+        assert!(sub_one.fee < one_sat.fee);
+        assert_eq!(sub_one.outputs[0].value.to_sat(), 5_000);
+    }
 
     #[test]
     fn test_plan_transfer() {
@@ -212,10 +231,10 @@ mod tests {
         assert!(plan.outputs[1].script_pubkey.is_op_return());
 
         let selected_amount = sum_inputs(&plan.inputs).unwrap();
-        let fee_without_change = estimate_fee(BitcoinChain::Bitcoin, &plan.inputs, &plan.outputs, 2);
+        let fee_without_change = estimate_fee(BitcoinChain::Bitcoin, &plan.inputs, &plan.outputs, 20);
         let mut outputs_with_change = plan.outputs.clone();
         outputs_with_change.push(PlanOutput::new(0, change_script.clone()));
-        let fee_with_change = estimate_fee(BitcoinChain::Bitcoin, &plan.inputs, &outputs_with_change, 2);
+        let fee_with_change = estimate_fee(BitcoinChain::Bitcoin, &plan.inputs, &outputs_with_change, 20);
         let dust_remainder = selected_amount - plan.outputs[0].value.to_sat() - fee_with_change;
         assert!(dust_remainder > 0);
         assert!(dust_remainder < dust_threshold(BitcoinChain::Bitcoin, &change_script));

--- a/core/crates/gem_bitcoin/src/testkit/planner_mock.rs
+++ b/core/crates/gem_bitcoin/src/testkit/planner_mock.rs
@@ -34,10 +34,10 @@ pub(crate) fn mock_signer_input(value: &str, is_max: bool) -> SignerInput {
 
 pub(crate) fn mock_signer_input_with(value: &str, is_max: bool, memo: Option<String>, utxos: Vec<UTXO>) -> SignerInput {
     let mut input = mock_transfer_input_with_utxos(BitcoinChain::Bitcoin, TEST_BITCOIN_P2WPKH_ADDRESS, TEST_SPEND_RECIPIENT, value, utxos);
-    input.input.gas_price = GasPriceType::regular(BigInt::from(2u64));
+    input.input.gas_price = GasPriceType::regular(BigInt::from(20u64));
     input.input.memo = memo;
     input.input.is_max_value = is_max;
-    input.fee = TransactionFee::new_from_fee(BigInt::from(2u64));
+    input.fee = TransactionFee::new_from_fee(BigInt::from(20u64));
     input
 }
 

--- a/core/crates/gem_bitcoin/src/testkit/signer_mock.rs
+++ b/core/crates/gem_bitcoin/src/testkit/signer_mock.rs
@@ -31,12 +31,12 @@ pub fn mock_transfer_input_with_utxos(chain: BitcoinChain, sender_address: &str,
             sender_address: sender_address.to_string(),
             destination_address: destination_address.to_string(),
             value: value.to_string(),
-            gas_price: GasPriceType::regular(BigInt::from(1u64)),
+            gas_price: GasPriceType::regular(BigInt::from(10u64)),
             memo: None,
             is_max_value: false,
             metadata,
         },
-        TransactionFee::new_from_fee(BigInt::from(1u64)),
+        TransactionFee::new_from_fee(BigInt::from(10u64)),
     )
 }
 

--- a/core/crates/primitives/src/chain_bitcoin.rs
+++ b/core/crates/primitives/src/chain_bitcoin.rs
@@ -43,6 +43,16 @@ impl BitcoinChain {
         }
     }
 
+    pub fn minimum_custom_fee_rate(&self) -> u32 {
+        match self {
+            BitcoinChain::Bitcoin => 1,
+            BitcoinChain::BitcoinCash => 50,
+            BitcoinChain::Litecoin => 50,
+            BitcoinChain::Doge => 10_000,
+            BitcoinChain::Zcash => 10,
+        }
+    }
+
     pub fn get_blocks_fee_priority(&self) -> BlocksFeePriority {
         match self {
             BitcoinChain::Bitcoin => BlocksFeePriority { slow: 6, normal: 3, fast: 1 },

--- a/core/crates/primitives/src/fee.rs
+++ b/core/crates/primitives/src/fee.rs
@@ -27,9 +27,14 @@ pub enum FeeUnitType {
 impl FeeUnitType {
     pub fn decimals(&self) -> u32 {
         match self {
-            FeeUnitType::SatVb | FeeUnitType::Native => 0,
+            FeeUnitType::Native => 0,
+            FeeUnitType::SatVb => 1,
             FeeUnitType::Gwei => 9,
         }
+    }
+
+    pub fn scale_factor(&self) -> u64 {
+        10u64.pow(self.decimals())
     }
 }
 

--- a/core/gemstone/src/config/chain.rs
+++ b/core/gemstone/src/config/chain.rs
@@ -1,4 +1,4 @@
-use primitives::{Chain, ChainType, FeeUnitType, chain_transaction_timeout};
+use primitives::{BitcoinChain, Chain, ChainType, FeeUnitType, chain_transaction_timeout};
 
 #[derive(uniffi::Record, Debug, Clone, PartialEq)]
 pub struct ChainConfig {
@@ -82,5 +82,12 @@ pub fn custom_fee_enabled(chain: Chain) -> bool {
     match chain.chain_type() {
         ChainType::Bitcoin => true,
         _ => false,
+    }
+}
+
+pub fn minimum_custom_fee_rate(chain: Chain) -> Option<u32> {
+    match chain.chain_type() {
+        ChainType::Bitcoin => BitcoinChain::from_chain(chain).map(|chain| chain.minimum_custom_fee_rate()),
+        _ => None,
     }
 }

--- a/core/gemstone/src/config/fee_config.rs
+++ b/core/gemstone/src/config/fee_config.rs
@@ -1,12 +1,13 @@
 use primitives::Chain;
 
-use crate::config::chain::{custom_fee_enabled, fee_unit_type};
+use crate::config::chain::{custom_fee_enabled, fee_unit_type, minimum_custom_fee_rate};
 
 #[derive(uniffi::Record, Clone, Debug, PartialEq, Eq)]
 pub struct FeeConfig {
     pub decimals: u32,
     pub max_multiplier: u32,
     pub custom_fee_enabled: bool,
+    pub minimum_custom_fee_rate: Option<u32>,
 }
 
 pub fn get_fee_config(chain: Chain) -> FeeConfig {
@@ -14,5 +15,6 @@ pub fn get_fee_config(chain: Chain) -> FeeConfig {
         decimals: fee_unit_type(chain).decimals(),
         max_multiplier: 10,
         custom_fee_enabled: custom_fee_enabled(chain),
+        minimum_custom_fee_rate: minimum_custom_fee_rate(chain),
     }
 }

--- a/ios/Packages/GemstonePrimitives/Sources/Extensions/Chain+GemstoneSwift.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/Extensions/Chain+GemstoneSwift.swift
@@ -83,8 +83,19 @@ public extension Primitives.Chain {
         Int(FeeConfig.config(chain: self).decimals)
     }
 
+    func feeRateDecimals(assetDecimals: Int) -> Int {
+        switch feeUnitType {
+        case .satVb, .gwei: feeUnitDecimals
+        case .native: assetDecimals
+        }
+    }
+
     var maxCustomFeeRateMultiplier: Int {
         Int(FeeConfig.config(chain: self).maxMultiplier)
+    }
+
+    var minimumCustomFeeRate: BigInt? {
+        FeeConfig.config(chain: self).minimumCustomFeeRate.map { BigInt($0) }
     }
 
     var customFeeEnabled: Bool {

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/FeeUnitViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/FeeUnitViewModel.swift
@@ -43,9 +43,9 @@ public struct FeeUnitViewModel {
     private var unitValueText: String {
         switch unit.type {
         case .satVb:
-            return IntegerFormatter().string(Int(unit.value))
+            return valueFormatter.string(unit.value, decimals: decimals)
         case .gwei:
-            guard let value = try? ValueFormatter.full.double(from: unit.value, decimals: 9) else {
+            guard let value = try? ValueFormatter.full.double(from: unit.value, decimals: decimals) else {
                 return ""
             }
             return numericFormatter.string(value)

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeCustomViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeCustomViewModel.swift
@@ -41,10 +41,7 @@ public final class NetworkFeeCustomViewModel {
         self.baseTotal = baseTotal
         self.normalTotal = normalTotal
         self.onSelect = onSelect
-        decimals = switch chain.feeUnitType {
-        case .satVb, .gwei: chain.feeUnitDecimals
-        case .native: feeAsset.decimals.asInt
-        }
+        decimals = chain.feeRateDecimals(assetDecimals: feeAsset.decimals.asInt)
         input = initialRate.map { ValueFormatter.full.string($0, decimals: decimals) } ?? ""
     }
 
@@ -68,13 +65,19 @@ public final class NetworkFeeCustomViewModel {
     }
 
     public var errorText: String? {
-        guard let estimate, estimate.isOverMax else { return nil }
-        let maxText = FeeUnitViewModel(unit: FeeUnit(type: chain.feeUnitType, value: estimate.maxRate), decimals: decimals, symbol: feeAsset.symbol).value
-        return Localized.Common.maximumValue(maxText)
+        if isBelowMinimum, let minimumRate {
+            let minText = FeeUnitViewModel(unit: FeeUnit(type: chain.feeUnitType, value: minimumRate), decimals: decimals, symbol: feeAsset.symbol).value
+            return Localized.Common.minimumValue(minText)
+        }
+        if let estimate, estimate.isOverMax {
+            let maxText = FeeUnitViewModel(unit: FeeUnit(type: chain.feeUnitType, value: estimate.maxRate), decimals: decimals, symbol: feeAsset.symbol).value
+            return Localized.Common.maximumValue(maxText)
+        }
+        return nil
     }
 
     public var isConfirmEnabled: Bool {
-        rate != nil && estimate?.isOverMax == false
+        rate != nil && !isBelowMinimum && estimate?.isOverMax == false
     }
 
     public func sanitize(_ text: String) -> String {
@@ -82,8 +85,17 @@ public final class NetworkFeeCustomViewModel {
     }
 
     public func confirm() {
-        guard let rate, estimate?.isOverMax == false else { return }
+        guard let rate, !isBelowMinimum, estimate?.isOverMax == false else { return }
         onSelect(rate)
+    }
+
+    private var minimumRate: BigInt? {
+        chain.minimumCustomFeeRate
+    }
+
+    private var isBelowMinimum: Bool {
+        guard let rate, let minimumRate else { return false }
+        return rate < minimumRate
     }
 
     private var rate: BigInt? {

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeSceneViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeSceneViewModel.swift
@@ -75,7 +75,7 @@ public final class NetworkFeeSceneViewModel {
             FeeRateViewModel(
                 feeRate: $0,
                 unitType: chain.feeUnitType,
-                decimals: feeAsset.decimals.asInt,
+                decimals: feeRateDecimals,
                 symbol: feeAsset.symbol,
             )
         }.sorted()
@@ -99,6 +99,10 @@ public final class NetworkFeeSceneViewModel {
         case .native: estimatedFee(for: rate.feeRate).map { display(for: $0).amount.text } ?? rate.valueText
         case .gwei, .satVb: rate.valueText
         }
+    }
+
+    private var feeRateDecimals: Int {
+        chain.feeRateDecimals(assetDecimals: feeAsset.decimals.asInt)
     }
 
     public func fiatValueForRate(_ rate: FeeRateViewModel) -> String? {
@@ -173,7 +177,7 @@ private extension NetworkFeeSceneViewModel {
             FeeRateViewModel(
                 feeRate: FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: $0)),
                 unitType: chain.feeUnitType,
-                decimals: feeAsset.decimals.asInt,
+                decimals: feeRateDecimals,
                 symbol: feeAsset.symbol,
             )
         }

--- a/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ViewModels/FeeUnitViewModelTests.swift
+++ b/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ViewModels/FeeUnitViewModelTests.swift
@@ -16,32 +16,40 @@ struct FeeUnitViewModelTests {
     func testValue() {
         #expect(
             FeeUnitViewModel(
-                unit: FeeUnit(type: .satVb, value: BigInt(100_000)),
-                decimals: Int(asset.decimals),
+                unit: FeeUnit(type: .satVb, value: BigInt(1_000_000)),
+                decimals: 1,
                 symbol: asset.symbol,
                 formatter: formatter,
             ).value == "100,000 sat/vB",
         )
         #expect(
             FeeUnitViewModel(
-                unit: FeeUnit(type: .satVb, value: BigInt(100_000_123)),
-                decimals: Int(asset.decimals),
+                unit: FeeUnit(type: .satVb, value: BigInt(10)),
+                decimals: 1,
                 symbol: asset.symbol,
                 formatter: formatter,
-            ).value == "100,000,123 sat/vB",
+            ).value == "1 sat/vB",
         )
         #expect(
             FeeUnitViewModel(
-                unit: FeeUnit(type: .satVb, value: BigInt(1000)),
-                decimals: Int(asset.decimals),
+                unit: FeeUnit(type: .satVb, value: BigInt(1)),
+                decimals: 1,
                 symbol: asset.symbol,
                 formatter: formatter,
-            ).value == "1,000 sat/vB",
+            ).value == "0.1 sat/vB",
+        )
+        #expect(
+            FeeUnitViewModel(
+                unit: FeeUnit(type: .satVb, value: BigInt(25)),
+                decimals: 1,
+                symbol: asset.symbol,
+                formatter: formatter,
+            ).value == "2.5 sat/vB",
         )
         #expect(
             FeeUnitViewModel(
                 unit: FeeUnit(type: .gwei, value: BigInt(100_000)),
-                decimals: Int(asset.decimals),
+                decimals: 9,
                 symbol: asset.symbol,
                 formatter: formatter,
             ).value == "0.0001 gwei",
@@ -49,7 +57,7 @@ struct FeeUnitViewModelTests {
         #expect(
             FeeUnitViewModel(
                 unit: FeeUnit(type: .gwei, value: BigInt(123_456_789)),
-                decimals: Int(asset.decimals),
+                decimals: 9,
                 symbol: asset.symbol,
                 formatter: formatter,
             ).value == "0.1235 gwei",
@@ -57,7 +65,7 @@ struct FeeUnitViewModelTests {
         #expect(
             FeeUnitViewModel(
                 unit: FeeUnit(type: .gwei, value: BigInt(123_456_789_012)),
-                decimals: Int(asset.decimals),
+                decimals: 9,
                 symbol: asset.symbol,
                 formatter: formatter,
             ).value == "123.46 gwei",
@@ -68,32 +76,32 @@ struct FeeUnitViewModelTests {
     func valueUS() {
         #expect(
             FeeUnitViewModel(
-                unit: FeeUnit(type: .satVb, value: BigInt(100_000)),
-                decimals: Int(asset.decimals),
+                unit: FeeUnit(type: .satVb, value: BigInt(1_000_000)),
+                decimals: 1,
                 symbol: asset.symbol,
                 formatter: usFormatter,
             ).value == "100,000 sat/vB",
         )
         #expect(
             FeeUnitViewModel(
-                unit: FeeUnit(type: .satVb, value: BigInt(1000)),
-                decimals: Int(asset.decimals),
+                unit: FeeUnit(type: .satVb, value: BigInt(1)),
+                decimals: 1,
                 symbol: asset.symbol,
                 formatter: usFormatter,
-            ).value == "1,000 sat/vB",
+            ).value == "0.1 sat/vB",
         )
         #expect(
             FeeUnitViewModel(
-                unit: FeeUnit(type: .satVb, value: BigInt(100_000_123)),
-                decimals: Int(asset.decimals),
+                unit: FeeUnit(type: .satVb, value: BigInt(5)),
+                decimals: 1,
                 symbol: asset.symbol,
                 formatter: usFormatter,
-            ).value == "100,000,123 sat/vB",
+            ).value == "0.5 sat/vB",
         )
         #expect(
             FeeUnitViewModel(
                 unit: FeeUnit(type: .gwei, value: BigInt(100_000)),
-                decimals: Int(asset.decimals),
+                decimals: 9,
                 symbol: asset.symbol,
                 formatter: usFormatter,
             ).value == "0.0001 gwei",
@@ -101,7 +109,7 @@ struct FeeUnitViewModelTests {
         #expect(
             FeeUnitViewModel(
                 unit: FeeUnit(type: .gwei, value: BigInt(123_456_789)),
-                decimals: Int(asset.decimals),
+                decimals: 9,
                 symbol: asset.symbol,
                 formatter: usFormatter,
             ).value == "0.1235 gwei",
@@ -109,7 +117,7 @@ struct FeeUnitViewModelTests {
         #expect(
             FeeUnitViewModel(
                 unit: FeeUnit(type: .gwei, value: BigInt(123_456_789_012)),
-                decimals: Int(asset.decimals),
+                decimals: 9,
                 symbol: asset.symbol,
                 formatter: usFormatter,
             ).value == "123.46 gwei",

--- a/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ViewModels/NetworkFeeSceneViewModelTests.swift
+++ b/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ViewModels/NetworkFeeSceneViewModelTests.swift
@@ -76,7 +76,7 @@ struct NetworkFeeSceneViewModelTests {
 
         model.update(rates: [.defaultRate()], feeAssetPrice: nil)
 
-        #expect(model.selectedFeeRateViewModel?.valueText == "1 sat/vB")
+        #expect(model.selectedFeeRateViewModel?.valueText == "0.1 sat/vB")
     }
 
     @Test
@@ -250,7 +250,7 @@ struct NetworkFeeSceneViewModelTests {
         custom.input = "4"
         custom.confirm()
 
-        #expect(scene.selection == .custom(4))
+        #expect(scene.selection == .custom(40))
         #expect(scene.isCustomSelected)
         #expect(scene.customRowItem.subtitle != nil)
     }
@@ -272,7 +272,7 @@ struct NetworkFeeSceneViewModelTests {
         let selected = scene.customFeeModel()
         selected.input = "20"
         selected.confirm()
-        #expect(scene.selection == .custom(20))
+        #expect(scene.selection == .custom(200))
 
         let reopened = scene.customFeeModel()
         reopened.input = "21"
@@ -296,7 +296,7 @@ struct NetworkFeeSceneViewModelTests {
 
     private func bitcoinScene() -> NetworkFeeSceneViewModel {
         let model = NetworkFeeSceneViewModel.mock(chain: .bitcoin, mode: .custom)
-        model.update(rates: [FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 2))], feeAssetPrice: nil)
+        model.update(rates: [FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 20))], feeAssetPrice: nil)
         model.update(feeAmount: BigInt(1000))
         return model
     }


### PR DESCRIPTION
Custom Bitcoin network fees can now be set to fractional values down to 0.1 sat/vB, so you can pay less when the network is quiet.

Closes #730