### PR TITLE
Add unit tests for AmountViewModel

### DIFF
--- a/android/features/transfer_amount/viewmodels/src/test/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountViewModelTest.kt
+++ b/android/features/transfer_amount/viewmodels/src/test/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/AmountViewModelTest.kt
@@ -1,0 +1,206 @@
+package com.gemwallet.android.features.transfer_amount.viewmodels
+
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.features.transfer_amount.models.AmountError
+import com.gemwallet.android.features.transfer_amount.viewmodels.providers.AmountDataProvider
+import com.gemwallet.android.features.transfer_amount.viewmodels.providers.AmountProviderFactory
+import com.gemwallet.android.model.AmountParams
+import com.gemwallet.android.model.AssetInfo
+import com.gemwallet.android.model.ConfirmParams
+import com.gemwallet.android.model.Crypto
+import com.gemwallet.android.model.DestinationAddress
+import com.gemwallet.android.testkit.mockAssetCosmos
+import com.gemwallet.android.testkit.mockAssetInfo
+import com.gemwallet.android.testkit.mockAssetPriceInfo
+import com.gemwallet.android.ui.models.AmountInputType
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.navigation.RouteArgument
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.math.BigInteger
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AmountViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val asset = mockAssetCosmos()
+
+    private val assetInfoFlow = MutableStateFlow<AssetInfo?>(
+        mockAssetInfo(asset = asset).copy(price = mockAssetPriceInfo(price = 10.0))
+    )
+    private val availableBalanceFlow = MutableStateFlow(HundredAtom)
+
+    private val builtAmounts = mutableListOf<Crypto>()
+    private val builtIsMax = mutableListOf<Boolean>()
+    private val confirmParams = mockk<ConfirmParams>(relaxed = true)
+
+    private val provider = mockk<AmountDataProvider>(relaxed = true) {
+        every { assetInfo } returns assetInfoFlow
+        every { availableBalance } returns availableBalanceFlow
+        every { minimumValue } returns MutableStateFlow(BigInteger.ZERO)
+        every { canChangeValue } returns true
+        every { canSwitchInputType } returns true
+        every { reserveForFee } returns BigInteger.ZERO
+        every { shouldReserveFee(any()) } returns false
+        coEvery { buildConfirmParams(capture(builtAmounts), capture(builtIsMax)) } returns confirmParams
+    }
+    private val factory = mockk<AmountProviderFactory> { every { create(any(), any()) } returns provider }
+
+    @Before
+    fun setUp() = Dispatchers.setMain(testDispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `continue is enabled for a valid amount within balance`() = viewModelTest { viewModel ->
+        viewModel.setAmount("1")
+
+        assertEquals(ButtonState.Enabled, viewModel.buttonState.value)
+        assertTrue(viewModel.amountError.value is AmountError.None)
+    }
+
+    @Test
+    fun `continue is disabled for empty, zero, and over-balance amounts`() = viewModelTest { viewModel ->
+        assertEquals(ButtonState.Disabled, viewModel.buttonState.value)
+
+        viewModel.setAmount("0")
+        assertEquals(ButtonState.Disabled, viewModel.buttonState.value)
+
+        availableBalanceFlow.value = OneAtom
+        viewModel.setAmount("5")
+        assertEquals(ButtonState.Disabled, viewModel.buttonState.value)
+        assertTrue(viewModel.amountError.value is AmountError.InsufficientBalance)
+    }
+
+    @Test
+    fun `onNext converts crypto input to the atomic amount that is sent`() = viewModelTest { viewModel ->
+        viewModel.setAmount("1.5")
+
+        assertEquals(confirmParams, viewModel.confirm())
+        assertEquals(BigInteger("1500000"), builtAmounts.last().atomicValue)
+        assertTrue(viewModel.amountError.value is AmountError.None)
+    }
+
+    @Test
+    fun `onNext converts fiat input to crypto using the asset price`() = viewModelTest { viewModel ->
+        viewModel.switchInputType()
+        viewModel.setAmount("20")
+
+        viewModel.confirm()
+
+        assertEquals(BigInteger("2000000"), builtAmounts.last().atomicValue)
+    }
+
+    @Test
+    fun `onNext rejects an amount over balance without confirming`() = viewModelTest { viewModel ->
+        availableBalanceFlow.value = OneAtom
+        viewModel.setAmount("5")
+
+        assertNull(viewModel.confirm())
+        assertTrue(builtAmounts.isEmpty())
+        assertTrue(viewModel.amountError.value is AmountError.InsufficientBalance)
+    }
+
+    @Test
+    fun `onNext marks isMax from the max flag`() = viewModelTest { viewModel ->
+        availableBalanceFlow.value = OneAtom
+        viewModel.setAmount("0.4", isMax = true)
+
+        viewModel.confirm()
+
+        assertEquals(true, builtIsMax.last())
+    }
+
+    @Test
+    fun `onNext marks isMax when the amount equals the full balance`() = viewModelTest { viewModel ->
+        availableBalanceFlow.value = OneAtom
+        viewModel.setAmount("1")
+
+        viewModel.confirm()
+
+        assertEquals(true, builtIsMax.last())
+    }
+
+    @Test
+    fun `switchInputType flips direction and clears the amount`() = viewModelTest { viewModel ->
+        viewModel.setAmount("1")
+
+        viewModel.switchInputType()
+        assertEquals(AmountInputType.Fiat, viewModel.amountInputType.value)
+        assertEquals("", viewModel.amount)
+
+        viewModel.switchInputType()
+        assertEquals(AmountInputType.Crypto, viewModel.amountInputType.value)
+    }
+
+    @Test
+    fun `onMaxAmount fills the full spendable balance`() = viewModelTest { viewModel ->
+        availableBalanceFlow.value = BigInteger("2000000")
+
+        viewModel.onMaxAmount()
+        runCurrent()
+
+        assertEquals("2", viewModel.amount)
+    }
+
+    @Test
+    fun `onMaxAmount reserves the network fee from the balance`() = viewModelTest { viewModel ->
+        availableBalanceFlow.value = BigInteger("2000000")
+        every { provider.shouldReserveFee(true) } returns true
+        every { provider.reserveForFee } returns BigInteger("500000")
+
+        viewModel.onMaxAmount()
+        runCurrent()
+
+        assertEquals("1.5", viewModel.amount)
+    }
+
+    private fun viewModelTest(block: suspend TestScope.(AmountViewModel) -> Unit) = runTest(testDispatcher) {
+        val params = AmountParams.Transfer(asset.id, DestinationAddress(address = "to", name = null))
+        val viewModel = AmountViewModel(factory, SavedStateHandle(mapOf(RouteArgument.Params.key to params.pack())))
+        try {
+            runCurrent()
+            block(viewModel)
+        } finally {
+            viewModel.viewModelScope.cancel()
+        }
+    }
+
+    private fun AmountViewModel.confirm(): ConfirmParams? {
+        var confirmed: ConfirmParams? = null
+        onNext { confirmed = it }
+        testDispatcher.scheduler.runCurrent()
+        return confirmed
+    }
+
+    private fun AmountViewModel.setAmount(value: String, isMax: Boolean = false) {
+        updateAmount(value, isMax)
+        Snapshot.sendApplyNotifications()
+        testDispatcher.scheduler.runCurrent()
+    }
+
+    private companion object {
+        val OneAtom = BigInteger("1000000")
+        val HundredAtom = BigInteger("100000000")
+    }
+}


### PR DESCRIPTION
AmountViewModel had no unit tests, so the logic that turns what you type into the amount to send, checks it against the balance, and decides whether Continue is enabled was only verified by hand.

This adds unit tests covering that logic: crypto and fiat input converting to the exact amount that gets sent, the Continue button staying disabled for empty, zero, and over-balance amounts, rejecting amounts over the balance, max-amount filling and fee reserving, and switching between crypto and fiat input.

Closes #723