### PR TITLE
Fix missing TransactionIdRequest import in chain integration tests

### DIFF
--- a/core/crates/gem_algorand/src/provider/transactions.rs
+++ b/core/crates/gem_algorand/src/provider/transactions.rs
@@ -33,7 +33,7 @@ impl<C: Client> ChainTransactions for AlgorandClient<C> {
 #[cfg(all(test, feature = "chain_integration_tests"))]
 mod chain_integration_tests {
     use crate::provider::testkit::*;
-    use chain_traits::{ChainState, ChainTransactions, TransactionsRequest};
+    use chain_traits::{ChainState, ChainTransactions, TransactionIdRequest, TransactionsRequest};
 
     #[tokio::test]
     async fn test_algorand_get_transactions_by_block() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/core/crates/gem_aptos/src/provider/transactions.rs
+++ b/core/crates/gem_aptos/src/provider/transactions.rs
@@ -30,7 +30,7 @@ impl<C: Client> ChainTransactions for AptosClient<C> {
 #[cfg(all(test, feature = "chain_integration_tests"))]
 mod chain_integration_tests {
     use crate::provider::testkit::{TEST_ADDRESS, TEST_TRANSACTION_ID, create_aptos_test_client};
-    use chain_traits::{ChainState, ChainTransactions};
+    use chain_traits::{ChainState, ChainTransactions, TransactionIdRequest};
 
     #[tokio::test]
     async fn test_aptos_get_transactions_by_block() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/core/crates/gem_bitcoin/src/provider/transactions.rs
+++ b/core/crates/gem_bitcoin/src/provider/transactions.rs
@@ -54,7 +54,7 @@ impl<C: Client> ChainTransactions for BitcoinClient<C> {
 #[cfg(all(test, feature = "chain_integration_tests"))]
 mod chain_integration_tests {
     use crate::provider::testkit::*;
-    use chain_traits::{ChainState, ChainTransactionState, ChainTransactions, TransactionsRequest};
+    use chain_traits::{ChainState, ChainTransactionState, ChainTransactions, TransactionIdRequest, TransactionsRequest};
     use primitives::{TransactionState, TransactionStateRequest};
 
     #[tokio::test]

--- a/core/crates/gem_cosmos/src/provider/transactions.rs
+++ b/core/crates/gem_cosmos/src/provider/transactions.rs
@@ -47,7 +47,7 @@ impl<C: Client> ChainTransactions for CosmosClient<C> {
 #[cfg(all(test, feature = "chain_integration_tests"))]
 mod chain_integration_tests {
     use crate::provider::testkit::{TEST_CELESTIA_ADDRESS, TEST_TRANSACTION_ID, create_celestia_test_client, create_cosmos_test_client};
-    use chain_traits::ChainTransactions;
+    use chain_traits::{ChainTransactions, TransactionIdRequest};
 
     #[tokio::test]
     async fn test_celestia_get_transactions_by_address() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/core/crates/gem_evm/src/provider/transactions.rs
+++ b/core/crates/gem_evm/src/provider/transactions.rs
@@ -137,7 +137,7 @@ mod tests {
 #[cfg(all(test, feature = "chain_integration_tests"))]
 mod chain_integration_tests {
     use crate::provider::testkit::{TEST_ADDRESS, TEST_TRANSACTION_ID, create_ethereum_test_client};
-    use chain_traits::{ChainBalances, ChainTransactionBroadcast, ChainTransactions, TransactionsRequest};
+    use chain_traits::{ChainBalances, ChainTransactionBroadcast, ChainTransactions, TransactionIdRequest, TransactionsRequest};
     use num_bigint::BigUint;
     use std::error::Error;
 

--- a/core/crates/gem_sui/src/provider/transactions.rs
+++ b/core/crates/gem_sui/src/provider/transactions.rs
@@ -29,7 +29,7 @@ impl ChainTransactions for SuiClient {
 #[cfg(all(test, feature = "chain_integration_tests"))]
 mod chain_integration_tests {
     use crate::provider::testkit::*;
-    use chain_traits::{ChainState, ChainTransactionState, ChainTransactions, TransactionsRequest};
+    use chain_traits::{ChainState, ChainTransactionState, ChainTransactions, TransactionIdRequest, TransactionsRequest};
     use primitives::{TransactionState, TransactionStateRequest};
 
     #[tokio::test]


### PR DESCRIPTION
The transactions refactor changed `get_transaction_by_hash` to take a `TransactionIdRequest`, but the integration-test modules in several chains were left without importing it, breaking Core CI's integration build.

This adds the missing import to gem_algorand, gem_aptos, gem_bitcoin, gem_cosmos, gem_evm, and gem_sui.