### PR TITLE
Add retry when building Tink Aead

### DIFF
--- a/android/app/src/androidTest/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStoreInstrumentedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStoreInstrumentedTest.kt
@@ -7,6 +7,10 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.gemwallet.android.math.fromHex
+import com.gemwallet.android.math.hex
+import com.google.crypto.tink.proto.EncryptedKeyset
+import com.google.crypto.tink.shaded.protobuf.ByteString
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -19,6 +23,7 @@ import org.junit.runner.RunWith
 import java.nio.charset.StandardCharsets.UTF_8
 import java.security.GeneralSecurityException
 import java.security.MessageDigest
+import javax.crypto.BadPaddingException
 
 @RunWith(AndroidJUnit4::class)
 class TinkEncryptedKeyValueStoreInstrumentedTest {
@@ -85,6 +90,47 @@ class TinkEncryptedKeyValueStoreInstrumentedTest {
         }
     }
 
+    @Test
+    fun encryptedStore_doesNotResetInvalidKeysetByDefault() {
+        val originalStore = TinkEncryptedKeyValueStore.create(
+            context = context,
+            config = TEST_STORE_CONFIG,
+        )
+        originalStore.putString("original-key", "original-value")
+        mockCorruptKeyset()
+
+        val reopenedStore = TinkEncryptedKeyValueStore.create(
+            context = context,
+            config = TEST_STORE_CONFIG,
+        )
+
+        try {
+            reopenedStore.putString("new-key", "new-value")
+            fail("Expected invalid keyset to fail decryption")
+        } catch (_: BadPaddingException) {
+        }
+        assertTrue(reopenedStore.contains("original-key"))
+    }
+
+    @Test
+    fun encryptedStore_resetsInvalidKeysetWhenConfigured() {
+        val originalStore = TinkEncryptedKeyValueStore.create(
+            context = context,
+            config = RECOVERABLE_TEST_STORE_CONFIG,
+        )
+        originalStore.putString("original-key", "original-value")
+        mockCorruptKeyset()
+
+        val reopenedStore = TinkEncryptedKeyValueStore.create(
+            context = context,
+            config = RECOVERABLE_TEST_STORE_CONFIG,
+        )
+        reopenedStore.putString("new-key", "new-value")
+
+        assertFalse(reopenedStore.contains("original-key"))
+        assertEquals("new-value", reopenedStore.getString("new-key"))
+    }
+
     private fun legacyPreferences() =
         EncryptedSharedPreferences.create(
             context,
@@ -108,6 +154,20 @@ class TinkEncryptedKeyValueStoreInstrumentedTest {
         ).forEach(context::deleteSharedPreferences)
     }
 
+    private fun mockCorruptKeyset() {
+        val preferences = context.getSharedPreferences(TEST_KEYSET_PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
+        val serializedKeyset = preferences.getString(TEST_KEYSET_NAME, null)!!.fromHex()
+        val keyset = EncryptedKeyset.parseFrom(serializedKeyset)
+        val encryptedKeyset = keyset.encryptedKeyset.toByteArray()
+        encryptedKeyset[encryptedKeyset.lastIndex] = (encryptedKeyset.last().toInt() xor 1).toByte()
+        val corruptedKeyset = keyset.toBuilder()
+            .setEncryptedKeyset(ByteString.copyFrom(encryptedKeyset))
+            .build()
+            .toByteArray()
+            .hex
+        assertTrue(preferences.edit().putString(TEST_KEYSET_NAME, corruptedKeyset).commit())
+    }
+
     private fun storageKey(namespace: String, key: String): String {
         val digest = MessageDigest.getInstance("SHA-256").digest("$namespace\u0000$key".toByteArray(UTF_8))
         return "${namespace}_${digest.joinToString(separator = "") { "%02x".format(it.toInt() and 0xff) }}"
@@ -125,6 +185,8 @@ class TinkEncryptedKeyValueStoreInstrumentedTest {
             keysetName = TEST_KEYSET_NAME,
             keysetPreferencesFileName = TEST_KEYSET_PREFERENCES_FILE_NAME,
             masterKeyAlias = TEST_MASTER_KEY_ALIAS,
+            resetOnInvalidKeyset = false,
         )
+        private val RECOVERABLE_TEST_STORE_CONFIG = TEST_STORE_CONFIG.copy(resetOnInvalidKeyset = true)
     }
 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStore.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStore.kt
@@ -12,6 +12,7 @@ import java.security.GeneralSecurityException
 import java.security.MessageDigest
 import java.security.ProviderException
 import java.util.Base64
+import javax.crypto.BadPaddingException
 
 internal class TinkEncryptedKeyValueStore(
     context: Context,
@@ -66,6 +67,7 @@ internal data class TinkStoreConfig(
     val keysetName: String,
     val keysetPreferencesFileName: String,
     val masterKeyAlias: String,
+    val resetOnInvalidKeyset: Boolean,
 )
 
 internal class TinkAeadProvider(
@@ -87,14 +89,33 @@ internal class TinkAeadProvider(
 
     private fun buildAead(): Aead {
         AeadConfig.register()
-        return retryAeadBuild {
-            AndroidKeysetManager.Builder()
-                .withSharedPref(context, config.keysetName, config.keysetPreferencesFileName)
-                .withKeyTemplate(AesGcmKeyManager.aes256GcmTemplate())
-                .withMasterKeyUri("android-keystore://${config.masterKeyAlias}")
-                .build()
-                .keysetHandle
-                .getPrimitive(RegistryConfiguration.get(), Aead::class.java)
+        return try {
+            retryAeadBuild(build = ::createAead)
+        } catch (error: BadPaddingException) {
+            if (!config.resetOnInvalidKeyset) {
+                throw error
+            }
+            resetInvalidKeyset()
+            retryAeadBuild(build = ::createAead)
+        }
+    }
+
+    private fun createAead(): Aead = AndroidKeysetManager.Builder()
+        .withSharedPref(context, config.keysetName, config.keysetPreferencesFileName)
+        .withKeyTemplate(AesGcmKeyManager.aes256GcmTemplate())
+        .withMasterKeyUri("android-keystore://${config.masterKeyAlias}")
+        .build()
+        .keysetHandle
+        .getPrimitive(RegistryConfiguration.get(), Aead::class.java)
+
+    private fun resetInvalidKeyset() {
+        val encryptedValues = context.getSharedPreferences(config.preferencesFileName, Context.MODE_PRIVATE)
+        if (!encryptedValues.edit().clear().commit()) {
+            throw IllegalStateException("Secure values reset failed")
+        }
+        val encryptedKeyset = context.getSharedPreferences(config.keysetPreferencesFileName, Context.MODE_PRIVATE)
+        if (!encryptedKeyset.edit().remove(config.keysetName).commit()) {
+            throw IllegalStateException("Secure keyset reset failed")
         }
     }
 }
@@ -108,6 +129,8 @@ internal fun retryAeadBuild(
     repeat(maxAttempts) { attempt ->
         try {
             return build()
+        } catch (error: BadPaddingException) {
+            throw error
         } catch (error: GeneralSecurityException) {
             lastError = error
         } catch (error: ProviderException) {

--- a/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStore.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkEncryptedKeyValueStore.kt
@@ -8,7 +8,9 @@ import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.aead.AesGcmKeyManager
 import com.google.crypto.tink.integration.android.AndroidKeysetManager
 import java.nio.charset.StandardCharsets.UTF_8
+import java.security.GeneralSecurityException
 import java.security.MessageDigest
+import java.security.ProviderException
 import java.util.Base64
 
 internal class TinkEncryptedKeyValueStore(
@@ -85,12 +87,38 @@ internal class TinkAeadProvider(
 
     private fun buildAead(): Aead {
         AeadConfig.register()
-        val keysetHandle = AndroidKeysetManager.Builder()
-            .withSharedPref(context, config.keysetName, config.keysetPreferencesFileName)
-            .withKeyTemplate(AesGcmKeyManager.aes256GcmTemplate())
-            .withMasterKeyUri("android-keystore://${config.masterKeyAlias}")
-            .build()
-            .keysetHandle
-        return keysetHandle.getPrimitive(RegistryConfiguration.get(), Aead::class.java)
+        return retryAeadBuild {
+            AndroidKeysetManager.Builder()
+                .withSharedPref(context, config.keysetName, config.keysetPreferencesFileName)
+                .withKeyTemplate(AesGcmKeyManager.aes256GcmTemplate())
+                .withMasterKeyUri("android-keystore://${config.masterKeyAlias}")
+                .build()
+                .keysetHandle
+                .getPrimitive(RegistryConfiguration.get(), Aead::class.java)
+        }
     }
 }
+
+internal fun retryAeadBuild(
+    maxAttempts: Int = MAX_BUILD_ATTEMPTS,
+    retryDelayMilliseconds: Long = BUILD_RETRY_DELAY_MILLISECONDS,
+    build: () -> Aead,
+): Aead {
+    var lastError: Exception? = null
+    repeat(maxAttempts) { attempt ->
+        try {
+            return build()
+        } catch (error: GeneralSecurityException) {
+            lastError = error
+        } catch (error: ProviderException) {
+            lastError = error
+        }
+        if (attempt < maxAttempts - 1) {
+            Thread.sleep(retryDelayMilliseconds * (attempt + 1))
+        }
+    }
+    throw lastError ?: GeneralSecurityException("Unable to build Aead")
+}
+
+private const val MAX_BUILD_ATTEMPTS = 3
+private const val BUILD_RETRY_DELAY_MILLISECONDS = 50L

--- a/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkGemPreferences.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkGemPreferences.kt
@@ -15,6 +15,7 @@ private val GEM_PREFERENCES_STORE_CONFIG = TinkStoreConfig(
     keysetName = GEM_PREFERENCES_KEYSET_NAME,
     keysetPreferencesFileName = GEM_PREFERENCES_KEYSET_FILE_NAME,
     masterKeyAlias = GEM_PREFERENCES_MASTER_KEY_ALIAS,
+    resetOnInvalidKeyset = false,
 )
 
 class TinkGemPreferences private constructor(

--- a/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkPasswordStore.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkPasswordStore.kt
@@ -18,6 +18,7 @@ private val PASSWORD_STORE_CONFIG = TinkStoreConfig(
     keysetName = PASSWORD_STORE_KEYSET_NAME,
     keysetPreferencesFileName = PASSWORD_STORE_KEYSET_PREFERENCES_FILE_NAME,
     masterKeyAlias = PASSWORD_STORE_MASTER_KEY_ALIAS,
+    resetOnInvalidKeyset = false,
 )
 
 class TinkPasswordStore internal constructor(

--- a/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkSecurityStore.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/data/password/TinkSecurityStore.kt
@@ -25,6 +25,7 @@ private val DEVICE_KEYS_STORE_CONFIG = TinkStoreConfig(
     keysetName = DEVICE_KEYSET_NAME,
     keysetPreferencesFileName = DEVICE_KEYSET_PREFERENCES_FILE_NAME,
     masterKeyAlias = DEVICE_MASTER_KEY_ALIAS,
+    resetOnInvalidKeyset = true,
 )
 
 class TinkSecurityStore(

--- a/android/app/src/test/kotlin/com/gemwallet/android/data/password/TinkAeadRetryTest.kt
+++ b/android/app/src/test/kotlin/com/gemwallet/android/data/password/TinkAeadRetryTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import java.security.GeneralSecurityException
 import java.security.InvalidKeyException
 import java.security.ProviderException
+import javax.crypto.AEADBadTagException
 
 class TinkAeadRetryTest {
 
@@ -46,6 +47,21 @@ class TinkAeadRetryTest {
         }
 
         assertEquals("not a keystore failure", error.message)
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun doesNotRetryInvalidAuthenticationTag() {
+        var attempts = 0
+
+        val error = assertThrows(AEADBadTagException::class.java) {
+            retryAeadBuild(retryDelayMilliseconds = 0) {
+                attempts += 1
+                throw AEADBadTagException("Invalid authentication tag")
+            }
+        }
+
+        assertEquals("Invalid authentication tag", error.message)
         assertEquals(1, attempts)
     }
 

--- a/android/app/src/test/kotlin/com/gemwallet/android/data/password/TinkAeadRetryTest.kt
+++ b/android/app/src/test/kotlin/com/gemwallet/android/data/password/TinkAeadRetryTest.kt
@@ -1,0 +1,66 @@
+package com.gemwallet.android.data.password
+
+import com.google.crypto.tink.Aead
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.security.GeneralSecurityException
+import java.security.InvalidKeyException
+import java.security.ProviderException
+
+class TinkAeadRetryTest {
+
+    private val aead = object : Aead {
+        override fun encrypt(plaintext: ByteArray?, associatedData: ByteArray?): ByteArray = ByteArray(0)
+
+        override fun decrypt(ciphertext: ByteArray?, associatedData: ByteArray?): ByteArray = ByteArray(0)
+    }
+
+    @Test
+    fun retriesTransientKeystoreFailures() {
+        var attempts = 0
+
+        val result = retryAeadBuild(retryDelayMilliseconds = 0) {
+            attempts += 1
+            when (attempts) {
+                1 -> throw InvalidKeyException("Keystore cannot load the key")
+                2 -> throw ProviderException("Keystore busy")
+                else -> aead
+            }
+        }
+
+        assertSame(aead, result)
+        assertEquals(3, attempts)
+    }
+
+    @Test
+    fun doesNotRetryUnrelatedFailure() {
+        var attempts = 0
+
+        val error = assertThrows(IllegalStateException::class.java) {
+            retryAeadBuild(retryDelayMilliseconds = 0) {
+                attempts += 1
+                throw IllegalStateException("not a keystore failure")
+            }
+        }
+
+        assertEquals("not a keystore failure", error.message)
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun rethrowsLastErrorWhenAllAttemptsFail() {
+        var attempts = 0
+
+        val error = assertThrows(GeneralSecurityException::class.java) {
+            retryAeadBuild(retryDelayMilliseconds = 0) {
+                attempts += 1
+                throw GeneralSecurityException("attempt $attempts")
+            }
+        }
+
+        assertEquals("attempt 3", error.message)
+        assertEquals(3, attempts)
+    }
+}

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptor.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptor.kt
@@ -20,13 +20,13 @@ class SecurityInterceptor internal constructor(
             it.writeTo(buffer)
             buffer.readByteArray()
         }
-        val signature = signer.sign(
-            method = request.method,
-            path = request.url.encodedPath,
-            body = body,
-            walletId = request.tag(WalletId::class.java)?.id.orEmpty(),
-        )
         return try {
+            val signature = signer.sign(
+                method = request.method,
+                path = request.url.encodedPath,
+                body = body,
+                walletId = request.tag(WalletId::class.java)?.id.orEmpty(),
+            )
             val builder = request.newBuilder()
             signature.toHeaders().forEach { (key, value) -> builder.header(key, value) }
             chain.proceed(builder.build())

--- a/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptorTest.kt
+++ b/android/data/services/remote-gem/src/test/kotlin/com/gemwallet/android/data/services/gemapi/http/SecurityInterceptorTest.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.data.services.gemapi.http
 
 import com.gemwallet.android.testkit.mockMulticoinWalletId
 import com.wallet.core.primitives.WalletId
+import java.security.GeneralSecurityException
 import java.util.concurrent.TimeUnit
 import okhttp3.Call
 import okhttp3.Connection
@@ -44,6 +45,22 @@ class SecurityInterceptorTest {
         assertEquals(walletId.id, signedWalletId)
         assertEquals(body, signedBody!!.toString(Charsets.UTF_8))
         assertNull(signedRequest.header("x-wallet-id"))
+    }
+
+    @Test
+    fun interceptReturnsPeekableResponseWhenSigningFails() {
+        val signer = object : DeviceRequestSigner {
+            override fun sign(method: String, path: String, body: ByteArray?, walletId: String): DeviceSignature =
+                throw GeneralSecurityException("Keystore operation failed")
+        }
+        val request = Request.Builder()
+            .url("https://api.gemwallet.com/v2/devices/rewards")
+            .build()
+
+        val response = SecurityInterceptor(signer).intercept(FakeChain(request))
+
+        assertEquals(503, response.code)
+        assertEquals("", response.peekBody(64L * 1024).string())
     }
 }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ espressoCore = "3.7.0"
 glance-widgets = "1.3.0-alpha01"
 work = "2.11.2"
 
-tink = "1.22.0"
+tink = "1.23.0"
 
 [libraries]
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }


### PR DESCRIPTION
## Summary

Fixes two Android Keystore failure modes that can occur while Tink builds the AEAD used by secure storage:

1. **Transient Keystore failures** — retry `Aead` creation up to 3 attempts with linear backoff for `GeneralSecurityException` and `ProviderException`, including the reported `InvalidKeyException` path. Tink 1.22 does not retry when the Keystore master key temporarily fails to load.
2. **Invalid encrypted keysets** — treat `BadPaddingException` / `AEADBadTagException` as non-retryable authentication failures. When a store explicitly opts in, clear its unreadable encrypted values and keyset, then build a fresh keyset.

Invalid-keyset reset is enabled only for `TinkSecurityStore`, where the device signing identity can be regenerated. `TinkPasswordStore` and `TinkGemPreferences` remain fail-closed so this recovery path cannot erase wallet password data or other non-regenerable values.

Request signing now also runs inside the `SecurityInterceptor` error boundary, so a failure that cannot be recovered returns a retryable HTTP 503 instead of escaping on the OkHttp dispatcher thread and crashing the app.

## Impact

- Transient Keystore failures can recover without deleting data.
- A corrupted or mismatched device keyset can self-heal by regenerating the device security store.
- Sensitive stores are never automatically reset.
- Unrecoverable signing failures degrade to HTTP 503 instead of a process crash.

## Tests

- `./gradlew :app:testGoogleDebugUnitTest --tests com.gemwallet.android.data.password.TinkAeadRetryTest`
- `./gradlew :data:services:remote-gem:testDebugUnitTest --tests com.gemwallet.android.data.services.gemapi.http.SecurityInterceptorTest`
- `./gradlew :app:connectedGoogleDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.gemwallet.android.data.password.TinkEncryptedKeyValueStoreInstrumentedTest`
- `./gradlew :app:assembleGoogleDebugAndroidTest`
- `./gradlew :app:lintGoogleDebug`
