### PR TITLE
Fix flaky wallet preferences race in transactions service test

### DIFF
--- a/ios/Packages/FeatureServices/TransactionsService/Tests/TransactionsServiceTests.swift
+++ b/ios/Packages/FeatureServices/TransactionsService/Tests/TransactionsServiceTests.swift
@@ -1,5 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
+import Foundation
 import Preferences
 import Primitives
 import PrimitivesTestKit
@@ -10,10 +11,9 @@ import TransactionsServiceTestKit
 struct TransactionsServiceTests {
     @Test
     func updateForAssetAdvancesTimestampOnEmptyResponse() async throws {
-        let walletId = WalletId.mock()
+        let walletId = WalletId.mock(address: UUID().uuidString)
         let assetId = AssetId.mockEthereum()
         let preferences = WalletPreferences(walletId: walletId)
-        preferences.clear()
 
         try await TransactionsService.mock().updateForAsset(walletId: walletId, assetId: assetId)
 


### PR DESCRIPTION
`TransactionsServiceTests.updateForAssetAdvancesTimestampOnEmptyResponse` fails intermittently in CI (seen twice on #751, passes on rerun).

The test raced its own `clear()`: every test shares one UserDefaults suite through the fixed `WalletId.mock()` id, and `clear()` calls `UserDefaults.standard.removePersistentDomain(forName:)` — an asynchronous cfprefsd operation. Under CI load the domain removal can be processed after the service's timestamp write lands, wiping it, so the assertion reads 0.

Fix: give the test a unique wallet id — fresh empty suite, no `clear()` needed, no shared state with other tests.