### PR TITLE
Share one PerpetualPositionData aggregate implementation

### DIFF
--- a/android/data/coordinators/src/androidTest/kotlin/com/gemwallet/android/data/coordinators/perpetuals/PerpetualPositionDataAggregateTest.kt
+++ b/android/data/coordinators/src/androidTest/kotlin/com/gemwallet/android/data/coordinators/perpetuals/PerpetualPositionDataAggregateTest.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.data.coordinators.perpetuals
 
 import com.gemwallet.android.data.repositories.perpetual.FakePerpetualRepository
+import com.gemwallet.android.domains.perpetual.aggregates.PerpetualPositionDataAggregateImpl
 import com.gemwallet.android.domains.price.ValueDirection
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualPositionImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualPositionImpl.kt
@@ -2,15 +2,14 @@ package com.gemwallet.android.data.coordinators.perpetuals
 
 import com.gemwallet.android.application.perpetual.coordinators.GetPerpetualPosition
 import com.gemwallet.android.data.repositories.perpetual.PerpetualRepository
+import com.gemwallet.android.domains.perpetual.aggregates.PerpetualPositionDataAggregate
+import com.gemwallet.android.domains.perpetual.aggregates.PerpetualPositionDataAggregateImpl
 import com.gemwallet.android.domains.perpetual.aggregates.PerpetualPositionDetailsDataAggregate
-import com.gemwallet.android.domains.perpetual.formatPnlWithPercentage
 import com.gemwallet.android.domains.price.ValueDirection
 import com.gemwallet.android.domains.price.toValueDirection
 import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.PriceChangeFormatter
-import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.Currency
-import com.wallet.core.primitives.PerpetualDirection
 import com.wallet.core.primitives.PerpetualId
 import com.wallet.core.primitives.PerpetualMarginType
 import com.wallet.core.primitives.PerpetualPositionData
@@ -28,7 +27,9 @@ class GetPerpetualPositionImpl @Inject constructor(
 
 class PerpetualPositionDetailsDataAggregateImpl(
     private val data: PerpetualPositionData,
-) : PerpetualPositionDetailsDataAggregate {
+) : PerpetualPositionDetailsDataAggregate,
+    PerpetualPositionDataAggregate by PerpetualPositionDataAggregateImpl(data) {
+
     private val amountFormatter = CurrencyFormatter(type = CurrencyFormatter.Type.Fiat, currency = Currency.USD)
     private val priceFormatter = CurrencyFormatter(currency = Currency.USD)
 
@@ -51,19 +52,7 @@ class PerpetualPositionDetailsDataAggregateImpl(
 
     override val fundingPaymentsDirection: ValueDirection = fundingPaymentsValue.toValueDirection()
 
-    override val positionId: String = data.position.id
-
     override val perpetualId: PerpetualId = data.position.perpetualId
-
-    override val asset: Asset = data.asset
-
-    override val name: String = data.perpetual.name
-
-    override val direction: PerpetualDirection = data.position.direction
-
-    override val leverage: Int = data.position.leverage.toInt()
-
-    override val marginAmount: String = amountFormatter.string(data.position.marginAmount)
 
     override val entryValue: Double? = data.position.entryPrice
 
@@ -72,10 +61,4 @@ class PerpetualPositionDetailsDataAggregateImpl(
     override val stopLoss: Double? = data.position.stopLoss?.price
 
     override val takeProfit: Double? = data.position.takeProfit?.price
-
-    override val pnlWithPercentage: String
-        get() = formatPnlWithPercentage(data.position.pnl, data.position.marginAmount)
-
-    override val pnlState: ValueDirection
-        get() = data.position.pnl.toValueDirection()
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualPositionsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualPositionsImpl.kt
@@ -4,15 +4,7 @@ import com.gemwallet.android.application.perpetual.coordinators.GetPerpetualPosi
 import com.gemwallet.android.data.repositories.perpetual.PerpetualRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.domains.perpetual.aggregates.PerpetualPositionDataAggregate
-import com.gemwallet.android.domains.perpetual.formatPnlWithPercentage
-import com.gemwallet.android.domains.price.ValueDirection
-import com.gemwallet.android.domains.price.toValueDirection
-import com.gemwallet.android.model.CurrencyFormatter
-import com.wallet.core.primitives.Asset
-import com.wallet.core.primitives.Currency
-import com.wallet.core.primitives.PerpetualDirection
-import com.wallet.core.primitives.PerpetualId
-import com.wallet.core.primitives.PerpetualPositionData
+import com.gemwallet.android.domains.perpetual.aggregates.PerpetualPositionDataAggregateImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
@@ -26,24 +18,10 @@ class GetPerpetualPositionsImpl @Inject constructor(
     private val perpetualRepository: PerpetualRepository,
 ) : GetPerpetualPositions {
 
-    override fun getPerpetualPositions(): Flow<List<PerpetualPositionDataAggregateImpl>> {
+    override fun getPerpetualPositions(): Flow<List<PerpetualPositionDataAggregate>> {
         return sessionRepository.session()
             .filterNotNull()
             .flatMapLatest { perpetualRepository.getPositions(it.wallet.id) }
             .map { items -> items.map { PerpetualPositionDataAggregateImpl(it) } }
     }
-}
-
-class PerpetualPositionDataAggregateImpl(val data: PerpetualPositionData) : PerpetualPositionDataAggregate {
-    override val positionId: String = data.position.id
-    override val perpetualId: PerpetualId = data.perpetual.id
-    override val asset: Asset = data.asset
-    override val name: String = data.perpetual.name
-    override val direction: PerpetualDirection = data.position.direction
-    override val leverage: Int = data.position.leverage.toInt()
-    override val marginAmount: String = CurrencyFormatter(type = CurrencyFormatter.Type.Fiat, currency = Currency.USD).string(data.position.marginAmount)
-    override val pnlWithPercentage: String
-        get() = formatPnlWithPercentage(data.position.pnl, data.position.marginAmount)
-    override val pnlState: ValueDirection
-        get() = data.position.pnl.toValueDirection()
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/perpetual/aggregates/PerpetualPositionDataAggregateImpl.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/perpetual/aggregates/PerpetualPositionDataAggregateImpl.kt
@@ -1,0 +1,30 @@
+package com.gemwallet.android.domains.perpetual.aggregates
+
+import com.gemwallet.android.domains.perpetual.formatPnlWithPercentage
+import com.gemwallet.android.domains.price.ValueDirection
+import com.gemwallet.android.domains.price.toValueDirection
+import com.gemwallet.android.model.CurrencyFormatter
+import com.wallet.core.primitives.Asset
+import com.wallet.core.primitives.Currency
+import com.wallet.core.primitives.PerpetualDirection
+import com.wallet.core.primitives.PerpetualId
+import com.wallet.core.primitives.PerpetualPositionData
+
+class PerpetualPositionDataAggregateImpl(
+    private val data: PerpetualPositionData,
+) : PerpetualPositionDataAggregate {
+    private val marginFormatter = CurrencyFormatter(type = CurrencyFormatter.Type.Fiat, currency = Currency.USD)
+
+    override val positionId: String = data.position.id
+    override val perpetualId: PerpetualId
+        get() = data.perpetual.id
+    override val asset: Asset = data.asset
+    override val name: String = data.perpetual.name
+    override val direction: PerpetualDirection = data.position.direction
+    override val leverage: Int = data.position.leverage.toInt()
+    override val marginAmount: String = marginFormatter.string(data.position.marginAmount)
+    override val pnlWithPercentage: String
+        get() = formatPnlWithPercentage(data.position.pnl, data.position.marginAmount)
+    override val pnlState: ValueDirection
+        get() = data.position.pnl.toValueDirection()
+}

--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/perpetual/autoclose/AutocloseUIModelFactory.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/perpetual/autoclose/AutocloseUIModelFactory.kt
@@ -2,17 +2,13 @@ package com.gemwallet.android.ui.models.perpetual.autoclose
 
 import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
 import com.gemwallet.android.domains.percentage.formatAsPercentage
-import com.gemwallet.android.domains.perpetual.aggregates.PerpetualPositionDataAggregate
+import com.gemwallet.android.domains.perpetual.aggregates.PerpetualPositionDataAggregateImpl
 import com.gemwallet.android.domains.perpetual.autoclose.AutocloseEstimator
 import com.gemwallet.android.domains.perpetual.autoclose.AutocloseField
-import com.gemwallet.android.domains.perpetual.formatPnlWithPercentage
 import com.gemwallet.android.domains.price.ValueDirection
 import com.gemwallet.android.domains.price.toValueDirection
 import com.gemwallet.android.model.CurrencyFormatter
-import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.Currency
-import com.wallet.core.primitives.PerpetualDirection
-import com.wallet.core.primitives.PerpetualId
 import com.wallet.core.primitives.PerpetualPositionData
 import com.wallet.core.primitives.TpslType
 import kotlin.math.abs
@@ -20,7 +16,6 @@ import kotlin.math.abs
 object AutocloseUIModelFactory {
 
     private val currencyFormatter = CurrencyFormatter(type = CurrencyFormatter.Type.Currency, currency = Currency.USD)
-    private val marginFormatter = CurrencyFormatter(type = CurrencyFormatter.Type.Fiat, currency = Currency.USD)
 
     fun create(
         position: PerpetualPositionData,
@@ -36,7 +31,7 @@ object AutocloseUIModelFactory {
             leverage = position.position.leverage,
         )
         return AutocloseUIModel(
-            position = positionSummary(position),
+            position = PerpetualPositionDataAggregateImpl(position),
             marketPriceText = currencyFormatter.string(position.perpetual.price),
             entryPriceText = currencyFormatter.string(position.position.entryPrice),
             takeProfit = createField(takeProfit, estimator, showErrors),
@@ -62,19 +57,6 @@ object AutocloseUIModelFactory {
             percentSuggestions = estimator.percentSuggestions,
             error = if (showErrors) field.error else null,
         )
-    }
-
-    private fun positionSummary(data: PerpetualPositionData): PerpetualPositionDataAggregate = object : PerpetualPositionDataAggregate {
-        override val positionId: String = data.position.id
-        override val perpetualId: PerpetualId = data.perpetual.id
-        override val asset: Asset = data.asset
-        override val name: String = data.perpetual.name
-        override val direction: PerpetualDirection = data.position.direction
-        override val leverage: Int = data.position.leverage.toInt()
-        override val marginAmount: String = marginFormatter.string(data.position.marginAmount)
-        override val pnlWithPercentage: String =
-            formatPnlWithPercentage(data.position.pnl, data.position.marginAmount)
-        override val pnlState: ValueDirection = data.position.pnl.toValueDirection()
     }
 
     private fun pnlText(pnl: Double?, roe: Double?, hasSize: Boolean): String {


### PR DESCRIPTION
The same mapping from `PerpetualPositionData` to `PerpetualPositionDataAggregate` was written out three times — in the positions list, in the position details, and in the autoclose sheet.

Now there is one implementation in `:gemcore`, next to the interface it belongs to. Position details delegates the shared part to it and keeps only its own fields.

No behaviour change.