### PR TITLE
Fix wallet assets not loading after an offline import

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/DeviceAssetsSyncService.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/DeviceAssetsSyncService.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.data.coordinators.asset
 import com.gemwallet.android.application.assets.coordinators.EnableAsset
 import com.gemwallet.android.application.assets.coordinators.EnsureWalletAssets
 import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
+import com.gemwallet.android.cases.device.SynchronizeDeviceIfNeeded
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.data.service.store.WalletPreferencesFactory
@@ -26,9 +27,12 @@ class DeviceAssetsSyncService @Inject constructor(
     private val enableAsset: EnableAsset,
     private val assetsRepository: AssetsRepository,
     private val walletsRepository: WalletsRepository,
+    private val synchronizeDeviceIfNeeded: SynchronizeDeviceIfNeeded,
 ) {
 
     suspend fun sync(walletId: String) {
+        synchronizeDeviceIfNeeded.synchronizeIfNeeded()
+
         val walletIdentifier = WalletId(walletId)
         val preferences = walletPreferencesFactory.create(walletId)
         val assetIds = gemDeviceApiClient.getAssets(

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/DeviceAssetsSyncServiceTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/DeviceAssetsSyncServiceTest.kt
@@ -1,0 +1,45 @@
+package com.gemwallet.android.data.coordinators.asset
+
+import com.gemwallet.android.cases.device.SynchronizeDeviceIfNeeded
+import com.gemwallet.android.data.service.store.WalletPreferences
+import com.gemwallet.android.data.service.store.WalletPreferencesFactory
+import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
+import io.mockk.coEvery
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DeviceAssetsSyncServiceTest {
+
+    private val walletPreferences = mockk<WalletPreferences>(relaxed = true)
+    private val walletPreferencesFactory = mockk<WalletPreferencesFactory> {
+        every { create(any()) } returns walletPreferences
+    }
+    private val gemDeviceApiClient = mockk<GemDeviceApiClient>()
+    private val synchronizeDeviceIfNeeded = mockk<SynchronizeDeviceIfNeeded>(relaxed = true)
+
+    private val subject = DeviceAssetsSyncService(
+        walletPreferencesFactory = walletPreferencesFactory,
+        gemDeviceApiClient = gemDeviceApiClient,
+        prefetchAssets = mockk(relaxed = true),
+        ensureWalletAssets = mockk(relaxed = true),
+        enableAsset = mockk(relaxed = true),
+        assetsRepository = mockk(relaxed = true),
+        walletsRepository = mockk(relaxed = true),
+        synchronizeDeviceIfNeeded = synchronizeDeviceIfNeeded,
+    )
+
+    @Test
+    fun sync_synchronizesDeviceBeforeRequestingAssets() = runTest {
+        coEvery { gemDeviceApiClient.getAssets(any(), any()) } returns emptyList()
+
+        subject.sync("wallet-1")
+
+        coVerifyOrder {
+            synchronizeDeviceIfNeeded.synchronizeIfNeeded()
+            gemDeviceApiClient.getAssets(any(), any())
+        }
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -14,6 +14,7 @@ import com.gemwallet.android.cases.device.SetPushToken
 import com.gemwallet.android.cases.device.SwitchPushEnabled
 import com.gemwallet.android.cases.device.SyncDeviceInfo
 import com.gemwallet.android.cases.device.SyncSubscription
+import com.gemwallet.android.cases.device.SynchronizeDeviceIfNeeded
 import com.gemwallet.android.data.repositories.config.UserConfig.Keys
 import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
@@ -60,6 +61,7 @@ class DeviceRepository(
     GetPushToken,
     SetPushToken,
     SyncSubscription,
+    SynchronizeDeviceIfNeeded,
     IsDeviceRegistered
 {
     private val Context.dataStore by preferencesDataStore(name = "device_config")
@@ -69,6 +71,13 @@ class DeviceRepository(
             wallets = loadWallets(),
             shouldInvalidateSubscriptions = false,
         )
+    }
+
+    override suspend fun synchronizeIfNeeded() {
+        if (isDeviceRegistered() && !hasPendingSubscriptionChanges()) {
+            return
+        }
+        syncDeviceInfo()
     }
 
     override suspend fun switchPushEnabled(enabled: Boolean, wallets: List<Wallet>) {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
@@ -10,6 +10,7 @@ import com.gemwallet.android.cases.device.SetPushToken
 import com.gemwallet.android.cases.device.SwitchPushEnabled
 import com.gemwallet.android.cases.device.SyncDeviceInfo
 import com.gemwallet.android.cases.device.SyncSubscription
+import com.gemwallet.android.cases.device.SynchronizeDeviceIfNeeded
 import com.gemwallet.android.data.repositories.device.DeviceRepository
 import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
@@ -76,4 +77,7 @@ object DeviceModule {
 
     @Provides
     fun provideIsDeviceRegisteredCase(repository: DeviceRepository): IsDeviceRegistered = repository
+
+    @Provides
+    fun provideSynchronizeDeviceIfNeededCase(repository: DeviceRepository): SynchronizeDeviceIfNeeded = repository
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SynchronizeDeviceIfNeeded.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SynchronizeDeviceIfNeeded.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.cases.device
+
+interface SynchronizeDeviceIfNeeded {
+    suspend fun synchronizeIfNeeded()
+}


### PR DESCRIPTION
Importing a wallet without a connection left its subscription unsent, so the backend did not know about the wallet and returned no assets for it. The wallet kept showing only the default assets even after going back online.

Now the subscription is sent before the app asks the backend for the wallet's assets.

Closes #760