### PR TITLE
Sync swap assets on Android

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/di/DataModule.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/di/DataModule.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.di
 
 import com.gemwallet.android.application.fiat.coordinators.SyncFiatAssets
+import com.gemwallet.android.application.swap.coordinators.SyncSwapAssets
 import com.gemwallet.android.blockchain.services.BroadcastService
 import com.gemwallet.android.blockchain.services.NodeStatusService
 import com.gemwallet.android.blockchain.services.SignerPreloaderProxy
@@ -50,10 +51,12 @@ object DataModule {
     @Provides
     fun provideSyncService(
         syncFiatAssets: SyncFiatAssets,
+        syncSwapAssets: SyncSwapAssets,
         syncDeviceInfo: SyncDeviceInfo,
     ): SyncService {
         return SyncService(
             syncFiatAssets = syncFiatAssets,
+            syncSwapAssets = syncSwapAssets,
             syncDeviceInfo = syncDeviceInfo,
         )
     }

--- a/android/app/src/main/kotlin/com/gemwallet/android/services/SyncService.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/services/SyncService.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.services
 
 import com.gemwallet.android.application.fiat.coordinators.SyncFiatAssets
+import com.gemwallet.android.application.swap.coordinators.SyncSwapAssets
 import com.gemwallet.android.cases.device.SyncDeviceInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -8,12 +9,14 @@ import javax.inject.Inject
 
 class SyncService @Inject constructor(
     private val syncFiatAssets: SyncFiatAssets,
+    private val syncSwapAssets: SyncSwapAssets,
     private val syncDeviceInfo: SyncDeviceInfo,
 ) {
 
     suspend fun sync() {
         withContext(Dispatchers.IO) {
             runCatching { syncFiatAssets() }
+            runCatching { syncSwapAssets() }
             runCatching { syncDeviceInfo.syncDeviceInfo() }
         }
     }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/SwapModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/SwapModule.kt
@@ -1,32 +1,61 @@
 package com.gemwallet.android.data.coordinators.di
 
+import android.content.Context
 import com.gemwallet.android.application.PasswordStore
+import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
+import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
 import com.gemwallet.android.application.swap.coordinators.BuildSwapConfirmParams
+import com.gemwallet.android.application.swap.coordinators.GetSwapAssets
 import com.gemwallet.android.application.swap.coordinators.GetSwapQuoteData
 import com.gemwallet.android.application.swap.coordinators.GetSwapQuotes
 import com.gemwallet.android.application.swap.coordinators.GetSwapSupported
 import com.gemwallet.android.application.swap.coordinators.RequestSwapQuotes
 import com.gemwallet.android.application.swap.coordinators.SearchSwapAssets
+import com.gemwallet.android.application.swap.coordinators.SyncSwapAssets
 import com.gemwallet.android.blockchain.services.GemSignMessageOperator
 import com.gemwallet.android.data.coordinators.swap.BuildSwapConfirmParamsImpl
+import com.gemwallet.android.data.coordinators.swap.GetSwapAssetsImpl
 import com.gemwallet.android.data.coordinators.swap.GetSwapQuoteDataImpl
 import com.gemwallet.android.data.coordinators.swap.GetSwapQuotesImpl
 import com.gemwallet.android.data.coordinators.swap.GetSwapSupportedImpl
 import com.gemwallet.android.data.coordinators.swap.RequestSwapQuotesImpl
 import com.gemwallet.android.data.coordinators.swap.SearchSwapAssetsImpl
+import com.gemwallet.android.data.coordinators.swap.SyncSwapAssetsImpl
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.data.service.store.ConfigStore
+import com.gemwallet.android.data.services.gemapi.GemApiClient
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import uniffi.gemstone.AlienProvider
 import uniffi.gemstone.GemSwapper
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class SwapConfigStore
 
 @InstallIn(SingletonComponent::class)
 @Module
 object SwapModule {
+
+    @Provides
+    @Singleton
+    @SwapConfigStore
+    fun provideSwapConfigStore(
+        @ApplicationContext context: Context,
+    ): ConfigStore {
+        return ConfigStore(
+            context.getSharedPreferences(
+                "swap_config",
+                Context.MODE_PRIVATE,
+            )
+        )
+    }
 
     @Singleton
     @Provides
@@ -82,5 +111,29 @@ object SwapModule {
     ): SearchSwapAssets = SearchSwapAssetsImpl(
         assetsRepository = assetsRepository,
         getSwapSupported = getSwapSupported,
+    )
+
+    @Singleton
+    @Provides
+    fun provideGetSwapAssets(
+        gemApiClient: GemApiClient,
+    ): GetSwapAssets = GetSwapAssetsImpl(
+        gemApiClient = gemApiClient,
+    )
+
+    @Singleton
+    @Provides
+    fun provideSyncSwapAssets(
+        @SwapConfigStore configStore: ConfigStore,
+        getRemoteConfig: GetRemoteConfig,
+        getSwapAssets: GetSwapAssets,
+        assetsRepository: AssetsRepository,
+        prefetchAssets: PrefetchAssets,
+    ): SyncSwapAssets = SyncSwapAssetsImpl(
+        configStore = configStore,
+        getRemoteConfig = getRemoteConfig,
+        getSwapAssets = getSwapAssets,
+        assetsRepository = assetsRepository,
+        prefetchAssets = prefetchAssets,
     )
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/swap/GetSwapAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/swap/GetSwapAssetsImpl.kt
@@ -1,0 +1,13 @@
+package com.gemwallet.android.data.coordinators.swap
+
+import com.gemwallet.android.application.swap.coordinators.GetSwapAssets
+import com.gemwallet.android.data.services.gemapi.GemApiClient
+import com.wallet.core.primitives.FiatAssets
+
+class GetSwapAssetsImpl(
+    private val gemApiClient: GemApiClient,
+) : GetSwapAssets {
+    override suspend fun invoke(): FiatAssets {
+        return gemApiClient.getSwapAssets()
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/swap/SyncSwapAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/swap/SyncSwapAssetsImpl.kt
@@ -1,0 +1,51 @@
+package com.gemwallet.android.data.coordinators.swap
+
+import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
+import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
+import com.gemwallet.android.application.swap.coordinators.GetSwapAssets
+import com.gemwallet.android.application.swap.coordinators.SyncSwapAssets
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.service.store.ConfigStore
+import com.gemwallet.android.ext.toAssetId
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+
+class SyncSwapAssetsImpl(
+    private val configStore: ConfigStore,
+    private val getRemoteConfig: GetRemoteConfig,
+    private val getSwapAssets: GetSwapAssets,
+    private val assetsRepository: AssetsRepository,
+    private val prefetchAssets: PrefetchAssets,
+) : SyncSwapAssets {
+
+    override suspend fun invoke() {
+        try {
+            val remoteVersion = getRemoteConfig.getRemoteConfig().versions.swapAssets
+            if (!shouldSync(remoteVersion)) {
+                return
+            }
+            val swapAssets = getSwapAssets()
+            val synced = swapAssets.assetIds.distinct().chunked(ASSET_BATCH_SIZE).map { batch ->
+                val assetIds = batch.mapNotNull(String::toAssetId)
+                prefetchAssets.prefetchAssets(assetIds)
+                assetsRepository.updateSwapAvailable(batch)
+                assetsRepository.hasAssets(assetIds).size == assetIds.size
+            }
+            if (synced.all { it }) {
+                configStore.putInt(SWAP_ASSETS_VERSION, swapAssets.version.toInt())
+            }
+        } catch (_: Exception) {
+            currentCoroutineContext().ensureActive()
+        }
+    }
+
+    private fun shouldSync(remoteVersion: Int): Boolean {
+        val currentVersion = configStore.getInt(SWAP_ASSETS_VERSION)
+        return currentVersion <= 0 || currentVersion < remoteVersion
+    }
+
+    private companion object {
+        const val SWAP_ASSETS_VERSION = "swap-assets-version"
+        const val ASSET_BATCH_SIZE = 500
+    }
+}

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/swap/SyncSwapAssetsImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/swap/SyncSwapAssetsImplTest.kt
@@ -1,0 +1,133 @@
+package com.gemwallet.android.data.coordinators.swap
+
+import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
+import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
+import com.gemwallet.android.application.swap.coordinators.GetSwapAssets
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.service.store.ConfigStore
+import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.ConfigResponse
+import com.wallet.core.primitives.ConfigVersions
+import com.wallet.core.primitives.FiatAssets
+import com.wallet.core.primitives.SwapConfig
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SyncSwapAssetsImplTest {
+
+    private val configStore = mockk<ConfigStore>(relaxed = true)
+    private val getRemoteConfig = mockk<GetRemoteConfig>()
+    private val getSwapAssets = mockk<GetSwapAssets>()
+    private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
+    private val prefetchAssets = mockk<PrefetchAssets>(relaxed = true)
+
+    private val subject = SyncSwapAssetsImpl(
+        configStore = configStore,
+        getRemoteConfig = getRemoteConfig,
+        getSwapAssets = getSwapAssets,
+        assetsRepository = assetsRepository,
+        prefetchAssets = prefetchAssets,
+    )
+
+    @Test
+    fun syncSwapAssets_marksAssetsSwappableAndStoresVersion() = runTest {
+        coEvery { getRemoteConfig.getRemoteConfig() } returns remoteConfig(swapAssets = 495776)
+        every { configStore.getInt(SWAP_ASSETS_VERSION) } returns 495775
+        coEvery { getSwapAssets() } returns FiatAssets(495776u, listOf("bitcoin", "ethereum"))
+        prefetchSucceeds()
+
+        subject()
+
+        coVerify { prefetchAssets.prefetchAssets(listOf(AssetId(Chain.Bitcoin), AssetId(Chain.Ethereum))) }
+        coVerify { assetsRepository.updateSwapAvailable(listOf("bitcoin", "ethereum")) }
+        verify { configStore.putInt(SWAP_ASSETS_VERSION, 495776, "") }
+    }
+
+    @Test
+    fun syncSwapAssets_skipsRequestWhenVersionIsCurrent() = runTest {
+        coEvery { getRemoteConfig.getRemoteConfig() } returns remoteConfig(swapAssets = 495776)
+        every { configStore.getInt(SWAP_ASSETS_VERSION) } returns 495776
+
+        subject()
+
+        coVerify(exactly = 0) { getSwapAssets() }
+        coVerify(exactly = 0) { prefetchAssets.prefetchAssets(any()) }
+        coVerify(exactly = 0) { assetsRepository.updateSwapAvailable(any()) }
+        verify(exactly = 0) { configStore.putInt(SWAP_ASSETS_VERSION, any(), any()) }
+    }
+
+    @Test
+    fun syncSwapAssets_keepsEveryQueryUnderSqliteVariableLimit() = runTest {
+        val assetIds = List(1180) { "ethereum_0x$it" }
+        coEvery { getRemoteConfig.getRemoteConfig() } returns remoteConfig(swapAssets = 495776)
+        every { configStore.getInt(SWAP_ASSETS_VERSION) } returns 0
+        coEvery { getSwapAssets() } returns FiatAssets(495776u, assetIds)
+        prefetchSucceeds()
+
+        val prefetched = mutableListOf<List<AssetId>>()
+        val marked = mutableListOf<List<String>>()
+
+        subject()
+
+        coVerify { prefetchAssets.prefetchAssets(capture(prefetched)) }
+        coVerify { assetsRepository.updateSwapAvailable(capture(marked)) }
+
+        assertTrue(prefetched.all { it.size <= SQLITE_VARIABLE_LIMIT })
+        assertTrue(marked.all { it.size <= SQLITE_VARIABLE_LIMIT })
+        assertEquals(assetIds, marked.flatten())
+    }
+
+    @Test
+    fun syncSwapAssets_keepsStoredVersionWhenRequestFails() = runTest {
+        coEvery { getRemoteConfig.getRemoteConfig() } returns remoteConfig(swapAssets = 495776)
+        every { configStore.getInt(SWAP_ASSETS_VERSION) } returns 495775
+        coEvery { getSwapAssets() } throws RuntimeException("network down")
+
+        subject()
+
+        coVerify(exactly = 0) { assetsRepository.updateSwapAvailable(any()) }
+        verify(exactly = 0) { configStore.putInt(SWAP_ASSETS_VERSION, any(), any()) }
+    }
+
+    @Test
+    fun syncSwapAssets_keepsStoredVersionWhenAssetsAreMissingAfterPrefetch() = runTest {
+        coEvery { getRemoteConfig.getRemoteConfig() } returns remoteConfig(swapAssets = 495776)
+        every { configStore.getInt(SWAP_ASSETS_VERSION) } returns 495775
+        coEvery { getSwapAssets() } returns FiatAssets(495776u, listOf("bitcoin", "ethereum"))
+        coEvery { assetsRepository.hasAssets(any()) } returns setOf(AssetId(Chain.Bitcoin))
+
+        subject()
+
+        coVerify { assetsRepository.updateSwapAvailable(listOf("bitcoin", "ethereum")) }
+        verify(exactly = 0) { configStore.putInt(SWAP_ASSETS_VERSION, any(), any()) }
+    }
+
+    private fun prefetchSucceeds() {
+        coEvery { assetsRepository.hasAssets(any()) } answers { firstArg<List<AssetId>>().toSet() }
+    }
+
+    private fun remoteConfig(swapAssets: Int) = ConfigResponse(
+        releases = emptyList(),
+        versions = ConfigVersions(
+            fiatOnRampAssets = 0,
+            fiatOffRampAssets = 0,
+            swapAssets = swapAssets,
+        ),
+        swap = SwapConfig(
+            enabledProviders = emptyList(),
+        ),
+    )
+
+    private companion object {
+        const val SWAP_ASSETS_VERSION = "swap-assets-version"
+        const val SQLITE_VARIABLE_LIMIT = 999
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsAvailabilityService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsAvailabilityService.kt
@@ -30,6 +30,15 @@ class AssetsAvailabilityService @Inject constructor(
         )
     }
 
+    suspend fun updateSwapAvailable(assets: List<String>) {
+        syncAvailability(
+            currentEnabledAssetIds = assetsDao.getSwapAvailableAssetIds(assets),
+            targetEnabledAssetIds = assets,
+            trackedAssetIds = assets,
+            setAvailability = assetsDao::setSwapAvailable,
+        )
+    }
+
     suspend fun syncSwapSupportChains() {
         val nativeAssetIds = Chain.entries.map { it.asset().id.toIdentifier() }
         syncAvailability(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
@@ -402,6 +402,8 @@ class AssetsRepository @Inject constructor(
 
     suspend fun updateSellAvailable(assets: List<String>) = availabilityService.updateSellAvailable(assets)
 
+    suspend fun updateSwapAvailable(assets: List<String>) = availabilityService.updateSwapAvailable(assets)
+
     fun getAssetLinks(id: AssetId): Flow<List<AssetLink>> {
         return assetsDao.getAssetLinks(id.toIdentifier())
             .toAssetLinksModel()

--- a/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/GemApiClient.kt
+++ b/android/data/services/remote-gem/src/main/kotlin/com/gemwallet/android/data/services/gemapi/GemApiClient.kt
@@ -31,6 +31,9 @@ interface GemApiClient {
     @GET("/v1/fiat/assets/{type}")
     suspend fun getFiatAssets(@Path("type") type: String): FiatAssets
 
+    @GET("/v1/swap/assets")
+    suspend fun getSwapAssets(): FiatAssets
+
     @GET("/v1/assets/search")
     suspend fun searchAssets(
         @Query("query") query: String,

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/swap/coordinators/GetSwapAssets.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/swap/coordinators/GetSwapAssets.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.swap.coordinators
+
+import com.wallet.core.primitives.FiatAssets
+
+interface GetSwapAssets {
+    suspend operator fun invoke(): FiatAssets
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/swap/coordinators/SyncSwapAssets.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/swap/coordinators/SyncSwapAssets.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.application.swap.coordinators
+
+interface SyncSwapAssets {
+    suspend operator fun invoke()
+}


### PR DESCRIPTION
Android never asked the backend which assets are swappable, so the swap picker only showed assets the app happened to run into. Importing the same wallet gave 354 assets on Android against 1350 on iOS.

Now the list is fetched on cold start, same as iOS.

Closes #718