### PR TITLE
Fix duplicate device requests on a slow connection

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -66,6 +66,8 @@ class DeviceRepository(
 {
     private val Context.dataStore by preferencesDataStore(name = "device_config")
 
+    private val syncCoordinator = DeviceSyncCoordinator()
+
     override suspend fun syncDeviceInfo() {
         synchronizeDevice(
             wallets = loadWallets(),
@@ -119,38 +121,52 @@ class DeviceRepository(
         shouldInvalidateSubscriptions: Boolean,
         pushTokenOverride: String? = null,
     ) {
-        try {
-            if (shouldInvalidateSubscriptions) {
-                invalidateSubscriptions()
-            }
+        syncCoordinator.synchronize {
+            try {
+                reconcileDevice(
+                    wallets = wallets,
+                    shouldInvalidateSubscriptions = shouldInvalidateSubscriptions,
+                    pushTokenOverride = pushTokenOverride,
+                )
+            } catch (_: Throwable) {}
+        }
+    }
 
-            val subscriptionState = getSubscriptionSyncState()
-            val pushState = resolvePushState(
-                wallets = wallets,
-                pushTokenOverride = pushTokenOverride,
-            ) ?: return
-            val localDevice = buildLocalDevice(
-                pushState = pushState,
-                subscriptionsVersion = subscriptionState.version,
-            )
-            val remoteDevice = getOrCreateDevice(localDevice)
-            val didSyncSubscriptions = maybeSyncSubscriptions(
-                wallets = wallets,
-                subscriptionState = subscriptionState,
-                remoteDevice = remoteDevice,
-            )
-            val requestDevice = buildDeviceUpdateRequest(
-                localDevice = localDevice,
-                remoteDevice = remoteDevice,
-                localSubscriptionVersion = subscriptionState.version,
-                didSyncSubscriptions = didSyncSubscriptions,
-            )
+    private suspend fun reconcileDevice(
+        wallets: List<Wallet>,
+        shouldInvalidateSubscriptions: Boolean,
+        pushTokenOverride: String?,
+    ) {
+        if (shouldInvalidateSubscriptions) {
+            invalidateSubscriptions()
+        }
 
-            updateDevice(
-                remote = remoteDevice,
-                request = requestDevice,
-            )
-        } catch (_: Throwable) {}
+        val subscriptionState = getSubscriptionSyncState()
+        val pushState = resolvePushState(
+            wallets = wallets,
+            pushTokenOverride = pushTokenOverride,
+        ) ?: return
+        val localDevice = buildLocalDevice(
+            pushState = pushState,
+            subscriptionsVersion = subscriptionState.version,
+        )
+        val remoteDevice = getOrCreateDevice(localDevice)
+        val didSyncSubscriptions = maybeSyncSubscriptions(
+            wallets = wallets,
+            subscriptionState = subscriptionState,
+            remoteDevice = remoteDevice,
+        )
+        val requestDevice = buildDeviceUpdateRequest(
+            localDevice = localDevice,
+            remoteDevice = remoteDevice,
+            localSubscriptionVersion = subscriptionState.version,
+            didSyncSubscriptions = didSyncSubscriptions,
+        )
+
+        updateDevice(
+            remote = remoteDevice,
+            request = requestDevice,
+        )
     }
 
     private suspend fun loadWallets(): List<Wallet> {
@@ -170,9 +186,9 @@ class DeviceRepository(
             setDeviceRegistered(false)
         }
 
-        val registeredDevice = gemDeviceApiClient.registerDevice(device) ?: device
-        setDeviceRegistered(gemDeviceApiClient.isDeviceRegistered())
-        return registeredDevice
+        val registeredDevice = gemDeviceApiClient.registerDevice(device)
+        setDeviceRegistered(registeredDevice != null)
+        return registeredDevice ?: device
     }
 
     private suspend fun updateDevice(remote: Device, request: Device) {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinator.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinator.kt
@@ -1,0 +1,15 @@
+package com.gemwallet.android.data.repositories.device
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class DeviceSyncCoordinator {
+
+    private val mutex = Mutex()
+
+    suspend fun synchronize(synchronize: suspend () -> Unit) {
+        mutex.withLock {
+            synchronize()
+        }
+    }
+}

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinatorTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinatorTest.kt
@@ -1,0 +1,45 @@
+package com.gemwallet.android.data.repositories.device
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeviceSyncCoordinatorTest {
+
+    @Test
+    fun synchronize_concurrentCalls_neverOverlap() = runTest {
+        val coordinator = DeviceSyncCoordinator()
+        var running = 0
+        var maxRunning = 0
+        var completed = 0
+
+        List(4) {
+            launch {
+                coordinator.synchronize {
+                    running += 1
+                    maxRunning = maxOf(maxRunning, running)
+                    delay(100)
+                    running -= 1
+                    completed += 1
+                }
+            }
+        }.joinAll()
+
+        assertEquals(1, maxRunning)
+        assertEquals(4, completed)
+    }
+
+    @Test
+    fun synchronize_failedPass_releasesLockForNextCaller() = runTest {
+        val coordinator = DeviceSyncCoordinator()
+        var completed = 0
+
+        runCatching { coordinator.synchronize { throw IllegalStateException("sync failed") } }
+        coordinator.synchronize { completed += 1 }
+
+        assertEquals(1, completed)
+    }
+}


### PR DESCRIPTION
On a slow connection the app registered the device and sent subscriptions several times instead of once. Now these run one at a time, so each request goes out once, same as iOS.

Closes #712