### PR TITLE
Fix crash on transaction confirmation

### DIFF
--- a/ios/Features/Transfer/Sources/Services/ConfirmService.swift
+++ b/ios/Features/Transfer/Sources/Services/ConfirmService.swift
@@ -57,7 +57,11 @@ public struct ConfirmService: Sendable {
         let metadata = try metadata(request: request)
         async let input = inputProvider.load(request: request, metadata: metadata, selection: selection)
         async let simulation = simulationService.updateState(data: request.data, simulation: request.simulation)
-        return try await ConfirmTransferData(metadata: metadata, input: input, simulation: simulation)
+
+        let simulationState = await simulation
+        let inputData = try await input
+
+        return ConfirmTransferData(metadata: metadata, input: inputData, simulation: simulationState)
     }
 
     func confirm(request: ConfirmTransferRequest, transactionData: TransactionData, amount: TransferAmount) async throws {


### PR DESCRIPTION
The app force closed on the confirmation screen when sending or swapping, on any chain. Started in 2.105, reported on TestFlight.

The screen starts two loads at once and the crash happens while they are being finished. This changes how their results are collected.

Not verified yet: the crash has not been reproduced locally.