### PR TITLE
Consolidate ChainSettings latency status mapping

### DIFF
--- a/ios/Features/Settings/Sources/ChainSettings/ViewModels/LatencyStatusViewModel.swift
+++ b/ios/Features/Settings/Sources/ChainSettings/ViewModels/LatencyStatusViewModel.swift
@@ -54,3 +54,21 @@ struct LatencyStatusViewModel {
         }
     }
 }
+
+extension LatencyStatusViewModel {
+    init(serviceStatus: ServiceStatusState) {
+        switch serviceStatus {
+        case let .result(milliseconds): self.init(state: .latency(.from(duration: Double(milliseconds))))
+        case .error: self.init(state: .error)
+        case .loading: self.init(state: .loading)
+        }
+    }
+
+    init(nodeStatus: NodeStatusState) {
+        switch nodeStatus {
+        case let .result(status): self.init(state: status.latestBlockNumber > 0 ? .latency(status.latency) : .error)
+        case .error: self.init(state: .error)
+        case .none: self.init(state: .loading)
+        }
+    }
+}

--- a/ios/Features/Settings/Sources/ChainSettings/ViewModels/NodeStatusStateViewModel.swift
+++ b/ios/Features/Settings/Sources/ChainSettings/ViewModels/NodeStatusStateViewModel.swift
@@ -29,16 +29,6 @@ struct NodeStatusStateViewModel {
     }
 
     private var statusTag: LatencyStatusViewModel {
-        switch nodeStatus {
-        case let .result(nodeStatus):
-            if nodeStatus.latestBlockNumber > 0 {
-                return LatencyStatusViewModel(state: .latency(nodeStatus.latency))
-            }
-            return LatencyStatusViewModel(state: .error)
-        case .error:
-            return LatencyStatusViewModel(state: .error)
-        case .none:
-            return LatencyStatusViewModel(state: .loading)
-        }
+        LatencyStatusViewModel(nodeStatus: nodeStatus)
     }
 }

--- a/ios/Features/Settings/Sources/ChainSettings/ViewModels/ServiceStatusItemViewModel.swift
+++ b/ios/Features/Settings/Sources/ChainSettings/ViewModels/ServiceStatusItemViewModel.swift
@@ -32,10 +32,6 @@ struct ServiceStatusItemViewModel: Identifiable {
     }
 
     private var statusTag: LatencyStatusViewModel {
-        switch statusState {
-        case let .result(milliseconds): LatencyStatusViewModel(state: .latency(.from(duration: Double(milliseconds))))
-        case .error: LatencyStatusViewModel(state: .error)
-        case .loading: LatencyStatusViewModel(state: .loading)
-        }
+        LatencyStatusViewModel(serviceStatus: statusState)
     }
 }


### PR DESCRIPTION
The service-status and node-status views each duplicated the same status-to-tag mapping. This moves it into `LatencyStatusViewModel` so both views forward to a single source of truth. No behavior change.