### PR TITLE
Deduplicate swap rate into a shared AssetRatePair

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionDetailsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionDetailsImpl.kt
@@ -8,7 +8,7 @@ import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.transactions.TransactionRepository
 import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.price.toValueDirection
-import com.gemwallet.android.domains.swap.AssetRateFormatter
+import com.gemwallet.android.domains.swap.buildAssetRatePair
 import com.gemwallet.android.domains.transaction.AmountSign
 import com.gemwallet.android.domains.transaction.aggregates.TransactionDetailsAggregate
 import com.gemwallet.android.domains.transaction.values.TransactionDetailsValue
@@ -322,18 +322,13 @@ class TransactionDetailsAggregateImpl(
             val metadata = swapMetadata ?: return null
             val fromAsset = associatedAssets.firstOrNull { it.id() == metadata.fromAsset }?.asset ?: return null
             val toAsset = associatedAssets.firstOrNull { it.id() == metadata.toAsset }?.asset ?: return null
-            return try {
-                val fromAmount = Crypto(metadata.fromValue).value(fromAsset.decimals)
-                val toAmount = Crypto(metadata.toValue).value(toAsset.decimals)
-                if (fromAmount.signum() == 0 || toAmount.signum() == 0) return null
-                val formatter = AssetRateFormatter()
-                TransactionDetailsValue.Rate(
-                    forward = formatter.format(fromAsset, toAsset, fromAmount, toAmount, AssetRateFormatter.Direction.Direct),
-                    reverse = formatter.format(fromAsset, toAsset, fromAmount, toAmount, AssetRateFormatter.Direction.Inverse),
-                )
-            } catch (_: Throwable) {
-                null
-            }
+            val rate = buildAssetRatePair(
+                fromAsset = fromAsset,
+                toAsset = toAsset,
+                fromValue = metadata.fromValue,
+                toValue = metadata.toValue,
+            ) ?: return null
+            return TransactionDetailsValue.Rate(rate)
         }
 
     override val swapAgain: TransactionDetailsValue.SwapAgain?

--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsScene.kt
@@ -14,13 +14,13 @@ import com.gemwallet.android.domains.transaction.values.TransactionDetailsValue
 import com.gemwallet.android.features.activities.presents.details.components.DestinationPropertyItem
 import com.gemwallet.android.features.activities.presents.details.components.SwapProgressItem
 import com.gemwallet.android.features.activities.presents.details.components.TransactionExplorer
-import com.gemwallet.android.features.activities.presents.details.components.TransactionRateProperty
 import com.gemwallet.android.features.activities.presents.details.components.TransactionStatusProperty
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.list_head.AmountListHead
 import com.gemwallet.android.ui.components.list_head.NftHead
 import com.gemwallet.android.ui.components.list_head.SwapListHead
+import com.gemwallet.android.ui.components.list_item.property.AssetRatePropertyItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkFee
 import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkItem
@@ -106,7 +106,7 @@ internal fun TransactionDetailsScene(
                         is TransactionDetailsValue.Pnl -> PropertyItem(stringResource(R.string.perpetual_pnl), item.value, dataColor = item.direction.color(), listPosition = position)
                         is TransactionDetailsValue.Price -> PropertyItem(R.string.asset_price, item.data, listPosition = position)
                         is TransactionDetailsValue.Status -> TransactionStatusProperty(data.asset, item, position)
-                        is TransactionDetailsValue.Rate -> TransactionRateProperty(item, position)
+                        is TransactionDetailsValue.Rate -> AssetRatePropertyItem(item.rate, position)
                         is TransactionDetailsValue.SwapProgress -> SwapProgressItem(item)
                         is TransactionDetailsValue.SwapAgain -> MainActionButton(
                             title = stringResource(R.string.transaction_swap_again),

--- a/android/features/swap/viewmodels/src/test/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModelTest.kt
+++ b/android/features/swap/viewmodels/src/test/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModelTest.kt
@@ -31,7 +31,7 @@ import com.gemwallet.android.ui.models.swap.SwapDetailsUIModel
 import com.gemwallet.android.ui.models.swap.SwapDetailsUIModelFactory
 import com.gemwallet.android.ui.models.swap.SwapPriceImpactUIModel
 import com.gemwallet.android.ui.models.swap.SwapProviderUIModel
-import com.gemwallet.android.ui.models.swap.SwapRateUIModel
+import com.gemwallet.android.domains.swap.AssetRatePair
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.clearMocks
@@ -472,7 +472,7 @@ class SwapViewModelTest {
                 title = "Uniswap v3",
                 icon = "",
             ),
-            rate = SwapRateUIModel(forward = "1 SOL = 2.5 USDC", reverse = "1 USDC = 0.4 SOL"),
+            rate = AssetRatePair(forward = "1 SOL = 2.5 USDC", reverse = "1 USDC = 0.4 SOL"),
             priceImpact = SwapPriceImpactUIModel(
                 type = SwapPriceImpactType.High,
                 displayText = "-15%",

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/swap/AssetRatePair.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/swap/AssetRatePair.kt
@@ -1,0 +1,44 @@
+package com.gemwallet.android.domains.swap
+
+import com.gemwallet.android.model.Crypto
+import com.wallet.core.primitives.Asset
+
+data class AssetRatePair(
+    val forward: String,
+    val reverse: String,
+)
+
+fun buildAssetRatePair(
+    fromAsset: Asset,
+    toAsset: Asset,
+    fromValue: String,
+    toValue: String,
+    formatter: AssetRateFormatter = AssetRateFormatter(),
+): AssetRatePair? {
+    return try {
+        val fromAmount = Crypto(fromValue).value(fromAsset.decimals)
+        val toAmount = Crypto(toValue).value(toAsset.decimals)
+        if (fromAmount.signum() == 0 || toAmount.signum() == 0) {
+            return null
+        }
+
+        AssetRatePair(
+            forward = formatter.format(
+                fromAsset = fromAsset,
+                toAsset = toAsset,
+                fromAmount = fromAmount,
+                toAmount = toAmount,
+                direction = AssetRateFormatter.Direction.Direct,
+            ),
+            reverse = formatter.format(
+                fromAsset = fromAsset,
+                toAsset = toAsset,
+                fromAmount = fromAmount,
+                toAmount = toAmount,
+                direction = AssetRateFormatter.Direction.Inverse,
+            ),
+        )
+    } catch (_: Throwable) {
+        null
+    }
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/transaction/values/TransactionDetailsValue.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/transaction/values/TransactionDetailsValue.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.domains.transaction.values
 
 import com.gemwallet.android.domains.price.ValueDirection
+import com.gemwallet.android.domains.swap.AssetRatePair
 import com.gemwallet.android.model.AssetInfo
 import com.wallet.core.primitives.AddressType
 import com.wallet.core.primitives.Asset
@@ -86,7 +87,7 @@ sealed interface TransactionDetailsValue {
 
     class Status(val data: TransactionState) : TransactionDetailsValue
 
-    class Rate(val forward: String, val reverse: String) : TransactionDetailsValue
+    class Rate(val rate: AssetRatePair) : TransactionDetailsValue
 
     class SwapProgress(
         val fromAsset: Asset,

--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModel.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModel.kt
@@ -1,12 +1,8 @@
 package com.gemwallet.android.ui.models.swap
 
+import com.gemwallet.android.domains.swap.AssetRatePair
 import com.wallet.core.primitives.swap.SwapPriceImpactType
 import uniffi.gemstone.SwapperProvider
-
-data class SwapRateUIModel(
-    val forward: String,
-    val reverse: String,
-)
 
 data class SwapProviderUIModel(
     val id: SwapperProvider,
@@ -26,7 +22,7 @@ data class SwapPriceImpactUIModel(
 data class SwapDetailsUIModel(
     val provider: SwapProviderUIModel,
     val providers: List<SwapProviderUIModel> = emptyList(),
-    val rate: SwapRateUIModel,
+    val rate: AssetRatePair,
     val priceImpact: SwapPriceImpactUIModel?,
     val minimumReceive: String,
     val slippageText: String,

--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModelFactory.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModelFactory.kt
@@ -6,11 +6,11 @@ import com.gemwallet.android.domains.asset.getSwapProviderIcon
 import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
 import com.gemwallet.android.domains.percentage.formatAsPercentage
 import com.gemwallet.android.domains.swap.AssetRateFormatter
+import com.gemwallet.android.domains.swap.buildAssetRatePair
 import com.gemwallet.android.domains.swap.toPrimitives
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.ValueFormatter
-import java.math.BigDecimal
 import java.math.BigInteger
 import uniffi.gemstone.SwapPriceImpact
 import uniffi.gemstone.SwapperProvider
@@ -77,11 +77,12 @@ object SwapDetailsUIModelFactory {
         input: SwapDetailsUIModelInput,
         priceImpactCalculator: (Double, Double) -> SwapPriceImpact?,
     ): SwapDetailsUIModel? {
-        val rate = estimateSwapRate(
-            payAsset = input.payAsset,
-            receiveAsset = input.receiveAsset,
+        val rate = buildAssetRatePair(
+            fromAsset = input.payAsset.asset,
+            toAsset = input.receiveAsset.asset,
             fromValue = input.fromValue,
             toValue = input.toValue,
+            formatter = rateFormatter,
         ) ?: return null
 
         val slippagePercent = input.slippageBps.toDouble() / 100.0
@@ -117,40 +118,6 @@ object SwapDetailsUIModelFactory {
 
     internal fun minimumReceiveAtomic(atomicValue: BigInteger, slippageBps: UInt): BigInteger =
         atomicValue * (BPS_SCALE - slippageBps.toInt()).toBigInteger() / BPS_SCALE.toBigInteger()
-
-    private fun estimateSwapRate(
-        payAsset: AssetInfo,
-        receiveAsset: AssetInfo,
-        fromValue: String,
-        toValue: String,
-    ): SwapRateUIModel? {
-        return try {
-            val fromAmount = Crypto(fromValue).value(payAsset.asset.decimals)
-            val toAmount = Crypto(toValue).value(receiveAsset.asset.decimals)
-            if (fromAmount.compareTo(BigDecimal.ZERO) == 0 || toAmount.compareTo(BigDecimal.ZERO) == 0) {
-                return null
-            }
-
-            SwapRateUIModel(
-                forward = rateFormatter.format(
-                    fromAsset = payAsset.asset,
-                    toAsset = receiveAsset.asset,
-                    fromAmount = fromAmount,
-                    toAmount = toAmount,
-                    direction = AssetRateFormatter.Direction.Direct,
-                ),
-                reverse = rateFormatter.format(
-                    fromAsset = payAsset.asset,
-                    toAsset = receiveAsset.asset,
-                    fromAmount = fromAmount,
-                    toAmount = toAmount,
-                    direction = AssetRateFormatter.Direction.Inverse,
-                ),
-            )
-        } catch (_: Throwable) {
-            null
-        }
-    }
 }
 
 private fun UInt.formatSwapEta(): String? {

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/AssetRatePropertyItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/AssetRatePropertyItem.kt
@@ -1,4 +1,4 @@
-package com.gemwallet.android.features.activities.presents.details.components
+package com.gemwallet.android.ui.components.list_item.property
 
 import androidx.compose.foundation.clickable
 import androidx.compose.material3.Icon
@@ -10,22 +10,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import com.gemwallet.android.domains.transaction.values.TransactionDetailsValue
+import com.gemwallet.android.domains.swap.AssetRatePair
 import com.gemwallet.android.ui.R
-import com.gemwallet.android.ui.components.list_item.property.PropertyDataText
-import com.gemwallet.android.ui.components.list_item.property.PropertyItem
-import com.gemwallet.android.ui.components.list_item.property.PropertyTitleText
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.theme.Spacer4
 
 @Composable
-internal fun TransactionRateProperty(
-    property: TransactionDetailsValue.Rate,
-    position: ListPosition,
+fun AssetRatePropertyItem(
+    rate: AssetRatePair,
+    listPosition: ListPosition,
 ) {
     var showReverse by remember { mutableStateOf(false) }
-    val displayedRate = if (showReverse) property.reverse else property.forward
+    val displayedRate = if (showReverse) rate.reverse else rate.forward
 
     PropertyItem(
         modifier = Modifier.clickable { showReverse = !showReverse },
@@ -44,6 +41,6 @@ internal fun TransactionRateProperty(
                 },
             )
         },
-        listPosition = position,
+        listPosition = listPosition,
     )
 }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapDetailsComponents.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapDetailsComponents.kt
@@ -9,17 +9,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -32,20 +26,18 @@ import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.ui.components.list_item.ListItemTitleText
 import com.gemwallet.android.ui.components.list_item.SelectionCheckmark
 import com.gemwallet.android.ui.components.list_item.SubheaderItem
+import com.gemwallet.android.ui.components.list_item.property.AssetRatePropertyItem
 import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
 import com.gemwallet.android.ui.components.list_item.property.PropertyDataText
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyTitleText
 import com.gemwallet.android.ui.components.progress.CircularProgressIndicator20
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet
-import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.models.swap.SwapDetailsUIModel
 import com.gemwallet.android.ui.models.swap.SwapPriceImpactUIModel
 import com.gemwallet.android.ui.models.swap.SwapProviderUIModel
-import com.gemwallet.android.ui.models.swap.SwapRateUIModel
 import com.wallet.core.primitives.swap.SwapPriceImpactType
-import com.gemwallet.android.ui.theme.Spacer4
 import com.gemwallet.android.ui.theme.Spacer8
 import com.gemwallet.android.ui.theme.pendingColor
 import com.gemwallet.android.ui.theme.listItemIconSize
@@ -147,7 +139,7 @@ fun SwapDetailsBottomSheet(
                 }
             }
             item {
-                SwapRatePropertyItem(model.rate, ListPosition.First)
+                AssetRatePropertyItem(model.rate, ListPosition.First)
             }
             model.estimatedTime?.let {
                 item {
@@ -226,32 +218,6 @@ private fun SwapCurrentProviderRow(
             SwapProviderAmounts(provider)
         },
         listPosition = ListPosition.Single,
-    )
-}
-
-@Composable
-private fun SwapRatePropertyItem(rate: SwapRateUIModel, listPosition: ListPosition) {
-    var showReverse by remember { mutableStateOf(false) }
-    val displayedRate = if (showReverse) rate.reverse else rate.forward
-
-    PropertyItem(
-        modifier = Modifier.clickable { showReverse = !showReverse },
-        title = { PropertyTitleText(R.string.buy_rate) },
-        data = {
-            PropertyDataText(
-                text = displayedRate,
-                badge = {
-                    Spacer4()
-                    Icon(
-                        modifier = Modifier.clip(MaterialTheme.shapes.small),
-                        imageVector = AppIcons.SwapVert,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.secondary,
-                    )
-                },
-            )
-        },
-        listPosition = listPosition,
     )
 }
 


### PR DESCRIPTION
The swap rate shown on the swap screen and on a swap transaction was built and rendered by two separate copies of the same code.

Both now use one shared rate type and one shared row. No behaviour changes.