### PR TITLE
Round Claim Rewards amount on stake overview to match iOS

### DIFF
--- a/android/features/earn/stake/viewmodels/src/main/kotlin/com/gemwallet/android/features/stake/viewmodels/StakeViewModel.kt
+++ b/android/features/earn/stake/viewmodels/src/main/kotlin/com/gemwallet/android/features/stake/viewmodels/StakeViewModel.kt
@@ -125,7 +125,7 @@ class StakeViewModel @Inject constructor(
                 .takeIf { assetInfo.chain.canClaimRewards && rewardsBalance > BigInteger.ZERO }
                 ?.let {
                     StakeAction.Rewards(
-                        data = ValueFormatter(style = ValueFormatter.Style.Full)
+                        data = ValueFormatter(style = ValueFormatter.Style.Auto)
                             .string(rewardsBalance, assetInfo.asset),
                     )
                 },


### PR DESCRIPTION
The Claim Rewards row on the staking overview screen showed the pending reward at full precision on Android, while iOS rounds it. This switches Android to the same rounded formatter so both platforms match.