### PR TITLE
Fix wallet assets not loading on a fresh install

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/AppLifecycleCoordinator.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/AppLifecycleCoordinator.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.gemwallet.android.data.repositories.connection.ConnectionStatusObserver
+import com.gemwallet.android.data.repositories.device.DeviceObserverService
 import com.gemwallet.android.data.repositories.perpetual.HyperliquidObserverService
 import com.gemwallet.android.data.repositories.stream.StreamObserverService
 import javax.inject.Inject
@@ -10,6 +11,7 @@ import javax.inject.Singleton
 
 @Singleton
 class AppLifecycleCoordinator @Inject constructor(
+    private val deviceObserver: DeviceObserverService,
     private val streamObserver: StreamObserverService,
     private val hyperliquidObserver: HyperliquidObserverService,
     private val nodeAuthTokenService: NodeAuthTokenService,
@@ -17,6 +19,7 @@ class AppLifecycleCoordinator @Inject constructor(
 ) : DefaultLifecycleObserver {
 
     override fun onStart(owner: LifecycleOwner) {
+        deviceObserver.start()
         streamObserver.start()
         hyperliquidObserver.start()
         nodeAuthTokenService.start()
@@ -24,6 +27,7 @@ class AppLifecycleCoordinator @Inject constructor(
     }
 
     override fun onStop(owner: LifecycleOwner) {
+        deviceObserver.stop()
         streamObserver.stop()
         hyperliquidObserver.stop()
         nodeAuthTokenService.stop()

--- a/android/app/src/main/kotlin/com/gemwallet/android/di/DataModule.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/di/DataModule.kt
@@ -5,7 +5,7 @@ import com.gemwallet.android.application.swap.coordinators.SyncSwapAssets
 import com.gemwallet.android.blockchain.services.BroadcastService
 import com.gemwallet.android.blockchain.services.NodeStatusService
 import com.gemwallet.android.blockchain.services.SignerPreloaderProxy
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
 import com.gemwallet.android.services.SyncService
 import dagger.Module
@@ -52,12 +52,12 @@ object DataModule {
     fun provideSyncService(
         syncFiatAssets: SyncFiatAssets,
         syncSwapAssets: SyncSwapAssets,
-        syncDeviceInfo: SyncDeviceInfo,
+        syncDevice: SyncDevice,
     ): SyncService {
         return SyncService(
             syncFiatAssets = syncFiatAssets,
             syncSwapAssets = syncSwapAssets,
-            syncDeviceInfo = syncDeviceInfo,
+            syncDevice = syncDevice,
         )
     }
 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/di/InteractsModule.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/di/InteractsModule.kt
@@ -25,7 +25,7 @@ import com.gemwallet.android.blockchain.operators.gemstone.GemValidatePhraseOper
 import com.gemwallet.android.blockchain.services.GemSignAuthOperator
 import com.gemwallet.android.blockchain.services.GemSignMessageOperator
 import com.gemwallet.android.blockchain.services.GemSignTransactionOperator
-import com.gemwallet.android.cases.device.SyncSubscription
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.cases.wallet.ImportWalletService
 import com.gemwallet.android.data.password.TinkPasswordStore
 import com.gemwallet.android.data.password.TinkSecurityStore
@@ -133,7 +133,7 @@ object InteractsModule {
         phraseValidate: ValidatePhraseOperator,
         addressValidate: ValidateAddressOperator,
         passwordStore: PasswordStore,
-        syncSubscription: SyncSubscription,
+        syncDevice: SyncDevice,
         walletImportSync: SyncWalletImport,
     ): ImportWalletService = PhraseAddressImportWalletService(
         walletsRepository = walletsRepository,
@@ -143,7 +143,7 @@ object InteractsModule {
         phraseValidate = phraseValidate,
         addressValidate = addressValidate,
         passwordStore = passwordStore,
-        syncSubscription = syncSubscription,
+        syncDevice = syncDevice,
         walletImportSync = walletImportSync,
     )
 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/services/CheckAccountsService.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/services/CheckAccountsService.kt
@@ -2,7 +2,6 @@ package com.gemwallet.android.services
 
 import com.gemwallet.android.application.PasswordStore
 import com.gemwallet.android.blockchain.operators.AddAccountsOperator
-import com.gemwallet.android.cases.device.SyncSubscription
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.ext.available
@@ -21,7 +20,6 @@ class CheckAccountsService @Inject constructor(
     private val assetsRepository: AssetsRepository,
     private val addAccountsOperator: AddAccountsOperator,
     private val passwordStore: PasswordStore,
-    private val syncSubscription: SyncSubscription,
 ) {
     suspend operator fun invoke() = withContext(Dispatchers.IO) {
         // TODO: Remove after legacy native assets with stale rank = 0 have been repaired.
@@ -55,7 +53,6 @@ class CheckAccountsService @Inject constructor(
                 if (newAccounts.isNotEmpty()) {
                     assetsRepository.invalidateDefault(newWallet)
                 }
-                syncSubscription.syncSubscription(walletsRepository.getAll().firstOrNull() ?: emptyList())
                 return@forEach
             }
 

--- a/android/app/src/main/kotlin/com/gemwallet/android/services/SyncService.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/services/SyncService.kt
@@ -2,7 +2,7 @@ package com.gemwallet.android.services
 
 import com.gemwallet.android.application.fiat.coordinators.SyncFiatAssets
 import com.gemwallet.android.application.swap.coordinators.SyncSwapAssets
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -10,14 +10,14 @@ import javax.inject.Inject
 class SyncService @Inject constructor(
     private val syncFiatAssets: SyncFiatAssets,
     private val syncSwapAssets: SyncSwapAssets,
-    private val syncDeviceInfo: SyncDeviceInfo,
+    private val syncDevice: SyncDevice,
 ) {
 
     suspend fun sync() {
         withContext(Dispatchers.IO) {
             runCatching { syncFiatAssets() }
             runCatching { syncSwapAssets() }
-            runCatching { syncDeviceInfo.syncDeviceInfo() }
+            runCatching { syncDevice.syncDevice() }
         }
     }
 }

--- a/android/app/src/test/kotlin/com/gemwallet/android/services/CheckAccountsServiceTest.kt
+++ b/android/app/src/test/kotlin/com/gemwallet/android/services/CheckAccountsServiceTest.kt
@@ -2,7 +2,6 @@ package com.gemwallet.android.services
 
 import com.gemwallet.android.application.PasswordStore
 import com.gemwallet.android.blockchain.operators.AddAccountsOperator
-import com.gemwallet.android.cases.device.SyncSubscription
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.ext.available
@@ -29,14 +28,12 @@ class CheckAccountsServiceTest {
     private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
     private val addAccountsOperator = mockk<AddAccountsOperator>(relaxed = true)
     private val passwordStore = mockk<PasswordStore>(relaxed = true)
-    private val syncSubscription = mockk<SyncSubscription>(relaxed = true)
 
     private val subject = CheckAccountsService(
         walletsRepository = walletsRepository,
         assetsRepository = assetsRepository,
         addAccountsOperator = addAccountsOperator,
         passwordStore = passwordStore,
-        syncSubscription = syncSubscription,
     )
 
     @After
@@ -60,7 +57,6 @@ class CheckAccountsServiceTest {
         every { walletsRepository.getAll() } returns flowOf(listOf(wallet))
         coJustRun { assetsRepository.updateNativeAssetRanks() }
         every { assetsRepository.invalidateDefault(wallet) } returns Job()
-        coJustRun { syncSubscription.syncSubscription(any()) }
         coJustRun { walletsRepository.updateWallet(any()) }
         coJustRun { walletsRepository.updateAccounts(any()) }
         coEvery { assetsRepository.getNativeAssets(wallet) } returns nativeAssets
@@ -75,7 +71,6 @@ class CheckAccountsServiceTest {
         coVerify(exactly = 0) { addAccountsOperator(any(), any(), any()) }
         coVerify(exactly = 0) { walletsRepository.updateWallet(any()) }
         coVerify(exactly = 0) { walletsRepository.updateAccounts(any()) }
-        coVerify(exactly = 0) { syncSubscription.syncSubscription(any()) }
     }
 
     @Test
@@ -104,6 +99,5 @@ class CheckAccountsServiceTest {
         coVerify(exactly = 0) { addAccountsOperator(any(), any(), any()) }
         coVerify(exactly = 0) { walletsRepository.updateWallet(any()) }
         coVerify(exactly = 0) { walletsRepository.updateAccounts(any()) }
-        coVerify(exactly = 0) { syncSubscription.syncSubscription(any()) }
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/DeviceAssetsSyncService.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/DeviceAssetsSyncService.kt
@@ -3,7 +3,7 @@ package com.gemwallet.android.data.coordinators.asset
 import com.gemwallet.android.application.assets.coordinators.EnableAsset
 import com.gemwallet.android.application.assets.coordinators.EnsureWalletAssets
 import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
-import com.gemwallet.android.cases.device.SynchronizeDeviceIfNeeded
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.data.service.store.WalletPreferencesFactory
@@ -27,11 +27,11 @@ class DeviceAssetsSyncService @Inject constructor(
     private val enableAsset: EnableAsset,
     private val assetsRepository: AssetsRepository,
     private val walletsRepository: WalletsRepository,
-    private val synchronizeDeviceIfNeeded: SynchronizeDeviceIfNeeded,
+    private val syncDevice: SyncDevice,
 ) {
 
     suspend fun sync(walletId: String) {
-        synchronizeDeviceIfNeeded.synchronizeIfNeeded()
+        syncDevice.syncDevice()
 
         val walletIdentifier = WalletId(walletId)
         val preferences = walletPreferencesFactory.create(walletId)

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PriceAlertModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PriceAlertModule.kt
@@ -9,7 +9,7 @@ import com.gemwallet.android.application.pricealerts.coordinators.IncludePriceAl
 import com.gemwallet.android.application.pricealerts.coordinators.SetAssetPriceAlertEnabled
 import com.gemwallet.android.application.pricealerts.coordinators.SetPriceAlertsEnabled
 import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAlerts
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.coordinators.pricealerts.ExcludePriceAlertImpl
 import com.gemwallet.android.data.coordinators.pricealerts.GetAssetPriceAlertStateImpl
 import com.gemwallet.android.data.coordinators.pricealerts.GetPriceAlertsEnabledImpl
@@ -38,13 +38,13 @@ object PriceAlertModule {
         gemDeviceApiClient: GemDeviceApiClient,
         priceAlertRepository: PriceAlertRepository,
         sessionRepository: SessionRepository,
-        syncDeviceInfo: SyncDeviceInfo,
+        syncDevice: SyncDevice,
     ): IncludePriceAlert {
         return IncludePriceAlertImpl(
             gemDeviceApiClient = gemDeviceApiClient,
             priceAlertRepository = priceAlertRepository,
             sessionRepository = sessionRepository,
-            syncDeviceInfo = syncDeviceInfo,
+            syncDevice = syncDevice,
         )
     }
 
@@ -74,11 +74,11 @@ object PriceAlertModule {
     @Singleton
     fun provideSetPriceAlertsEnabled(
         priceAlertRepository: PriceAlertRepository,
-        syncDeviceInfo: SyncDeviceInfo,
+        syncDevice: SyncDevice,
     ): SetPriceAlertsEnabled {
         return SetPriceAlertsEnabledImpl(
             priceAlertRepository = priceAlertRepository,
-            syncDeviceInfo = syncDeviceInfo,
+            syncDevice = syncDevice,
         )
     }
 

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/SessionModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/SessionModule.kt
@@ -2,7 +2,7 @@ package com.gemwallet.android.data.coordinators.di
 
 import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.application.session.coordinators.SetCurrentCurrency
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.coordinators.session.GetSessionImpl
 import com.gemwallet.android.data.coordinators.session.SetCurrentCurrencyImpl
 import com.gemwallet.android.data.repositories.session.SessionRepository
@@ -26,11 +26,11 @@ object SessionModule {
     @Singleton
     fun provideSetCurrentCurrency(
         sessionRepository: SessionRepository,
-        syncDeviceInfo: SyncDeviceInfo,
+        syncDevice: SyncDevice,
     ): SetCurrentCurrency {
         return SetCurrentCurrencyImpl(
             sessionRepository = sessionRepository,
-            syncDeviceInfo = syncDeviceInfo,
+            syncDevice = syncDevice,
         )
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/WalletImportModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/WalletImportModule.kt
@@ -6,7 +6,7 @@ import com.gemwallet.android.application.wallet_import.coordinators.SyncWalletCo
 import com.gemwallet.android.application.wallet_import.coordinators.SyncWalletImport
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
 import com.gemwallet.android.cases.banners.AddBanner
-import com.gemwallet.android.cases.device.SyncSubscription
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.cases.nft.SyncNfts
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.data.coordinators.wallet_import.SyncWalletConfigurationImpl
@@ -53,7 +53,7 @@ object WalletImportModule {
         getAvailableAssetIds: GetAvailableAssetIds,
         searchTokensCase: SearchTokensCase,
         assetsRepository: AssetsRepository,
-        syncSubscription: SyncSubscription,
+        syncDevice: SyncDevice,
         syncTransactions: SyncTransactions,
         syncNfts: SyncNfts,
         walletConfigurationSync: SyncWalletConfiguration,
@@ -62,7 +62,7 @@ object WalletImportModule {
         getAvailableAssetIds = getAvailableAssetIds,
         searchTokensCase = searchTokensCase,
         assetsRepository = assetsRepository,
-        syncSubscription = syncSubscription,
+        syncDevice = syncDevice,
         syncTransactions = syncTransactions,
         syncNfts = syncNfts,
         walletConfigurationSync = walletConfigurationSync,

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/WalletModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/WalletModule.kt
@@ -13,7 +13,6 @@ import com.gemwallet.android.application.wallet.coordinators.WalletIdGenerator
 import com.gemwallet.android.blockchain.operators.DeleteKeyStoreOperator
 import com.gemwallet.android.blockchain.operators.LoadPrivateDataOperator
 import com.gemwallet.android.cases.addresses.RenameWalletAddresses
-import com.gemwallet.android.cases.device.SyncSubscription
 import com.gemwallet.android.data.coordinators.wallet.DeleteWalletImpl
 import com.gemwallet.android.data.coordinators.wallet.GetAllWalletsImpl
 import com.gemwallet.android.data.coordinators.wallet.GetWalletDetailsImpl
@@ -94,10 +93,9 @@ object WalletModule {
         sessionRepository: SessionRepository,
         walletsRepository: WalletsRepository,
         deleteKeyStoreOperator: DeleteKeyStoreOperator,
-        syncSubscription: SyncSubscription,
         walletPreferencesFactory: WalletPreferencesFactory,
     ): DeleteWallet {
-        return DeleteWalletImpl(sessionRepository, walletsRepository, deleteKeyStoreOperator, syncSubscription, walletPreferencesFactory)
+        return DeleteWalletImpl(sessionRepository, walletsRepository, deleteKeyStoreOperator, walletPreferencesFactory)
     }
 
     @Provides

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/pricealerts/IncludePriceAlertImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/pricealerts/IncludePriceAlertImpl.kt
@@ -1,7 +1,7 @@
 package com.gemwallet.android.data.coordinators.pricealerts
 
 import com.gemwallet.android.application.pricealerts.coordinators.IncludePriceAlert
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
@@ -17,7 +17,7 @@ class IncludePriceAlertImpl(
     private val gemDeviceApiClient: GemDeviceApiClient,
     private val sessionRepository: SessionRepository,
     private val priceAlertRepository: PriceAlertRepository,
-    private val syncDeviceInfo: SyncDeviceInfo,
+    private val syncDevice: SyncDevice,
 ) : IncludePriceAlert {
 
     override suspend fun invoke(
@@ -54,7 +54,7 @@ class IncludePriceAlertImpl(
 
         priceAlertRepository.togglePriceAlerts(true)
         try {
-            syncDeviceInfo.syncDeviceInfo()
+            syncDevice.syncDevice()
         } catch (_: Exception) {
             currentCoroutineContext().ensureActive()
         }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/pricealerts/SetPriceAlertsEnabledImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/pricealerts/SetPriceAlertsEnabledImpl.kt
@@ -1,13 +1,13 @@
 package com.gemwallet.android.data.coordinators.pricealerts
 
 import com.gemwallet.android.application.pricealerts.coordinators.SetPriceAlertsEnabled
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import kotlinx.coroutines.flow.firstOrNull
 
 class SetPriceAlertsEnabledImpl(
     private val priceAlertRepository: PriceAlertRepository,
-    private val syncDeviceInfo: SyncDeviceInfo,
+    private val syncDevice: SyncDevice,
 ) : SetPriceAlertsEnabled {
 
     override suspend fun invoke(enabled: Boolean) {
@@ -16,6 +16,6 @@ class SetPriceAlertsEnabledImpl(
         }
 
         priceAlertRepository.togglePriceAlerts(enabled)
-        syncDeviceInfo.syncDeviceInfo()
+        syncDevice.syncDevice()
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/session/SetCurrentCurrencyImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/session/SetCurrentCurrencyImpl.kt
@@ -1,7 +1,7 @@
 package com.gemwallet.android.data.coordinators.session
 
 import com.gemwallet.android.application.session.coordinators.SetCurrentCurrency
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.wallet.core.primitives.Currency
 import kotlinx.coroutines.CoroutineScope
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 
 class SetCurrentCurrencyImpl(
     private val sessionRepository: SessionRepository,
-    private val syncDeviceInfo: SyncDeviceInfo,
+    private val syncDevice: SyncDevice,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) : SetCurrentCurrency {
 
@@ -22,7 +22,7 @@ class SetCurrentCurrencyImpl(
             }
 
             sessionRepository.setCurrency(currency)
-            syncDeviceInfo.syncDeviceInfo()
+            syncDevice.syncDevice()
         }
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/wallet/DeleteWalletImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/wallet/DeleteWalletImpl.kt
@@ -3,18 +3,13 @@ package com.gemwallet.android.data.coordinators.wallet
 import android.util.Log
 import com.gemwallet.android.application.wallet.coordinators.DeleteWallet
 import com.gemwallet.android.blockchain.operators.DeleteKeyStoreOperator
-import com.gemwallet.android.cases.device.SyncSubscription
 import com.gemwallet.android.data.service.store.WalletPreferencesFactory
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.wallet.core.primitives.WalletId
 import com.wallet.core.primitives.WalletType
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -24,11 +19,8 @@ class DeleteWalletImpl @Inject constructor(
     private val sessionRepository: SessionRepository,
     private val walletsRepository: WalletsRepository,
     private val deleteKeyStoreOperator: DeleteKeyStoreOperator,
-    private val syncSubscription: SyncSubscription,
     private val walletPreferencesFactory: WalletPreferencesFactory,
 ) : DeleteWallet {
-
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO + CoroutineExceptionHandler { _, _ -> })
 
     override suspend fun deleteWallet(
         walletId: WalletId,
@@ -49,11 +41,6 @@ class DeleteWalletImpl @Inject constructor(
         }
 
         walletPreferencesFactory.create(walletId.id).clear()
-
-        scope.launch {
-            walletsRepository.getAll().firstOrNull()
-                ?.let { syncSubscription.syncSubscription(it) }
-        }
 
         val callback: () -> Unit = if (currentWalletId == walletId) {
             val nextWallet = walletsRepository.getAll().firstOrNull()

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/wallet_import/services/ImportWalletService.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/wallet_import/services/ImportWalletService.kt
@@ -6,7 +6,7 @@ import com.gemwallet.android.application.wallet_import.coordinators.GetImportWal
 import com.gemwallet.android.application.wallet_import.coordinators.SyncWalletConfiguration
 import com.gemwallet.android.application.wallet_import.coordinators.SyncWalletImport
 import com.gemwallet.android.application.wallet_import.values.ImportWalletState
-import com.gemwallet.android.cases.device.SyncSubscription
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.cases.nft.SyncNfts
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
@@ -37,7 +37,7 @@ class ImportWalletService(
     private val getAvailableAssetIds: GetAvailableAssetIds,
     private val searchTokensCase: SearchTokensCase,
     private val assetsRepository: AssetsRepository,
-    private val syncSubscription: SyncSubscription,
+    private val syncDevice: SyncDevice,
     private val syncTransactions: SyncTransactions,
     private val syncNfts: SyncNfts,
     private val walletConfigurationSync: SyncWalletConfiguration,
@@ -58,7 +58,7 @@ class ImportWalletService(
     }
 
     private suspend fun syncWallet(wallet: Wallet) {
-        syncSubscription.syncSubscription(listOf(wallet))
+        syncDevice.syncDevice()
         supervisorScope {
             launch { walletConfigurationSync.sync(wallet.id) }
             launch { discoverAssets(wallet) }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/DeviceAssetsSyncServiceTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/DeviceAssetsSyncServiceTest.kt
@@ -1,6 +1,6 @@
 package com.gemwallet.android.data.coordinators.asset
 
-import com.gemwallet.android.cases.device.SynchronizeDeviceIfNeeded
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.service.store.WalletPreferences
 import com.gemwallet.android.data.service.store.WalletPreferencesFactory
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
@@ -18,7 +18,7 @@ class DeviceAssetsSyncServiceTest {
         every { create(any()) } returns walletPreferences
     }
     private val gemDeviceApiClient = mockk<GemDeviceApiClient>()
-    private val synchronizeDeviceIfNeeded = mockk<SynchronizeDeviceIfNeeded>(relaxed = true)
+    private val syncDevice = mockk<SyncDevice>(relaxed = true)
 
     private val subject = DeviceAssetsSyncService(
         walletPreferencesFactory = walletPreferencesFactory,
@@ -28,7 +28,7 @@ class DeviceAssetsSyncServiceTest {
         enableAsset = mockk(relaxed = true),
         assetsRepository = mockk(relaxed = true),
         walletsRepository = mockk(relaxed = true),
-        synchronizeDeviceIfNeeded = synchronizeDeviceIfNeeded,
+        syncDevice = syncDevice,
     )
 
     @Test
@@ -38,7 +38,7 @@ class DeviceAssetsSyncServiceTest {
         subject.sync("wallet-1")
 
         coVerifyOrder {
-            synchronizeDeviceIfNeeded.synchronizeIfNeeded()
+            syncDevice.syncDevice()
             gemDeviceApiClient.getAssets(any(), any())
         }
     }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/pricealerts/SetPriceAlertsEnabledImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/pricealerts/SetPriceAlertsEnabledImplTest.kt
@@ -1,6 +1,6 @@
 package com.gemwallet.android.data.coordinators.pricealerts
 
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.model.PriceAlertInfo
 import com.wallet.core.primitives.AssetId
@@ -17,35 +17,35 @@ class SetPriceAlertsEnabledImplTest {
     @Test
     fun enable_whenAlreadyEnabled_skipsToggleAndDeviceSync() = runBlocking {
         val repository = FakePriceAlertRepository(enabled = true)
-        val syncDeviceInfo = RecordingSyncDeviceInfo()
+        val syncDevice = RecordingSyncDevice()
 
-        SetPriceAlertsEnabledImpl(repository, syncDeviceInfo).invoke(true)
+        SetPriceAlertsEnabledImpl(repository, syncDevice).invoke(true)
 
         assertEquals(0, repository.toggleCalls)
-        assertEquals(0, syncDeviceInfo.calls)
+        assertEquals(0, syncDevice.calls)
         assertEquals(true, repository.enabled.value)
     }
 
     @Test
     fun enable_whenDisabled_togglesAndSyncsDevice() = runBlocking {
         val repository = FakePriceAlertRepository(enabled = false)
-        val syncDeviceInfo = RecordingSyncDeviceInfo()
+        val syncDevice = RecordingSyncDevice()
 
-        SetPriceAlertsEnabledImpl(repository, syncDeviceInfo).invoke(true)
+        SetPriceAlertsEnabledImpl(repository, syncDevice).invoke(true)
 
         assertEquals(1, repository.toggleCalls)
-        assertEquals(1, syncDeviceInfo.calls)
+        assertEquals(1, syncDevice.calls)
         assertEquals(true, repository.enabled.value)
     }
 
     @Test
     fun disable_togglesAndSyncsDeviceEvenWhenAlreadyDisabled() = runBlocking {
         val enabledRepository = FakePriceAlertRepository(enabled = true)
-        val enabledSync = RecordingSyncDeviceInfo()
+        val enabledSync = RecordingSyncDevice()
         SetPriceAlertsEnabledImpl(enabledRepository, enabledSync).invoke(false)
 
         val disabledRepository = FakePriceAlertRepository(enabled = false)
-        val disabledSync = RecordingSyncDeviceInfo()
+        val disabledSync = RecordingSyncDevice()
         SetPriceAlertsEnabledImpl(disabledRepository, disabledSync).invoke(false)
 
         assertEquals(1, enabledRepository.toggleCalls)
@@ -56,10 +56,10 @@ class SetPriceAlertsEnabledImplTest {
         assertEquals(false, disabledRepository.enabled.value)
     }
 
-    private class RecordingSyncDeviceInfo : SyncDeviceInfo {
+    private class RecordingSyncDevice : SyncDevice {
         var calls = 0
 
-        override suspend fun syncDeviceInfo() {
+        override suspend fun syncDevice() {
             calls += 1
         }
     }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/wallet/DeleteWalletImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/wallet/DeleteWalletImplTest.kt
@@ -1,7 +1,6 @@
 package com.gemwallet.android.data.coordinators.wallet
 
 import com.gemwallet.android.blockchain.operators.DeleteKeyStoreOperator
-import com.gemwallet.android.cases.device.SyncSubscription
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.data.service.store.WalletPreferences
@@ -32,7 +31,6 @@ class DeleteWalletImplTest {
     private val sessionRepository = mockk<SessionRepository>(relaxed = true)
     private val walletsRepository = mockk<WalletsRepository>(relaxed = true)
     private val deleteKeyStoreOperator = mockk<DeleteKeyStoreOperator>()
-    private val syncSubscription = mockk<SyncSubscription>(relaxed = true)
     private val walletPreferences = mockk<WalletPreferences>(relaxed = true)
     private val walletPreferencesFactory = mockk<WalletPreferencesFactory> {
         every { create(any()) } returns walletPreferences
@@ -42,7 +40,6 @@ class DeleteWalletImplTest {
         sessionRepository,
         walletsRepository,
         deleteKeyStoreOperator,
-        syncSubscription,
         walletPreferencesFactory,
     )
 

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/wallet_import/services/ImportWalletServiceTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/wallet_import/services/ImportWalletServiceTest.kt
@@ -3,7 +3,7 @@ package com.gemwallet.android.data.coordinators.wallet_import.services
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
 import com.gemwallet.android.application.wallet_import.coordinators.GetAvailableAssetIds
 import com.gemwallet.android.application.wallet_import.coordinators.SyncWalletConfiguration
-import com.gemwallet.android.cases.device.SyncSubscription
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.cases.nft.SyncNfts
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
@@ -34,7 +34,7 @@ class ImportWalletServiceTest {
     private val sessionRepository = mockk<SessionRepository>()
     private val searchTokensCase = mockk<SearchTokensCase>(relaxed = true)
     private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
-    private val syncSubscription = mockk<SyncSubscription>(relaxed = true)
+    private val syncDevice = mockk<SyncDevice>(relaxed = true)
     private val syncTransactions = mockk<SyncTransactions>(relaxed = true)
     private val syncNfts = mockk<SyncNfts>(relaxed = true)
     private val walletConfigurationSync = mockk<SyncWalletConfiguration>(relaxed = true)
@@ -70,7 +70,7 @@ class ImportWalletServiceTest {
         advanceUntilIdle()
 
         coVerifyOrder {
-            syncSubscription.syncSubscription(listOf(wallet))
+            syncDevice.syncDevice()
             walletConfigurationSync.sync(wallet.id)
         }
     }
@@ -80,7 +80,7 @@ class ImportWalletServiceTest {
         getAvailableAssetIds = GetAvailableAssetIds { availableAssetIds },
         searchTokensCase = searchTokensCase,
         assetsRepository = assetsRepository,
-        syncSubscription = syncSubscription,
+        syncDevice = syncDevice,
         syncTransactions = syncTransactions,
         syncNfts = syncNfts,
         walletConfigurationSync = walletConfigurationSync,

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/config/UserConfig.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/config/UserConfig.kt
@@ -237,7 +237,6 @@ class UserConfig(
         DevelopEnabled("develop_enabled"),
         PerpetualChartPeriod("perpetual_chart_period"),
         SubscriptionVersion("subscription_version"),
-        SubscriptionVersionHasChange("subscription_version_has_change"),
         LaunchNumber("launch_number"),
         ;
 

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceObserverService.kt
@@ -1,0 +1,33 @@
+package com.gemwallet.android.data.repositories.device
+
+import com.gemwallet.android.cases.device.SyncDevice
+import com.gemwallet.android.data.repositories.wallets.WalletsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+class DeviceObserverService(
+    private val walletsRepository: WalletsRepository,
+    private val syncDevice: SyncDevice,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+) {
+    private var observeJob: Job? = null
+
+    fun start() {
+        if (observeJob != null) return
+
+        observeJob = scope.launch {
+            walletsRepository.getAll().collectLatest {
+                runCatching { syncDevice.syncDevice() }
+            }
+        }
+    }
+
+    fun stop() {
+        observeJob?.cancel()
+        observeJob = null
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -11,10 +11,10 @@ import com.gemwallet.android.cases.device.GetPushToken
 import com.gemwallet.android.cases.device.IsDeviceRegistered
 import com.gemwallet.android.cases.device.RequestPushToken
 import com.gemwallet.android.cases.device.SetPushToken
-import com.gemwallet.android.cases.device.SwitchPushEnabled
-import com.gemwallet.android.cases.device.SyncDeviceInfo
-import com.gemwallet.android.cases.device.SyncSubscription
 import com.gemwallet.android.cases.device.SynchronizeDeviceIfNeeded
+import com.gemwallet.android.cases.device.SyncSubscription
+import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SwitchPushEnabled
 import com.gemwallet.android.data.repositories.config.UserConfig.Keys
 import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
@@ -24,6 +24,7 @@ import com.gemwallet.android.ext.getAccount
 import com.gemwallet.android.ext.model
 import com.gemwallet.android.ext.os
 import com.gemwallet.android.model.NotificationsAvailable
+import com.gemwallet.android.serializer.jsonEncoder
 import com.wallet.core.primitives.AddressChains
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.Device
@@ -40,9 +41,6 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.util.Locale
-import kotlin.collections.firstOrNull
-import kotlin.collections.map
-import kotlin.collections.plus
 
 class DeviceRepository(
     private val context: Context,
@@ -70,18 +68,19 @@ class DeviceRepository(
 
     private val syncCoordinator = DeviceSyncCoordinator(scope)
 
-    override suspend fun syncDeviceInfo() {
-        synchronizeDevice(
-            wallets = loadWallets(),
-            shouldInvalidateSubscriptions = false,
-        )
-    }
+    override suspend fun syncDeviceInfo() = syncDevice()
 
-    override suspend fun synchronizeIfNeeded() {
-        if (isDeviceRegistered() && !hasPendingSubscriptionChanges()) {
-            return
+    override suspend fun syncSubscription(wallets: List<Wallet>) = syncDevice()
+
+    override suspend fun synchronizeIfNeeded() = syncDevice()
+
+    private suspend fun syncDevice() {
+        repeat(SYNC_ATTEMPTS) {
+            if (!needsSynchronization()) {
+                return
+            }
+            syncCoordinator.synchronize { reconcileDevice() }
         }
-        syncDeviceInfo()
     }
 
     override suspend fun switchPushEnabled(enabled: Boolean, wallets: List<Wallet>) {
@@ -89,7 +88,7 @@ class DeviceRepository(
             preferences[Key.PushEnabled] = enabled && notificationsAvailable
         }
         try {
-            syncDeviceInfo()
+            syncDevice()
         } catch (_: Throwable) {}
     }
 
@@ -108,67 +107,48 @@ class DeviceRepository(
         }
     }
 
-    override suspend fun syncSubscription(wallets: List<Wallet>) {
-        synchronizeDevice(
-            wallets = walletsForSubscriptionSync(
-                storedWallets = loadWallets(),
-                requestedWallets = wallets,
-            ),
-            shouldInvalidateSubscriptions = true,
+    private suspend fun needsSynchronization(): Boolean {
+        if (!isDeviceRegistered()) {
+            return true
+        }
+        val pushedDevice = pushedDevice() ?: return true
+        val localDevice = buildDevice(
+            pushToken = getPushToken(),
+            pushEnabled = getPushEnabled().firstOrNull() ?: false,
+            subscriptionsVersion = getSubscriptionVersion(),
         )
+
+        return localDevice.hasChanges(pushedDevice)
+            || loadWallets().subscriptionSignature() != pushedSubscriptionSignature()
     }
 
-    private suspend fun synchronizeDevice(
-        wallets: List<Wallet>,
-        shouldInvalidateSubscriptions: Boolean,
-        pushTokenOverride: String? = null,
-    ) {
-        syncCoordinator.synchronize {
-            try {
-                reconcileDevice(
-                    wallets = wallets,
-                    shouldInvalidateSubscriptions = shouldInvalidateSubscriptions,
-                    pushTokenOverride = pushTokenOverride,
-                )
-            } catch (_: Throwable) {}
-        }
-    }
-
-    private suspend fun reconcileDevice(
-        wallets: List<Wallet>,
-        shouldInvalidateSubscriptions: Boolean,
-        pushTokenOverride: String?,
-    ) {
-        if (shouldInvalidateSubscriptions) {
-            invalidateSubscriptions()
-        }
-
-        val subscriptionState = getSubscriptionSyncState()
-        val pushState = resolvePushState(
-            wallets = wallets,
-            pushTokenOverride = pushTokenOverride,
-        ) ?: return
-        val localDevice = buildLocalDevice(
-            pushState = pushState,
-            subscriptionsVersion = subscriptionState.version,
+    private suspend fun reconcileDevice() {
+        val wallets = loadWallets()
+        val pushState = resolvePushState() ?: return
+        val signature = wallets.subscriptionSignature()
+        var version = getSubscriptionVersion()
+        val localDevice = buildDevice(
+            pushToken = pushState.token,
+            pushEnabled = pushState.enabled,
+            subscriptionsVersion = version,
         )
         val remoteDevice = getOrCreateDevice(localDevice)
-        val didSyncSubscriptions = maybeSyncSubscriptions(
-            wallets = wallets,
-            subscriptionState = subscriptionState,
-            remoteDevice = remoteDevice,
-        )
-        val requestDevice = buildDeviceUpdateRequest(
-            localDevice = localDevice,
-            remoteDevice = remoteDevice,
-            localSubscriptionVersion = subscriptionState.version,
-            didSyncSubscriptions = didSyncSubscriptions,
-        )
 
-        updateDevice(
-            remote = remoteDevice,
-            request = requestDevice,
-        )
+        val signatureChanged = signature != pushedSubscriptionSignature()
+        if (signatureChanged || remoteDevice.subscriptionsVersion != version) {
+            reconcileSubscriptions(wallets)
+            if (signatureChanged) {
+                version += 1
+                setSubscriptionVersion(version)
+            }
+        }
+
+        val requestDevice = localDevice.copy(subscriptionsVersion = version)
+        if (remoteDevice.hasChanges(requestDevice)) {
+            gemDeviceApiClient.updateDevice(request = requestDevice)
+            setDeviceRegistered(true)
+        }
+        recordPushedState(requestDevice, signature)
     }
 
     private suspend fun loadWallets(): List<Wallet> {
@@ -193,56 +173,31 @@ class DeviceRepository(
         return registeredDevice ?: device
     }
 
-    private suspend fun updateDevice(remote: Device, request: Device) {
-        if (!remote.hasChanges(request)) {
-            return
-        }
-
-        gemDeviceApiClient.updateDevice(request = request)
-        setDeviceRegistered(true)
-    }
-
     private suspend fun setDeviceRegistered(isRegistered: Boolean = true) {
         context.dataStore.edit { it[Key.DeviceRegistered] = isRegistered }
     }
 
-    private suspend fun reconcileSubscriptions(wallets: List<Wallet>): Boolean {
-        return try {
-            val remoteSubscriptions = gemDeviceApiClient.getSubscriptions() ?: emptyList()
-            val (toAdd, toRemove) = wallets.subscriptionsDiff(remoteSubscriptions)
+    private suspend fun reconcileSubscriptions(wallets: List<Wallet>) {
+        val remoteSubscriptions = gemDeviceApiClient.getSubscriptions() ?: emptyList()
+        val (toAdd, toRemove) = wallets.subscriptionsDiff(remoteSubscriptions)
 
-            if (toAdd.isNotEmpty()) {
-                gemDeviceApiClient.addSubscriptions(toAdd)
-            }
+        if (toAdd.isNotEmpty()) {
+            gemDeviceApiClient.addSubscriptions(toAdd)
+        }
 
-            if (toRemove.isNotEmpty()) {
-                gemDeviceApiClient.deleteSubscriptions(toRemove)
-            }
-
-            setSubscriptionVersionHasChange(false)
-            true
-        } catch (_: Throwable) {
-            false
+        if (toRemove.isNotEmpty()) {
+            gemDeviceApiClient.deleteSubscriptions(toRemove)
         }
     }
 
-    private suspend fun resolvePushState(
-        wallets: List<Wallet>,
-        pushTokenOverride: String?,
-    ): PushState? {
+    private suspend fun resolvePushState(): PushState? {
         val pushEnabled = getPushEnabled().firstOrNull() ?: false
-        val pushToken = if (pushEnabled) pushTokenOverride ?: getPushToken() else ""
+        val pushToken = if (pushEnabled) getPushToken() else ""
 
-        if (pushEnabled && pushToken.isEmpty() && pushTokenOverride == null) {
+        if (pushEnabled && pushToken.isEmpty()) {
             requestPushToken.requestToken { token ->
                 setPushToken(token)
-                CoroutineScope(Dispatchers.IO).launch {
-                    synchronizeDevice(
-                        wallets = wallets,
-                        shouldInvalidateSubscriptions = false,
-                        pushTokenOverride = token,
-                    )
-                }
+                scope.launch { syncDevice() }
             }
             return null
         }
@@ -250,51 +205,6 @@ class DeviceRepository(
         return PushState(
             enabled = pushEnabled,
             token = pushToken,
-        )
-    }
-
-    private suspend fun buildLocalDevice(
-        pushState: PushState,
-        subscriptionsVersion: Int,
-    ): Device {
-        return buildDevice(
-            pushToken = pushState.token,
-            pushEnabled = pushState.enabled,
-            subscriptionsVersion = subscriptionsVersion,
-        )
-    }
-
-    private suspend fun maybeSyncSubscriptions(
-        wallets: List<Wallet>,
-        subscriptionState: SubscriptionSyncState,
-        remoteDevice: Device,
-    ): Boolean {
-        if (!subscriptionState.shouldSync(remoteDevice.subscriptionsVersion)) {
-            return false
-        }
-
-        return reconcileSubscriptions(wallets)
-    }
-
-    private fun buildDeviceUpdateRequest(
-        localDevice: Device,
-        remoteDevice: Device,
-        localSubscriptionVersion: Int,
-        didSyncSubscriptions: Boolean,
-    ): Device {
-        return localDevice.copy(
-            subscriptionsVersion = subscriptionVersionForDeviceUpdate(
-                localVersion = localSubscriptionVersion,
-                remoteVersion = remoteDevice.subscriptionsVersion,
-                useLocalVersion = didSyncSubscriptions,
-            )
-        )
-    }
-
-    private fun getSubscriptionSyncState(): SubscriptionSyncState {
-        return SubscriptionSyncState(
-            version = getSubscriptionVersion(),
-            hasPendingChanges = hasPendingSubscriptionChanges(),
         )
     }
 
@@ -309,18 +219,21 @@ class DeviceRepository(
         )
     }
 
-    private fun hasPendingSubscriptionChanges(): Boolean {
-        return configStore.getBoolean(Keys.SubscriptionVersionHasChange.string)
+    private fun pushedDevice(): Device? {
+        val raw = configStore.getString(ConfigKey.PushedDevice.string)
+        if (raw.isEmpty()) {
+            return null
+        }
+        return runCatching { jsonEncoder.decodeFromString(Device.serializer(), raw) }.getOrNull()
     }
 
-    private fun setSubscriptionVersionHasChange(hasChange: Boolean) {
-        configStore.putBoolean(Keys.SubscriptionVersionHasChange.string, hasChange)
+    private fun pushedSubscriptionSignature(): String {
+        return configStore.getString(ConfigKey.PushedSubscriptions.string)
     }
 
-    private fun invalidateSubscriptions() {
-        val invalidatedState = getSubscriptionSyncState().invalidate()
-        setSubscriptionVersion(invalidatedState.version)
-        setSubscriptionVersionHasChange(invalidatedState.hasPendingChanges)
+    private fun recordPushedState(device: Device, subscriptionSignature: String) {
+        configStore.putString(ConfigKey.PushedDevice.string, jsonEncoder.encodeToString(Device.serializer(), device))
+        configStore.putString(ConfigKey.PushedSubscriptions.string, subscriptionSignature)
     }
 
     private suspend fun buildDevice(
@@ -348,6 +261,8 @@ class DeviceRepository(
 
     internal enum class ConfigKey(val string: String) {
         PushToken("push_token"),
+        PushedDevice("pushed_device"),
+        PushedSubscriptions("pushed_subscriptions"),
         ;
     }
 
@@ -357,6 +272,8 @@ class DeviceRepository(
     }
 
     companion object {
+        private const val SYNC_ATTEMPTS = 2
+
         fun getLocale(locale: Locale): String {
             val tag = locale.toLanguageTag()
             if (tag == "pt-BR" || tag == "pt_BR") {
@@ -375,38 +292,6 @@ private data class PushState(
     val token: String,
 )
 
-internal data class SubscriptionSyncState(
-    val version: Int,
-    val hasPendingChanges: Boolean,
-) {
-    fun invalidate(): SubscriptionSyncState {
-        return if (hasPendingChanges) {
-            this
-        } else {
-            copy(
-                version = version + 1,
-                hasPendingChanges = true,
-            )
-        }
-    }
-
-    fun shouldSync(remoteVersion: Int): Boolean {
-        return hasPendingChanges || remoteVersion != version
-    }
-}
-
-internal fun subscriptionVersionForDeviceUpdate(
-    localVersion: Int,
-    remoteVersion: Int?,
-    useLocalVersion: Boolean,
-): Int {
-    return if (useLocalVersion || remoteVersion == null) {
-        localVersion
-    } else {
-        remoteVersion
-    }
-}
-
 internal fun deviceHasChanges(current: Device, other: Device): Boolean {
     return current.id != other.id
             || current.token != other.token
@@ -418,17 +303,12 @@ internal fun deviceHasChanges(current: Device, other: Device): Boolean {
             || current.subscriptionsVersion != other.subscriptionsVersion
 }
 
-internal fun walletsForSubscriptionSync(
-    storedWallets: List<Wallet>,
-    requestedWallets: List<Wallet>,
-): List<Wallet> {
-    if (storedWallets.isEmpty()) return requestedWallets
-    if (requestedWallets.isEmpty()) return storedWallets
-
-    return (storedWallets + requestedWallets)
-        .associateBy { it.id }
-        .values
-        .toList()
+internal fun List<Wallet>.subscriptionSignature(): String {
+    return flatMap { wallet ->
+        wallet.accounts.map { account -> "${wallet.id.id}/${account.chain.string}/${account.address}" }
+    }
+        .sorted()
+        .joinToString(";")
 }
 
 // TODO: Temp solution. Move to App Layer with subscriptions subsystem when will prepared.

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -34,6 +34,7 @@ import com.wallet.core.primitives.WalletSubscription
 import com.wallet.core.primitives.WalletSubscriptionChains
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
@@ -55,6 +56,7 @@ class DeviceRepository(
     private val priceAlertRepository: PriceAlertRepository,
     private val getCurrentCurrency: GetCurrentCurrency,
     private val walletsRepository: WalletsRepository,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) : SyncDeviceInfo,
     SwitchPushEnabled,
     GetPushEnabled,
@@ -66,7 +68,7 @@ class DeviceRepository(
 {
     private val Context.dataStore by preferencesDataStore(name = "device_config")
 
-    private val syncCoordinator = DeviceSyncCoordinator()
+    private val syncCoordinator = DeviceSyncCoordinator(scope)
 
     override suspend fun syncDeviceInfo() {
         synchronizeDevice(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -11,10 +11,8 @@ import com.gemwallet.android.cases.device.GetPushToken
 import com.gemwallet.android.cases.device.IsDeviceRegistered
 import com.gemwallet.android.cases.device.RequestPushToken
 import com.gemwallet.android.cases.device.SetPushToken
-import com.gemwallet.android.cases.device.SynchronizeDeviceIfNeeded
-import com.gemwallet.android.cases.device.SyncSubscription
-import com.gemwallet.android.cases.device.SyncDeviceInfo
 import com.gemwallet.android.cases.device.SwitchPushEnabled
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.repositories.config.UserConfig.Keys
 import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
@@ -55,26 +53,18 @@ class DeviceRepository(
     private val getCurrentCurrency: GetCurrentCurrency,
     private val walletsRepository: WalletsRepository,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
-) : SyncDeviceInfo,
-    SwitchPushEnabled,
+) : SwitchPushEnabled,
     GetPushEnabled,
     GetPushToken,
     SetPushToken,
-    SyncSubscription,
-    SynchronizeDeviceIfNeeded,
+    SyncDevice,
     IsDeviceRegistered
 {
     private val Context.dataStore by preferencesDataStore(name = "device_config")
 
     private val syncCoordinator = DeviceSyncCoordinator(scope)
 
-    override suspend fun syncDeviceInfo() = syncDevice()
-
-    override suspend fun syncSubscription(wallets: List<Wallet>) = syncDevice()
-
-    override suspend fun synchronizeIfNeeded() = syncDevice()
-
-    private suspend fun syncDevice() {
+    override suspend fun syncDevice() {
         repeat(SYNC_ATTEMPTS) {
             if (!needsSynchronization()) {
                 return

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinator.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinator.kt
@@ -1,15 +1,30 @@
 package com.gemwallet.android.data.repositories.device
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-internal class DeviceSyncCoordinator {
-
+internal class DeviceSyncCoordinator(
+    private val scope: CoroutineScope,
+) {
     private val mutex = Mutex()
+    private var current: Deferred<Unit> = CompletableDeferred(Unit)
 
-    suspend fun synchronize(synchronize: suspend () -> Unit) {
-        mutex.withLock {
-            synchronize()
+    suspend fun synchronize(operation: suspend () -> Unit) {
+        val task = mutex.withLock {
+            current.takeIf { it.isActive } ?: scope.async {
+                try {
+                    operation()
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (_: Throwable) {
+                }
+            }.also { current = it }
         }
+        task.await()
     }
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
@@ -7,8 +7,7 @@ import com.gemwallet.android.application.fiat.coordinators.SyncFiatTransactions
 import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAlerts
 import com.gemwallet.android.blockchain.services.BalancesService
 import com.gemwallet.android.blockchain.services.PerpetualService
-import com.gemwallet.android.cases.device.IsDeviceRegistered
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.cases.nft.SyncNfts
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
@@ -150,8 +149,7 @@ object AssetsModule {
         deviceRequestSigner: DeviceRequestSigner,
         streamSubscriptionService: StreamSubscriptionService,
         eventHandler: StreamEventHandler,
-        syncDeviceInfo: SyncDeviceInfo,
-        isDeviceRegistered: IsDeviceRegistered,
+        syncDevice: SyncDevice,
         okHttpClient: OkHttpClient,
     ): StreamObserverService = StreamObserverService(
         sessionRepository = sessionRepository,
@@ -170,8 +168,7 @@ object AssetsModule {
             },
             reconnection = ExponentialReconnection(maxDelay = 30.0),
         ),
-        syncDeviceInfo = syncDeviceInfo,
-        isDeviceRegistered = isDeviceRegistered,
+        syncDevice = syncDevice,
     )
 
     @Provides

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
@@ -9,6 +9,7 @@ import com.gemwallet.android.cases.device.IsDeviceRegistered
 import com.gemwallet.android.cases.device.SetPushToken
 import com.gemwallet.android.cases.device.SwitchPushEnabled
 import com.gemwallet.android.cases.device.SyncDevice
+import com.gemwallet.android.data.repositories.device.DeviceObserverService
 import com.gemwallet.android.data.repositories.device.DeviceRepository
 import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
@@ -73,4 +74,13 @@ object DeviceModule {
     @Provides
     fun provideSyncDeviceCase(repository: DeviceRepository): SyncDevice = repository
 
+    @Provides
+    @Singleton
+    fun provideDeviceObserverService(
+        walletsRepository: WalletsRepository,
+        syncDevice: SyncDevice,
+    ): DeviceObserverService = DeviceObserverService(
+        walletsRepository = walletsRepository,
+        syncDevice = syncDevice,
+    )
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/DeviceModule.kt
@@ -8,9 +8,7 @@ import com.gemwallet.android.cases.device.GetPushToken
 import com.gemwallet.android.cases.device.IsDeviceRegistered
 import com.gemwallet.android.cases.device.SetPushToken
 import com.gemwallet.android.cases.device.SwitchPushEnabled
-import com.gemwallet.android.cases.device.SyncDeviceInfo
-import com.gemwallet.android.cases.device.SyncSubscription
-import com.gemwallet.android.cases.device.SynchronizeDeviceIfNeeded
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.repositories.device.DeviceRepository
 import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
@@ -58,9 +56,6 @@ object DeviceModule {
     }
 
     @Provides
-    fun provideSyncDeviceInfoCase(repository: DeviceRepository): SyncDeviceInfo = repository
-
-    @Provides
     fun provideSwitchPushEnabledCase(repository: DeviceRepository): SwitchPushEnabled = repository
 
     @Provides
@@ -73,11 +68,9 @@ object DeviceModule {
     fun provideGetPushTokenCase(repository: DeviceRepository): GetPushToken = repository
 
     @Provides
-    fun provideSyncSubscriptionCase(repository: DeviceRepository): SyncSubscription = repository
-
-    @Provides
     fun provideIsDeviceRegisteredCase(repository: DeviceRepository): IsDeviceRegistered = repository
 
     @Provides
-    fun provideSynchronizeDeviceIfNeededCase(repository: DeviceRepository): SynchronizeDeviceIfNeeded = repository
+    fun provideSyncDeviceCase(repository: DeviceRepository): SyncDevice = repository
+
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
@@ -3,8 +3,7 @@ package com.gemwallet.android.data.repositories.stream
 import android.util.Log
 import com.gemwallet.android.application.assets.coordinators.SyncAssets
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetuals
-import com.gemwallet.android.cases.device.IsDeviceRegistered
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.repositories.config.UserConfig
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.ext.hasPerpetualsSupport
@@ -31,8 +30,7 @@ class StreamObserverService(
     private val subscriptionService: StreamSubscriptionService,
     private val eventHandler: StreamEventHandler,
     private val connection: WebSocketConnectable,
-    private val syncDeviceInfo: SyncDeviceInfo,
-    private val isDeviceRegistered: IsDeviceRegistered,
+    private val syncDevice: SyncDevice,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
 ) {
     private var connectionJob: Job? = null
@@ -61,9 +59,8 @@ class StreamObserverService(
         if (sessionRepository.session().value?.wallet == null) return
 
         connectionJob = scope.launch {
-            if (!isDeviceRegistered.isDeviceRegistered()) {
-                registerDevice()
-            }
+            runCatching { syncDevice.syncDevice() }
+                .onFailure { Log.e(TAG, "Device synchronization error", it) }
             launch {
                 for (message in subscriptionService.messages) {
                     connection.send(message.toJson())
@@ -77,11 +74,6 @@ class StreamObserverService(
                 }
             }
         }
-    }
-
-    private suspend fun registerDevice() {
-        runCatching { syncDeviceInfo.syncDeviceInfo() }
-            .onFailure { Log.e(TAG, "Device registration error", it) }
     }
 
     fun stop() {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/wallets/PhraseAddressImportWalletService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/wallets/PhraseAddressImportWalletService.kt
@@ -7,7 +7,7 @@ import com.gemwallet.android.blockchain.operators.InvalidWords
 import com.gemwallet.android.blockchain.operators.StorePhraseOperator
 import com.gemwallet.android.blockchain.operators.ValidateAddressOperator
 import com.gemwallet.android.blockchain.operators.ValidatePhraseOperator
-import com.gemwallet.android.cases.device.SyncSubscription
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.cases.wallet.ImportError
 import com.gemwallet.android.cases.wallet.ImportWalletService
 import com.gemwallet.android.cases.wallet.WalletImportResult
@@ -29,7 +29,7 @@ class PhraseAddressImportWalletService(
     private val phraseValidate: ValidatePhraseOperator,
     private val addressValidate: ValidateAddressOperator,
     private val passwordStore: PasswordStore,
-    private val syncSubscription: SyncSubscription,
+    private val syncDevice: SyncDevice,
     private val walletImportSync: SyncWalletImport,
 ) : ImportWalletService {
 
@@ -58,7 +58,7 @@ class PhraseAddressImportWalletService(
         val wallet = handlePhrase(ImportType(WalletType.Multicoin), walletName, data, WalletSource.Create)
 
         setupWallet(wallet)
-        syncSubscription.syncSubscription(listOf(wallet))
+        syncDevice.syncDevice()
 
         return wallet
     }

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceObserverServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceObserverServiceTest.kt
@@ -1,0 +1,46 @@
+package com.gemwallet.android.data.repositories.device
+
+import com.gemwallet.android.cases.device.SyncDevice
+import com.gemwallet.android.data.repositories.wallets.WalletsRepository
+import com.gemwallet.android.testkit.mockAccount
+import com.gemwallet.android.testkit.mockWallet
+import com.wallet.core.primitives.Chain
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeviceObserverServiceTest {
+
+    private val wallet = mockWallet(id = "wallet-1", accounts = listOf(mockAccount(chain = Chain.Ethereum)))
+    private val wallets = MutableStateFlow(listOf(wallet))
+    private val walletsRepository = mockk<WalletsRepository> {
+        every { getAll() } returns wallets
+    }
+    private val syncDevice = mockk<SyncDevice>(relaxed = true)
+
+    @Test
+    fun synchronizesOnEveryWalletsChange() = runTest {
+        val subject = service()
+        subject.start()
+        advanceUntilIdle()
+
+        wallets.value = listOf(wallet.copy(accounts = wallet.accounts + mockAccount(chain = Chain.Bitcoin)))
+        advanceUntilIdle()
+        subject.stop()
+
+        coVerify(exactly = 2) { syncDevice.syncDevice() }
+    }
+
+    private fun TestScope.service() = DeviceObserverService(
+        walletsRepository = walletsRepository,
+        syncDevice = syncDevice,
+        scope = this,
+    )
+}

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepositoryTest.kt
@@ -10,6 +10,7 @@ import com.wallet.core.primitives.WalletSubscriptionChains
 import com.wallet.core.primitives.WalletType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -38,59 +39,40 @@ class DeviceRepositoryTest {
         assertFalse(deviceHasChanges(remote, remote.copy()))
     }
 
-    @Test
-    fun subscriptionSyncState_invalidate_isIdempotent() {
-        val initial = SubscriptionSyncState(version = 4, hasPendingChanges = false)
 
-        val invalidated = initial.invalidate()
-        val invalidatedAgain = invalidated.invalidate()
 
-        assertEquals(5, invalidated.version)
-        assertTrue(invalidated.hasPendingChanges)
-        assertEquals(invalidated, invalidatedAgain)
-    }
+
+
+
 
     @Test
-    fun subscriptionSyncState_shouldSync_falseWhenVersionsMatchAndStateClean() {
-        val state = SubscriptionSyncState(version = 4, hasPendingChanges = false)
-
-        assertFalse(state.shouldSync(remoteVersion = 4))
-    }
-
-    @Test
-    fun subscriptionSyncState_shouldSync_trueWhenVersionChanged() {
-        val state = SubscriptionSyncState(version = 4, hasPendingChanges = false)
-
-        assertTrue(state.shouldSync(remoteVersion = 5))
-    }
-
-    @Test
-    fun subscriptionSyncState_shouldSync_trueWhenStateIsDirty() {
-        val state = SubscriptionSyncState(version = 4, hasPendingChanges = true)
-
-        assertTrue(state.shouldSync(remoteVersion = 4))
-    }
-
-    @Test
-    fun subscriptionVersionForDeviceUpdate_preservesRemoteVersionForUnrelatedUpdate() {
-        val version = subscriptionVersionForDeviceUpdate(
-            localVersion = 5,
-            remoteVersion = 9,
-            useLocalVersion = false,
+    fun subscriptionSignature_ignoresRenameAndPin() {
+        val wallet = createWallet(
+            id = "wallet1",
+            accounts = listOf(createAccount(Chain.Ethereum, "0xabc")),
         )
+        val renamed = wallet.copy(name = "Renamed", isPinned = true)
 
-        assertEquals(9, version)
+        assertEquals(listOf(wallet).subscriptionSignature(), listOf(renamed).subscriptionSignature())
     }
 
     @Test
-    fun subscriptionVersionForDeviceUpdate_usesLocalVersionAfterSubscriptionSync() {
-        val version = subscriptionVersionForDeviceUpdate(
-            localVersion = 5,
-            remoteVersion = 9,
-            useLocalVersion = true,
+    fun subscriptionSignature_changesWhenAccountAdded() {
+        val wallet = createWallet(
+            id = "wallet1",
+            accounts = listOf(createAccount(Chain.Ethereum, "0xabc")),
         )
+        val extended = wallet.copy(accounts = wallet.accounts + createAccount(Chain.Bitcoin, "bc1xyz"))
 
-        assertEquals(5, version)
+        assertNotEquals(listOf(wallet).subscriptionSignature(), listOf(extended).subscriptionSignature())
+    }
+
+    @Test
+    fun subscriptionSignature_isOrderIndependent() {
+        val first = createWallet(id = "wallet1", accounts = listOf(createAccount(Chain.Ethereum, "0xabc")))
+        val second = createWallet(id = "wallet2", accounts = listOf(createAccount(Chain.Solana, "solana123")))
+
+        assertEquals(listOf(first, second).subscriptionSignature(), listOf(second, first).subscriptionSignature())
     }
 
     @Test
@@ -299,36 +281,6 @@ class DeviceRepositoryTest {
         assertTrue(toRemove.isEmpty())
     }
 
-    @Test
-    fun walletsForSubscriptionSync_addWallet_keepsStoredWalletsInDiff() {
-        val storedWallet = createWallet(
-            id = "wallet1",
-            accounts = listOf(
-                createAccount(Chain.Ethereum, "0xabc"),
-                createAccount(Chain.Bitcoin, "bc1xyz")
-            )
-        )
-        val requestedWallet = createWallet(
-            id = "wallet2",
-            accounts = listOf(
-                createAccount(Chain.Solana, "solana123")
-            )
-        )
-        val remote = listOf(
-            WalletSubscriptionChains("wallet1", listOf(Chain.Ethereum, Chain.Bitcoin))
-        )
-
-        val walletsForSync = walletsForSubscriptionSync(
-            storedWallets = listOf(storedWallet),
-            requestedWallets = listOf(requestedWallet),
-        )
-        val (toAdd, toRemove) = walletsForSync.subscriptionsDiff(remote)
-
-        assertEquals(2, walletsForSync.size)
-        assertEquals(1, toAdd.size)
-        assertEquals("wallet2", toAdd[0].walletId)
-        assertTrue(toRemove.isEmpty())
-    }
 
     @Test
     fun subscriptionsDiff_multipleWalletsWithSameAddress_groupsByAddress() {

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinatorTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinatorTest.kt
@@ -1,45 +1,53 @@
 package com.gemwallet.android.data.repositories.device
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DeviceSyncCoordinatorTest {
 
     @Test
-    fun synchronize_concurrentCalls_neverOverlap() = runTest {
-        val coordinator = DeviceSyncCoordinator()
-        var running = 0
-        var maxRunning = 0
-        var completed = 0
+    fun synchronize_joinsConcurrentCallersIntoOneRun() = runTest {
+        val coordinator = DeviceSyncCoordinator(this)
+        var runs = 0
 
-        List(4) {
+        repeat(3) {
             launch {
                 coordinator.synchronize {
-                    running += 1
-                    maxRunning = maxOf(maxRunning, running)
                     delay(100)
-                    running -= 1
-                    completed += 1
+                    runs += 1
                 }
             }
-        }.joinAll()
+        }
+        advanceUntilIdle()
 
-        assertEquals(1, maxRunning)
-        assertEquals(4, completed)
+        assertEquals(1, runs)
     }
 
     @Test
-    fun synchronize_failedPass_releasesLockForNextCaller() = runTest {
-        val coordinator = DeviceSyncCoordinator()
-        var completed = 0
+    fun synchronize_runsAgainAfterPreviousCompletes() = runTest {
+        val coordinator = DeviceSyncCoordinator(this)
+        var runs = 0
 
-        runCatching { coordinator.synchronize { throw IllegalStateException("sync failed") } }
-        coordinator.synchronize { completed += 1 }
+        coordinator.synchronize { runs += 1 }
+        coordinator.synchronize { runs += 1 }
 
-        assertEquals(1, completed)
+        assertEquals(2, runs)
+    }
+
+    @Test
+    fun synchronize_keepsFailureFromReachingCallers() = runTest {
+        val coordinator = DeviceSyncCoordinator(this)
+        var runs = 0
+
+        coordinator.synchronize { error("network") }
+        coordinator.synchronize { runs += 1 }
+
+        assertEquals(1, runs)
     }
 }

--- a/android/flavors/fcm/src/main/kotlin/com/gemwallet/android/flavors/FCM.kt
+++ b/android/flavors/fcm/src/main/kotlin/com/gemwallet/android/flavors/FCM.kt
@@ -2,7 +2,7 @@ package com.gemwallet.android.flavors
 
 import com.gemwallet.android.cases.device.GetPushEnabled
 import com.gemwallet.android.cases.device.SetPushToken
-import com.gemwallet.android.cases.device.SyncDeviceInfo
+import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.cases.pushes.ShowSystemNotification
 import com.gemwallet.android.model.PushNotificationField
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -19,7 +19,7 @@ import javax.inject.Inject
 class FCM : FirebaseMessagingService() {
 
     @Inject
-    lateinit var syncDeviceInfo: SyncDeviceInfo
+    lateinit var syncDevice: SyncDevice
     @Inject
     lateinit var getPushEnabled: GetPushEnabled
     @Inject
@@ -46,7 +46,7 @@ class FCM : FirebaseMessagingService() {
     override fun onNewToken(token: String) {
         scope.launch {
             setPushToken.setPushToken(token)
-            syncDeviceInfo.syncDeviceInfo()
+            syncDevice.syncDevice()
         }
     }
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SyncDevice.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SyncDevice.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.cases.device
+
+interface SyncDevice {
+    suspend fun syncDevice()
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SyncDeviceInfo.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SyncDeviceInfo.kt
@@ -1,5 +1,0 @@
-package com.gemwallet.android.cases.device
-
-interface SyncDeviceInfo {
-    suspend fun syncDeviceInfo()
-}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SyncSubscription.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SyncSubscription.kt
@@ -1,7 +1,0 @@
-package com.gemwallet.android.cases.device
-
-import com.wallet.core.primitives.Wallet
-
-interface SyncSubscription {
-    suspend fun syncSubscription(wallets: List<Wallet>)
-}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SynchronizeDeviceIfNeeded.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SynchronizeDeviceIfNeeded.kt
@@ -1,5 +1,0 @@
-package com.gemwallet.android.cases.device
-
-interface SynchronizeDeviceIfNeeded {
-    suspend fun synchronizeIfNeeded()
-}


### PR DESCRIPTION
On a fresh install the wallet's session is set before its subscription is sent, so the asset
request runs for a wallet the backend does not know yet and returns 404.

The root cause was that "subscriptions need syncing" was a mutable flag: call sites had to
remember to set it, the sync set it too late (inside its own coroutine), and whichever sync
finished first cleared it. This replaces the flag with derived state — the sync compares the
current wallets and device fields against what was last successfully pushed:

- one entry point, `syncDevice()`: a no-op without a single request when nothing changed,
  otherwise exactly one sync; concurrent triggers join the in-flight sync
- `SyncDeviceInfo`, `SyncSubscription` and the dirty flag are deleted; wallet delete and
  chain backfill no longer call the device layer at all — a wallets observer reacts to any
  change, mirroring the iOS accounts observer
- app relaunch with no changes now makes zero device requests (previously a full sync each
  launch), and wallet import makes exactly one subscription cycle

Closes #713