### PR TITLE
Move SwapPriceImpact to primitives and drop Gemstone imports from feature code

### DIFF
--- a/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/components/WalletTypeTab.kt
+++ b/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/components/WalletTypeTab.kt
@@ -13,13 +13,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.gemwallet.android.ext.isPrivateKeyImportSupported
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.theme.alpha10
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.WalletType
 
 internal fun importWalletTabs(chain: Chain?): List<WalletType> {
-    if (chain != null && uniffi.gemstone.supportsPrivateKeyImport(chain.string)) {
+    if (chain != null && chain.isPrivateKeyImportSupported()) {
         return listOf(WalletType.Single, WalletType.PrivateKey, WalletType.View)
     }
     return listOf(WalletType.Single, WalletType.View)

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/swap/SwapPriceImpactExt.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/swap/SwapPriceImpactExt.kt
@@ -1,7 +1,15 @@
 package com.gemwallet.android.domains.swap
 
+import com.wallet.core.primitives.swap.SwapPriceImpact
 import com.wallet.core.primitives.swap.SwapPriceImpactType
-import uniffi.gemstone.SwapPriceImpactType as GemSwapPriceImpactType
+import uniffi.gemstone.GemSwapPriceImpact
+import uniffi.gemstone.GemSwapPriceImpactType
+
+fun GemSwapPriceImpact.toPrimitives(): SwapPriceImpact = SwapPriceImpact(
+    percentage = percentage,
+    impactType = impactType.toPrimitives(),
+    isHigh = isHigh,
+)
 
 fun GemSwapPriceImpactType.toPrimitives(): SwapPriceImpactType = when (this) {
     GemSwapPriceImpactType.POSITIVE -> SwapPriceImpactType.Positive

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/Chain.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/Chain.kt
@@ -11,6 +11,7 @@ import com.wallet.core.primitives.EVMChain
 import com.wallet.core.primitives.EncodingType
 import com.wallet.core.primitives.FeeUnitType
 import uniffi.gemstone.Config
+import uniffi.gemstone.supportsPrivateKeyImport
 import uniffi.gemstone.validateAddress
 import uniffi.gemstone.checksumAddress as gemstoneChecksumAddress
 import java.math.BigInteger
@@ -227,6 +228,8 @@ fun Chain.isMemoSupport() = Config().getChainConfig(string).isMemoSupported
 fun Chain.isValidAddress(address: String): Boolean = validateAddress(checksumAddress(address), string)
 
 fun Chain.checksumAddress(address: String): String = gemstoneChecksumAddress(address = address, chain = string)
+
+fun Chain.isPrivateKeyImportSupported(): Boolean = supportsPrivateKeyImport(string)
 
 fun uniffi.gemstone.Chain.toChain(): Chain? {
     return Chain.entries.firstOrNull { it.string == this }

--- a/android/gemcore/src/main/kotlin/com/wallet/core/primitives/generated/swap/PriceImpact.kt
+++ b/android/gemcore/src/main/kotlin/com/wallet/core/primitives/generated/swap/PriceImpact.kt
@@ -19,3 +19,10 @@ enum class SwapPriceImpactType(val string: String) {
 	High("high"),
 }
 
+@Serializable
+data class SwapPriceImpact (
+	val percentage: Double,
+	val impactType: SwapPriceImpactType,
+	val isHigh: Boolean
+)
+

--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModelFactory.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModelFactory.kt
@@ -11,8 +11,8 @@ import com.gemwallet.android.domains.swap.toPrimitives
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.ValueFormatter
+import com.wallet.core.primitives.swap.SwapPriceImpact
 import java.math.BigInteger
-import uniffi.gemstone.SwapPriceImpact
 import uniffi.gemstone.SwapperProvider
 import uniffi.gemstone.SwapperProviderType
 import uniffi.gemstone.calculateSwapPriceImpact
@@ -70,7 +70,9 @@ object SwapDetailsUIModelFactory {
     private val rateFormatter = AssetRateFormatter()
 
     fun create(input: SwapDetailsUIModelInput): SwapDetailsUIModel? {
-        return create(input, ::calculateSwapPriceImpact)
+        return create(input) { payFiatValue, receiveFiatValue ->
+            calculateSwapPriceImpact(payFiatValue, receiveFiatValue)?.toPrimitives()
+        }
     }
 
     internal fun create(
@@ -91,7 +93,7 @@ object SwapDetailsUIModelFactory {
             input.receiveAsset.calculateFiat(input.toValue).toDouble(),
         )?.let {
             SwapPriceImpactUIModel(
-                type = it.impactType.toPrimitives(),
+                type = it.impactType,
                 displayText = it.percentage.formatAsPercentage(),
                 warningText = it.percentage.formatAsPercentage(style = PercentageFormatterStyle.PercentSignLess),
                 isHigh = it.isHigh,

--- a/android/ui-models/src/test/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModelFactoryTest.kt
+++ b/android/ui-models/src/test/kotlin/com/gemwallet/android/ui/models/swap/SwapDetailsUIModelFactoryTest.kt
@@ -9,8 +9,8 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import uniffi.gemstone.SwapPriceImpact
-import uniffi.gemstone.SwapPriceImpactType
+import com.wallet.core.primitives.swap.SwapPriceImpact
+import com.wallet.core.primitives.swap.SwapPriceImpactType
 import uniffi.gemstone.SwapperProvider
 
 class SwapDetailsUIModelFactoryTest {
@@ -25,7 +25,7 @@ class SwapDetailsUIModelFactoryTest {
             etaInSeconds = 30u,
             priceImpact = SwapPriceImpact(
                 percentage = -1.0,
-                impactType = SwapPriceImpactType.LOW,
+                impactType = SwapPriceImpactType.Low,
                 isHigh = false,
             ),
         )
@@ -48,7 +48,7 @@ class SwapDetailsUIModelFactoryTest {
             isProviderSelectable = true,
             priceImpact = SwapPriceImpact(
                 percentage = -5.0,
-                impactType = SwapPriceImpactType.MEDIUM,
+                impactType = SwapPriceImpactType.Medium,
                 isHigh = false,
             ),
         )
@@ -66,7 +66,7 @@ class SwapDetailsUIModelFactoryTest {
             toValue = DEFAULT_TO_VALUE,
             priceImpact = SwapPriceImpact(
                 percentage = 2.345,
-                impactType = SwapPriceImpactType.POSITIVE,
+                impactType = SwapPriceImpactType.Positive,
                 isHigh = false,
             ),
         )

--- a/core/crates/primitives/src/swap/price_impact.rs
+++ b/core/crates/primitives/src/swap/price_impact.rs
@@ -10,3 +10,12 @@ pub enum SwapPriceImpactType {
     Medium,
     High,
 }
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[typeshare(swift = "Equatable, Hashable, Sendable")]
+#[serde(rename_all = "camelCase")]
+pub struct SwapPriceImpact {
+    pub percentage: f64,
+    pub impact_type: SwapPriceImpactType,
+    pub is_high: bool,
+}

--- a/core/gemstone/src/models/swap.rs
+++ b/core/gemstone/src/models/swap.rs
@@ -1,10 +1,12 @@
 use crate::config::swap_config::get_swap_config;
 use primitives::swap::SwapQuoteDataType;
-pub use primitives::swap::{ApprovalData, SwapData, SwapProviderData, SwapQuote, SwapQuoteData};
+pub use primitives::swap::{ApprovalData, SwapData, SwapPriceImpact, SwapPriceImpactType, SwapProviderData, SwapQuote, SwapQuoteData};
 pub use swapper::SwapperProvider;
 
 pub type GemApprovalData = ApprovalData;
 pub type GemSwapData = SwapData;
+pub type GemSwapPriceImpact = SwapPriceImpact;
+pub type GemSwapPriceImpactType = SwapPriceImpactType;
 pub type GemSwapProviderData = SwapProviderData;
 pub type GemSwapQuote = SwapQuote;
 pub type GemSwapQuoteData = SwapQuoteData;
@@ -61,18 +63,18 @@ pub struct GemSwapProviderData {
     pub protocol_name: String,
 }
 
-#[derive(Debug, Clone, PartialEq, uniffi::Enum)]
-pub enum SwapPriceImpactType {
+#[uniffi::remote(Enum)]
+pub enum GemSwapPriceImpactType {
     Positive,
     Low,
     Medium,
     High,
 }
 
-#[derive(Debug, Clone, PartialEq, uniffi::Record)]
-pub struct SwapPriceImpact {
+#[uniffi::remote(Record)]
+pub struct GemSwapPriceImpact {
     pub percentage: f64,
-    pub impact_type: SwapPriceImpactType,
+    pub impact_type: GemSwapPriceImpactType,
     pub is_high: bool,
 }
 

--- a/ios/Features/Onboarding/Sources/ViewModels/ImportWalletSceneViewModel.swift
+++ b/ios/Features/Onboarding/Sources/ViewModels/ImportWalletSceneViewModel.swift
@@ -1,4 +1,3 @@
-internal import func Gemstone.supportsPrivateKeyImport
 import Components
 import Foundation
 import GemstonePrimitives
@@ -89,7 +88,7 @@ final class ImportWalletSceneViewModel {
         case .multicoin:
             return [.phrase]
         case let .chain(chain):
-            if supportsPrivateKeyImport(chain: chain.rawValue) {
+            if chain.isPrivateKeyImportSupported {
                 return [.phrase, .privateKey, .address]
             }
             return [.phrase, .address]

--- a/ios/Features/Swap/Sources/ViewModels/PriceImpactViewModel.swift
+++ b/ios/Features/Swap/Sources/ViewModels/PriceImpactViewModel.swift
@@ -2,7 +2,6 @@
 
 import BigInt
 import Formatters
-import Gemstone
 import GemstonePrimitives
 import Localization
 import Primitives
@@ -39,7 +38,7 @@ struct PriceImpactViewModel {
         guard let swapPriceImpact else { return nil }
 
         return PriceImpactValue(
-            type: swapPriceImpact.impactType.map(),
+            type: swapPriceImpact.impactType,
             value: percentFormatter.string(swapPriceImpact.percentage),
         )
     }
@@ -70,7 +69,7 @@ extension PriceImpactViewModel {
         swapPriceImpact?.isHigh == true
     }
 
-    private var swapPriceImpact: Gemstone.SwapPriceImpact? {
+    private var swapPriceImpact: Primitives.SwapPriceImpact? {
         guard
             let fromAmount = getSwapAmount(value: fromValue, decimals: fromAssetPrice.asset.decimals.asInt),
             let toAmount = getSwapAmount(value: toValue, decimals: toAssetPrice.asset.decimals.asInt),

--- a/ios/Features/Transfer/Sources/ViewModels/AmountStakeViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/AmountStakeViewModel.swift
@@ -3,7 +3,6 @@
 import BigInt
 import Formatters
 import Foundation
-import Gemstone
 import GemstonePrimitives
 import Localization
 import Primitives
@@ -142,9 +141,10 @@ public final class AmountStakeViewModel: AmountDataProvidable {
     }
 
     var reserveForFee: BigInt {
-        switch action {
+        guard let stakeChain = asset.chain.stakeChain else { return .zero }
+        return switch action {
         case .stake where asset.chain != .tron, .freeze:
-            BigInt(Gemstone.Config.shared.getStakeConfig(chain: asset.chain.rawValue).reservedForFees)
+            BigInt(StakeConfig.config(chain: stakeChain).reservedForFees)
         default:
             .zero
         }

--- a/ios/Gem/Services/ServicesFactory.swift
+++ b/ios/Gem/Services/ServicesFactory.swift
@@ -22,7 +22,6 @@ import FiatService
 import Foundation
 import GemAPI
 import GemAPIDevice
-import Gemstone
 import GemstonePrimitives
 import Keystore
 import NameService

--- a/ios/Packages/Blockchain/Sources/ChainCoreError.swift
+++ b/ios/Packages/Blockchain/Sources/ChainCoreError.swift
@@ -1,7 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Gemstone
 import Primitives
 
 public enum ChainCoreError: String, Error, Equatable {

--- a/ios/Packages/GemstonePrimitives/Sources/Extensions/Chain+GemstoneSwift.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/Extensions/Chain+GemstoneSwift.swift
@@ -134,6 +134,10 @@ public extension Primitives.Chain {
         Gemstone.checksumAddress(address: address, chain: rawValue)
     }
 
+    var isPrivateKeyImportSupported: Bool {
+        Gemstone.supportsPrivateKeyImport(chain: rawValue)
+    }
+
     func matches(query: String) -> Bool {
         networkName.localizedCaseInsensitiveContains(query) ||
             rawValue.localizedCaseInsensitiveContains(query) ||

--- a/ios/Packages/GemstonePrimitives/Sources/Extensions/GemSwapPriceImpact+GemstonePrimitives.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/Extensions/GemSwapPriceImpact+GemstonePrimitives.swift
@@ -3,7 +3,7 @@
 import Gemstone
 import Primitives
 
-public extension Gemstone.SwapPriceImpactType {
+public extension Gemstone.GemSwapPriceImpactType {
     func map() -> Primitives.SwapPriceImpactType {
         switch self {
         case .positive: .positive
@@ -11,5 +11,15 @@ public extension Gemstone.SwapPriceImpactType {
         case .medium: .medium
         case .high: .high
         }
+    }
+}
+
+public extension Gemstone.GemSwapPriceImpact {
+    func map() -> Primitives.SwapPriceImpact {
+        Primitives.SwapPriceImpact(
+            percentage: percentage,
+            impactType: impactType.map(),
+            isHigh: isHigh,
+        )
     }
 }

--- a/ios/Packages/GemstonePrimitives/Sources/SwapPriceImpact.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/SwapPriceImpact.swift
@@ -1,8 +1,9 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Gemstone
+import func Gemstone.calculateSwapPriceImpact
+import Primitives
 
-public func calculateSwapPriceImpact(payFiatValue: Double, receiveFiatValue: Double) -> Gemstone.SwapPriceImpact? {
-    Gemstone.calculateSwapPriceImpact(payFiatValue: payFiatValue, receiveFiatValue: receiveFiatValue)
+public func calculateSwapPriceImpact(payFiatValue: Double, receiveFiatValue: Double) -> Primitives.SwapPriceImpact? {
+    Gemstone.calculateSwapPriceImpact(payFiatValue: payFiatValue, receiveFiatValue: receiveFiatValue)?.map()
 }

--- a/ios/Packages/Primitives/Sources/Generated/Swap/PriceImpact.swift
+++ b/ios/Packages/Primitives/Sources/Generated/Swap/PriceImpact.swift
@@ -10,3 +10,15 @@ public enum SwapPriceImpactType: String, Codable, Equatable, Hashable, Sendable 
 	case medium
 	case high
 }
+
+public struct SwapPriceImpact: Codable, Equatable, Hashable, Sendable {
+	public let percentage: Double
+	public let impactType: SwapPriceImpactType
+	public let isHigh: Bool
+
+	public init(percentage: Double, impactType: SwapPriceImpactType, isHigh: Bool) {
+		self.percentage = percentage
+		self.impactType = impactType
+		self.isHigh = isHigh
+	}
+}


### PR DESCRIPTION
SwapPriceImpact had no primitives twin, so iOS feature code had to import Gemstone to read it. It now lives in primitives next to its enum, and Swap, Transfer and Onboarding no longer import Gemstone.

reserveForFee now guards the non-stake-chain case that core panics on.
