### PR TITLE
Vend SelectAssetViewModel from ViewModelFactory

### DIFF
--- a/ios/Gem/Navigation/NFT/CollectionsSceneNavigationView.swift
+++ b/ios/Gem/Navigation/NFT/CollectionsSceneNavigationView.swift
@@ -1,6 +1,5 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
-import Assets
 import Components
 import NFT
 import Primitives
@@ -8,10 +7,7 @@ import Style
 import SwiftUI
 
 struct CollectionsSceneNavigationView: View {
-    @Environment(\.assetsEnabler) private var assetsEnabler
-    @Environment(\.priceAlertService) private var priceAlertService
-    @Environment(\.activityService) private var activityService
-    @Environment(\.assetSearchService) private var assetSearchService
+    @Environment(\.viewModelFactory) private var viewModelFactory
 
     @State private var model: CollectionsViewModel
 
@@ -23,13 +19,9 @@ struct CollectionsSceneNavigationView: View {
         CollectionsScene(model: model)
             .sheet(item: $model.isPresentingReceiveSelectAssetType) {
                 SelectAssetSceneNavigationStack(
-                    model: SelectAssetViewModel(
+                    model: viewModelFactory.selectAssetScene(
                         wallet: model.wallet,
                         selectType: $0,
-                        searchService: assetSearchService,
-                        assetsEnabler: assetsEnabler,
-                        priceAlertService: priceAlertService,
-                        activityService: activityService,
                     ),
                 )
             }

--- a/ios/Gem/Navigation/Price Alerts/PriceAlertsNavigationView.swift
+++ b/ios/Gem/Navigation/Price Alerts/PriceAlertsNavigationView.swift
@@ -1,7 +1,5 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
-import Assets
-import AssetsService
 import Components
 import Foundation
 import Localization
@@ -11,11 +9,8 @@ import Style
 import SwiftUI
 
 struct PriceAlertsNavigationView: View {
-    @Environment(\.assetsEnabler) private var assetsEnabler
-    @Environment(\.priceAlertService) private var priceAlertService
     @Environment(\.walletService) private var walletService
-    @Environment(\.activityService) private var activityService
-    @Environment(\.assetSearchService) private var assetSearchService
+    @Environment(\.viewModelFactory) private var viewModelFactory
 
     @State private var isPresentingAddAsset: Bool = false
     @State private var isPresentingToastMessage: ToastMessage?
@@ -35,13 +30,9 @@ struct PriceAlertsNavigationView: View {
             }
             .sheet(isPresented: $isPresentingAddAsset) {
                 AddAssetPriceAlertsNavigationStack(
-                    selectAssetModel: SelectAssetViewModel(
+                    selectAssetModel: viewModelFactory.selectAssetScene(
                         wallet: walletService.currentWallet!,
                         selectType: .priceAlert,
-                        searchService: assetSearchService,
-                        assetsEnabler: assetsEnabler,
-                        priceAlertService: priceAlertService,
-                        activityService: activityService,
                         selectAssetAction: onSelectAsset,
                     ),
                 )

--- a/ios/Gem/Navigation/Swap/SwapNavigationView.swift
+++ b/ios/Gem/Navigation/Swap/SwapNavigationView.swift
@@ -1,7 +1,5 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
-import Assets
-import AssetsService
 import Components
 import InfoSheet
 import Primitives
@@ -10,10 +8,7 @@ import Swap
 import SwiftUI
 
 struct SwapNavigationView: View {
-    @Environment(\.priceAlertService) private var priceAlertService
-    @Environment(\.activityService) private var activityService
-    @Environment(\.assetSearchService) private var assetSearchService
-    @Environment(\.assetsEnabler) private var assetsEnabler
+    @Environment(\.viewModelFactory) private var viewModelFactory
 
     @State private var model: SwapSceneViewModel
 
@@ -29,13 +24,9 @@ struct SwapNavigationView: View {
                     InfoSheetScene(type: type)
                 case let .selectAsset(type):
                     SelectAssetSceneNavigationStack(
-                        model: SelectAssetViewModel(
+                        model: viewModelFactory.selectAssetScene(
                             wallet: model.wallet,
                             selectType: .swap(type),
-                            searchService: assetSearchService,
-                            assetsEnabler: assetsEnabler,
-                            priceAlertService: priceAlertService,
-                            activityService: activityService,
                             selectAssetAction: model.onFinishAssetSelection,
                         ),
                     )

--- a/ios/Gem/Navigation/Transactions/TransactionsNavigationStack.swift
+++ b/ios/Gem/Navigation/Transactions/TransactionsNavigationStack.swift
@@ -1,6 +1,5 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
-import Assets
 import AssetsService
 import Components
 import Localization
@@ -14,11 +13,8 @@ import Transactions
 
 struct TransactionsNavigationStack: View {
     @Environment(\.navigationState) private var navigationState
-    @Environment(\.assetsEnabler) private var assetsEnabler
     @Environment(\.assetsService) private var assetsService
-    @Environment(\.priceAlertService) private var priceAlertService
-    @Environment(\.activityService) private var activityService
-    @Environment(\.assetSearchService) private var assetSearchService
+    @Environment(\.viewModelFactory) private var viewModelFactory
     @Environment(\.avatarService) private var avatarService
     @Environment(\.navigationPresenter) private var presenter
     @Environment(\.nftService) private var nftService
@@ -85,13 +81,9 @@ struct TransactionsNavigationStack: View {
                         .presentationBackground(Colors.grayBackground)
                     case let .selectAsset(selectType):
                         SelectAssetSceneNavigationStack(
-                            model: SelectAssetViewModel(
+                            model: viewModelFactory.selectAssetScene(
                                 wallet: model.wallet,
                                 selectType: selectType,
-                                searchService: assetSearchService,
-                                assetsEnabler: assetsEnabler,
-                                priceAlertService: priceAlertService,
-                                activityService: activityService,
                             ),
                         )
                     case let .addContact(action):

--- a/ios/Gem/Navigation/Wallet/WalletNavigationStack.swift
+++ b/ios/Gem/Navigation/Wallet/WalletNavigationStack.swift
@@ -35,7 +35,7 @@ struct WalletNavigationStack: View {
     @Environment(\.hyperliquidObserverService) private var hyperliquidObserverService
     @Environment(\.activityService) private var activityService
     @Environment(\.walletSearchService) private var walletSearchService
-    @Environment(\.assetSearchService) private var assetSearchService
+    @Environment(\.viewModelFactory) private var viewModelFactory
     @Environment(\.avatarService) private var avatarService
     @Environment(\.nftService) private var nftService
     @Environment(\.walletService) private var walletService
@@ -225,13 +225,9 @@ struct WalletNavigationStack: View {
                         WalletsNavigationStack()
                     case let .selectAsset(type):
                         SelectAssetSceneNavigationStack(
-                            model: SelectAssetViewModel(
+                            model: viewModelFactory.selectAssetScene(
                                 wallet: model.wallet,
                                 selectType: type,
-                                searchService: assetSearchService,
-                                assetsEnabler: assetsEnabler,
-                                priceAlertService: priceAlertService,
-                                activityService: activityService,
                             ),
                         )
                     case let .infoSheet(type):

--- a/ios/Gem/Services/ServicesFactory.swift
+++ b/ios/Gem/Services/ServicesFactory.swift
@@ -346,6 +346,8 @@ struct ServicesFactory {
             eventPresenterService: eventPresenterService,
             fiatService: fiatService,
             assetsService: assetsService,
+            assetSearchService: assetSearchService,
+            priceAlertService: priceAlertService,
         )
 
         return AppResolver.Services(

--- a/ios/Gem/Services/ViewModelFactory.swift
+++ b/ios/Gem/Services/ViewModelFactory.swift
@@ -14,6 +14,7 @@ import Foundation
 import Keystore
 import NameService
 import Preferences
+import PriceAlertService
 import PriceService
 import Primitives
 import PrimitivesComponents
@@ -49,6 +50,8 @@ public struct ViewModelFactory: Sendable {
     let eventPresenterService: EventPresenterService
     let fiatService: FiatService
     let assetsService: AssetsService
+    let assetSearchService: AssetSearchService
+    let priceAlertService: PriceAlertService
 
     public init(
         keystore: any Keystore,
@@ -70,6 +73,8 @@ public struct ViewModelFactory: Sendable {
         eventPresenterService: EventPresenterService,
         fiatService: FiatService,
         assetsService: AssetsService,
+        assetSearchService: AssetSearchService,
+        priceAlertService: PriceAlertService,
     ) {
         self.keystore = keystore
         self.chainServiceFactory = chainServiceFactory
@@ -90,6 +95,25 @@ public struct ViewModelFactory: Sendable {
         self.eventPresenterService = eventPresenterService
         self.fiatService = fiatService
         self.assetsService = assetsService
+        self.assetSearchService = assetSearchService
+        self.priceAlertService = priceAlertService
+    }
+
+    @MainActor
+    public func selectAssetScene(
+        wallet: Wallet,
+        selectType: SelectAssetType,
+        selectAssetAction: AssetAction = .none,
+    ) -> SelectAssetViewModel {
+        SelectAssetViewModel(
+            wallet: wallet,
+            selectType: selectType,
+            searchService: assetSearchService,
+            assetsEnabler: assetsEnabler,
+            priceAlertService: priceAlertService,
+            activityService: activityService,
+            selectAssetAction: selectAssetAction,
+        )
     }
 
     @MainActor


### PR DESCRIPTION
The five navigation views that present the select-asset sheet each built the view model by hand with the same four services. Those services were held as environment properties only to feed that initializer.

Now they all call a single `selectAssetScene` on the existing `ViewModelFactory`, which removes 17 environment declarations and the imports that came with them. Two of the views end up with no service dependencies at all.

No behavior change.