### PR TITLE
Show WalletConnect approvals with correct type and token

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/confirm/ConfirmTransactionImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/confirm/ConfirmTransactionImpl.kt
@@ -14,6 +14,7 @@ import com.gemwallet.android.model.Session
 import com.gemwallet.android.model.SignerParams
 import com.gemwallet.android.model.blockNumber
 import com.gemwallet.android.serializer.jsonEncoder
+import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.TransactionDirection
 import com.wallet.core.primitives.TransactionNFTTransferMetadata
 import com.wallet.core.primitives.TransactionResourceTypeMetadata
@@ -38,6 +39,7 @@ class ConfirmTransactionImpl(
         session: Session,
         assetInfo: AssetInfo,
         scope: CoroutineScope,
+        transactionAssetId: AssetId?,
     ): String {
         val account = assetInfo.owner ?: throw ConfirmError.TransactionIncorrect
 
@@ -59,7 +61,7 @@ class ConfirmTransactionImpl(
                 delay(500)
             } else {
                 lastHash = transactionHash
-                addTransaction(transactionHash, signerParams, assetInfo, account, session)
+                addTransaction(transactionHash, signerParams, assetInfo, account, session, transactionAssetId)
                 scope.launch(Dispatchers.IO) { addRecent(assetInfo, signerParams.input) }
             }
         }
@@ -88,13 +90,14 @@ class ConfirmTransactionImpl(
         assetInfo: AssetInfo,
         account: Account,
         session: Session,
+        transactionAssetId: AssetId?,
     ) {
         val destinationAddress = signerParams.input.destination()?.address ?: ""
 
         createTransactionsCase.createTransaction(
             hash = transactionHash,
             walletId = session.wallet.id,
-            assetId = assetInfo.id(),
+            assetId = transactionAssetId ?: assetInfo.id(),
             owner = account,
             to = destinationAddress,
             state = TransactionState.Pending,

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WCRequest.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WCRequest.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.features.bridge.viewmodels.model
 import com.gemwallet.android.ext.asset
 import com.gemwallet.android.ext.getShortUrl
 import com.gemwallet.android.ext.shortName
+import com.gemwallet.android.ext.toPrimitives
 import com.gemwallet.android.math.hexToBigInteger
 import com.gemwallet.android.model.ConfirmParams
 import com.gemwallet.android.model.ConfirmParams.TransferParams.Generic
@@ -217,6 +218,7 @@ private fun WalletConnectTransaction.map(
             destination = DestinationAddress(data.to),
             amount = data.value?.hexToBigInteger() ?: BigInteger.ZERO,
             isSendable = isSendable,
+            decodedTransactionType = transactionType.toPrimitives(),
         )
         is WalletConnectTransaction.Solana -> Generic(
             requestId = request.requestId.toString(),

--- a/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
+++ b/android/features/confirm/viewmodels/src/main/kotlin/com/gemwallet/android/features/confirm/viewmodels/ConfirmViewModel.kt
@@ -305,7 +305,9 @@ class ConfirmViewModel @Inject constructor(
                 feeAssetInfo,
                 getBalance(assetInfo, signerParams.input),
             )
-            val transactionHash = confirmTransaction(signerParams, session, assetInfo, viewModelScope)
+            val transactionAssetId = (signerParams.input as? ConfirmParams.TransferParams.Generic)
+                ?.let { simulationResult.value?.header?.assetId }
+            val transactionHash = confirmTransaction(signerParams, session, assetInfo, viewModelScope, transactionAssetId)
             state.update { ConfirmState.Result(transactionHash = transactionHash) }
             viewModelScope.launch(Dispatchers.Main) {
                 finishAction(transactionHash)

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/confirm/coordinators/ConfirmTransaction.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/confirm/coordinators/ConfirmTransaction.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.application.confirm.coordinators
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.Session
 import com.gemwallet.android.model.SignerParams
+import com.wallet.core.primitives.AssetId
 import kotlinx.coroutines.CoroutineScope
 
 interface ConfirmTransaction {
@@ -11,5 +12,6 @@ interface ConfirmTransaction {
         session: Session,
         assetInfo: AssetInfo,
         scope: CoroutineScope,
+        transactionAssetId: AssetId? = null,
     ): String
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/GemTransactionType.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/ext/GemTransactionType.kt
@@ -1,0 +1,25 @@
+package com.gemwallet.android.ext
+
+import com.wallet.core.primitives.TransactionType
+import uniffi.gemstone.TransactionType as GemTransactionType
+
+fun GemTransactionType.toPrimitives(): TransactionType = when (this) {
+    GemTransactionType.TRANSFER -> TransactionType.Transfer
+    GemTransactionType.TRANSFER_NFT -> TransactionType.TransferNFT
+    GemTransactionType.SWAP -> TransactionType.Swap
+    GemTransactionType.TOKEN_APPROVAL -> TransactionType.TokenApproval
+    GemTransactionType.STAKE_DELEGATE -> TransactionType.StakeDelegate
+    GemTransactionType.STAKE_UNDELEGATE -> TransactionType.StakeUndelegate
+    GemTransactionType.STAKE_REWARDS -> TransactionType.StakeRewards
+    GemTransactionType.STAKE_REDELEGATE -> TransactionType.StakeRedelegate
+    GemTransactionType.STAKE_WITHDRAW -> TransactionType.StakeWithdraw
+    GemTransactionType.STAKE_FREEZE -> TransactionType.StakeFreeze
+    GemTransactionType.STAKE_UNFREEZE -> TransactionType.StakeUnfreeze
+    GemTransactionType.ASSET_ACTIVATION -> TransactionType.AssetActivation
+    GemTransactionType.SMART_CONTRACT_CALL -> TransactionType.SmartContractCall
+    GemTransactionType.PERPETUAL_OPEN_POSITION -> TransactionType.PerpetualOpenPosition
+    GemTransactionType.PERPETUAL_CLOSE_POSITION -> TransactionType.PerpetualClosePosition
+    GemTransactionType.PERPETUAL_MODIFY_POSITION -> TransactionType.PerpetualModifyPosition
+    GemTransactionType.EARN_DEPOSIT -> TransactionType.EarnDeposit
+    GemTransactionType.EARN_WITHDRAW -> TransactionType.EarnWithdraw
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/ConfirmParams.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/ConfirmParams.kt
@@ -190,6 +190,7 @@ sealed class ConfirmParams() {
             val url: String,
             val icon: String,
             val gasLimit: String?,
+            val decodedTransactionType: TransactionType = TransactionType.SmartContractCall,
         ) : TransferParams() {
             override fun toDto(): GemTransactionInputType {
                 val type = requireNotNull(inputType) { "inputType is required for Generic transactions" }
@@ -238,6 +239,7 @@ sealed class ConfirmParams() {
                 result = 31 * result + url.hashCode()
                 result = 31 * result + icon.hashCode()
                 result = 31 * result + (gasLimit?.hashCode() ?: 0)
+                result = 31 * result + decodedTransactionType.hashCode()
                 return result
             }
 
@@ -638,7 +640,7 @@ sealed class ConfirmParams() {
 
     fun getTransactionType() : TransactionType {
         return when (this) {
-            is TransferParams.Generic -> TransactionType.SmartContractCall
+            is TransferParams.Generic -> decodedTransactionType
             is TransferParams -> TransactionType.Transfer
             is TokenApprovalParams -> TransactionType.TokenApproval
             is SwapParams -> TransactionType.Swap

--- a/core/crates/gem_evm/src/lib.rs
+++ b/core/crates/gem_evm/src/lib.rs
@@ -22,6 +22,7 @@ pub mod signer;
 pub mod siwe;
 pub mod slippage;
 pub mod thorchain;
+pub mod transaction;
 pub mod u256;
 pub mod uniswap;
 pub mod weth;

--- a/core/crates/gem_evm/src/transaction.rs
+++ b/core/crates/gem_evm/src/transaction.rs
@@ -1,0 +1,42 @@
+use alloy_primitives::hex;
+use alloy_sol_types::SolCall;
+use primitives::TransactionType;
+
+use crate::contracts::erc20::IERC20;
+
+pub fn decode_transaction_type(input: Option<&str>) -> TransactionType {
+    let calldata = input
+        .map(|value| value.strip_prefix("0x").unwrap_or(value))
+        .and_then(|value| hex::decode(value).ok())
+        .unwrap_or_default();
+    match calldata.as_slice() {
+        [] => TransactionType::Transfer,
+        selector if selector.starts_with(&IERC20::approveCall::SELECTOR) => TransactionType::TokenApproval,
+        _ => TransactionType::SmartContractCall,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_transaction_type() {
+        assert_eq!(decode_transaction_type(None), TransactionType::Transfer);
+        assert_eq!(decode_transaction_type(Some("")), TransactionType::Transfer);
+        assert_eq!(decode_transaction_type(Some("0x")), TransactionType::Transfer);
+        assert_eq!(
+            decode_transaction_type(Some("0x095ea7b3000000000000000000000000111122223333444455556666777788889999aaaa")),
+            TransactionType::TokenApproval
+        );
+        assert_eq!(
+            decode_transaction_type(Some("0x095EA7B3000000000000000000000000111122223333444455556666777788889999AAAA")),
+            TransactionType::TokenApproval
+        );
+        assert_eq!(
+            decode_transaction_type(Some("0xa9059cbb000000000000000000000000111122223333444455556666777788889999aaaa")),
+            TransactionType::SmartContractCall
+        );
+        assert_eq!(decode_transaction_type(Some("0xdeadbeef")), TransactionType::SmartContractCall);
+    }
+}

--- a/core/crates/gem_wallet_connect/src/actions.rs
+++ b/core/crates/gem_wallet_connect/src/actions.rs
@@ -1,5 +1,5 @@
 use crate::sign_type::SignDigestType;
-use primitives::{Chain, TransferDataOutputType, WCEthereumTransaction};
+use primitives::{Chain, TransactionType, TransferDataOutputType, WCEthereumTransaction};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum WalletConnectAction {
@@ -90,6 +90,7 @@ pub struct WCSuiTransactionData {
 pub enum WalletConnectTransaction {
     Ethereum {
         data: WCEthereumTransactionData,
+        transaction_type: TransactionType,
     },
     Solana {
         data: WCSolanaTransactionData,

--- a/core/crates/gem_wallet_connect/src/request_handler/ethereum.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/ethereum.rs
@@ -1,4 +1,4 @@
-use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
+use crate::actions::{WalletConnectAction, WalletConnectTransaction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
 use primitives::{Chain, ValueAccess, WCEthereumTransaction, WalletConnectionMethods};
 use serde_json::Value;
@@ -61,6 +61,15 @@ impl EthereumRequestHandler {
             chain,
             transaction_type: WalletConnectTransactionType::Ethereum,
             data,
+        })
+    }
+
+    pub fn decode_send_transaction(data: String) -> Result<WalletConnectTransaction, String> {
+        let transaction: WCEthereumTransaction = serde_json::from_str(&data).map_err(|e| e.to_string())?;
+        let transaction_type = gem_evm::transaction::decode_transaction_type(transaction.data.as_deref());
+        Ok(WalletConnectTransaction::Ethereum {
+            data: transaction.into(),
+            transaction_type,
         })
     }
 

--- a/core/crates/gem_wallet_connect/src/request_handler/mod.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/mod.rs
@@ -77,7 +77,11 @@ impl WalletConnectRequestHandler {
         match transaction_type {
             WalletConnectTransactionType::Ethereum => {
                 let tx: WCEthereumTransaction = serde_json::from_str(&data).map_err(|e| e.to_string())?;
-                Ok(WalletConnectTransaction::Ethereum { data: tx.into() })
+                let transaction_type = gem_evm::transaction::decode_transaction_type(tx.data.as_deref());
+                Ok(WalletConnectTransaction::Ethereum {
+                    data: tx.into(),
+                    transaction_type,
+                })
             }
             WalletConnectTransactionType::Solana { output_type } => {
                 let json: serde_json::Value = serde_json::from_str(&data).map_err(|e| e.to_string())?;
@@ -303,10 +307,33 @@ mod tests {
             .unwrap();
 
             match decoded {
-                WalletConnectTransaction::Ethereum { data } => {
+                WalletConnectTransaction::Ethereum { data, transaction_type } => {
                     assert_eq!(data.chain_id, Some(expected));
                     assert_eq!(data.data, Some("0x1234".to_string()));
+                    assert_eq!(transaction_type, primitives::TransactionType::SmartContractCall);
                 }
+                _ => panic!("Expected Ethereum transaction"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_decode_ethereum_transaction_type_from_payload() {
+        let cases = [
+            (r#""0x095ea7b3abcd""#, primitives::TransactionType::TokenApproval),
+            (r#""0x""#, primitives::TransactionType::Transfer),
+            (r#"null"#, primitives::TransactionType::Transfer),
+            (r#""0xdeadbeef""#, primitives::TransactionType::SmartContractCall),
+        ];
+        for (data, expected) in cases {
+            let decoded = WalletConnectRequestHandler::decode_send_transaction(
+                WalletConnectTransactionType::Ethereum,
+                format!(r#"{{"from":"0xsender","to":"0xrouter","data":{data},"value":"0x0"}}"#),
+            )
+            .unwrap();
+
+            match decoded {
+                WalletConnectTransaction::Ethereum { transaction_type, .. } => assert_eq!(transaction_type, expected),
                 _ => panic!("Expected Ethereum transaction"),
             }
         }

--- a/core/crates/gem_wallet_connect/src/request_handler/mod.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/mod.rs
@@ -4,9 +4,9 @@ mod sui;
 mod ton;
 mod tron;
 
-use crate::actions::{WCSolanaTransactionData, WCSuiTransactionData, WalletConnectAction, WalletConnectChainOperation, WalletConnectTransaction, WalletConnectTransactionType};
+use crate::actions::{WalletConnectAction, WalletConnectChainOperation, WalletConnectTransaction, WalletConnectTransactionType};
 use ethereum::EthereumRequestHandler;
-use primitives::{Chain, ChainType, ValueAccess, WCEthereumTransaction, WalletConnectCAIP2, WalletConnectRequest, WalletConnectionMethods, hex};
+use primitives::{Chain, ChainType, ValueAccess, WalletConnectCAIP2, WalletConnectRequest, WalletConnectionMethods, hex};
 use serde_json::Value;
 use solana::SolanaRequestHandler;
 use sui::SuiRequestHandler;
@@ -75,41 +75,11 @@ impl WalletConnectRequestHandler {
 
     pub fn decode_send_transaction(transaction_type: WalletConnectTransactionType, data: String) -> Result<WalletConnectTransaction, String> {
         match transaction_type {
-            WalletConnectTransactionType::Ethereum => {
-                let tx: WCEthereumTransaction = serde_json::from_str(&data).map_err(|e| e.to_string())?;
-                let transaction_type = gem_evm::transaction::decode_transaction_type(tx.data.as_deref());
-                Ok(WalletConnectTransaction::Ethereum {
-                    data: tx.into(),
-                    transaction_type,
-                })
-            }
-            WalletConnectTransactionType::Solana { output_type } => {
-                let json: serde_json::Value = serde_json::from_str(&data).map_err(|e| e.to_string())?;
-                let transaction = json
-                    .get("transaction")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| "Missing transaction field".to_string())?
-                    .to_string();
-                Ok(WalletConnectTransaction::Solana {
-                    data: WCSolanaTransactionData { transaction },
-                    output_type,
-                })
-            }
-            WalletConnectTransactionType::Sui { output_type } => {
-                let json: serde_json::Value = serde_json::from_str(&data).map_err(|e| e.to_string())?;
-                let transaction = json
-                    .get("transaction")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| "Missing transaction field".to_string())?
-                    .to_string();
-                let wallet_address = json.get("account").or_else(|| json.get("address")).and_then(|v| v.as_str()).unwrap_or_default().to_string();
-                Ok(WalletConnectTransaction::Sui {
-                    data: WCSuiTransactionData { transaction, wallet_address },
-                    output_type,
-                })
-            }
-            WalletConnectTransactionType::Ton { output_type } => Ok(WalletConnectTransaction::Ton { data, output_type }),
-            WalletConnectTransactionType::Tron { output_type } => Ok(WalletConnectTransaction::Tron { data, output_type }),
+            WalletConnectTransactionType::Ethereum => EthereumRequestHandler::decode_send_transaction(data),
+            WalletConnectTransactionType::Solana { output_type } => SolanaRequestHandler::decode_send_transaction(data, output_type),
+            WalletConnectTransactionType::Sui { output_type } => SuiRequestHandler::decode_send_transaction(data, output_type),
+            WalletConnectTransactionType::Ton { output_type } => TonRequestHandler::decode_send_transaction(data, output_type),
+            WalletConnectTransactionType::Tron { output_type } => TronRequestHandler::decode_send_transaction(data, output_type),
         }
     }
 

--- a/core/crates/gem_wallet_connect/src/request_handler/solana.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/solana.rs
@@ -1,4 +1,4 @@
-use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
+use crate::actions::{WCSolanaTransactionData, WalletConnectAction, WalletConnectTransaction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
 use primitives::{Chain, TransferDataOutputType, ValueAccess, WalletConnectionMethods};
 use serde_json::Value;
@@ -47,6 +47,19 @@ impl SolanaRequestHandler {
                 output_type: TransferDataOutputType::EncodedTransaction,
             },
             data: params.to_string(),
+        })
+    }
+
+    pub fn decode_send_transaction(data: String, output_type: TransferDataOutputType) -> Result<WalletConnectTransaction, String> {
+        let json: Value = serde_json::from_str(&data).map_err(|e| e.to_string())?;
+        let transaction = json
+            .get("transaction")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| "Missing transaction field".to_string())?
+            .to_string();
+        Ok(WalletConnectTransaction::Solana {
+            data: WCSolanaTransactionData { transaction },
+            output_type,
         })
     }
 

--- a/core/crates/gem_wallet_connect/src/request_handler/sui.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/sui.rs
@@ -1,4 +1,4 @@
-use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
+use crate::actions::{WCSuiTransactionData, WalletConnectAction, WalletConnectTransaction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
 use primitives::{Chain, TransferDataOutputType, ValueAccess, WalletConnectionMethods};
 use serde_json::Value;
@@ -47,6 +47,20 @@ impl SuiRequestHandler {
                 output_type: TransferDataOutputType::EncodedTransaction,
             },
             data: params.to_string(),
+        })
+    }
+
+    pub fn decode_send_transaction(data: String, output_type: TransferDataOutputType) -> Result<WalletConnectTransaction, String> {
+        let json: Value = serde_json::from_str(&data).map_err(|e| e.to_string())?;
+        let transaction = json
+            .get("transaction")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| "Missing transaction field".to_string())?
+            .to_string();
+        let wallet_address = json.get("account").or_else(|| json.get("address")).and_then(|value| value.as_str()).unwrap_or_default().to_string();
+        Ok(WalletConnectTransaction::Sui {
+            data: WCSuiTransactionData { transaction, wallet_address },
+            output_type,
         })
     }
 }

--- a/core/crates/gem_wallet_connect/src/request_handler/ton.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/ton.rs
@@ -1,4 +1,4 @@
-use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
+use crate::actions::{WalletConnectAction, WalletConnectTransaction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
 use gem_ton::signer::TonSignMessageData;
 use primitives::{Chain, TransferDataOutputType, ValueAccess, WalletConnectionMethods};
@@ -41,6 +41,10 @@ impl TonRequestHandler {
             },
             data: params.to_string(),
         })
+    }
+
+    pub fn decode_send_transaction(data: String, output_type: TransferDataOutputType) -> Result<WalletConnectTransaction, String> {
+        Ok(WalletConnectTransaction::Ton { data, output_type })
     }
 }
 

--- a/core/crates/gem_wallet_connect/src/request_handler/tron.rs
+++ b/core/crates/gem_wallet_connect/src/request_handler/tron.rs
@@ -1,4 +1,4 @@
-use crate::actions::{WalletConnectAction, WalletConnectTransactionType};
+use crate::actions::{WalletConnectAction, WalletConnectTransaction, WalletConnectTransactionType};
 use crate::sign_type::SignDigestType;
 use primitives::{Chain, TransferDataOutputType, ValueAccess, WalletConnectionMethods};
 use serde_json::Value;
@@ -47,6 +47,10 @@ impl TronRequestHandler {
             },
             data: params.to_string(),
         })
+    }
+
+    pub fn decode_send_transaction(data: String, output_type: TransferDataOutputType) -> Result<WalletConnectTransaction, String> {
+        Ok(WalletConnectTransaction::Tron { data, output_type })
     }
 }
 

--- a/core/gemstone/src/wallet_connect/mod.rs
+++ b/core/gemstone/src/wallet_connect/mod.rs
@@ -5,7 +5,8 @@ use gem_wallet_connect::{
     WalletConnectTransactionType as WcWalletConnectTransactionType, WalletConnectVerifier, config_session_properties,
 };
 use primitives::{
-    Account, Chain, ChainAddress, TransferDataOutputType, WCEthereumTransaction, WalletConnectCAIP2, WalletConnectLink, WalletConnectRequest, WalletConnectionVerificationStatus,
+    Account, Chain, ChainAddress, TransactionType, TransferDataOutputType, WCEthereumTransaction, WalletConnectCAIP2, WalletConnectLink, WalletConnectRequest,
+    WalletConnectionVerificationStatus,
 };
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -123,6 +124,7 @@ pub enum WalletConnectChainOperation {
 pub enum WalletConnectTransaction {
     Ethereum {
         data: WCEthereumTransactionData,
+        transaction_type: TransactionType,
     },
     Solana {
         data: WCSolanaTransactionData,
@@ -287,7 +289,10 @@ impl From<WcEthereumTransactionData> for WCEthereumTransactionData {
 impl From<WcWalletConnectTransaction> for WalletConnectTransaction {
     fn from(t: WcWalletConnectTransaction) -> Self {
         match t {
-            WcWalletConnectTransaction::Ethereum { data } => Self::Ethereum { data: data.into() },
+            WcWalletConnectTransaction::Ethereum { data, transaction_type } => Self::Ethereum {
+                data: data.into(),
+                transaction_type,
+            },
             WcWalletConnectTransaction::Solana { data, output_type } => Self::Solana {
                 data: WCSolanaTransactionData { transaction: data.transaction },
                 output_type,

--- a/core/gemstone/src/wallet_connect/simulation.rs
+++ b/core/gemstone/src/wallet_connect/simulation.rs
@@ -44,7 +44,7 @@ pub(super) fn send_transaction_validation_warnings(transaction_type: &WcWalletCo
 pub(super) fn decode_ethereum_transaction(data: &str) -> Result<WcEthereumTransactionData, String> {
     let transaction = WalletConnectRequestHandler::decode_send_transaction(WcWalletConnectTransactionType::Ethereum, data.to_string())?;
     match transaction {
-        WcWalletConnectTransaction::Ethereum { data } => Ok(data),
+        WcWalletConnectTransaction::Ethereum { data, .. } => Ok(data),
         _ => Err("Invalid Ethereum transaction".to_string()),
     }
 }

--- a/ios/Features/Transfer/Sources/Services/ConfirmService.swift
+++ b/ios/Features/Transfer/Sources/Services/ConfirmService.swift
@@ -70,6 +70,7 @@ public struct ConfirmService: Sendable {
             wallet: request.wallet,
             transactionData: transactionData,
             amount: amount,
+            simulation: request.simulation,
             delegate: request.delegate,
         )
         try await transferExecutor.execute(input: input)

--- a/ios/Features/Transfer/Sources/Services/TransactionFactory.swift
+++ b/ios/Features/Transfer/Sources/Services/TransactionFactory.swift
@@ -11,6 +11,7 @@ enum TransactionFactory {
         amount: TransferAmount,
         hash: String,
         transactionIndex: Int,
+        simulation: SimulationResult? = nil,
     ) throws -> Primitives.Transaction {
         let senderAddress = try wallet.account(for: transferData.chain).address
 
@@ -19,6 +20,10 @@ enum TransactionFactory {
         default: transferData.recipientData.recipient.address
         }
 
+        let assetId: AssetId = switch transferData.type {
+        case .generic: simulation?.header?.assetId ?? transferData.type.asset.id
+        default: transferData.type.asset.id
+        }
         let metadata = transferData.type.metadata
         let direction: TransactionDirection = senderAddress == recipientAddress ? .selfTransfer : .outgoing
 
@@ -41,7 +46,7 @@ enum TransactionFactory {
 
         return Transaction(
             id: TransactionId(chain: transferData.chain, hash: hash),
-            assetId: transferData.type.asset.id,
+            assetId: assetId,
             from: senderAddress,
             to: recipientAddress,
             contract: nil,

--- a/ios/Features/Transfer/Sources/Services/TransferExecutor.swift
+++ b/ios/Features/Transfer/Sources/Services/TransferExecutor.swift
@@ -76,6 +76,7 @@ extension TransferExecutor {
             amount: input.amount,
             hash: hash,
             transactionIndex: transactionIndex,
+            simulation: input.simulation,
         )
         let assetIds = assetIdsToEnable(for: transaction)
         let transactions = pendingTransactions(

--- a/ios/Features/Transfer/Sources/Types/TransferConfirmationInput.swift
+++ b/ios/Features/Transfer/Sources/Types/TransferConfirmationInput.swift
@@ -9,6 +9,7 @@ public struct TransferConfirmationInput: Sendable {
     public let wallet: Wallet
     public let transactionData: TransactionData
     public let amount: TransferAmount
+    public let simulation: SimulationResult?
     public let delegate: TransferDataCallback.ConfirmTransferDelegate?
 
     public init(
@@ -16,12 +17,14 @@ public struct TransferConfirmationInput: Sendable {
         wallet: Wallet,
         transactionData: TransactionData,
         amount: TransferAmount,
+        simulation: SimulationResult? = nil,
         delegate: TransferDataCallback.ConfirmTransferDelegate?,
     ) {
         self.data = data
         self.wallet = wallet
         self.transactionData = transactionData
         self.amount = amount
+        self.simulation = simulation
         self.delegate = delegate
     }
 

--- a/ios/Features/WalletConnector/Sources/WalletConnector/Services/WalletConnectorSigner.swift
+++ b/ios/Features/WalletConnector/Sources/WalletConnector/Services/WalletConnectorSigner.swift
@@ -174,7 +174,7 @@ public final class WalletConnectorSigner: WalletConnectorSignable {
         let wallet = try getWallet(id: session.wallet.id)
 
         switch transaction {
-        case let .ethereum(transaction):
+        case let .ethereum(transaction, transactionType):
             let address = transaction.to
             let value = try BigInt.fromHex(transaction.value ?? .zero)
             let gasLimit: BigInt? = {
@@ -209,6 +209,7 @@ public final class WalletConnectorSigner: WalletConnectorSignable {
                     gasLimit: gasLimit,
                     gasPrice: gasPrice,
                     data: data,
+                    transactionType: transactionType,
                 )),
                 recipientData: RecipientData(
                     recipient: Recipient(name: .none, address: address, memo: .none),

--- a/ios/Packages/ChainServices/WalletConnectorService/Extensions/WalletConnectTransaction+ChainServices.swift
+++ b/ios/Packages/ChainServices/WalletConnectorService/Extensions/WalletConnectTransaction+ChainServices.swift
@@ -10,7 +10,7 @@ import Primitives
 extension WalletConnectTransaction {
     func map() -> WalletConnectorTransaction {
         switch self {
-        case let .ethereum(data): .ethereum(data.map())
+        case let .ethereum(data, transactionType): .ethereum(data.map(), transactionType.map())
         case let .solana(data, outputType): .solana(data.transaction, outputType.map())
         case let .sui(data, outputType): .sui(data.transaction, outputType.map())
         case let .ton(data, outputType): .ton(data, outputType.map())

--- a/ios/Packages/ChainServices/WalletConnectorService/WalletConnectorTransaction.swift
+++ b/ios/Packages/ChainServices/WalletConnectorService/WalletConnectorTransaction.swift
@@ -4,7 +4,7 @@ import Foundation
 import Primitives
 
 public enum WalletConnectorTransaction {
-    case ethereum(WCEthereumTransaction)
+    case ethereum(WCEthereumTransaction, TransactionType)
     case solana(String, TransferDataOutputType)
     case sui(String, TransferDataOutputType)
     case ton(String, TransferDataOutputType)

--- a/ios/Packages/GemstonePrimitives/Sources/Extensions/GemTransactionType+GemstonePrimitives.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/Extensions/GemTransactionType+GemstonePrimitives.swift
@@ -1,0 +1,30 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Gemstone
+import Primitives
+
+public extension Gemstone.TransactionType {
+    func map() -> Primitives.TransactionType {
+        switch self {
+        case .transfer: .transfer
+        case .transferNft: .transferNFT
+        case .swap: .swap
+        case .tokenApproval: .tokenApproval
+        case .stakeDelegate: .stakeDelegate
+        case .stakeUndelegate: .stakeUndelegate
+        case .stakeRewards: .stakeRewards
+        case .stakeRedelegate: .stakeRedelegate
+        case .stakeWithdraw: .stakeWithdraw
+        case .stakeFreeze: .stakeFreeze
+        case .stakeUnfreeze: .stakeUnfreeze
+        case .assetActivation: .assetActivation
+        case .smartContractCall: .smartContractCall
+        case .perpetualOpenPosition: .perpetualOpenPosition
+        case .perpetualClosePosition: .perpetualClosePosition
+        case .perpetualModifyPosition: .perpetualModifyPosition
+        case .earnDeposit: .earnDeposit
+        case .earnWithdraw: .earnWithdraw
+        }
+    }
+}

--- a/ios/Packages/Primitives/Sources/TransferDataExtra.swift
+++ b/ios/Packages/Primitives/Sources/TransferDataExtra.swift
@@ -10,6 +10,7 @@ public struct TransferDataExtra: Equatable, Sendable {
     public let data: Data?
     public let outputType: TransferDataOutputType
     public let outputAction: TransferDataOutputAction
+    public let transactionType: TransactionType
 
     public init(
         to: String,
@@ -18,6 +19,7 @@ public struct TransferDataExtra: Equatable, Sendable {
         data: Data? = .none,
         outputType: TransferDataOutputType = .encodedTransaction,
         outputAction: TransferDataOutputAction = .send,
+        transactionType: TransactionType = .smartContractCall,
     ) {
         self.to = to
         self.gasLimit = gasLimit
@@ -25,6 +27,7 @@ public struct TransferDataExtra: Equatable, Sendable {
         self.data = data
         self.outputType = outputType
         self.outputAction = outputAction
+        self.transactionType = transactionType
     }
 }
 

--- a/ios/Packages/Primitives/Sources/TransferDataType.swift
+++ b/ios/Packages/Primitives/Sources/TransferDataType.swift
@@ -20,7 +20,7 @@ public enum TransferDataType: Hashable, Equatable, Sendable {
         case .transfer: .transfer
         case .deposit: .transfer
         case .withdrawal: .transfer
-        case .generic: .smartContractCall
+        case let .generic(_, _, extra): extra.transactionType
         case .transferNft: .transferNFT
         case .tokenApprove: .tokenApproval
         case .swap: .swap

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
@@ -93,7 +93,7 @@ public struct TransactionViewModel: Sendable {
     public var titleTextValue: TextValue {
         let title: String = {
             switch transaction.transaction.type {
-            case .transfer, .transferNFT, .smartContractCall:
+            case .transfer, .transferNFT:
                 switch transaction.transaction.state {
                 case .confirmed:
                     switch transaction.transaction.direction {
@@ -105,6 +105,8 @@ public struct TransactionViewModel: Sendable {
                 case .failed, .pending, .reverted, .inTransit:
                     return Localized.Transfer.title
                 }
+            case .smartContractCall:
+                return Localized.Transfer.SmartContract.title
             case .swap:
                 return Localized.Wallet.swap
             case .tokenApproval:


### PR DESCRIPTION
WalletConnect token approvals now show as "Approve" with the approved token in the Activity list, instead of "Sent 0 ETH".

Closes #763

<img width="320" alt="Screenshot_1785229100" src="https://github.com/user-attachments/assets/6c0419ff-bb85-480d-b412-c9f6a19a29c1" />
<img width="320" alt="Screenshot_1785229104" src="https://github.com/user-attachments/assets/2151e3ba-24af-4ca3-831a-3e3a28a3bbd6" />
<img width="320" alt="Simulator Screenshot - wt2 - 2026-07-28 at 16 58 34" src="https://github.com/user-attachments/assets/05623dd9-ad19-4bac-b353-5ee50f1560e2" />
<img width="320" alt="Simulator Screenshot - wt2 - 2026-07-28 at 16 58 38" src="https://github.com/user-attachments/assets/9e24a843-28b4-49e0-8bf6-5f50dea5d175" />
