### PR TITLE
[codex] Cache static Dynode RPC calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ This is a crypto wallet. Treat security-sensitive changes as high risk by defaul
 
 - When two patterns contradict (iOS vs. Android handling of a shared flow, two error-mapping styles in `core/`, parallel provider implementations), do not blend them. Pick the more recent or more tested one, state why, and flag the other for follow-up
 - Never wrap an immutable request client in a shared `Mutex` or hold that client lock across network or database I/O. Use mutexes only for narrowly scoped mutable coordination
+- Prefer immutable bindings and transformations. Use `mut` only when ownership requires mutation, and keep its scope narrow
 - Use full domain terms in code names: write `transaction`, not `tx`, except when preserving external protocol field names, database columns, or URLs verbatim
 - For multi-step work that crosses Core → bindings → iOS/Android, checkpoint after each step: state what changed, what was verified, what is left. Do not continue from a state you cannot describe back
 - If a regeneration's effect on either app is unclear, stop and restate before adding more changes

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2836,7 +2836,6 @@ dependencies = [
  "gem_auth",
  "gem_client",
  "gem_tracing",
- "hex",
  "metrics",
  "primitives",
  "prometheus-client",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2836,6 +2836,7 @@ dependencies = [
  "gem_auth",
  "gem_client",
  "gem_tracing",
+ "hex",
  "metrics",
  "primitives",
  "prometheus-client",

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -44,4 +44,5 @@ FROM runtime-base AS dynode
 WORKDIR /app
 COPY --from=builder-dynode /app/dynode /app/
 COPY --from=builder-dynode /app/apps/dynode/config.yml /app/
+COPY --from=builder-dynode /app/apps/dynode/cache.yml /app/
 CMD ["/app/dynode"]

--- a/core/Settings.yaml
+++ b/core/Settings.yaml
@@ -79,7 +79,7 @@ charter:
 name:
   max_name_length: 20
   ens:
-    url: https://eth.llamarpc.com
+    url: https://ethereum.publicnode.com
   ud:
     url: https://api.unstoppabledomains.com
     key:

--- a/core/apps/dynode/Cargo.toml
+++ b/core/apps/dynode/Cargo.toml
@@ -10,6 +10,7 @@ testkit = []
 config = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+hex = { workspace = true }
 strum = { workspace = true }
 tokio = { workspace = true }
 prometheus-client = { workspace = true }

--- a/core/apps/dynode/Cargo.toml
+++ b/core/apps/dynode/Cargo.toml
@@ -10,7 +10,6 @@ testkit = []
 config = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-hex = { workspace = true }
 strum = { workspace = true }
 tokio = { workspace = true }
 prometheus-client = { workspace = true }

--- a/core/apps/dynode/cache.yml
+++ b/core/apps/dynode/cache.yml
@@ -1,5 +1,5 @@
 cache:
-  max_memory_mb: 1024
+  max_memory: 1 GB
   chain_types:
     ethereum:
       - rpc_method: eth_chainId
@@ -31,9 +31,10 @@ cache:
         params:
           function: "0x1::delegation_pool::operator_commission_percentage"
   evm_calls:
-    - selector: "0x1698ee82"
-      ttl: 5m
+    ethereum:
       contracts:
-        ethereum: "0x1F98431c8aD98523631AE4a59f267346ea31F984"
-        optimism: "0x1F98431c8aD98523631AE4a59f267346ea31F984"
-        robinhood: "0x1f7d7550B1b028f7571E69A784071F0205FD2EfA"
+        - "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+        - "0x1f7d7550B1b028f7571E69A784071F0205FD2EfA"
+      selectors:
+        "0x1698ee82":
+          ttl: 5m

--- a/core/apps/dynode/cache.yml
+++ b/core/apps/dynode/cache.yml
@@ -1,5 +1,5 @@
 cache:
-  max_memory: 1 GB
+  max_memory: 1GB
   chain_types:
     ethereum:
       rules:
@@ -10,6 +10,7 @@ cache:
           - "0x1F98431c8aD98523631AE4a59f267346ea31F984"
           - "0x1f7d7550B1b028f7571E69A784071F0205FD2EfA"
         methods:
+          # Uniswap V3 Factory getPool(address,address,uint24)
           "0x1698ee82":
             ttl: 5m
     tron:

--- a/core/apps/dynode/cache.yml
+++ b/core/apps/dynode/cache.yml
@@ -1,0 +1,48 @@
+cache:
+  max_memory_mb: 1024
+  chain_types:
+    ethereum:
+      - rpc_method: eth_chainId
+        ttl: 1h
+    tron:
+      - path: /wallet/getchainparameters
+        method: GET
+        ttl: 1d
+      - path: /wallet/listwitnesses
+        method: GET
+        ttl: 1d
+    solana:
+      - rpc_method: getVoteAccounts
+        ttl: 1h
+    cosmos:
+      - path: /cosmos/staking/v1beta1/validators
+        method: GET
+        ttl: 1d
+    hypercore:
+      - path: /info
+        method: POST
+        ttl: 1h
+        params:
+          type: metaAndAssetCtxs
+    aptos:
+      - path: /v1/view
+        method: POST
+        ttl: 1h
+        params:
+          function: "0x1::delegation_pool::operator_commission_percentage"
+  chains:
+    ethereum:
+      - rpc_method: eth_call
+        contract: "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+        selector: "0x1698ee82"
+        ttl: 5m
+    optimism:
+      - rpc_method: eth_call
+        contract: "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+        selector: "0x1698ee82"
+        ttl: 5m
+    robinhood:
+      - rpc_method: eth_call
+        contract: "0x1f7d7550B1b028f7571E69A784071F0205FD2EfA"
+        selector: "0x1698ee82"
+        ttl: 5m

--- a/core/apps/dynode/cache.yml
+++ b/core/apps/dynode/cache.yml
@@ -2,39 +2,44 @@ cache:
   max_memory: 1 GB
   chain_types:
     ethereum:
-      - rpc_method: eth_chainId
-        ttl: 1h
-    tron:
-      - path: /wallet/getchainparameters
-        method: GET
-        ttl: 1d
-      - path: /wallet/listwitnesses
-        method: GET
-        ttl: 1d
-    solana:
-      - rpc_method: getVoteAccounts
-        ttl: 1h
-    cosmos:
-      - path: /cosmos/staking/v1beta1/validators
-        method: GET
-        ttl: 1d
-    hypercore:
-      - path: /info
-        method: POST
-        ttl: 1h
-        params:
-          type: metaAndAssetCtxs
-    aptos:
-      - path: /v1/view
-        method: POST
-        ttl: 1h
-        params:
-          function: "0x1::delegation_pool::operator_commission_percentage"
-  evm_calls:
-    ethereum:
+      rules:
+        - rpc_method: eth_chainId
+          ttl: 1h
       contracts:
-        - "0x1F98431c8aD98523631AE4a59f267346ea31F984"
-        - "0x1f7d7550B1b028f7571E69A784071F0205FD2EfA"
-      selectors:
-        "0x1698ee82":
-          ttl: 5m
+        addresses:
+          - "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+          - "0x1f7d7550B1b028f7571E69A784071F0205FD2EfA"
+        methods:
+          "0x1698ee82":
+            ttl: 5m
+    tron:
+      rules:
+        - path: /wallet/getchainparameters
+          method: GET
+          ttl: 1d
+        - path: /wallet/listwitnesses
+          method: GET
+          ttl: 1d
+    solana:
+      rules:
+        - rpc_method: getVoteAccounts
+          ttl: 1h
+    cosmos:
+      rules:
+        - path: /cosmos/staking/v1beta1/validators
+          method: GET
+          ttl: 1d
+    hypercore:
+      rules:
+        - path: /info
+          method: POST
+          ttl: 1h
+          params:
+            type: metaAndAssetCtxs
+    aptos:
+      rules:
+        - path: /v1/view
+          method: POST
+          ttl: 1h
+          params:
+            function: "0x1::delegation_pool::operator_commission_percentage"

--- a/core/apps/dynode/cache.yml
+++ b/core/apps/dynode/cache.yml
@@ -1,5 +1,5 @@
 cache:
-  max_memory: 1GB
+  max_memory: 2GB
   chain_types:
     ethereum:
       rules:

--- a/core/apps/dynode/cache.yml
+++ b/core/apps/dynode/cache.yml
@@ -30,19 +30,10 @@ cache:
         ttl: 1h
         params:
           function: "0x1::delegation_pool::operator_commission_percentage"
-  chains:
-    ethereum:
-      - rpc_method: eth_call
-        contract: "0x1F98431c8aD98523631AE4a59f267346ea31F984"
-        selector: "0x1698ee82"
-        ttl: 5m
-    optimism:
-      - rpc_method: eth_call
-        contract: "0x1F98431c8aD98523631AE4a59f267346ea31F984"
-        selector: "0x1698ee82"
-        ttl: 5m
-    robinhood:
-      - rpc_method: eth_call
-        contract: "0x1f7d7550B1b028f7571E69A784071F0205FD2EfA"
-        selector: "0x1698ee82"
-        ttl: 5m
+  evm_calls:
+    - selector: "0x1698ee82"
+      ttl: 5m
+      contracts:
+        ethereum: "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+        optimism: "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+        robinhood: "0x1f7d7550B1b028f7571E69A784071F0205FD2EfA"

--- a/core/apps/dynode/cache.yml
+++ b/core/apps/dynode/cache.yml
@@ -10,8 +10,7 @@ cache:
           - "0x1F98431c8aD98523631AE4a59f267346ea31F984"
           - "0x1f7d7550B1b028f7571E69A784071F0205FD2EfA"
         methods:
-          # Uniswap V3 Factory getPool(address,address,uint24)
-          "0x1698ee82":
+          "0x1698ee82": # Uniswap V3 Factory getPool(address,address,uint24)
             ttl: 5m
     tron:
       rules:

--- a/core/apps/dynode/chains.yml
+++ b/core/apps/dynode/chains.yml
@@ -6,8 +6,7 @@ chains:
         url: https://public-eth.nownodes.io
     urls:
       - url: https://rpc.ankr.com/eth
-      - url: https://eth.llamarpc.com
-      - url: https://rpc.ankr.com/eth
+      - url: https://ethereum-rpc.publicnode.com
 
   # Optimism
   - chain: optimism
@@ -39,7 +38,6 @@ chains:
   # TON
   - chain: ton
     urls:
-      - url: https://toncenter.com
       - url: https://toncenter.com
 
   # Tron

--- a/core/apps/dynode/config.yml
+++ b/core/apps/dynode/config.yml
@@ -45,40 +45,18 @@ retry:
       - "Exceeded the quota usage"
       - "Unauthorized"
 
-cache:
-  max_memory_mb: 1024
-
 chain_types:
   ethereum:
     allowlist:
       - rpc_method: eth_chainId
       - rpc_method: eth_sendRawTransaction
-    cache:
-      - rpc_method: eth_chainId
-        ttl: 1h
   bitcoin:
     allowlist:
       - path: /api/v2/address/**
         method: GET
       - path: /api/v2/sendtx/
         method: POST
-  tron:
-    cache:
-      - path: /wallet/getchainparameters
-        method: GET
-        ttl: 1d
-      - path: /wallet/listwitnesses
-        method: GET
-        ttl: 1d
-  solana:
-    cache:
-      - rpc_method: getVoteAccounts
-        ttl: 1h
   cosmos:
-    cache:
-      - path: /cosmos/staking/v1beta1/validators
-        method: GET
-        ttl: 1d
     chains:
       thorchain:
         allowlist:
@@ -88,10 +66,6 @@ chain_types:
             method: GET
           - path: /thorchain/tx/status/**
             method: GET
-        cache:
-          - path: /thorchain/inbound_addresses
-            method: GET
-            ttl: 10m
       mayachain:
         allowlist:
           - path: /mayachain/inbound_addresses
@@ -100,17 +74,3 @@ chain_types:
             method: GET
           - path: /mayachain/tx/status/**
             method: GET
-  hypercore:
-    cache:
-      - path: /info
-        method: POST
-        ttl: 1h
-        params:
-          type: metaAndAssetCtxs
-  aptos:
-    cache:
-      - path: /v1/view
-        method: POST
-        ttl: 1h
-        params:
-          function: "0x1::delegation_pool::operator_commission_percentage"

--- a/core/apps/dynode/config.yml
+++ b/core/apps/dynode/config.yml
@@ -50,6 +50,8 @@ chain_types:
     allowlist:
       - rpc_method: eth_chainId
       - rpc_method: eth_sendRawTransaction
+      - rpc_method: eth_blockNumber
+      - rpc_method: eth_call
   bitcoin:
     allowlist:
       - path: /api/v2/address/**

--- a/core/apps/dynode/src/cache/memory.rs
+++ b/core/apps/dynode/src/cache/memory.rs
@@ -1,4 +1,4 @@
-use crate::config::{CacheConfig, ChainCacheRules, ChainConfig};
+use crate::config::{CacheConfig, ChainCacheRules, ChainConfig, ETH_CALL};
 use crate::jsonrpc_types::{JsonRpcCall, RequestType};
 use crate::proxy::CachedResponse;
 use primitives::Chain;
@@ -13,7 +13,7 @@ use super::types::CacheEntry;
 #[derive(Debug, Clone)]
 pub struct MemoryCache {
     caches: Arc<HashMap<Chain, Arc<RwLock<HashMap<String, CacheEntry>>>>>,
-    max_memory_mb: usize,
+    max_memory: usize,
     rules: Arc<HashMap<Chain, ChainCacheRules>>,
 }
 
@@ -21,22 +21,19 @@ impl MemoryCache {
     pub fn new<'a>(config: CacheConfig, chains: impl IntoIterator<Item = &'a ChainConfig>) -> Self {
         let rules = chains
             .into_iter()
-            .filter_map(|chain_config| {
-                let cache_rules = config.rules(chain_config.chain);
-                (!cache_rules.cache.is_empty() || !cache_rules.evm_calls.is_empty()).then_some((chain_config.chain, cache_rules))
-            })
+            .filter_map(|chain_config| config.rules(chain_config.chain).map(|cache_rules| (chain_config.chain, cache_rules)))
             .collect::<HashMap<_, _>>();
         let caches = rules.keys().copied().map(|chain| (chain, Arc::new(RwLock::new(HashMap::new())))).collect();
         Self {
             caches: Arc::new(caches),
-            max_memory_mb: config.max_memory_mb,
+            max_memory: config.max_memory,
             rules: Arc::new(rules),
         }
     }
 
     fn max_size_per_chain(&self) -> usize {
         let chain_count = self.caches.len().max(1);
-        (self.max_memory_mb * 1_000_000) / chain_count
+        self.max_memory / chain_count
     }
 
     fn evict_if_needed(cache: &mut HashMap<String, CacheEntry>, max_size: usize) {
@@ -104,13 +101,10 @@ impl CacheProvider for MemoryCache {
 
     fn should_cache_call(&self, chain: &Chain, call: &JsonRpcCall) -> Option<Duration> {
         let rules = self.rules.get(chain)?;
-        rules.cache.iter().find(|rule| rule.matches_rpc(&call.method)).and_then(|rule| rule.ttl).or_else(|| {
-            if call.method == crate::config::ETH_CALL {
-                rules.evm_calls.iter().find(|rule| rule.matches(&call.params)).map(|rule| rule.ttl)
-            } else {
-                None
-            }
-        })
+        if call.method == ETH_CALL {
+            return rules.evm_call_ttl(&call.params);
+        }
+        rules.cache.iter().find(|rule| rule.matches_rpc(&call.method)).and_then(|rule| rule.ttl)
     }
 }
 
@@ -123,7 +117,7 @@ mod tests {
     use reqwest::StatusCode;
     fn create_test_cache_config() -> CacheConfig {
         serde_json::from_value(serde_json::json!({
-            "max_memory_mb": 64,
+            "max_memory": "64 MB",
             "chain_types": {
                 "ethereum": [
                     { "path": "/api/v1/data", "method": "GET", "ttl": "5m" },
@@ -188,7 +182,7 @@ mod tests {
     #[test]
     fn test_should_cache_with_params() {
         let config: CacheConfig = serde_json::from_value(serde_json::json!({
-            "max_memory_mb": 64,
+            "max_memory": "64 MB",
             "chain_types": {
                 "ethereum": [
                     {
@@ -236,7 +230,7 @@ mod tests {
     #[test]
     fn test_should_cache_with_function_params() {
         let config: CacheConfig = serde_json::from_value(serde_json::json!({
-            "max_memory_mb": 64,
+            "max_memory": "64 MB",
             "chain_types": {
                 "aptos": [
                     {
@@ -291,7 +285,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_eviction() {
-        let config: CacheConfig = serde_json::from_value(serde_json::json!({ "max_memory_mb": 0 })).unwrap();
+        let config: CacheConfig = serde_json::from_value(serde_json::json!({ "max_memory": "0 B" })).unwrap();
         let chains = [create_chain_config(Chain::Ethereum)];
         let cache = MemoryCache::new(config, chains.iter());
         let chain = Chain::Ethereum;
@@ -311,21 +305,22 @@ mod tests {
         const SELECTOR: &str = "0x1698ee82";
 
         let config: CacheConfig = serde_json::from_value(serde_json::json!({
-            "max_memory_mb": 64,
+            "max_memory": "64 MB",
             "chain_types": {
                 "ethereum": [
                     { "rpc_method": "eth_blockNumber", "ttl": "1m" }
                 ]
             },
-            "evm_calls": [
-                {
-                    "selector": SELECTOR,
-                    "ttl": "30s",
-                    "contracts": {
-                        "ethereum": CONTRACT
+            "evm_calls": {
+                "ethereum": {
+                    "contracts": [CONTRACT],
+                    "selectors": {
+                        SELECTOR: {
+                            "ttl": "30s"
+                        }
                     }
                 }
-            ]
+            }
         }))
         .unwrap();
         let chains = [create_chain_config(Chain::Ethereum)];

--- a/core/apps/dynode/src/cache/memory.rs
+++ b/core/apps/dynode/src/cache/memory.rs
@@ -10,29 +10,42 @@ use tokio::sync::RwLock;
 use super::CacheProvider;
 use super::types::CacheEntry;
 
+#[derive(Debug)]
+struct ChainCache {
+    entries: RwLock<HashMap<String, CacheEntry>>,
+    rules: ChainCacheRules,
+}
+
 #[derive(Debug, Clone)]
 pub struct MemoryCache {
-    caches: Arc<HashMap<Chain, Arc<RwLock<HashMap<String, CacheEntry>>>>>,
+    chains: Arc<HashMap<Chain, ChainCache>>,
     max_memory: usize,
-    rules: Arc<HashMap<Chain, ChainCacheRules>>,
 }
 
 impl MemoryCache {
     pub fn new<'a>(config: CacheConfig, chains: impl IntoIterator<Item = &'a ChainConfig>) -> Self {
-        let rules = chains
+        let chains = chains
             .into_iter()
-            .filter_map(|chain_config| config.rules(chain_config.chain).map(|cache_rules| (chain_config.chain, cache_rules)))
+            .filter_map(|chain_config| {
+                config.rules(chain_config.chain).map(|rules| {
+                    (
+                        chain_config.chain,
+                        ChainCache {
+                            entries: RwLock::new(HashMap::new()),
+                            rules,
+                        },
+                    )
+                })
+            })
             .collect::<HashMap<_, _>>();
-        let caches = rules.keys().copied().map(|chain| (chain, Arc::new(RwLock::new(HashMap::new())))).collect();
         Self {
-            caches: Arc::new(caches),
+            chains: Arc::new(chains),
             max_memory: config.max_memory,
-            rules: Arc::new(rules),
         }
     }
 
     fn max_size_per_chain(&self) -> usize {
-        let chain_count = self.caches.len().max(1);
+        let chain_count = self.chains.len().max(1);
         self.max_memory / chain_count
     }
 
@@ -67,21 +80,24 @@ impl MemoryCache {
 
 impl CacheProvider for MemoryCache {
     async fn get(&self, chain: &Chain, key: &str) -> Option<CachedResponse> {
-        let cache = self.caches.get(chain)?;
-        let read_guard = cache.read().await;
+        let cache = self.chains.get(chain)?;
+        let read_guard = cache.entries.read().await;
         let entry = read_guard.get(key)?;
         if entry.is_expired() {
             drop(read_guard);
-            cache.write().await.remove(key);
+            let mut write_guard = cache.entries.write().await;
+            if write_guard.get(key).is_some_and(CacheEntry::is_expired) {
+                write_guard.remove(key);
+            }
             return None;
         }
         Some(entry.response.clone())
     }
 
     async fn set(&self, chain: &Chain, key: String, response: CachedResponse, ttl: Duration) {
-        if let Some(cache) = self.caches.get(chain) {
+        if let Some(cache) = self.chains.get(chain) {
             let entry = CacheEntry::new(response, ttl);
-            let mut guard = cache.write().await;
+            let mut guard = cache.entries.write().await;
             guard.insert(key, entry);
             Self::evict_if_needed(&mut guard, self.max_size_per_chain());
         }
@@ -91,8 +107,9 @@ impl CacheProvider for MemoryCache {
         let RequestType::Regular { path, method, body } = request_type else {
             return None;
         };
-        self.rules
+        self.chains
             .get(chain)?
+            .rules
             .cache
             .iter()
             .find(|rule| rule.matches_path_request(path, method, Some(body)))
@@ -100,7 +117,7 @@ impl CacheProvider for MemoryCache {
     }
 
     fn should_cache_call(&self, chain: &Chain, call: &JsonRpcCall) -> Option<Duration> {
-        let rules = self.rules.get(chain)?;
+        let rules = &self.chains.get(chain)?.rules;
         if let Some(ttl) = rules.ttl(call) {
             return Some(ttl);
         }
@@ -220,12 +237,7 @@ mod tests {
         let cache = create_test_cache();
         let chain = Chain::Ethereum;
 
-        let call = JsonRpcCall {
-            jsonrpc: "2.0".to_string(),
-            method: "eth_blockNumber".to_string(),
-            params: serde_json::json!([]),
-            id: 1,
-        };
+        let call = JsonRpcCall::mock(1, "eth_blockNumber");
 
         let ttl = cache.should_cache_call(&chain, &call);
         assert_eq!(ttl, Some(MINUTE));
@@ -333,32 +345,23 @@ mod tests {
         let cache = MemoryCache::new(config, chains.iter());
 
         assert_eq!(
-            cache.should_cache_call(
-                &Chain::Ethereum,
-                &JsonRpcCall {
-                    jsonrpc: "2.0".to_string(),
-                    method: "eth_blockNumber".to_string(),
-                    params: serde_json::json!([]),
-                    id: 1,
-                }
-            ),
+            cache.should_cache_call(&Chain::Ethereum, &JsonRpcCall::mock(1, "eth_blockNumber")),
             Some(Duration::from_secs(60))
         );
         assert_eq!(
             cache.should_cache_call(
                 &Chain::Ethereum,
-                &JsonRpcCall {
-                    jsonrpc: "2.0".to_string(),
-                    method: "eth_call".to_string(),
-                    params: serde_json::json!([
+                &JsonRpcCall::mock_with_params(
+                    1,
+                    "eth_call",
+                    serde_json::json!([
                         {
                             "to": CONTRACT,
                             "data": SELECTOR
                         },
                         "latest"
-                    ]),
-                    id: 1,
-                }
+                    ])
+                )
             ),
             Some(Duration::from_secs(30))
         );

--- a/core/apps/dynode/src/cache/memory.rs
+++ b/core/apps/dynode/src/cache/memory.rs
@@ -1,4 +1,4 @@
-use crate::config::{CacheConfig, CacheRule, ChainConfig};
+use crate::config::{CacheConfig, ChainCacheRules, ChainConfig};
 use crate::jsonrpc_types::{JsonRpcCall, RequestType};
 use crate::proxy::CachedResponse;
 use primitives::Chain;
@@ -14,7 +14,7 @@ use super::types::CacheEntry;
 pub struct MemoryCache {
     caches: Arc<HashMap<Chain, Arc<RwLock<HashMap<String, CacheEntry>>>>>,
     max_memory_mb: usize,
-    rules: Arc<HashMap<Chain, Vec<CacheRule>>>,
+    rules: Arc<HashMap<Chain, ChainCacheRules>>,
 }
 
 impl MemoryCache {
@@ -23,7 +23,7 @@ impl MemoryCache {
             .into_iter()
             .filter_map(|chain_config| {
                 let cache_rules = config.rules(chain_config.chain);
-                (!cache_rules.is_empty()).then_some((chain_config.chain, cache_rules))
+                (!cache_rules.cache.is_empty() || !cache_rules.evm_calls.is_empty()).then_some((chain_config.chain, cache_rules))
             })
             .collect::<HashMap<_, _>>();
         let caches = rules.keys().copied().map(|chain| (chain, Arc::new(RwLock::new(HashMap::new())))).collect();
@@ -96,17 +96,21 @@ impl CacheProvider for MemoryCache {
         };
         self.rules
             .get(chain)?
+            .cache
             .iter()
             .find(|rule| rule.matches_path_request(path, method, Some(body)))
             .and_then(|rule| rule.ttl)
     }
 
     fn should_cache_call(&self, chain: &Chain, call: &JsonRpcCall) -> Option<Duration> {
-        self.rules
-            .get(chain)?
-            .iter()
-            .find(|rule| rule.matches_rpc(&call.method, &call.params))
-            .and_then(|rule| rule.ttl)
+        let rules = self.rules.get(chain)?;
+        rules.cache.iter().find(|rule| rule.matches_rpc(&call.method)).and_then(|rule| rule.ttl).or_else(|| {
+            if call.method == crate::config::ETH_CALL {
+                rules.evm_calls.iter().find(|rule| rule.matches(&call.params)).map(|rule| rule.ttl)
+            } else {
+                None
+            }
+        })
     }
 }
 
@@ -313,16 +317,15 @@ mod tests {
                     { "rpc_method": "eth_blockNumber", "ttl": "1m" }
                 ]
             },
-            "chains": {
-                "ethereum": [
-                    {
-                        "rpc_method": "eth_call",
-                        "contract": CONTRACT,
-                        "selector": SELECTOR,
-                        "ttl": "30s"
+            "evm_calls": [
+                {
+                    "selector": SELECTOR,
+                    "ttl": "30s",
+                    "contracts": {
+                        "ethereum": CONTRACT
                     }
-                ]
-            }
+                }
+            ]
         }))
         .unwrap();
         let chains = [create_chain_config(Chain::Ethereum)];

--- a/core/apps/dynode/src/cache/memory.rs
+++ b/core/apps/dynode/src/cache/memory.rs
@@ -1,4 +1,4 @@
-use crate::config::{CacheConfig, ChainCacheRules, ChainConfig, ETH_CALL};
+use crate::config::{CacheConfig, ChainCacheRules, ChainConfig};
 use crate::jsonrpc_types::{JsonRpcCall, RequestType};
 use crate::proxy::CachedResponse;
 use primitives::Chain;
@@ -101,8 +101,8 @@ impl CacheProvider for MemoryCache {
 
     fn should_cache_call(&self, chain: &Chain, call: &JsonRpcCall) -> Option<Duration> {
         let rules = self.rules.get(chain)?;
-        if call.method == ETH_CALL {
-            return rules.evm_call_ttl(&call.params);
+        if let Some(ttl) = rules.ttl(call) {
+            return Some(ttl);
         }
         rules.cache.iter().find(|rule| rule.matches_rpc(&call.method)).and_then(|rule| rule.ttl)
     }
@@ -119,10 +119,12 @@ mod tests {
         serde_json::from_value(serde_json::json!({
             "max_memory": "64 MB",
             "chain_types": {
-                "ethereum": [
-                    { "path": "/api/v1/data", "method": "GET", "ttl": "5m" },
-                    { "rpc_method": "eth_blockNumber", "ttl": "1m" }
-                ]
+                "ethereum": {
+                    "rules": [
+                        { "path": "/api/v1/data", "method": "GET", "ttl": "5m" },
+                        { "rpc_method": "eth_blockNumber", "ttl": "1m" }
+                    ]
+                }
             }
         }))
         .unwrap()
@@ -184,16 +186,18 @@ mod tests {
         let config: CacheConfig = serde_json::from_value(serde_json::json!({
             "max_memory": "64 MB",
             "chain_types": {
-                "ethereum": [
-                    {
-                        "path": "/info",
-                        "method": "POST",
-                        "ttl": "200s",
-                        "params": {
-                            "type": "metaAndAssetCtxs"
+                "ethereum": {
+                    "rules": [
+                        {
+                            "path": "/info",
+                            "method": "POST",
+                            "ttl": "200s",
+                            "params": {
+                                "type": "metaAndAssetCtxs"
+                            }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         }))
         .unwrap();
@@ -232,16 +236,18 @@ mod tests {
         let config: CacheConfig = serde_json::from_value(serde_json::json!({
             "max_memory": "64 MB",
             "chain_types": {
-                "aptos": [
-                    {
-                        "path": "/v1/view",
-                        "method": "POST",
-                        "ttl": "1h",
-                        "params": {
-                            "function": "0x1::delegation_pool::operator_commission_percentage"
+                "aptos": {
+                    "rules": [
+                        {
+                            "path": "/v1/view",
+                            "method": "POST",
+                            "ttl": "1h",
+                            "params": {
+                                "function": "0x1::delegation_pool::operator_commission_percentage"
+                            }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         }))
         .unwrap();
@@ -307,16 +313,16 @@ mod tests {
         let config: CacheConfig = serde_json::from_value(serde_json::json!({
             "max_memory": "64 MB",
             "chain_types": {
-                "ethereum": [
-                    { "rpc_method": "eth_blockNumber", "ttl": "1m" }
-                ]
-            },
-            "evm_calls": {
                 "ethereum": {
-                    "contracts": [CONTRACT],
-                    "selectors": {
-                        SELECTOR: {
-                            "ttl": "30s"
+                    "rules": [
+                        { "rpc_method": "eth_blockNumber", "ttl": "1m" }
+                    ],
+                    "contracts": {
+                        "addresses": [CONTRACT],
+                        "methods": {
+                            SELECTOR: {
+                                "ttl": "30s"
+                            }
                         }
                     }
                 }

--- a/core/apps/dynode/src/cache/memory.rs
+++ b/core/apps/dynode/src/cache/memory.rs
@@ -1,5 +1,5 @@
-use crate::config::{CacheConfig, CacheRule, ChainConfig, ChainTypesConfig};
-use crate::jsonrpc_types::{JsonRpcCall, JsonRpcRequest, RequestType};
+use crate::config::{CacheConfig, CacheRule, ChainConfig};
+use crate::jsonrpc_types::{JsonRpcCall, RequestType};
 use crate::proxy::CachedResponse;
 use primitives::Chain;
 use std::collections::HashMap;
@@ -18,16 +18,15 @@ pub struct MemoryCache {
 }
 
 impl MemoryCache {
-    pub fn new<'a>(config: CacheConfig, chain_types: &ChainTypesConfig, chains: impl IntoIterator<Item = &'a ChainConfig>) -> Self {
-        let mut caches = HashMap::new();
-        let mut rules = HashMap::new();
-        for chain_config in chains {
-            let cache_rules = chain_types.cache_rules(chain_config);
-            if !cache_rules.is_empty() {
-                caches.insert(chain_config.chain, Arc::new(RwLock::new(HashMap::new())));
-                rules.insert(chain_config.chain, cache_rules);
-            }
-        }
+    pub fn new<'a>(config: CacheConfig, chains: impl IntoIterator<Item = &'a ChainConfig>) -> Self {
+        let rules = chains
+            .into_iter()
+            .filter_map(|chain_config| {
+                let cache_rules = config.rules(chain_config.chain);
+                (!cache_rules.is_empty()).then_some((chain_config.chain, cache_rules))
+            })
+            .collect::<HashMap<_, _>>();
+        let caches = rules.keys().copied().map(|chain| (chain, Arc::new(RwLock::new(HashMap::new())))).collect();
         Self {
             caches: Arc::new(caches),
             max_memory_mb: config.max_memory_mb,
@@ -67,14 +66,6 @@ impl MemoryCache {
             }
         }
     }
-
-    fn rule_for_request<'a>(&'a self, chain: &Chain, request_type: &RequestType) -> Option<&'a CacheRule> {
-        self.rules.get(chain)?.iter().find(|rule| match request_type {
-            RequestType::Regular { path, method, body } => rule.matches_path_request(path, method, Some(body.as_slice())),
-            RequestType::JsonRpc(JsonRpcRequest::Single(call)) => rule.matches_rpc(&call.method),
-            RequestType::JsonRpc(JsonRpcRequest::Batch(_)) => false,
-        })
-    }
 }
 
 impl CacheProvider for MemoryCache {
@@ -100,11 +91,22 @@ impl CacheProvider for MemoryCache {
     }
 
     fn should_cache_request(&self, chain: &Chain, request_type: &RequestType) -> Option<Duration> {
-        self.rule_for_request(chain, request_type).and_then(|rule| rule.ttl)
+        let RequestType::Regular { path, method, body } = request_type else {
+            return None;
+        };
+        self.rules
+            .get(chain)?
+            .iter()
+            .find(|rule| rule.matches_path_request(path, method, Some(body)))
+            .and_then(|rule| rule.ttl)
     }
 
     fn should_cache_call(&self, chain: &Chain, call: &JsonRpcCall) -> Option<Duration> {
-        self.rules.get(chain)?.iter().find(|rule| rule.matches_rpc(&call.method)).and_then(|rule| rule.ttl)
+        self.rules
+            .get(chain)?
+            .iter()
+            .find(|rule| rule.matches_rpc(&call.method, &call.params))
+            .and_then(|rule| rule.ttl)
     }
 }
 
@@ -115,12 +117,11 @@ mod tests {
     use crate::proxy::constants::JSON_CONTENT_TYPE;
     use primitives::{HOUR, MINUTE};
     use reqwest::StatusCode;
-    use std::collections::HashMap;
-
-    fn create_test_chain_types() -> ChainTypesConfig {
+    fn create_test_cache_config() -> CacheConfig {
         serde_json::from_value(serde_json::json!({
-            "ethereum": {
-                "cache": [
+            "max_memory_mb": 64,
+            "chain_types": {
+                "ethereum": [
                     { "path": "/api/v1/data", "method": "GET", "ttl": "5m" },
                     { "rpc_method": "eth_blockNumber", "ttl": "1m" }
                 ]
@@ -135,7 +136,6 @@ mod tests {
             poll_interval_seconds: None,
             overrides: None,
             allowlist: None,
-            cache: None,
             urls: vec![Url {
                 url: "https://example.com".to_string(),
                 headers: None,
@@ -145,7 +145,7 @@ mod tests {
 
     fn create_test_cache() -> MemoryCache {
         let chains = [create_chain_config(Chain::Ethereum)];
-        MemoryCache::new(CacheConfig { max_memory_mb: 64 }, &create_test_chain_types(), chains.iter())
+        MemoryCache::new(create_test_cache_config(), chains.iter())
     }
 
     fn regular_request(path: &str, method: &str, body: &[u8]) -> RequestType {
@@ -161,7 +161,7 @@ mod tests {
         let cache = create_test_cache();
         let chain = Chain::Ethereum;
 
-        let response = CachedResponse::new(b"test".to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string(), MINUTE);
+        let response = CachedResponse::new(b"test".to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string());
         cache.set(&chain, "test_key".to_string(), response.clone(), MINUTE).await;
 
         let cached = cache.get(&chain, "test_key").await.unwrap();
@@ -183,9 +183,10 @@ mod tests {
 
     #[test]
     fn test_should_cache_with_params() {
-        let chain_types: ChainTypesConfig = serde_json::from_value(serde_json::json!({
-            "ethereum": {
-                "cache": [
+        let config: CacheConfig = serde_json::from_value(serde_json::json!({
+            "max_memory_mb": 64,
+            "chain_types": {
+                "ethereum": [
                     {
                         "path": "/info",
                         "method": "POST",
@@ -199,7 +200,7 @@ mod tests {
         }))
         .unwrap();
         let chains = [create_chain_config(Chain::Ethereum)];
-        let cache = MemoryCache::new(CacheConfig { max_memory_mb: 64 }, &chain_types, chains.iter());
+        let cache = MemoryCache::new(config, chains.iter());
         let chain = Chain::Ethereum;
 
         let ttl = cache.should_cache_request(&chain, &regular_request("/info", "POST", br#"{"type":"metaAndAssetCtxs"}"#));
@@ -210,22 +211,6 @@ mod tests {
 
         let ttl = cache.should_cache_request(&chain, &regular_request("/info", "POST", &[]));
         assert_eq!(ttl, None);
-    }
-
-    #[test]
-    fn test_should_cache_request() {
-        let cache = create_test_cache();
-        let chain = Chain::Ethereum;
-
-        let request = RequestType::JsonRpc(JsonRpcRequest::Single(JsonRpcCall {
-            jsonrpc: "2.0".to_string(),
-            method: "eth_blockNumber".to_string(),
-            params: serde_json::json!([]),
-            id: 1,
-        }));
-
-        let ttl = cache.should_cache_request(&chain, &request);
-        assert_eq!(ttl, Some(MINUTE));
     }
 
     #[test]
@@ -246,9 +231,10 @@ mod tests {
 
     #[test]
     fn test_should_cache_with_function_params() {
-        let chain_types: ChainTypesConfig = serde_json::from_value(serde_json::json!({
-            "aptos": {
-                "cache": [
+        let config: CacheConfig = serde_json::from_value(serde_json::json!({
+            "max_memory_mb": 64,
+            "chain_types": {
+                "aptos": [
                     {
                         "path": "/v1/view",
                         "method": "POST",
@@ -262,7 +248,7 @@ mod tests {
         }))
         .unwrap();
         let chains = [create_chain_config(Chain::Aptos)];
-        let cache = MemoryCache::new(CacheConfig { max_memory_mb: 64 }, &chain_types, chains.iter());
+        let cache = MemoryCache::new(config, chains.iter());
         let chain = Chain::Aptos;
 
         let body1 = r#"{
@@ -301,33 +287,46 @@ mod tests {
 
     #[tokio::test]
     async fn test_eviction() {
-        let config = CacheConfig { max_memory_mb: 0 };
+        let config: CacheConfig = serde_json::from_value(serde_json::json!({ "max_memory_mb": 0 })).unwrap();
         let chains = [create_chain_config(Chain::Ethereum)];
-        let cache = MemoryCache::new(config, &create_test_chain_types(), chains.iter());
+        let cache = MemoryCache::new(config, chains.iter());
         let chain = Chain::Ethereum;
 
-        let response1 = CachedResponse::new(b"first".to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string(), MINUTE);
+        let response1 = CachedResponse::new(b"first".to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string());
         cache.set(&chain, "key1".to_string(), response1, MINUTE).await;
 
-        let response2 = CachedResponse::new(b"second".to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string(), MINUTE);
+        let response2 = CachedResponse::new(b"second".to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string());
         cache.set(&chain, "key2".to_string(), response2, MINUTE).await;
 
         assert!(cache.get(&chain, "key1").await.is_none());
     }
 
     #[test]
-    fn test_chain_cache_replaces_chain_type_cache() {
-        let chain_types = create_test_chain_types();
-        let mut chain_config = create_chain_config(Chain::Ethereum);
-        chain_config.cache = Some(vec![CacheRule {
-            path: None,
-            method: None,
-            rpc_method: Some("eth_getLogs".to_string()),
-            ttl: Some(Duration::from_secs(30)),
-            params: HashMap::new(),
-        }]);
-        let chains = [chain_config];
-        let cache = MemoryCache::new(CacheConfig { max_memory_mb: 64 }, &chain_types, chains.iter());
+    fn test_chain_cache_extends_chain_type_cache() {
+        const CONTRACT: &str = "0x1111111111111111111111111111111111111111";
+        const SELECTOR: &str = "0x1698ee82";
+
+        let config: CacheConfig = serde_json::from_value(serde_json::json!({
+            "max_memory_mb": 64,
+            "chain_types": {
+                "ethereum": [
+                    { "rpc_method": "eth_blockNumber", "ttl": "1m" }
+                ]
+            },
+            "chains": {
+                "ethereum": [
+                    {
+                        "rpc_method": "eth_call",
+                        "contract": CONTRACT,
+                        "selector": SELECTOR,
+                        "ttl": "30s"
+                    }
+                ]
+            }
+        }))
+        .unwrap();
+        let chains = [create_chain_config(Chain::Ethereum)];
+        let cache = MemoryCache::new(config, chains.iter());
 
         assert_eq!(
             cache.should_cache_call(
@@ -339,15 +338,21 @@ mod tests {
                     id: 1,
                 }
             ),
-            None
+            Some(Duration::from_secs(60))
         );
         assert_eq!(
             cache.should_cache_call(
                 &Chain::Ethereum,
                 &JsonRpcCall {
                     jsonrpc: "2.0".to_string(),
-                    method: "eth_getLogs".to_string(),
-                    params: serde_json::json!([]),
+                    method: "eth_call".to_string(),
+                    params: serde_json::json!([
+                        {
+                            "to": CONTRACT,
+                            "data": SELECTOR
+                        },
+                        "latest"
+                    ]),
                     id: 1,
                 }
             ),

--- a/core/apps/dynode/src/cache/types.rs
+++ b/core/apps/dynode/src/cache/types.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn test_cache_entry_with_ttl() {
-        let response = CachedResponse::new(b"test".to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string(), MINUTE);
+        let response = CachedResponse::new(b"test".to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string());
         let entry = CacheEntry::new(response, MINUTE);
 
         assert!(entry.expires_at.is_some());
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn test_cache_entry_without_ttl() {
-        let response = CachedResponse::new(b"test".to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string(), Duration::ZERO);
+        let response = CachedResponse::new(b"test".to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string());
         let entry = CacheEntry::new(response, Duration::ZERO);
 
         assert!(entry.expires_at.is_none());
@@ -56,7 +56,7 @@ mod tests {
     fn test_cache_entry_size() {
         let body = b"hello world".to_vec();
         let content_type = "application/json".to_string();
-        let response = CachedResponse::new(body.clone(), StatusCode::OK.as_u16(), content_type.clone(), MINUTE);
+        let response = CachedResponse::new(body.clone(), StatusCode::OK.as_u16(), content_type.clone());
         let entry = CacheEntry::new(response, MINUTE);
 
         assert_eq!(entry.size(), body.len() + content_type.len() + 64);

--- a/core/apps/dynode/src/config/cache.rs
+++ b/core/apps/dynode/src/config/cache.rs
@@ -31,7 +31,7 @@ impl CacheConfig {
             .chain(self.chains.get(&chain).into_iter().flatten())
             .cloned()
             .collect();
-        let contracts = chain_type_config.and_then(|config| config.contracts.as_ref()).and_then(Contracts::new);
+        let contracts = chain_type_config.and_then(|config| config.contracts.clone()).filter(|contracts| !contracts.is_empty());
 
         let rules = ChainCacheRules { cache, contracts };
         if rules.is_empty() {
@@ -61,7 +61,7 @@ impl ChainCacheRules {
 struct ChainTypeCacheConfig {
     #[serde(default)]
     rules: Vec<CacheRule>,
-    contracts: Option<ContractsConfig>,
+    contracts: Option<Contracts>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -76,21 +76,15 @@ pub(crate) struct CacheRule {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct ContractsConfig {
+struct Contracts {
     addresses: HashSet<String>,
-    methods: HashMap<String, MethodConfig>,
+    methods: HashMap<String, Method>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct MethodConfig {
+struct Method {
     #[serde(deserialize_with = "duration::deserialize")]
     ttl: Duration,
-}
-
-#[derive(Debug, Clone)]
-struct Contracts {
-    addresses: HashSet<String>,
-    methods: HashMap<String, Duration>,
 }
 
 impl CacheRule {
@@ -134,19 +128,8 @@ impl CacheRule {
 }
 
 impl Contracts {
-    fn new(config: &ContractsConfig) -> Option<Self> {
-        let addresses = config.addresses.iter().map(|address| address.to_ascii_lowercase()).collect::<HashSet<_>>();
-        let methods = config
-            .methods
-            .iter()
-            .map(|(method, config)| (method.to_ascii_lowercase(), config.ttl))
-            .collect::<HashMap<_, _>>();
-
-        if addresses.is_empty() || methods.is_empty() {
-            return None;
-        }
-
-        Some(Self { addresses, methods })
+    fn is_empty(&self) -> bool {
+        self.addresses.is_empty() || self.methods.is_empty()
     }
 
     fn ttl(&self, call: &JsonRpcCall) -> Option<Duration> {
@@ -164,13 +147,13 @@ impl Contracts {
             return None;
         }
 
-        let address = call.get("to")?.as_str()?.to_ascii_lowercase();
-        if !self.addresses.contains(&address) {
+        let address = call.get("to")?.as_str()?;
+        if !self.addresses.contains(address) {
             return None;
         }
 
-        let method = call.get("data")?.as_str()?.get(..10)?.to_ascii_lowercase();
-        self.methods.get(&method).copied()
+        let method = call.get("data")?.as_str()?.get(..10)?;
+        self.methods.get(method).map(|method| method.ttl)
     }
 }
 
@@ -212,33 +195,41 @@ mod tests {
     fn test_contract_call_matching() {
         let rules = Contracts {
             addresses: HashSet::from([CONTRACT.to_string()]),
-            methods: HashMap::from([("0x1698ee82".to_string(), MINUTE)]),
+            methods: HashMap::from([("0x1698ee82".to_string(), Method { ttl: MINUTE })]),
         };
         let wrong_block = serde_json::json!([{ "to": CONTRACT, "data": "0x1698ee820000" }, "pending"]);
 
-        assert_eq!(rules.ttl(&jsonrpc_call(eth_call_params(CONTRACT, "0x1698ee820000"))), Some(MINUTE));
         assert_eq!(
-            rules.ttl(&jsonrpc_call(eth_call_params(&CONTRACT.to_uppercase().replacen("0X", "0x", 1), "0x1698EE820000"))),
+            rules.ttl(&JsonRpcCall::mock_with_params(1, ETH_CALL, eth_call_params(CONTRACT, "0x1698ee820000"))),
             Some(MINUTE)
         );
-        assert_eq!(rules.ttl(&jsonrpc_call(wrong_block)), None);
+        assert_eq!(rules.ttl(&JsonRpcCall::mock_with_params(1, ETH_CALL, eth_call_params(CONTRACT, "0x1698EE820000"))), None);
+        assert_eq!(rules.ttl(&JsonRpcCall::mock_with_params(1, ETH_CALL, wrong_block)), None);
         assert_eq!(
-            rules.ttl(&jsonrpc_call(eth_call_params("0x2222222222222222222222222222222222222222", "0x1698ee820000"))),
+            rules.ttl(&JsonRpcCall::mock_with_params(
+                1,
+                ETH_CALL,
+                eth_call_params("0x2222222222222222222222222222222222222222", "0x1698ee820000")
+            )),
             None
         );
-        assert_eq!(rules.ttl(&jsonrpc_call(eth_call_params(CONTRACT, "0xaa9d21cb0000"))), None);
+        assert_eq!(rules.ttl(&JsonRpcCall::mock_with_params(1, ETH_CALL, eth_call_params(CONTRACT, "0xaa9d21cb0000"))), None);
         assert_eq!(
-            rules.ttl(&jsonrpc_call(serde_json::json!([
-                {
-                    "to": CONTRACT,
-                    "data": "0x1698ee82",
-                    "value": "0x1"
-                },
-                "latest"
-            ]))),
+            rules.ttl(&JsonRpcCall::mock_with_params(
+                1,
+                ETH_CALL,
+                serde_json::json!([
+                    {
+                        "to": CONTRACT,
+                        "data": "0x1698ee82",
+                        "value": "0x1"
+                    },
+                    "latest"
+                ])
+            )),
             None
         );
-        assert_eq!(rules.ttl(&jsonrpc_call(eth_call_params(CONTRACT, "0x1698"))), None);
+        assert_eq!(rules.ttl(&JsonRpcCall::mock_with_params(1, ETH_CALL, eth_call_params(CONTRACT, "0x1698"))), None);
     }
 
     #[test]
@@ -262,13 +253,12 @@ mod tests {
 
     #[test]
     fn test_contract_call_config_resolves_by_chain_type() {
-        let uppercase_contract = CONTRACT.to_uppercase().replacen("0X", "0x", 1);
         let config: CacheConfig = serde_json::from_value(serde_json::json!({
             "max_memory": "64 MB",
             "chain_types": {
                 "ethereum": {
                     "contracts": {
-                        "addresses": [CONTRACT, uppercase_contract],
+                        "addresses": [CONTRACT],
                         "methods": {
                             "0x1698ee82": {
                                 "ttl": "5m"
@@ -284,20 +274,17 @@ mod tests {
         assert_eq!(config.max_memory, 64_000_000);
         assert_eq!(ethereum.contracts.as_ref().unwrap().addresses.len(), 1);
         assert_eq!(ethereum.contracts.as_ref().unwrap().methods.len(), 1);
-        assert_eq!(ethereum.ttl(&jsonrpc_call(eth_call_params(CONTRACT, "0x1698ee82"))), Some(MINUTE * 5));
         assert_eq!(
-            config.rules(Chain::Optimism).unwrap().ttl(&jsonrpc_call(eth_call_params(CONTRACT, "0x1698ee82"))),
+            ethereum.ttl(&JsonRpcCall::mock_with_params(1, ETH_CALL, eth_call_params(CONTRACT, "0x1698ee82"))),
+            Some(MINUTE * 5)
+        );
+        assert_eq!(
+            config
+                .rules(Chain::Optimism)
+                .unwrap()
+                .ttl(&JsonRpcCall::mock_with_params(1, ETH_CALL, eth_call_params(CONTRACT, "0x1698ee82"))),
             Some(MINUTE * 5)
         );
         assert!(config.rules(Chain::Solana).is_none());
-    }
-
-    fn jsonrpc_call(params: Value) -> JsonRpcCall {
-        JsonRpcCall {
-            jsonrpc: "2.0".to_string(),
-            method: ETH_CALL.to_string(),
-            params,
-            id: 1,
-        }
     }
 }

--- a/core/apps/dynode/src/config/cache.rs
+++ b/core/apps/dynode/src/config/cache.rs
@@ -17,18 +17,40 @@ pub struct CacheConfig {
     chain_types: HashMap<ChainType, Vec<CacheRule>>,
     #[serde(default)]
     chains: HashMap<Chain, Vec<CacheRule>>,
+    #[serde(default)]
+    evm_calls: Vec<EvmCallConfig>,
 }
 
 impl CacheConfig {
-    pub(crate) fn rules(&self, chain: Chain) -> Vec<CacheRule> {
-        self.chain_types
+    pub(crate) fn rules(&self, chain: Chain) -> ChainCacheRules {
+        let cache = self
+            .chain_types
             .get(&chain.chain_type())
             .into_iter()
             .flatten()
             .chain(self.chains.get(&chain).into_iter().flatten())
             .cloned()
-            .collect()
+            .collect();
+        let evm_calls = self
+            .evm_calls
+            .iter()
+            .filter_map(|config| {
+                config.contracts.get(&chain).map(|contract| EvmCallRule {
+                    contract: contract.clone(),
+                    selector: config.selector.clone(),
+                    ttl: config.ttl,
+                })
+            })
+            .collect();
+
+        ChainCacheRules { cache, evm_calls }
     }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ChainCacheRules {
+    pub(crate) cache: Vec<CacheRule>,
+    pub(crate) evm_calls: Vec<EvmCallRule>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -36,12 +58,25 @@ pub(crate) struct CacheRule {
     pub(crate) path: Option<String>,
     pub(crate) method: Option<String>,
     pub(crate) rpc_method: Option<String>,
-    pub(crate) contract: Option<String>,
-    pub(crate) selector: Option<String>,
     #[serde(default, alias = "ttl_seconds", deserialize_with = "duration::deserialize_option")]
     pub(crate) ttl: Option<Duration>,
     #[serde(default)]
     pub(crate) params: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct EvmCallConfig {
+    selector: String,
+    #[serde(deserialize_with = "duration::deserialize")]
+    ttl: Duration,
+    contracts: HashMap<Chain, String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct EvmCallRule {
+    contract: String,
+    selector: String,
+    pub(crate) ttl: Duration,
 }
 
 impl CacheRule {
@@ -59,18 +94,8 @@ impl CacheRule {
         path_without_query(path) == rule_path && self.matches_body(body)
     }
 
-    pub(crate) fn matches_rpc(&self, rpc_method: &str, params: &Value) -> bool {
-        if self.rpc_method.as_deref() != Some(rpc_method) {
-            return false;
-        }
-        if rpc_method != ETH_CALL {
-            return true;
-        }
-
-        let (Some(contract), Some(selector)) = (&self.contract, &self.selector) else {
-            return false;
-        };
-        matches_evm_call(params, contract, selector)
+    pub(crate) fn matches_rpc(&self, rpc_method: &str) -> bool {
+        rpc_method != ETH_CALL && self.rpc_method.as_deref() == Some(rpc_method)
     }
 
     fn matches_body(&self, body: Option<&[u8]>) -> bool {
@@ -91,6 +116,12 @@ impl CacheRule {
         };
 
         self.params.iter().all(|(key, expected)| object.get(key) == Some(expected))
+    }
+}
+
+impl EvmCallRule {
+    pub(crate) fn matches(&self, params: &Value) -> bool {
+        matches_evm_call(params, &self.contract, &self.selector)
     }
 }
 
@@ -130,14 +161,12 @@ mod tests {
 
     const CONTRACT: &str = "0x1111111111111111111111111111111111111111";
 
-    fn evm_call_rule(selector: &str) -> CacheRule {
-        serde_json::from_value(serde_json::json!({
-            "rpc_method": "eth_call",
-            "contract": CONTRACT,
-            "selector": selector,
-            "ttl": "1h"
-        }))
-        .unwrap()
+    fn evm_call_rule(selector: &str) -> EvmCallRule {
+        EvmCallRule {
+            contract: CONTRACT.to_string(),
+            selector: selector.to_string(),
+            ttl: Duration::from_secs(60 * 60),
+        }
     }
 
     fn eth_call_params(contract: &str, data: &str) -> Value {
@@ -172,40 +201,21 @@ mod tests {
         let rule = evm_call_rule("0x1698ee82");
         let wrong_block = serde_json::json!([{ "to": CONTRACT, "data": "0x1698ee820000" }, "pending"]);
 
-        assert!(rule.matches_rpc(ETH_CALL, &eth_call_params(CONTRACT, "0x1698ee820000")));
-        assert!(rule.matches_rpc(ETH_CALL, &eth_call_params(&CONTRACT.to_uppercase().replacen("0X", "0x", 1), "0x1698EE820000")));
-        assert!(!rule.matches_rpc("eth_estimateGas", &eth_call_params(CONTRACT, "0x1698ee820000")));
-        assert!(!rule.matches_rpc(ETH_CALL, &wrong_block));
-        assert!(!rule.matches_rpc(ETH_CALL, &eth_call_params("0x2222222222222222222222222222222222222222", "0x1698ee820000")));
-        assert!(!rule.matches_rpc(ETH_CALL, &eth_call_params(CONTRACT, "0xaa9d21cb0000")));
-        assert!(!rule.matches_rpc(
-            ETH_CALL,
-            &serde_json::json!([
-                {
-                    "to": CONTRACT,
-                    "data": "0x1698ee82",
-                    "value": "0x1"
-                },
-                "latest"
-            ])
-        ));
+        assert!(rule.matches(&eth_call_params(CONTRACT, "0x1698ee820000")));
+        assert!(rule.matches(&eth_call_params(&CONTRACT.to_uppercase().replacen("0X", "0x", 1), "0x1698EE820000")));
+        assert!(!rule.matches(&wrong_block));
+        assert!(!rule.matches(&eth_call_params("0x2222222222222222222222222222222222222222", "0x1698ee820000")));
+        assert!(!rule.matches(&eth_call_params(CONTRACT, "0xaa9d21cb0000")));
+        assert!(!rule.matches(&serde_json::json!([
+            {
+                "to": CONTRACT,
+                "data": "0x1698ee82",
+                "value": "0x1"
+            },
+            "latest"
+        ])));
 
-        let method_only: CacheRule = serde_json::from_value(serde_json::json!({
-            "rpc_method": "eth_call",
-            "ttl": "1h"
-        }))
-        .unwrap();
-        let params = eth_call_params(CONTRACT, "0x1698ee82");
-
-        assert!(!method_only.matches_rpc(ETH_CALL, &params));
-        let invalid_selector: CacheRule = serde_json::from_value(serde_json::json!({
-            "rpc_method": "eth_call",
-            "contract": CONTRACT,
-            "selector": "0x1698",
-            "ttl": "1h"
-        }))
-        .unwrap();
-        assert!(!invalid_selector.matches_rpc(ETH_CALL, &params));
+        assert!(!evm_call_rule("0x1698").matches(&eth_call_params(CONTRACT, "0x1698ee82")));
     }
 
     #[test]
@@ -216,7 +226,35 @@ mod tests {
         }))
         .unwrap();
 
-        assert!(rule.matches_rpc("eth_chainId", &Value::Null));
-        assert!(!rule.matches_rpc("eth_blockNumber", &Value::Null));
+        assert!(rule.matches_rpc("eth_chainId"));
+        assert!(!rule.matches_rpc("eth_blockNumber"));
+
+        let broad_evm_rule: CacheRule = serde_json::from_value(serde_json::json!({
+            "rpc_method": "eth_call",
+            "ttl": "1h"
+        }))
+        .unwrap();
+        assert!(!broad_evm_rule.matches_rpc(ETH_CALL));
+    }
+
+    #[test]
+    fn test_evm_call_config_resolves_contract_by_chain() {
+        let config: CacheConfig = serde_json::from_value(serde_json::json!({
+            "max_memory_mb": 64,
+            "evm_calls": [{
+                "selector": "0x1698ee82",
+                "ttl": "5m",
+                "contracts": {
+                    "ethereum": CONTRACT
+                }
+            }]
+        }))
+        .unwrap();
+
+        let ethereum = config.rules(Chain::Ethereum);
+        assert_eq!(ethereum.evm_calls.len(), 1);
+        assert_eq!(ethereum.evm_calls[0].ttl, MINUTE * 5);
+        assert!(ethereum.evm_calls[0].matches(&eth_call_params(CONTRACT, "0x1698ee82")));
+        assert!(config.rules(Chain::Optimism).evm_calls.is_empty());
     }
 }

--- a/core/apps/dynode/src/config/cache.rs
+++ b/core/apps/dynode/src/config/cache.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use primitives::{Chain, ChainType};
 use serde::Deserialize;
 use serde_json::Value;
-use serde_serializers::duration;
+use serde_serializers::{duration, size};
 
 use super::path_without_query;
 
@@ -12,17 +12,18 @@ pub(crate) const ETH_CALL: &str = "eth_call";
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct CacheConfig {
-    pub max_memory_mb: usize,
+    #[serde(deserialize_with = "size::deserialize")]
+    pub max_memory: usize,
     #[serde(default)]
     chain_types: HashMap<ChainType, Vec<CacheRule>>,
     #[serde(default)]
     chains: HashMap<Chain, Vec<CacheRule>>,
     #[serde(default)]
-    evm_calls: Vec<EvmCallConfig>,
+    evm_calls: HashMap<ChainType, EvmCallConfig>,
 }
 
 impl CacheConfig {
-    pub(crate) fn rules(&self, chain: Chain) -> ChainCacheRules {
+    pub(crate) fn rules(&self, chain: Chain) -> Option<ChainCacheRules> {
         let cache = self
             .chain_types
             .get(&chain.chain_type())
@@ -31,26 +32,30 @@ impl CacheConfig {
             .chain(self.chains.get(&chain).into_iter().flatten())
             .cloned()
             .collect();
-        let evm_calls = self
-            .evm_calls
-            .iter()
-            .filter_map(|config| {
-                config.contracts.get(&chain).map(|contract| EvmCallRule {
-                    contract: contract.clone(),
-                    selector: config.selector.clone(),
-                    ttl: config.ttl,
-                })
-            })
-            .collect();
+        let evm_calls = self.evm_calls.get(&chain.chain_type()).map(EvmCallRules::from).unwrap_or_default();
 
-        ChainCacheRules { cache, evm_calls }
+        let rules = ChainCacheRules { cache, evm_calls };
+        if rules.is_empty() {
+            return None;
+        }
+        Some(rules)
     }
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct ChainCacheRules {
     pub(crate) cache: Vec<CacheRule>,
-    pub(crate) evm_calls: Vec<EvmCallRule>,
+    evm_calls: EvmCallRules,
+}
+
+impl ChainCacheRules {
+    fn is_empty(&self) -> bool {
+        self.cache.is_empty() && self.evm_calls.is_empty()
+    }
+
+    pub(crate) fn evm_call_ttl(&self, params: &Value) -> Option<Duration> {
+        self.evm_calls.ttl_for_params(params)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -66,17 +71,20 @@ pub(crate) struct CacheRule {
 
 #[derive(Debug, Clone, Deserialize)]
 struct EvmCallConfig {
-    selector: String,
-    #[serde(deserialize_with = "duration::deserialize")]
-    ttl: Duration,
-    contracts: HashMap<Chain, String>,
+    contracts: HashSet<String>,
+    selectors: HashMap<String, EvmSelectorConfig>,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct EvmCallRule {
-    contract: String,
-    selector: String,
-    pub(crate) ttl: Duration,
+#[derive(Debug, Clone, Deserialize)]
+struct EvmSelectorConfig {
+    #[serde(deserialize_with = "duration::deserialize")]
+    ttl: Duration,
+}
+
+#[derive(Debug, Default, Clone)]
+struct EvmCallRules {
+    contracts: HashSet<[u8; 20]>,
+    selectors: HashMap<[u8; 4], Duration>,
 }
 
 impl CacheRule {
@@ -119,39 +127,49 @@ impl CacheRule {
     }
 }
 
-impl EvmCallRule {
-    pub(crate) fn matches(&self, params: &Value) -> bool {
-        matches_evm_call(params, &self.contract, &self.selector)
+impl From<&EvmCallConfig> for EvmCallRules {
+    fn from(config: &EvmCallConfig) -> Self {
+        Self {
+            contracts: config.contracts.iter().filter_map(|contract| decode_hex(contract)).collect(),
+            selectors: config
+                .selectors
+                .iter()
+                .filter_map(|(selector, config)| decode_hex(selector).map(|selector| (selector, config.ttl)))
+                .collect(),
+        }
     }
 }
 
-fn matches_evm_call(params: &Value, contract: &str, selector: &str) -> bool {
-    if !is_hex(contract, 42) || !is_hex(selector, 10) {
-        return false;
+impl EvmCallRules {
+    fn is_empty(&self) -> bool {
+        self.contracts.is_empty() || self.selectors.is_empty()
     }
-    let Some(params) = params.as_array() else {
-        return false;
-    };
-    if params.len() != 2 || params.get(1).and_then(Value::as_str) != Some("latest") {
-        return false;
+
+    fn ttl_for_params(&self, params: &Value) -> Option<Duration> {
+        let params = params.as_array()?;
+        if params.len() != 2 || params.get(1).and_then(Value::as_str) != Some("latest") {
+            return None;
+        }
+
+        let call = params.first()?.as_object()?;
+        if call.len() != 2 {
+            return None;
+        }
+
+        let contract = decode_hex(call.get("to")?.as_str()?)?;
+        if !self.contracts.contains(&contract) {
+            return None;
+        }
+
+        let selector = decode_hex(call.get("data")?.as_str()?.get(..10)?)?;
+        self.selectors.get(&selector).copied()
     }
-    let Some(call) = params.first().and_then(Value::as_object) else {
-        return false;
-    };
-    let Some(call_contract) = call.get("to").and_then(Value::as_str) else {
-        return false;
-    };
-    let Some(data) = call.get("data").and_then(Value::as_str) else {
-        return false;
-    };
-    let Some(call_selector) = data.get(..10) else {
-        return false;
-    };
-    call.len() == 2 && is_hex(call_contract, 42) && is_hex(call_selector, 10) && call_contract.eq_ignore_ascii_case(contract) && call_selector.eq_ignore_ascii_case(selector)
 }
 
-fn is_hex(value: &str, length: usize) -> bool {
-    value.len() == length && value.starts_with("0x") && value[2..].bytes().all(|byte| byte.is_ascii_hexdigit())
+fn decode_hex<const N: usize>(value: &str) -> Option<[u8; N]> {
+    let mut bytes = [0; N];
+    hex::decode_to_slice(value.strip_prefix("0x")?, &mut bytes).ok()?;
+    Some(bytes)
 }
 
 #[cfg(test)]
@@ -160,14 +178,6 @@ mod tests {
     use primitives::MINUTE;
 
     const CONTRACT: &str = "0x1111111111111111111111111111111111111111";
-
-    fn evm_call_rule(selector: &str) -> EvmCallRule {
-        EvmCallRule {
-            contract: CONTRACT.to_string(),
-            selector: selector.to_string(),
-            ttl: Duration::from_secs(60 * 60),
-        }
-    }
 
     fn eth_call_params(contract: &str, data: &str) -> Value {
         serde_json::json!([{ "to": contract, "data": data }, "latest"])
@@ -198,24 +208,32 @@ mod tests {
 
     #[test]
     fn test_static_evm_call_matching() {
-        let rule = evm_call_rule("0x1698ee82");
+        let rules = EvmCallRules {
+            contracts: HashSet::from([decode_hex(CONTRACT).unwrap()]),
+            selectors: HashMap::from([(decode_hex("0x1698ee82").unwrap(), MINUTE)]),
+        };
         let wrong_block = serde_json::json!([{ "to": CONTRACT, "data": "0x1698ee820000" }, "pending"]);
 
-        assert!(rule.matches(&eth_call_params(CONTRACT, "0x1698ee820000")));
-        assert!(rule.matches(&eth_call_params(&CONTRACT.to_uppercase().replacen("0X", "0x", 1), "0x1698EE820000")));
-        assert!(!rule.matches(&wrong_block));
-        assert!(!rule.matches(&eth_call_params("0x2222222222222222222222222222222222222222", "0x1698ee820000")));
-        assert!(!rule.matches(&eth_call_params(CONTRACT, "0xaa9d21cb0000")));
-        assert!(!rule.matches(&serde_json::json!([
-            {
-                "to": CONTRACT,
-                "data": "0x1698ee82",
-                "value": "0x1"
-            },
-            "latest"
-        ])));
-
-        assert!(!evm_call_rule("0x1698").matches(&eth_call_params(CONTRACT, "0x1698ee82")));
+        assert_eq!(rules.ttl_for_params(&eth_call_params(CONTRACT, "0x1698ee820000")), Some(MINUTE));
+        assert_eq!(
+            rules.ttl_for_params(&eth_call_params(&CONTRACT.to_uppercase().replacen("0X", "0x", 1), "0x1698EE820000")),
+            Some(MINUTE)
+        );
+        assert_eq!(rules.ttl_for_params(&wrong_block), None);
+        assert_eq!(rules.ttl_for_params(&eth_call_params("0x2222222222222222222222222222222222222222", "0x1698ee820000")), None);
+        assert_eq!(rules.ttl_for_params(&eth_call_params(CONTRACT, "0xaa9d21cb0000")), None);
+        assert_eq!(
+            rules.ttl_for_params(&serde_json::json!([
+                {
+                    "to": CONTRACT,
+                    "data": "0x1698ee82",
+                    "value": "0x1"
+                },
+                "latest"
+            ])),
+            None
+        );
+        assert_eq!(decode_hex::<4>("0x1698"), None);
     }
 
     #[test]
@@ -238,23 +256,32 @@ mod tests {
     }
 
     #[test]
-    fn test_evm_call_config_resolves_contract_by_chain() {
+    fn test_evm_call_config_resolves_contract_by_chain_type() {
+        let uppercase_contract = CONTRACT.to_uppercase().replacen("0X", "0x", 1);
         let config: CacheConfig = serde_json::from_value(serde_json::json!({
-            "max_memory_mb": 64,
-            "evm_calls": [{
-                "selector": "0x1698ee82",
-                "ttl": "5m",
-                "contracts": {
-                    "ethereum": CONTRACT
+            "max_memory": "64 MB",
+            "evm_calls": {
+                "ethereum": {
+                    "contracts": [CONTRACT, uppercase_contract],
+                    "selectors": {
+                        "0x1698ee82": {
+                            "ttl": "5m"
+                        }
+                    }
                 }
-            }]
+            }
         }))
         .unwrap();
 
-        let ethereum = config.rules(Chain::Ethereum);
-        assert_eq!(ethereum.evm_calls.len(), 1);
-        assert_eq!(ethereum.evm_calls[0].ttl, MINUTE * 5);
-        assert!(ethereum.evm_calls[0].matches(&eth_call_params(CONTRACT, "0x1698ee82")));
-        assert!(config.rules(Chain::Optimism).evm_calls.is_empty());
+        let ethereum = config.rules(Chain::Ethereum).unwrap();
+        assert_eq!(config.max_memory, 64_000_000);
+        assert_eq!(ethereum.evm_calls.contracts.len(), 1);
+        assert_eq!(ethereum.evm_calls.selectors.len(), 1);
+        assert_eq!(ethereum.evm_call_ttl(&eth_call_params(CONTRACT, "0x1698ee82")), Some(MINUTE * 5));
+        assert_eq!(
+            config.rules(Chain::Optimism).unwrap().evm_call_ttl(&eth_call_params(CONTRACT, "0x1698ee82")),
+            Some(MINUTE * 5)
+        );
+        assert!(config.rules(Chain::Solana).is_none());
     }
 }

--- a/core/apps/dynode/src/config/cache.rs
+++ b/core/apps/dynode/src/config/cache.rs
@@ -1,23 +1,43 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use primitives::{Chain, ChainType};
 use serde::Deserialize;
 use serde_json::Value;
 use serde_serializers::duration;
 
 use super::path_without_query;
 
+pub(crate) const ETH_CALL: &str = "eth_call";
+
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct CacheConfig {
-    #[serde(default)]
     pub max_memory_mb: usize,
+    #[serde(default)]
+    chain_types: HashMap<ChainType, Vec<CacheRule>>,
+    #[serde(default)]
+    chains: HashMap<Chain, Vec<CacheRule>>,
+}
+
+impl CacheConfig {
+    pub(crate) fn rules(&self, chain: Chain) -> Vec<CacheRule> {
+        self.chain_types
+            .get(&chain.chain_type())
+            .into_iter()
+            .flatten()
+            .chain(self.chains.get(&chain).into_iter().flatten())
+            .cloned()
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct CacheRule {
+pub(crate) struct CacheRule {
     pub(crate) path: Option<String>,
     pub(crate) method: Option<String>,
     pub(crate) rpc_method: Option<String>,
+    pub(crate) contract: Option<String>,
+    pub(crate) selector: Option<String>,
     #[serde(default, alias = "ttl_seconds", deserialize_with = "duration::deserialize_option")]
     pub(crate) ttl: Option<Duration>,
     #[serde(default)]
@@ -39,8 +59,18 @@ impl CacheRule {
         path_without_query(path) == rule_path && self.matches_body(body)
     }
 
-    pub(crate) fn matches_rpc(&self, rpc_method: &str) -> bool {
-        self.rpc_method.as_ref().is_some_and(|m| m == rpc_method)
+    pub(crate) fn matches_rpc(&self, rpc_method: &str, params: &Value) -> bool {
+        if self.rpc_method.as_deref() != Some(rpc_method) {
+            return false;
+        }
+        if rpc_method != ETH_CALL {
+            return true;
+        }
+
+        let (Some(contract), Some(selector)) = (&self.contract, &self.selector) else {
+            return false;
+        };
+        matches_evm_call(params, contract, selector)
     }
 
     fn matches_body(&self, body: Option<&[u8]>) -> bool {
@@ -60,14 +90,59 @@ impl CacheRule {
             return false;
         };
 
-        self.params.iter().all(|(key, expected)| object.get(key).map(|actual| actual == expected).unwrap_or(false))
+        self.params.iter().all(|(key, expected)| object.get(key) == Some(expected))
     }
+}
+
+fn matches_evm_call(params: &Value, contract: &str, selector: &str) -> bool {
+    if !is_hex(contract, 42) || !is_hex(selector, 10) {
+        return false;
+    }
+    let Some(params) = params.as_array() else {
+        return false;
+    };
+    if params.len() != 2 || params.get(1).and_then(Value::as_str) != Some("latest") {
+        return false;
+    }
+    let Some(call) = params.first().and_then(Value::as_object) else {
+        return false;
+    };
+    let Some(call_contract) = call.get("to").and_then(Value::as_str) else {
+        return false;
+    };
+    let Some(data) = call.get("data").and_then(Value::as_str) else {
+        return false;
+    };
+    let Some(call_selector) = data.get(..10) else {
+        return false;
+    };
+    call.len() == 2 && is_hex(call_contract, 42) && is_hex(call_selector, 10) && call_contract.eq_ignore_ascii_case(contract) && call_selector.eq_ignore_ascii_case(selector)
+}
+
+fn is_hex(value: &str, length: usize) -> bool {
+    value.len() == length && value.starts_with("0x") && value[2..].bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use primitives::MINUTE;
+
+    const CONTRACT: &str = "0x1111111111111111111111111111111111111111";
+
+    fn evm_call_rule(selector: &str) -> CacheRule {
+        serde_json::from_value(serde_json::json!({
+            "rpc_method": "eth_call",
+            "contract": CONTRACT,
+            "selector": selector,
+            "ttl": "1h"
+        }))
+        .unwrap()
+    }
+
+    fn eth_call_params(contract: &str, data: &str) -> Value {
+        serde_json::json!([{ "to": contract, "data": data }, "latest"])
+    }
 
     #[test]
     fn test_ttl_default_none() {
@@ -90,5 +165,58 @@ mod tests {
         .unwrap();
 
         assert_eq!(rule.ttl, Some(MINUTE));
+    }
+
+    #[test]
+    fn test_static_evm_call_matching() {
+        let rule = evm_call_rule("0x1698ee82");
+        let wrong_block = serde_json::json!([{ "to": CONTRACT, "data": "0x1698ee820000" }, "pending"]);
+
+        assert!(rule.matches_rpc(ETH_CALL, &eth_call_params(CONTRACT, "0x1698ee820000")));
+        assert!(rule.matches_rpc(ETH_CALL, &eth_call_params(&CONTRACT.to_uppercase().replacen("0X", "0x", 1), "0x1698EE820000")));
+        assert!(!rule.matches_rpc("eth_estimateGas", &eth_call_params(CONTRACT, "0x1698ee820000")));
+        assert!(!rule.matches_rpc(ETH_CALL, &wrong_block));
+        assert!(!rule.matches_rpc(ETH_CALL, &eth_call_params("0x2222222222222222222222222222222222222222", "0x1698ee820000")));
+        assert!(!rule.matches_rpc(ETH_CALL, &eth_call_params(CONTRACT, "0xaa9d21cb0000")));
+        assert!(!rule.matches_rpc(
+            ETH_CALL,
+            &serde_json::json!([
+                {
+                    "to": CONTRACT,
+                    "data": "0x1698ee82",
+                    "value": "0x1"
+                },
+                "latest"
+            ])
+        ));
+
+        let method_only: CacheRule = serde_json::from_value(serde_json::json!({
+            "rpc_method": "eth_call",
+            "ttl": "1h"
+        }))
+        .unwrap();
+        let params = eth_call_params(CONTRACT, "0x1698ee82");
+
+        assert!(!method_only.matches_rpc(ETH_CALL, &params));
+        let invalid_selector: CacheRule = serde_json::from_value(serde_json::json!({
+            "rpc_method": "eth_call",
+            "contract": CONTRACT,
+            "selector": "0x1698",
+            "ttl": "1h"
+        }))
+        .unwrap();
+        assert!(!invalid_selector.matches_rpc(ETH_CALL, &params));
+    }
+
+    #[test]
+    fn test_legacy_rpc_rule_compatibility() {
+        let rule: CacheRule = serde_json::from_value(serde_json::json!({
+            "rpc_method": "eth_chainId",
+            "ttl": "1h"
+        }))
+        .unwrap();
+
+        assert!(rule.matches_rpc("eth_chainId", &Value::Null));
+        assert!(!rule.matches_rpc("eth_blockNumber", &Value::Null));
     }
 }

--- a/core/apps/dynode/src/config/cache.rs
+++ b/core/apps/dynode/src/config/cache.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use serde_serializers::{duration, size};
 
 use super::path_without_query;
+use crate::jsonrpc_types::JsonRpcCall;
 
 pub(crate) const ETH_CALL: &str = "eth_call";
 
@@ -15,26 +16,24 @@ pub struct CacheConfig {
     #[serde(deserialize_with = "size::deserialize")]
     pub max_memory: usize,
     #[serde(default)]
-    chain_types: HashMap<ChainType, Vec<CacheRule>>,
+    chain_types: HashMap<ChainType, ChainTypeCacheConfig>,
     #[serde(default)]
     chains: HashMap<Chain, Vec<CacheRule>>,
-    #[serde(default)]
-    evm_calls: HashMap<ChainType, EvmCallConfig>,
 }
 
 impl CacheConfig {
     pub(crate) fn rules(&self, chain: Chain) -> Option<ChainCacheRules> {
-        let cache = self
-            .chain_types
-            .get(&chain.chain_type())
+        let chain_type = chain.chain_type();
+        let chain_type_config = self.chain_types.get(&chain_type);
+        let cache = chain_type_config
             .into_iter()
-            .flatten()
+            .flat_map(|config| &config.rules)
             .chain(self.chains.get(&chain).into_iter().flatten())
             .cloned()
             .collect();
-        let evm_calls = self.evm_calls.get(&chain.chain_type()).map(EvmCallRules::from).unwrap_or_default();
+        let contracts = chain_type_config.and_then(|config| config.contracts.as_ref()).and_then(Contracts::new);
 
-        let rules = ChainCacheRules { cache, evm_calls };
+        let rules = ChainCacheRules { cache, contracts };
         if rules.is_empty() {
             return None;
         }
@@ -45,17 +44,24 @@ impl CacheConfig {
 #[derive(Debug, Clone)]
 pub(crate) struct ChainCacheRules {
     pub(crate) cache: Vec<CacheRule>,
-    evm_calls: EvmCallRules,
+    contracts: Option<Contracts>,
 }
 
 impl ChainCacheRules {
     fn is_empty(&self) -> bool {
-        self.cache.is_empty() && self.evm_calls.is_empty()
+        self.cache.is_empty() && self.contracts.is_none()
     }
 
-    pub(crate) fn evm_call_ttl(&self, params: &Value) -> Option<Duration> {
-        self.evm_calls.ttl_for_params(params)
+    pub(crate) fn ttl(&self, call: &JsonRpcCall) -> Option<Duration> {
+        self.contracts.as_ref()?.ttl(call)
     }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ChainTypeCacheConfig {
+    #[serde(default)]
+    rules: Vec<CacheRule>,
+    contracts: Option<ContractsConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -70,21 +76,21 @@ pub(crate) struct CacheRule {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct EvmCallConfig {
-    contracts: HashSet<String>,
-    selectors: HashMap<String, EvmSelectorConfig>,
+struct ContractsConfig {
+    addresses: HashSet<String>,
+    methods: HashMap<String, MethodConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct EvmSelectorConfig {
+struct MethodConfig {
     #[serde(deserialize_with = "duration::deserialize")]
     ttl: Duration,
 }
 
-#[derive(Debug, Default, Clone)]
-struct EvmCallRules {
-    contracts: HashSet<[u8; 20]>,
-    selectors: HashMap<[u8; 4], Duration>,
+#[derive(Debug, Clone)]
+struct Contracts {
+    addresses: HashSet<String>,
+    methods: HashMap<String, Duration>,
 }
 
 impl CacheRule {
@@ -127,26 +133,28 @@ impl CacheRule {
     }
 }
 
-impl From<&EvmCallConfig> for EvmCallRules {
-    fn from(config: &EvmCallConfig) -> Self {
-        Self {
-            contracts: config.contracts.iter().filter_map(|contract| decode_hex(contract)).collect(),
-            selectors: config
-                .selectors
-                .iter()
-                .filter_map(|(selector, config)| decode_hex(selector).map(|selector| (selector, config.ttl)))
-                .collect(),
+impl Contracts {
+    fn new(config: &ContractsConfig) -> Option<Self> {
+        let addresses = config.addresses.iter().map(|address| address.to_ascii_lowercase()).collect::<HashSet<_>>();
+        let methods = config
+            .methods
+            .iter()
+            .map(|(method, config)| (method.to_ascii_lowercase(), config.ttl))
+            .collect::<HashMap<_, _>>();
+
+        if addresses.is_empty() || methods.is_empty() {
+            return None;
         }
-    }
-}
 
-impl EvmCallRules {
-    fn is_empty(&self) -> bool {
-        self.contracts.is_empty() || self.selectors.is_empty()
+        Some(Self { addresses, methods })
     }
 
-    fn ttl_for_params(&self, params: &Value) -> Option<Duration> {
-        let params = params.as_array()?;
+    fn ttl(&self, call: &JsonRpcCall) -> Option<Duration> {
+        if call.method != ETH_CALL {
+            return None;
+        }
+
+        let params = call.params.as_array()?;
         if params.len() != 2 || params.get(1).and_then(Value::as_str) != Some("latest") {
             return None;
         }
@@ -156,20 +164,14 @@ impl EvmCallRules {
             return None;
         }
 
-        let contract = decode_hex(call.get("to")?.as_str()?)?;
-        if !self.contracts.contains(&contract) {
+        let address = call.get("to")?.as_str()?.to_ascii_lowercase();
+        if !self.addresses.contains(&address) {
             return None;
         }
 
-        let selector = decode_hex(call.get("data")?.as_str()?.get(..10)?)?;
-        self.selectors.get(&selector).copied()
+        let method = call.get("data")?.as_str()?.get(..10)?.to_ascii_lowercase();
+        self.methods.get(&method).copied()
     }
-}
-
-fn decode_hex<const N: usize>(value: &str) -> Option<[u8; N]> {
-    let mut bytes = [0; N];
-    hex::decode_to_slice(value.strip_prefix("0x")?, &mut bytes).ok()?;
-    Some(bytes)
 }
 
 #[cfg(test)]
@@ -207,33 +209,36 @@ mod tests {
     }
 
     #[test]
-    fn test_static_evm_call_matching() {
-        let rules = EvmCallRules {
-            contracts: HashSet::from([decode_hex(CONTRACT).unwrap()]),
-            selectors: HashMap::from([(decode_hex("0x1698ee82").unwrap(), MINUTE)]),
+    fn test_contract_call_matching() {
+        let rules = Contracts {
+            addresses: HashSet::from([CONTRACT.to_string()]),
+            methods: HashMap::from([("0x1698ee82".to_string(), MINUTE)]),
         };
         let wrong_block = serde_json::json!([{ "to": CONTRACT, "data": "0x1698ee820000" }, "pending"]);
 
-        assert_eq!(rules.ttl_for_params(&eth_call_params(CONTRACT, "0x1698ee820000")), Some(MINUTE));
+        assert_eq!(rules.ttl(&jsonrpc_call(eth_call_params(CONTRACT, "0x1698ee820000"))), Some(MINUTE));
         assert_eq!(
-            rules.ttl_for_params(&eth_call_params(&CONTRACT.to_uppercase().replacen("0X", "0x", 1), "0x1698EE820000")),
+            rules.ttl(&jsonrpc_call(eth_call_params(&CONTRACT.to_uppercase().replacen("0X", "0x", 1), "0x1698EE820000"))),
             Some(MINUTE)
         );
-        assert_eq!(rules.ttl_for_params(&wrong_block), None);
-        assert_eq!(rules.ttl_for_params(&eth_call_params("0x2222222222222222222222222222222222222222", "0x1698ee820000")), None);
-        assert_eq!(rules.ttl_for_params(&eth_call_params(CONTRACT, "0xaa9d21cb0000")), None);
+        assert_eq!(rules.ttl(&jsonrpc_call(wrong_block)), None);
         assert_eq!(
-            rules.ttl_for_params(&serde_json::json!([
+            rules.ttl(&jsonrpc_call(eth_call_params("0x2222222222222222222222222222222222222222", "0x1698ee820000"))),
+            None
+        );
+        assert_eq!(rules.ttl(&jsonrpc_call(eth_call_params(CONTRACT, "0xaa9d21cb0000"))), None);
+        assert_eq!(
+            rules.ttl(&jsonrpc_call(serde_json::json!([
                 {
                     "to": CONTRACT,
                     "data": "0x1698ee82",
                     "value": "0x1"
                 },
                 "latest"
-            ])),
+            ]))),
             None
         );
-        assert_eq!(decode_hex::<4>("0x1698"), None);
+        assert_eq!(rules.ttl(&jsonrpc_call(eth_call_params(CONTRACT, "0x1698"))), None);
     }
 
     #[test]
@@ -256,16 +261,18 @@ mod tests {
     }
 
     #[test]
-    fn test_evm_call_config_resolves_contract_by_chain_type() {
+    fn test_contract_call_config_resolves_by_chain_type() {
         let uppercase_contract = CONTRACT.to_uppercase().replacen("0X", "0x", 1);
         let config: CacheConfig = serde_json::from_value(serde_json::json!({
             "max_memory": "64 MB",
-            "evm_calls": {
+            "chain_types": {
                 "ethereum": {
-                    "contracts": [CONTRACT, uppercase_contract],
-                    "selectors": {
-                        "0x1698ee82": {
-                            "ttl": "5m"
+                    "contracts": {
+                        "addresses": [CONTRACT, uppercase_contract],
+                        "methods": {
+                            "0x1698ee82": {
+                                "ttl": "5m"
+                            }
                         }
                     }
                 }
@@ -275,13 +282,22 @@ mod tests {
 
         let ethereum = config.rules(Chain::Ethereum).unwrap();
         assert_eq!(config.max_memory, 64_000_000);
-        assert_eq!(ethereum.evm_calls.contracts.len(), 1);
-        assert_eq!(ethereum.evm_calls.selectors.len(), 1);
-        assert_eq!(ethereum.evm_call_ttl(&eth_call_params(CONTRACT, "0x1698ee82")), Some(MINUTE * 5));
+        assert_eq!(ethereum.contracts.as_ref().unwrap().addresses.len(), 1);
+        assert_eq!(ethereum.contracts.as_ref().unwrap().methods.len(), 1);
+        assert_eq!(ethereum.ttl(&jsonrpc_call(eth_call_params(CONTRACT, "0x1698ee82"))), Some(MINUTE * 5));
         assert_eq!(
-            config.rules(Chain::Optimism).unwrap().evm_call_ttl(&eth_call_params(CONTRACT, "0x1698ee82")),
+            config.rules(Chain::Optimism).unwrap().ttl(&jsonrpc_call(eth_call_params(CONTRACT, "0x1698ee82"))),
             Some(MINUTE * 5)
         );
         assert!(config.rules(Chain::Solana).is_none());
+    }
+
+    fn jsonrpc_call(params: Value) -> JsonRpcCall {
+        JsonRpcCall {
+            jsonrpc: "2.0".to_string(),
+            method: ETH_CALL.to_string(),
+            params,
+            id: 1,
+        }
     }
 }

--- a/core/apps/dynode/src/config/chain_types.rs
+++ b/core/apps/dynode/src/config/chain_types.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 use crate::jsonrpc_types::RequestType;
 
-use super::{AllowlistConfig, CacheRule, ChainConfig};
+use super::{AllowlistConfig, ChainConfig};
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(transparent)]
@@ -20,14 +20,6 @@ impl ChainTypesConfig {
         }
 
         self.chain_type_config(chain_config).is_none_or(|config| config.allows(chain_config.chain, request_type))
-    }
-
-    pub fn cache_rules(&self, chain_config: &ChainConfig) -> Vec<CacheRule> {
-        if let Some(rules) = chain_config.cache.as_ref() {
-            return rules.clone();
-        }
-
-        self.chain_type_config(chain_config).map(|config| config.cache(chain_config.chain)).unwrap_or_default()
     }
 
     fn chain_type_config(&self, chain_config: &ChainConfig) -> Option<&ChainTypeConfig> {
@@ -60,20 +52,11 @@ impl ChainTypeConfig {
 
         !has_rules
     }
-
-    fn cache(&self, chain: Chain) -> Vec<CacheRule> {
-        let mut rules = self.policy.cache.clone().unwrap_or_default();
-        if let Some(chain_rules) = self.chains.get(&chain).and_then(|config| config.cache.as_ref()) {
-            rules.extend(chain_rules.clone());
-        }
-        rules
-    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
 struct ChainPolicyConfig {
     allowlist: Option<AllowlistConfig>,
-    cache: Option<Vec<CacheRule>>,
 }
 
 #[cfg(test)]
@@ -103,7 +86,6 @@ mod tests {
             poll_interval_seconds: None,
             overrides: None,
             allowlist: None,
-            cache: None,
             urls: vec![Url {
                 url: "https://example.com".to_string(),
                 headers: None,
@@ -162,29 +144,5 @@ mod tests {
         assert!(config.allows(&chain_config(Chain::Thorchain), &balance));
         assert!(config.allows(&chain_config(Chain::Thorchain), &quote));
         assert!(!config.allows(&chain_config(Chain::Thorchain), &denied));
-    }
-
-    #[test]
-    fn test_chain_cache_extends_chain_type_cache() {
-        let config: ChainTypesConfig = serde_json::from_value(json!({
-            "cosmos": {
-                "cache": [
-                    { "path": "/cosmos/staking/v1beta1/validators", "method": "GET", "ttl": "1d" }
-                ],
-                "chains": {
-                    "thorchain": {
-                        "cache": [
-                            { "path": "/thorchain/inbound_addresses", "method": "GET", "ttl": "10m" }
-                        ]
-                    }
-                }
-            }
-        }))
-        .unwrap();
-
-        let rules = config.cache_rules(&chain_config(Chain::Thorchain));
-        assert_eq!(rules.len(), 2);
-        assert_eq!(rules[0].path.as_deref(), Some("/cosmos/staking/v1beta1/validators"));
-        assert_eq!(rules[1].path.as_deref(), Some("/thorchain/inbound_addresses"));
     }
 }

--- a/core/apps/dynode/src/config/domain.rs
+++ b/core/apps/dynode/src/config/domain.rs
@@ -2,9 +2,9 @@ use primitives::Chain;
 use serde::Deserialize;
 use std::time::Duration;
 
+use super::AllowlistConfig;
 use super::NodeMonitoringConfig;
 use super::url::{Override, Url};
-use super::{AllowlistConfig, CacheRule};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ChainConfig {
@@ -12,7 +12,6 @@ pub struct ChainConfig {
     pub poll_interval_seconds: Option<u64>,
     pub overrides: Option<Vec<Override>>,
     pub allowlist: Option<AllowlistConfig>,
-    pub cache: Option<Vec<CacheRule>>,
     pub urls: Vec<Url>,
 }
 
@@ -58,7 +57,6 @@ mod tests {
             poll_interval_seconds: poll_interval,
             overrides: None,
             allowlist: None,
-            cache: None,
             urls: vec![],
         }
     }
@@ -76,7 +74,6 @@ mod tests {
             poll_interval_seconds: None,
             overrides: Some(overrides),
             allowlist: None,
-            cache: None,
             urls: vec![make_url("https://example.com")],
         }
     }

--- a/core/apps/dynode/src/config/mod.rs
+++ b/core/apps/dynode/src/config/mod.rs
@@ -19,7 +19,7 @@ mod url;
 
 pub use allowlist::AllowlistConfig;
 pub use cache::CacheConfig;
-pub(crate) use cache::CacheRule;
+pub(crate) use cache::{ChainCacheRules, ETH_CALL};
 pub use chain_types::ChainTypesConfig;
 pub use domain::ChainConfig;
 pub use metrics::MetricsConfig;

--- a/core/apps/dynode/src/config/mod.rs
+++ b/core/apps/dynode/src/config/mod.rs
@@ -19,7 +19,7 @@ mod url;
 
 pub use allowlist::AllowlistConfig;
 pub use cache::CacheConfig;
-pub(crate) use cache::{ChainCacheRules, ETH_CALL};
+pub(crate) use cache::ChainCacheRules;
 pub use chain_types::ChainTypesConfig;
 pub use domain::ChainConfig;
 pub use metrics::MetricsConfig;

--- a/core/apps/dynode/src/config/mod.rs
+++ b/core/apps/dynode/src/config/mod.rs
@@ -18,7 +18,8 @@ mod metrics;
 mod url;
 
 pub use allowlist::AllowlistConfig;
-pub use cache::{CacheConfig, CacheRule};
+pub use cache::CacheConfig;
+pub(crate) use cache::CacheRule;
 pub use chain_types::ChainTypesConfig;
 pub use domain::ChainConfig;
 pub use metrics::MetricsConfig;
@@ -211,7 +212,6 @@ pub struct NodeConfig {
     pub port: u16,
     pub address: String,
     pub metrics: MetricsConfig,
-    #[serde(default)]
     pub cache: CacheConfig,
     #[serde(default)]
     pub chain_types: ChainTypesConfig,
@@ -266,6 +266,7 @@ pub fn load_config() -> Result<(NodeConfig, HashMap<Chain, ChainConfig>), Config
 
     let mut config: NodeConfig = Config::builder()
         .add_source(File::from(base_dir.join("config.yml")))
+        .add_source(File::from(base_dir.join("cache.yml")))
         .add_source(Environment::default().separator("_"))
         .build()?
         .try_deserialize()?;

--- a/core/apps/dynode/src/jsonrpc_types.rs
+++ b/core/apps/dynode/src/jsonrpc_types.rs
@@ -1,4 +1,3 @@
-use crate::proxy::constants::JSON_CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -136,10 +135,6 @@ impl RequestType {
         self.get_methods_for_metrics().join(",")
     }
 
-    pub fn content_type(&self) -> &'static str {
-        JSON_CONTENT_TYPE
-    }
-
     pub fn cache_key(&self, host: &str) -> Option<String> {
         match self {
             Self::Regular { path, method, body } => {
@@ -218,12 +213,7 @@ mod tests {
 
     #[test]
     fn test_jsonrpc_call_cache_key() {
-        let call = JsonRpcCall {
-            jsonrpc: "2.0".to_string(),
-            method: "eth_getBalance".to_string(),
-            params: json!(["0x123", "latest"]),
-            id: 1,
-        };
+        let call = JsonRpcCall::mock_with_params(1, "eth_getBalance", json!(["0x123", "latest"]));
 
         let key = call.cache_key("example.com", "/rpc");
         assert_eq!(key, "example.com:POST:/rpc:eth_getBalance:[\"0x123\",\"latest\"]");

--- a/core/apps/dynode/src/jsonrpc_types.rs
+++ b/core/apps/dynode/src/jsonrpc_types.rs
@@ -94,13 +94,6 @@ pub enum JsonRpcRequest {
 }
 
 impl JsonRpcRequest {
-    pub fn cache_key(&self, host: &str, path: &str) -> Option<String> {
-        match self {
-            Self::Single(call) => Some(call.cache_key(host, path)),
-            Self::Batch(_) => None,
-        }
-    }
-
     pub fn get_methods_list(&self) -> String {
         self.get_methods_for_metrics().join(",")
     }
@@ -147,7 +140,7 @@ impl RequestType {
         JSON_CONTENT_TYPE
     }
 
-    pub fn cache_key(&self, host: &str, path: &str) -> Option<String> {
+    pub fn cache_key(&self, host: &str) -> Option<String> {
         match self {
             Self::Regular { path, method, body } => {
                 let mut key = format!("{}:{}:{}", host, method, path);
@@ -157,7 +150,7 @@ impl RequestType {
                 }
                 Some(key)
             }
-            Self::JsonRpc(json_rpc) => json_rpc.cache_key(host, path),
+            Self::JsonRpc(_) => None,
         }
     }
 }
@@ -166,51 +159,6 @@ impl RequestType {
 mod tests {
     use super::*;
     use serde_json::json;
-
-    #[test]
-    fn test_cache_key_generation() {
-        let call = JsonRpcCall {
-            jsonrpc: "2.0".to_string(),
-            method: "eth_blockNumber".to_string(),
-            params: json!([]),
-            id: 1,
-        };
-
-        let request = JsonRpcRequest::Single(call);
-        let key = request.cache_key("example.com", "/rpc").unwrap();
-
-        assert_eq!(key, "example.com:POST:/rpc:eth_blockNumber:[]");
-    }
-
-    #[test]
-    fn test_cache_key_with_params() {
-        let call = JsonRpcCall {
-            jsonrpc: "2.0".to_string(),
-            method: "eth_getBalance".to_string(),
-            params: json!(["0x123", "latest"]),
-            id: 1,
-        };
-
-        let request = JsonRpcRequest::Single(call);
-        let key = request.cache_key("example.com", "/rpc").unwrap();
-
-        assert_eq!(key, "example.com:POST:/rpc:eth_getBalance:[\"0x123\",\"latest\"]");
-    }
-
-    #[test]
-    fn test_cache_key_null_params() {
-        let call = JsonRpcCall {
-            jsonrpc: "2.0".to_string(),
-            method: "eth_blockNumber".to_string(),
-            params: json!(null),
-            id: 1,
-        };
-
-        let request = JsonRpcRequest::Single(call);
-        let key = request.cache_key("example.com", "/rpc").unwrap();
-
-        assert_eq!(key, "example.com:POST:/rpc:eth_blockNumber");
-    }
 
     #[test]
     fn test_request_parsing_params_serialization() {
@@ -266,19 +214,6 @@ mod tests {
             }
             _ => panic!("Expected batch request"),
         }
-    }
-
-    #[test]
-    fn test_batch_cache_key_returns_none() {
-        let calls = vec![JsonRpcCall {
-            jsonrpc: "2.0".to_string(),
-            method: "eth_blockNumber".to_string(),
-            params: json!([]),
-            id: 1,
-        }];
-
-        let request = JsonRpcRequest::Batch(calls);
-        assert!(request.cache_key("example.com", "/rpc").is_none());
     }
 
     #[test]
@@ -339,31 +274,6 @@ mod tests {
     }
 
     #[test]
-    fn test_batch_with_duplicate_ids() {
-        let batch_json = r#"[
-            {"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},
-            {"jsonrpc":"2.0","method":"eth_getBalance","params":["0x123","latest"],"id":1},
-            {"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}
-        ]"#;
-
-        let body = batch_json.as_bytes().to_vec();
-        let request_type = RequestType::from_request("POST", "/rpc".to_string(), body);
-
-        match request_type {
-            RequestType::JsonRpc(JsonRpcRequest::Batch(calls)) => {
-                assert_eq!(calls.len(), 3);
-                assert_eq!(calls[0].id, 1);
-                assert_eq!(calls[1].id, 1);
-                assert_eq!(calls[2].id, 1);
-                assert_eq!(calls[0].method, "eth_blockNumber");
-                assert_eq!(calls[1].method, "eth_getBalance");
-                assert_eq!(calls[2].method, "eth_gasPrice");
-            }
-            _ => panic!("Expected batch request with duplicate IDs"),
-        }
-    }
-
-    #[test]
     fn test_regular_request_cache_key_with_different_bodies() {
         let body1 = r#"{"type":"metaAndAssetCtxs"}"#.as_bytes().to_vec();
         let body2 = r#"{"type":"spotMeta"}"#.as_bytes().to_vec();
@@ -380,32 +290,11 @@ mod tests {
             body: body2,
         };
 
-        let key1 = request1.cache_key("example.com", "/info").unwrap();
-        let key2 = request2.cache_key("example.com", "/info").unwrap();
+        let key1 = request1.cache_key("example.com").unwrap();
+        let key2 = request2.cache_key("example.com").unwrap();
 
         assert_ne!(key1, key2, "Different request bodies should produce different cache keys");
         assert!(key1.contains(r#"{"type":"metaAndAssetCtxs"}"#));
         assert!(key2.contains(r#"{"type":"spotMeta"}"#));
-    }
-
-    #[test]
-    fn test_batch_positional_mapping() {
-        let calls = [
-            JsonRpcCall {
-                jsonrpc: "2.0".to_string(),
-                method: "method_a".to_string(),
-                params: json!([]),
-                id: 999,
-            },
-            JsonRpcCall {
-                jsonrpc: "2.0".to_string(),
-                method: "method_b".to_string(),
-                params: json!([]),
-                id: 999,
-            },
-        ];
-
-        assert_eq!(calls[0].id, calls[1].id);
-        assert_ne!(calls[0].method, calls[1].method);
     }
 }

--- a/core/apps/dynode/src/main.rs
+++ b/core/apps/dynode/src/main.rs
@@ -139,7 +139,14 @@ fn resolve_chain(path: &str) -> Option<Chain> {
 
 #[rocket::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let (config, chains) = load_config()?;
+    let selected_chain = std::env::args()
+        .nth(1)
+        .map(|value| Chain::from_str(&value).unwrap_or_else(|_| panic!("Invalid chain: {value}")));
+    let (config, mut chains) = load_config()?;
+    if let Some(chain) = selected_chain {
+        assert!(chains.contains_key(&chain), "Chain is not configured: {chain}");
+        chains.retain(|configured, _| *configured == chain);
+    }
 
     let node_address = IpAddr::from_str(config.address.as_str())?;
     let metrics = Metrics::new(config.metrics.clone());
@@ -158,15 +165,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     );
     node_service.start_monitoring();
 
-    info_with_fields!("Server started", node_address = &format!("{}:{}", node_address, config.port), metrics_path = "/metrics",);
-
     let proxy_server = rocket::custom(Config::figment().merge(("address", node_address)).merge(("port", config.port)))
         .manage(node_service)
         .manage(metrics.clone())
         .manage(config.jwt)
         .mount("/", proxy_routes())
-        .mount("/", rocket::routes![health_endpoint, root_endpoint, auth_endpoint, metrics_endpoint]);
+        .mount("/", rocket::routes![health_endpoint, root_endpoint, auth_endpoint, metrics_endpoint])
+        .ignite()
+        .await?;
 
+    info_with_fields!(
+        "Server started",
+        chain = selected_chain.as_ref().map_or("all", AsRef::as_ref),
+        node_address = &format!("{}:{}", node_address, config.port),
+        metrics_path = "/metrics",
+    );
     proxy_server.launch().await?;
 
     Ok(())

--- a/core/apps/dynode/src/monitoring/evaluator.rs
+++ b/core/apps/dynode/src/monitoring/evaluator.rs
@@ -146,7 +146,6 @@ mod tests {
             poll_interval_seconds: None,
             overrides: None,
             allowlist: None,
-            cache: None,
             urls: vec![url("https://a"), url("https://b"), url("https://c")],
         };
         let nodes = Arc::new(RwLock::new(HashMap::from([(chain_config.chain, NodeDomain::new(url("https://a"), chain_config.clone()))])));

--- a/core/apps/dynode/src/node_service.rs
+++ b/core/apps/dynode/src/node_service.rs
@@ -56,7 +56,7 @@ impl NodeService {
             .filter_map(|config| config.urls.first().cloned().map(|url| (config.chain, NodeDomain::new(url, config.clone()))))
             .collect();
 
-        let cache = RequestCache::new(cache_config, &chain_types, chains.values());
+        let cache = RequestCache::new(cache_config, chains.values());
         let broadcast_providers = Arc::new(BroadcastProviders::from_chains(chains.keys().copied()));
         let proxy_builder = ProxyBuilder::new(metrics.clone(), cache, client, headers_config, broadcast_webhook, broadcast_providers);
         let nodes = Arc::new(RwLock::new(nodes));
@@ -393,7 +393,6 @@ mod tests {
             poll_interval_seconds: None,
             overrides: None,
             allowlist: None,
-            cache: None,
             urls: vec![Url {
                 url: url.to_string(),
                 headers: None,

--- a/core/apps/dynode/src/proxy/jsonrpc.rs
+++ b/core/apps/dynode/src/proxy/jsonrpc.rs
@@ -1,7 +1,7 @@
 use crate::cache::{CacheProvider, RequestCache};
-use crate::jsonrpc_types::{JsonRpcCall, JsonRpcRequest, JsonRpcResponse, JsonRpcResult};
+use crate::jsonrpc_types::{JsonRpcCall, JsonRpcRequest, JsonRpcResult};
 use crate::metrics::Metrics;
-use crate::proxy::CachedResponse;
+use crate::proxy::ProxyResponse;
 use crate::proxy::constants::JSON_CONTENT_TYPE;
 use crate::proxy::proxy_request::ProxyRequest;
 use crate::proxy::request_builder::RequestBuilder;
@@ -12,8 +12,10 @@ use gem_tracing::{DurationMs, info_with_fields};
 use reqwest::header::HeaderMap;
 use reqwest::{Method, StatusCode};
 use settings_chain::BroadcastProviders;
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 
-use crate::proxy::ProxyResponse;
+mod cache;
 
 pub struct JsonRpcHandler;
 
@@ -31,7 +33,7 @@ impl JsonRpcHandler {
     ) -> Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>> {
         match rpc_request {
             JsonRpcRequest::Single(call) => Self::handle_single_request(call, request, cache, metrics, url, client, forward_headers, broadcast_webhook, broadcast_providers).await,
-            JsonRpcRequest::Batch(calls) => Self::handle_batch_request(rpc_request, calls, request, cache, metrics, url, client, forward_headers).await,
+            JsonRpcRequest::Batch(calls) => Self::handle_batch_request(calls, request, cache, metrics, url, client, forward_headers).await,
         }
     }
 
@@ -46,11 +48,9 @@ impl JsonRpcHandler {
         broadcast_webhook: &DynodeBroadcastWebhookClient,
         broadcast_providers: &BroadcastProviders,
     ) -> Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>> {
-        let cache_key = call.cache_key(&request.host, &request.path_with_query);
-        let cacheable = cache.should_cache_call(&request.chain, call).is_some();
-        if cacheable
-            && let Some(cached) = cache.get(&request.chain, &cache_key).await
-            && let Some(response) = Self::cached_result(call, &cached)
+        let cache_ttl = cache.should_cache_call(&request.chain, call);
+        if cache_ttl.is_some()
+            && let Some(response) = cache::get(call, request, cache).await
         {
             metrics.add_cache_hit(request.chain.as_ref(), &call.method);
             let request_id = request.id.as_str();
@@ -63,13 +63,14 @@ impl JsonRpcHandler {
             );
 
             let proxy_headers = ResponseBuilder::create_proxy_headers(request.id.as_str(), request.elapsed());
-            return Self::build_json_response(&response, proxy_headers, StatusCode::OK.as_u16()).map(ProxyResponse::into_cached);
+            let body = serde_json::to_vec(&response)?;
+            return ResponseBuilder::build_with_headers(body, StatusCode::OK.as_u16(), JSON_CONTENT_TYPE, proxy_headers).map(ProxyResponse::into_cached);
         }
-        if cacheable {
+        if cache_ttl.is_some() {
             metrics.add_cache_miss(request.chain.as_ref(), &call.method);
         }
 
-        let (response, response_status, response_body) = Self::fetch_single_response(call, request, cache, url, client, forward_headers).await?;
+        let (response, response_status, response_body) = Self::fetch_single_response(call, cache_ttl, request, cache, url, client, forward_headers).await?;
 
         metrics.add_proxy_upstream_response(
             request.chain.as_ref(),
@@ -114,11 +115,10 @@ impl JsonRpcHandler {
         broadcast_webhook.notify_broadcast(request, response_status, &response_body, broadcast_providers);
 
         let proxy_headers = ResponseBuilder::create_proxy_headers(request.id.as_str(), request.elapsed());
-        Self::build_json_response(&response, proxy_headers, response_status)
+        ResponseBuilder::build_with_headers(response_body, response_status, JSON_CONTENT_TYPE, proxy_headers)
     }
 
     async fn handle_batch_request(
-        rpc_request: &JsonRpcRequest,
         calls: &[JsonRpcCall],
         request: &ProxyRequest,
         cache: &RequestCache,
@@ -127,58 +127,48 @@ impl JsonRpcHandler {
         client: &reqwest::Client,
         forward_headers: &HeaderMap,
     ) -> Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>> {
-        let mut cached_results = vec![None; calls.len()];
-        let mut misses = Vec::new();
-
-        for (index, call) in calls.iter().enumerate() {
-            let cacheable = cache.should_cache_call(&request.chain, call).is_some();
-            let cached = if cacheable {
-                cache
-                    .get(&request.chain, &call.cache_key(&request.host, &request.path_with_query))
-                    .await
-                    .and_then(|response| Self::cached_result(call, &response))
-            } else {
-                None
-            };
-
-            if let Some(result) = cached {
-                metrics.add_cache_hit(request.chain.as_ref(), &call.method);
-                cached_results[index] = Some(result);
-            } else {
-                if cacheable {
+        let cache_ttls = calls.iter().map(|call| cache.should_cache_call(&request.chain, call)).collect::<Option<Vec<_>>>();
+        let cached_results = if cache_ttls.is_some() { cache::get_all(calls, request, cache).await } else { None };
+        if cache_ttls.is_some() {
+            for call in calls {
+                if cached_results.is_some() {
+                    metrics.add_cache_hit(request.chain.as_ref(), &call.method);
+                } else {
                     metrics.add_cache_miss(request.chain.as_ref(), &call.method);
                 }
-                misses.push(call.clone());
             }
         }
 
-        let all_cached = misses.is_empty();
-        let (responses, response_status) = if all_cached {
-            (serde_json::to_value(cached_results.into_iter().flatten().collect::<Vec<_>>())?, StatusCode::OK.as_u16())
+        let (response_body, response_status, from_cache) = if let Some(results) = cached_results {
+            (serde_json::to_vec(&results)?, StatusCode::OK.as_u16(), true)
         } else {
-            let (upstream, status) = Self::fetch_batch_responses(&misses, url, client, &request.method, forward_headers).await?;
-            match serde_json::from_value::<Vec<JsonRpcResult>>(upstream.clone()) {
-                Ok(live_results) => {
-                    if status == StatusCode::OK.as_u16() {
-                        Self::store_batch_results(&misses, &live_results, request, cache).await?;
-                    }
-                    (serde_json::to_value(Self::merge_batch_results(calls, cached_results, live_results))?, status)
-                }
-                Err(_) => (upstream, status),
+            let (body, status) = Self::fetch(calls, &request.method, url, client, forward_headers).await?;
+            let response = serde_json::from_slice::<serde_json::Value>(&body).map_err(|error| Self::format_parse_error(status, &body, error))?;
+            let body = if response.is_array() {
+                serde_json::to_vec(&Self::order_batch(calls, response)?)?
+            } else {
+                body
+            };
+            let results = serde_json::from_slice::<Vec<JsonRpcResult>>(&body);
+            if status == StatusCode::OK.as_u16()
+                && let (Some(ttls), Ok(results)) = (cache_ttls.as_deref(), results.as_ref())
+            {
+                cache::set_all(calls, ttls, results, request, cache).await?;
             }
+
+            for call in calls {
+                metrics.add_proxy_upstream_response(
+                    request.chain.as_ref(),
+                    &call.method,
+                    url.url.host_str().unwrap_or_default(),
+                    status,
+                    request.elapsed().as_millis(),
+                );
+            }
+            (body, status, false)
         };
 
-        for call in &misses {
-            metrics.add_proxy_upstream_response(
-                request.chain.as_ref(),
-                &call.method,
-                url.url.host_str().unwrap_or_default(),
-                response_status,
-                request.elapsed().as_millis(),
-            );
-        }
-
-        let rpc_methods = rpc_request.get_methods_list();
+        let rpc_methods = request.request_type().get_methods_list();
         let request_id = request.id.as_str();
         info_with_fields!(
             "Proxy response",
@@ -193,141 +183,76 @@ impl JsonRpcHandler {
         );
 
         let proxy_headers = ResponseBuilder::create_proxy_headers(request.id.as_str(), request.elapsed());
-        let response = Self::build_json_response(&responses, proxy_headers, response_status)?;
-        Ok(if all_cached { response.into_cached() } else { response })
+        let response = ResponseBuilder::build_with_headers(response_body, response_status, JSON_CONTENT_TYPE, proxy_headers)?;
+        Ok(if from_cache { response.into_cached() } else { response })
     }
 
-    async fn send_jsonrpc_request(
-        client: &reqwest::Client,
+    async fn fetch<T: serde::Serialize + ?Sized>(
+        data: &T,
         method: &Method,
         url: &RequestUrl,
-        body: Vec<u8>,
+        client: &reqwest::Client,
         headers: &HeaderMap,
-    ) -> Result<reqwest::Response, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<(Vec<u8>, u16), Box<dyn std::error::Error + Send + Sync>> {
+        let body = serde_json::to_vec(data)?;
         let request = RequestBuilder::build(method, url, body, headers.clone())?;
-        Ok(client.execute(request).await?)
+        let response = client.execute(request).await?;
+        let status = response.status().as_u16();
+        Ok((response.bytes().await?.to_vec(), status))
     }
 
     async fn fetch_single_response(
         call: &JsonRpcCall,
+        cache_ttl: Option<Duration>,
         request: &ProxyRequest,
         cache: &RequestCache,
         url: &RequestUrl,
         client: &reqwest::Client,
         forward_headers: &HeaderMap,
     ) -> Result<(JsonRpcResult, u16, Vec<u8>), Box<dyn std::error::Error + Send + Sync>> {
-        let body = serde_json::to_vec(call)?;
-        let response = Self::send_jsonrpc_request(client, &request.method, url, body, forward_headers).await?;
-        let status = response.status().as_u16();
-        let body_bytes = response.bytes().await?.to_vec();
+        let (body, status) = Self::fetch(call, &request.method, url, client, forward_headers).await?;
 
-        let result: JsonRpcResult = serde_json::from_slice(&body_bytes).map_err(|e| Self::format_parse_error(status, &body_bytes, e))?;
+        let result: JsonRpcResult = serde_json::from_slice(&body).map_err(|error| Self::format_parse_error(status, &body, error))?;
+        let version = match &result {
+            JsonRpcResult::Success(response) => response.jsonrpc.as_str(),
+            JsonRpcResult::Error(response) => response.jsonrpc.as_str(),
+        };
+        if result.id() != Some(call.id) || version != call.jsonrpc {
+            return Err(format!("invalid JSON-RPC response correlation for request {}", call.id).into());
+        }
 
         if status == StatusCode::OK.as_u16()
-            && let (JsonRpcResult::Success(success), Some(ttl)) = (&result, cache.should_cache_call(&request.chain, call))
+            && let (JsonRpcResult::Success(success), Some(ttl)) = (&result, cache_ttl)
         {
-            let result_bytes = serde_json::to_vec(&success.result)?;
-            let size_bytes = result_bytes.len();
-            let cached = CachedResponse::new(result_bytes, StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string());
-            let cache_key = call.cache_key(&request.host, &request.path_with_query);
-            cache.set(&request.chain, cache_key, cached, ttl).await;
-
-            info_with_fields!(
-                "Cache SET",
-                id = request.id.as_str(),
-                chain = request.chain.as_ref(),
-                host = request.host.as_str(),
-                method = call.method.as_str(),
-                ttl_ms = ttl.as_millis(),
-                size_bytes = size_bytes,
-                latency = DurationMs(request.elapsed()),
-            );
+            cache::set(call, success, ttl, request, cache).await?;
         }
 
-        Ok((result, status, body_bytes))
+        Ok((result, status, body))
     }
 
-    async fn fetch_batch_responses(
-        calls: &[JsonRpcCall],
-        url: &RequestUrl,
-        client: &reqwest::Client,
-        method: &Method,
-        forward_headers: &HeaderMap,
-    ) -> Result<(serde_json::Value, u16), Box<dyn std::error::Error + Send + Sync>> {
-        let body = serde_json::to_vec(&calls)?;
-        let response = Self::send_jsonrpc_request(client, method, url, body, forward_headers).await?;
-        let status = response.status().as_u16();
-        let body_bytes = response.bytes().await?.to_vec();
-        let responses: serde_json::Value = serde_json::from_slice(&body_bytes).map_err(|e| Self::format_parse_error(status, &body_bytes, e))?;
-        Ok((responses, status))
-    }
+    fn order_batch(calls: &[JsonRpcCall], response: serde_json::Value) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+        let serde_json::Value::Array(results) = response else {
+            return Ok(response);
+        };
 
-    async fn store_batch_results(
-        calls: &[JsonRpcCall],
-        results: &[JsonRpcResult],
-        request: &ProxyRequest,
-        cache: &RequestCache,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        for call in calls {
-            if calls.iter().filter(|candidate| candidate.id == call.id).count() != 1 {
-                continue;
-            }
-            let Some(ttl) = cache.should_cache_call(&request.chain, call) else {
-                continue;
-            };
-            let Some(JsonRpcResult::Success(success)) = results.iter().find(|result| result.id() == Some(call.id)) else {
-                continue;
-            };
-
-            let result_bytes = serde_json::to_vec(&success.result)?;
-            let size_bytes = result_bytes.len();
-            let cached = CachedResponse::new(result_bytes, StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string());
-            cache.set(&request.chain, call.cache_key(&request.host, &request.path_with_query), cached, ttl).await;
-
-            info_with_fields!(
-                "Cache SET",
-                id = request.id.as_str(),
-                chain = request.chain.as_ref(),
-                host = request.host.as_str(),
-                method = call.method.as_str(),
-                ttl_ms = ttl.as_millis(),
-                size_bytes = size_bytes,
-                latency = DurationMs(request.elapsed()),
-            );
+        let request_ids = calls.iter().map(|call| call.id).collect::<HashSet<_>>();
+        if request_ids.len() != calls.len() {
+            return Ok(serde_json::Value::Array(results));
         }
-        Ok(())
-    }
-
-    fn merge_batch_results(calls: &[JsonRpcCall], cached_results: Vec<Option<JsonRpcResult>>, live_results: Vec<JsonRpcResult>) -> Vec<JsonRpcResult> {
-        let mut used = vec![false; live_results.len()];
-        let mut merged = Vec::with_capacity(calls.len().max(live_results.len()));
-
-        for (call, cached) in calls.iter().zip(cached_results) {
-            if let Some(result) = cached {
-                merged.push(result);
-                continue;
-            }
-            if let Some((index, result)) = live_results.iter().enumerate().find(|(index, result)| !used[*index] && result.id() == Some(call.id)) {
-                used[index] = true;
-                merged.push(result.clone());
-            }
+        if results.len() != calls.len() {
+            return Err("invalid JSON-RPC batch response length".into());
         }
 
-        merged.extend(live_results.into_iter().enumerate().filter_map(|(index, result)| (!used[index]).then_some(result)));
-        merged
-    }
+        let results_by_id = results
+            .into_iter()
+            .filter_map(|result| result.get("id").and_then(serde_json::Value::as_u64).map(|id| (id, result)))
+            .collect::<HashMap<_, _>>();
+        if results_by_id.len() != calls.len() || !results_by_id.keys().all(|id| request_ids.contains(id)) {
+            return Err("invalid JSON-RPC batch response IDs".into());
+        }
 
-    fn cached_result(call: &JsonRpcCall, cached: &CachedResponse) -> Option<JsonRpcResult> {
-        Some(JsonRpcResult::Success(JsonRpcResponse {
-            jsonrpc: call.jsonrpc.clone(),
-            result: serde_json::from_slice(&cached.body).ok()?,
-            id: Some(call.id),
-        }))
-    }
-
-    fn build_json_response<T: serde::Serialize>(data: &T, headers: HeaderMap, status: u16) -> Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>> {
-        let response_body = serde_json::to_vec(data)?;
-        ResponseBuilder::build_with_headers(response_body, status, JSON_CONTENT_TYPE, headers)
+        let ordered = calls.iter().filter_map(|call| results_by_id.get(&call.id).cloned()).collect();
+        Ok(serde_json::Value::Array(ordered))
     }
 
     fn format_parse_error(status: u16, body: &[u8], error: serde_json::Error) -> String {
@@ -345,35 +270,7 @@ impl JsonRpcHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::jsonrpc_types::{JsonRpcError, JsonRpcErrorResponse};
     use serde_json::json;
-    fn make_call(id: u64, method: &str) -> JsonRpcCall {
-        JsonRpcCall {
-            jsonrpc: "2.0".into(),
-            method: method.into(),
-            params: json!([]),
-            id,
-        }
-    }
-
-    fn success(id: u64, value: serde_json::Value) -> JsonRpcResult {
-        JsonRpcResult::Success(JsonRpcResponse {
-            jsonrpc: "2.0".to_string(),
-            result: value,
-            id: Some(id),
-        })
-    }
-
-    fn error(id: Option<u64>, code: i32) -> JsonRpcResult {
-        JsonRpcResult::Error(JsonRpcErrorResponse {
-            jsonrpc: "2.0".to_string(),
-            error: JsonRpcError {
-                code,
-                message: "upstream error".to_string(),
-            },
-            id,
-        })
-    }
 
     #[test]
     fn test_format_parse_error() {
@@ -398,29 +295,50 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_batch_results_preserves_request_order_ids_and_errors() {
-        let calls = vec![make_call(7, "cached"), make_call(3, "failed"), make_call(9, "live")];
-        let cached_results = vec![Some(success(7, json!("cached"))), None, None];
-        let live_results = vec![success(9, json!("live")), error(Some(3), -32000), error(None, -32600)];
+    fn test_order_batch_matches_response_ids() {
+        let calls = vec![JsonRpcCall::mock(7, "cached"), JsonRpcCall::mock(3, "failed")];
+        let response = json!([
+            {
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": -32000,
+                    "message": "upstream error",
+                    "data": { "retry": true }
+                },
+                "id": 3
+            },
+            {
+                "jsonrpc": "2.0",
+                "result": "cached",
+                "id": 7
+            }
+        ]);
 
-        let merged = JsonRpcHandler::merge_batch_results(&calls, cached_results, live_results);
-
+        let ordered = JsonRpcHandler::order_batch(&calls, response).unwrap();
         assert_eq!(
-            serde_json::to_value(merged).unwrap(),
-            serde_json::to_value(vec![success(7, json!("cached")), error(Some(3), -32000), success(9, json!("live")), error(None, -32600),]).unwrap()
+            ordered,
+            json!([
+                {
+                    "jsonrpc": "2.0",
+                    "result": "cached",
+                    "id": 7
+                },
+                {
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32000,
+                        "message": "upstream error",
+                        "data": { "retry": true }
+                    },
+                    "id": 3
+                }
+            ])
         );
-    }
 
-    #[test]
-    fn test_cached_result_rewrites_client_id_and_rejects_invalid_json() {
-        let call = make_call(42, "eth_chainId");
-        let cached = CachedResponse::new(br#""0x1""#.to_vec(), 200, JSON_CONTENT_TYPE.to_string());
-        let invalid = CachedResponse::new(b"invalid".to_vec(), 200, JSON_CONTENT_TYPE.to_string());
-
-        assert_eq!(
-            serde_json::to_value(JsonRpcHandler::cached_result(&call, &cached).unwrap()).unwrap(),
-            serde_json::to_value(success(42, json!("0x1"))).unwrap()
-        );
-        assert!(JsonRpcHandler::cached_result(&call, &invalid).is_none());
+        let duplicate = json!([
+            { "jsonrpc": "2.0", "result": "first", "id": 7 },
+            { "jsonrpc": "2.0", "result": "second", "id": 7 }
+        ]);
+        assert!(JsonRpcHandler::order_batch(&calls, duplicate).is_err());
     }
 }

--- a/core/apps/dynode/src/proxy/jsonrpc.rs
+++ b/core/apps/dynode/src/proxy/jsonrpc.rs
@@ -31,7 +31,7 @@ impl JsonRpcHandler {
     ) -> Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>> {
         match rpc_request {
             JsonRpcRequest::Single(call) => Self::handle_single_request(call, request, cache, metrics, url, client, forward_headers, broadcast_webhook, broadcast_providers).await,
-            JsonRpcRequest::Batch(calls) => Self::handle_batch_request(rpc_request, calls, request, metrics, url, client, forward_headers).await,
+            JsonRpcRequest::Batch(calls) => Self::handle_batch_request(rpc_request, calls, request, cache, metrics, url, client, forward_headers).await,
         }
     }
 
@@ -47,39 +47,25 @@ impl JsonRpcHandler {
         broadcast_providers: &BroadcastProviders,
     ) -> Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>> {
         let cache_key = call.cache_key(&request.host, &request.path_with_query);
-        if let Some(_ttl) = cache.should_cache_call(&request.chain, call) {
-            if let Some(cached) = cache.get(&request.chain, &cache_key).await {
-                metrics.add_cache_hit(request.chain.as_ref(), &call.method);
-                let request_id = request.id.as_str();
-                info_with_fields!(
-                    "Cache HIT",
-                    id = request_id,
-                    chain = request.chain.as_ref(),
-                    host = request.host.as_str(),
-                    method = call.method.as_str()
-                );
+        let cacheable = cache.should_cache_call(&request.chain, call).is_some();
+        if cacheable
+            && let Some(cached) = cache.get(&request.chain, &cache_key).await
+            && let Some(response) = Self::cached_result(call, &cached)
+        {
+            metrics.add_cache_hit(request.chain.as_ref(), &call.method);
+            let request_id = request.id.as_str();
+            info_with_fields!(
+                "Cache HIT",
+                id = request_id,
+                chain = request.chain.as_ref(),
+                host = request.host.as_str(),
+                method = call.method.as_str()
+            );
 
-                let result = serde_json::from_slice(&cached.body).unwrap_or_default();
-                let response = JsonRpcResult::Success(JsonRpcResponse {
-                    jsonrpc: call.jsonrpc.clone(),
-                    result,
-                    id: Some(call.id),
-                });
-
-                metrics.add_proxy_upstream_response(
-                    request.chain.as_ref(),
-                    &call.method,
-                    url.url.host_str().unwrap_or_default(),
-                    StatusCode::OK.as_u16(),
-                    request.elapsed().as_millis(),
-                );
-
-                let proxy_headers = ResponseBuilder::create_proxy_headers(request.id.as_str(), request.elapsed());
-                return Self::build_json_response(&response, proxy_headers, StatusCode::OK.as_u16()).map(ProxyResponse::into_cached);
-            } else {
-                metrics.add_cache_miss(request.chain.as_ref(), &call.method);
-            }
-        } else {
+            let proxy_headers = ResponseBuilder::create_proxy_headers(request.id.as_str(), request.elapsed());
+            return Self::build_json_response(&response, proxy_headers, StatusCode::OK.as_u16()).map(ProxyResponse::into_cached);
+        }
+        if cacheable {
             metrics.add_cache_miss(request.chain.as_ref(), &call.method);
         }
 
@@ -135,18 +121,54 @@ impl JsonRpcHandler {
         rpc_request: &JsonRpcRequest,
         calls: &[JsonRpcCall],
         request: &ProxyRequest,
+        cache: &RequestCache,
         metrics: &Metrics,
         url: &RequestUrl,
         client: &reqwest::Client,
         forward_headers: &HeaderMap,
     ) -> Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>> {
-        for call in calls {
-            metrics.add_cache_miss(request.chain.as_ref(), &call.method);
+        let mut cached_results = vec![None; calls.len()];
+        let mut misses = Vec::new();
+
+        for (index, call) in calls.iter().enumerate() {
+            let cacheable = cache.should_cache_call(&request.chain, call).is_some();
+            let cached = if cacheable {
+                cache
+                    .get(&request.chain, &call.cache_key(&request.host, &request.path_with_query))
+                    .await
+                    .and_then(|response| Self::cached_result(call, &response))
+            } else {
+                None
+            };
+
+            if let Some(result) = cached {
+                metrics.add_cache_hit(request.chain.as_ref(), &call.method);
+                cached_results[index] = Some(result);
+            } else {
+                if cacheable {
+                    metrics.add_cache_miss(request.chain.as_ref(), &call.method);
+                }
+                misses.push(call.clone());
+            }
         }
 
-        let (responses, response_status) = Self::fetch_batch_responses(calls, url, client, &request.method, forward_headers).await?;
+        let all_cached = misses.is_empty();
+        let (responses, response_status) = if all_cached {
+            (serde_json::to_value(cached_results.into_iter().flatten().collect::<Vec<_>>())?, StatusCode::OK.as_u16())
+        } else {
+            let (upstream, status) = Self::fetch_batch_responses(&misses, url, client, &request.method, forward_headers).await?;
+            match serde_json::from_value::<Vec<JsonRpcResult>>(upstream.clone()) {
+                Ok(live_results) => {
+                    if status == StatusCode::OK.as_u16() {
+                        Self::store_batch_results(&misses, &live_results, request, cache).await?;
+                    }
+                    (serde_json::to_value(Self::merge_batch_results(calls, cached_results, live_results))?, status)
+                }
+                Err(_) => (upstream, status),
+            }
+        };
 
-        for call in calls {
+        for call in &misses {
             metrics.add_proxy_upstream_response(
                 request.chain.as_ref(),
                 &call.method,
@@ -171,7 +193,8 @@ impl JsonRpcHandler {
         );
 
         let proxy_headers = ResponseBuilder::create_proxy_headers(request.id.as_str(), request.elapsed());
-        Self::build_json_response(&responses, proxy_headers, response_status)
+        let response = Self::build_json_response(&responses, proxy_headers, response_status)?;
+        Ok(if all_cached { response.into_cached() } else { response })
     }
 
     async fn send_jsonrpc_request(
@@ -203,9 +226,9 @@ impl JsonRpcHandler {
         if status == StatusCode::OK.as_u16()
             && let (JsonRpcResult::Success(success), Some(ttl)) = (&result, cache.should_cache_call(&request.chain, call))
         {
-            let result_bytes = serde_json::to_string(&success.result).unwrap_or_default().into_bytes();
+            let result_bytes = serde_json::to_vec(&success.result)?;
             let size_bytes = result_bytes.len();
-            let cached = CachedResponse::new(result_bytes, StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string(), ttl);
+            let cached = CachedResponse::new(result_bytes, StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string());
             let cache_key = call.cache_key(&request.host, &request.path_with_query);
             cache.set(&request.chain, cache_key, cached, ttl).await;
 
@@ -239,6 +262,69 @@ impl JsonRpcHandler {
         Ok((responses, status))
     }
 
+    async fn store_batch_results(
+        calls: &[JsonRpcCall],
+        results: &[JsonRpcResult],
+        request: &ProxyRequest,
+        cache: &RequestCache,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        for call in calls {
+            if calls.iter().filter(|candidate| candidate.id == call.id).count() != 1 {
+                continue;
+            }
+            let Some(ttl) = cache.should_cache_call(&request.chain, call) else {
+                continue;
+            };
+            let Some(JsonRpcResult::Success(success)) = results.iter().find(|result| result.id() == Some(call.id)) else {
+                continue;
+            };
+
+            let result_bytes = serde_json::to_vec(&success.result)?;
+            let size_bytes = result_bytes.len();
+            let cached = CachedResponse::new(result_bytes, StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string());
+            cache.set(&request.chain, call.cache_key(&request.host, &request.path_with_query), cached, ttl).await;
+
+            info_with_fields!(
+                "Cache SET",
+                id = request.id.as_str(),
+                chain = request.chain.as_ref(),
+                host = request.host.as_str(),
+                method = call.method.as_str(),
+                ttl_ms = ttl.as_millis(),
+                size_bytes = size_bytes,
+                latency = DurationMs(request.elapsed()),
+            );
+        }
+        Ok(())
+    }
+
+    fn merge_batch_results(calls: &[JsonRpcCall], cached_results: Vec<Option<JsonRpcResult>>, live_results: Vec<JsonRpcResult>) -> Vec<JsonRpcResult> {
+        let mut used = vec![false; live_results.len()];
+        let mut merged = Vec::with_capacity(calls.len().max(live_results.len()));
+
+        for (call, cached) in calls.iter().zip(cached_results) {
+            if let Some(result) = cached {
+                merged.push(result);
+                continue;
+            }
+            if let Some((index, result)) = live_results.iter().enumerate().find(|(index, result)| !used[*index] && result.id() == Some(call.id)) {
+                used[index] = true;
+                merged.push(result.clone());
+            }
+        }
+
+        merged.extend(live_results.into_iter().enumerate().filter_map(|(index, result)| (!used[index]).then_some(result)));
+        merged
+    }
+
+    fn cached_result(call: &JsonRpcCall, cached: &CachedResponse) -> Option<JsonRpcResult> {
+        Some(JsonRpcResult::Success(JsonRpcResponse {
+            jsonrpc: call.jsonrpc.clone(),
+            result: serde_json::from_slice(&cached.body).ok()?,
+            id: Some(call.id),
+        }))
+    }
+
     fn build_json_response<T: serde::Serialize>(data: &T, headers: HeaderMap, status: u16) -> Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>> {
         let response_body = serde_json::to_vec(data)?;
         ResponseBuilder::build_with_headers(response_body, status, JSON_CONTENT_TYPE, headers)
@@ -259,8 +345,8 @@ impl JsonRpcHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::jsonrpc_types::{JsonRpcError, JsonRpcErrorResponse};
     use serde_json::json;
-
     fn make_call(id: u64, method: &str) -> JsonRpcCall {
         JsonRpcCall {
             jsonrpc: "2.0".into(),
@@ -270,20 +356,23 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_single_and_batch_request_distinction() {
-        let single_call = make_call(1, "eth_blockNumber");
-        let batch_calls = vec![make_call(1, "eth_blockNumber"), make_call(2, "eth_gasPrice")];
+    fn success(id: u64, value: serde_json::Value) -> JsonRpcResult {
+        JsonRpcResult::Success(JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            result: value,
+            id: Some(id),
+        })
+    }
 
-        let single_request = JsonRpcRequest::Single(single_call);
-        let batch_request = JsonRpcRequest::Batch(batch_calls);
-
-        let JsonRpcRequest::Single(_) = single_request else {
-            panic!("Expected single request");
-        };
-        let JsonRpcRequest::Batch(_) = batch_request else {
-            panic!("Expected batch request");
-        };
+    fn error(id: Option<u64>, code: i32) -> JsonRpcResult {
+        JsonRpcResult::Error(JsonRpcErrorResponse {
+            jsonrpc: "2.0".to_string(),
+            error: JsonRpcError {
+                code,
+                message: "upstream error".to_string(),
+            },
+            id,
+        })
     }
 
     #[test]
@@ -306,5 +395,32 @@ mod tests {
             JsonRpcHandler::format_parse_error(500, &[0xff, 0xfe], err()),
             "status=500, parse error: expected value at line 1 column 1"
         );
+    }
+
+    #[test]
+    fn test_merge_batch_results_preserves_request_order_ids_and_errors() {
+        let calls = vec![make_call(7, "cached"), make_call(3, "failed"), make_call(9, "live")];
+        let cached_results = vec![Some(success(7, json!("cached"))), None, None];
+        let live_results = vec![success(9, json!("live")), error(Some(3), -32000), error(None, -32600)];
+
+        let merged = JsonRpcHandler::merge_batch_results(&calls, cached_results, live_results);
+
+        assert_eq!(
+            serde_json::to_value(merged).unwrap(),
+            serde_json::to_value(vec![success(7, json!("cached")), error(Some(3), -32000), success(9, json!("live")), error(None, -32600),]).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_cached_result_rewrites_client_id_and_rejects_invalid_json() {
+        let call = make_call(42, "eth_chainId");
+        let cached = CachedResponse::new(br#""0x1""#.to_vec(), 200, JSON_CONTENT_TYPE.to_string());
+        let invalid = CachedResponse::new(b"invalid".to_vec(), 200, JSON_CONTENT_TYPE.to_string());
+
+        assert_eq!(
+            serde_json::to_value(JsonRpcHandler::cached_result(&call, &cached).unwrap()).unwrap(),
+            serde_json::to_value(success(42, json!("0x1"))).unwrap()
+        );
+        assert!(JsonRpcHandler::cached_result(&call, &invalid).is_none());
     }
 }

--- a/core/apps/dynode/src/proxy/jsonrpc/cache.rs
+++ b/core/apps/dynode/src/proxy/jsonrpc/cache.rs
@@ -1,0 +1,102 @@
+use std::time::Duration;
+
+use gem_tracing::{DurationMs, info_with_fields};
+use reqwest::StatusCode;
+
+use crate::cache::{CacheProvider, RequestCache};
+use crate::jsonrpc_types::{JsonRpcCall, JsonRpcResponse, JsonRpcResult};
+use crate::proxy::CachedResponse;
+use crate::proxy::constants::JSON_CONTENT_TYPE;
+use crate::proxy::proxy_request::ProxyRequest;
+
+pub(super) async fn get(call: &JsonRpcCall, request: &ProxyRequest, cache: &RequestCache) -> Option<JsonRpcResult> {
+    cache
+        .get(&request.chain, &call.cache_key(&request.host, &request.path_with_query))
+        .await
+        .and_then(|response| result(call, &response))
+}
+
+pub(super) async fn get_all(calls: &[JsonRpcCall], request: &ProxyRequest, cache: &RequestCache) -> Option<Vec<JsonRpcResult>> {
+    let mut results = Vec::with_capacity(calls.len());
+
+    for call in calls {
+        results.push(get(call, request, cache).await);
+    }
+
+    results.into_iter().collect()
+}
+
+pub(super) async fn set(
+    call: &JsonRpcCall,
+    response: &JsonRpcResponse,
+    ttl: Duration,
+    request: &ProxyRequest,
+    cache: &RequestCache,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let result = serde_json::to_vec(&response.result)?;
+    let size = result.len();
+    let cached = CachedResponse::new(result, StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string());
+    cache.set(&request.chain, call.cache_key(&request.host, &request.path_with_query), cached, ttl).await;
+
+    info_with_fields!(
+        "Cache SET",
+        id = request.id.as_str(),
+        chain = request.chain.as_ref(),
+        host = request.host.as_str(),
+        method = call.method.as_str(),
+        ttl_ms = ttl.as_millis(),
+        size_bytes = size,
+        latency = DurationMs(request.elapsed()),
+    );
+    Ok(())
+}
+
+pub(super) async fn set_all(
+    calls: &[JsonRpcCall],
+    ttls: &[Duration],
+    results: &[JsonRpcResult],
+    request: &ProxyRequest,
+    cache: &RequestCache,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if calls.len() != ttls.len() || calls.len() != results.len() {
+        return Ok(());
+    }
+    if calls.iter().zip(results).any(|(call, result)| result.id() != Some(call.id)) {
+        return Ok(());
+    }
+
+    for ((call, ttl), result) in calls.iter().zip(ttls).zip(results) {
+        if let JsonRpcResult::Success(response) = result {
+            set(call, response, *ttl, request, cache).await?;
+        }
+    }
+    Ok(())
+}
+
+fn result(call: &JsonRpcCall, cached: &CachedResponse) -> Option<JsonRpcResult> {
+    Some(JsonRpcResult::Success(JsonRpcResponse {
+        jsonrpc: call.jsonrpc.clone(),
+        result: serde_json::from_slice(&cached.body).ok()?,
+        id: Some(call.id),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_cached_result_uses_request_id_and_rejects_invalid_json() {
+        let call = JsonRpcCall::mock(42, "eth_chainId");
+        let cached = CachedResponse::new(br#""0x1""#.to_vec(), 200, JSON_CONTENT_TYPE.to_string());
+        let invalid = CachedResponse::new(b"invalid".to_vec(), 200, JSON_CONTENT_TYPE.to_string());
+
+        assert_eq!(
+            serde_json::to_value(result(&call, &cached).unwrap()).unwrap(),
+            json!({ "jsonrpc": "2.0", "result": "0x1", "id": 42 })
+        );
+        assert!(result(&call, &invalid).is_none());
+    }
+}

--- a/core/apps/dynode/src/proxy/proxy_builder.rs
+++ b/core/apps/dynode/src/proxy/proxy_builder.rs
@@ -35,7 +35,7 @@ impl ProxyBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{CacheConfig, ChainTypesConfig};
+    use crate::config::CacheConfig;
     use primitives::Chain;
     use reqwest::header;
     use std::collections::HashMap;
@@ -50,7 +50,7 @@ mod tests {
     #[test]
     fn test_proxy_builder_creation() {
         let metrics = Metrics::new(MetricsConfig::default());
-        let cache = RequestCache::new(CacheConfig::default(), &ChainTypesConfig::default(), std::iter::empty());
+        let cache = RequestCache::new(CacheConfig::default(), std::iter::empty());
         let client = gem_client::reqwest_client();
         let headers_config = create_test_headers_config();
         let broadcast_webhook = DynodeBroadcastWebhookClient::disabled();

--- a/core/apps/dynode/src/proxy/response_builder.rs
+++ b/core/apps/dynode/src/proxy/response_builder.rs
@@ -83,7 +83,6 @@ impl ResponseBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use primitives::MINUTE;
 
     #[test]
     fn test_create_proxy_headers() {
@@ -96,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_cached_response_source() {
-        let cached = super::super::CachedResponse::new(Vec::new(), 200, JSON_CONTENT_TYPE.to_string(), MINUTE);
+        let cached = super::super::CachedResponse::new(Vec::new(), 200, JSON_CONTENT_TYPE.to_string());
         let response = ResponseBuilder::build_cached_with_headers(cached, HeaderMap::new());
 
         assert!(response.is_from_cache());

--- a/core/apps/dynode/src/proxy/service.rs
+++ b/core/apps/dynode/src/proxy/service.rs
@@ -3,6 +3,7 @@ use crate::config::{ChainConfig, HeadersConfig, Url};
 use crate::jsonrpc_types::{JsonRpcRequest, RequestType};
 use crate::metrics::Metrics;
 use crate::proxy::CachedResponse;
+use crate::proxy::constants::JSON_CONTENT_TYPE;
 use crate::proxy::jsonrpc::JsonRpcHandler;
 use crate::proxy::proxy_request::ProxyRequest;
 use crate::proxy::request_builder::RequestBuilder;
@@ -10,25 +11,12 @@ use crate::proxy::request_url::RequestUrl;
 use crate::proxy::response_builder::{ProxyResponse, ResponseBuilder};
 use crate::webhook::DynodeBroadcastWebhookClient;
 use gem_tracing::{DurationMs, info_with_fields};
-use primitives::Chain;
-use reqwest::Method;
 use reqwest::StatusCode;
 use reqwest::header::{HeaderMap, HeaderName};
 use settings_chain::BroadcastProviders;
 use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
-
-struct CacheStoreInfo {
-    id: String,
-    chain: Chain,
-    host: String,
-    method: String,
-    path: String,
-    elapsed: Duration,
-    content_type: String,
-}
 
 #[derive(Clone)]
 pub struct ProxyRequestService {
@@ -91,12 +79,6 @@ impl ProxyRequestService {
         headers
     }
 
-    fn add_proxy_response_metrics(metrics: &Metrics, request: &ProxyRequest, methods_for_metrics: &[String], host: &str, status: u16) {
-        for method_name in methods_for_metrics {
-            metrics.add_proxy_upstream_response(request.chain.as_ref(), method_name, host, status, request.elapsed().as_millis());
-        }
-    }
-
     pub async fn handle_request(&self, request: ProxyRequest, node_domain: &NodeDomain) -> Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>> {
         let chain = request.chain;
         let request_type = request.request_type();
@@ -131,26 +113,28 @@ impl ProxyRequestService {
         let cache_ttl = self.cache.should_cache_request(&chain, request_type);
         let cache_key = cache_ttl.and_then(|_| request_type.cache_key(&request.host));
         if let Some(key) = &cache_key
-            && let Some(result) = Self::try_cache_hit(&self.cache, key, &request, &self.metrics, &methods_for_metrics).await
+            && let Some(response) = Self::try_cache_hit(&self.cache, key, &request, &self.metrics, &methods_for_metrics).await
         {
-            return result;
+            return Ok(response);
         }
 
-        let response = match Self::proxy_pass_get_data(request.method.clone(), request.body.clone(), url.clone(), &self.client, headers).await {
-            Ok(response) => response,
-            Err(error) => return Err(error),
-        };
+        let upstream_request = RequestBuilder::build(&request.method, &url, request.body.clone(), headers)?;
+        let response = self.client.execute(upstream_request).await?;
         let status = response.status().as_u16();
+        let response_headers = response.headers().clone();
+        let body = response.bytes().await?.to_vec();
+
         let proxy_headers = ResponseBuilder::create_proxy_headers(request.id.as_str(), request.elapsed());
-        let (processed_response, body_bytes) = match Self::proxy_pass_response(response, &self.forward_headers, proxy_headers).await {
-            Ok(result) => result,
-            Err(error) => return Err(error),
-        };
+        let mut headers = RequestBuilder::filter_headers(&response_headers, &self.forward_headers);
+        headers.extend(proxy_headers);
 
         let remote_host = url.url.host_str().unwrap_or_default();
-        Self::add_proxy_response_metrics(&self.metrics, &request, &methods_for_metrics, remote_host, status);
+        for method in &methods_for_metrics {
+            self.metrics
+                .add_proxy_upstream_response(request.chain.as_ref(), method, remote_host, status, request.elapsed().as_millis());
+        }
 
-        self.broadcast_webhook.notify_broadcast(&request, status, &body_bytes, &self.broadcast_providers);
+        self.broadcast_webhook.notify_broadcast(&request, status, &body, &self.broadcast_providers);
 
         info_with_fields!(
             "Proxy response",
@@ -166,31 +150,34 @@ impl ProxyRequestService {
         if status == StatusCode::OK.as_u16()
             && let (Some(ttl), Some(key)) = (cache_ttl, cache_key)
         {
-            let store_info = CacheStoreInfo {
-                id: request.id.clone(),
-                chain: request.chain,
-                host: request.host.clone(),
-                method: request.method.to_string(),
-                path: request.path.clone(),
-                elapsed: request.elapsed(),
-                content_type: request_type.content_type().to_string(),
-            };
-            let cache_clone = self.cache.clone();
+            let cache = self.cache.clone();
+            let cached = CachedResponse::new(body.clone(), status, JSON_CONTENT_TYPE.to_string());
+            let size = cached.body.len();
+            let id = request.id.clone();
+            let host = request.host.clone();
+            let method = request.method.to_string();
+            let path = request.path.clone();
+            let elapsed = request.elapsed();
             tokio::spawn(async move {
-                Self::store_cache(status, ttl, key, body_bytes, store_info, cache_clone).await;
+                cache.set(&chain, key, cached, ttl).await;
+                info_with_fields!(
+                    "Cache SET",
+                    id = id.as_str(),
+                    chain = chain.as_ref(),
+                    host = &host,
+                    method = method.as_str(),
+                    path = &path,
+                    ttl_ms = ttl.as_millis(),
+                    size_bytes = size,
+                    latency = DurationMs(elapsed),
+                );
             });
         }
 
-        Ok(processed_response)
+        Ok(ProxyResponse::new(status, headers, body))
     }
 
-    async fn try_cache_hit(
-        cache: &RequestCache,
-        cache_key: &str,
-        request: &ProxyRequest,
-        metrics: &Metrics,
-        methods_for_metrics: &[String],
-    ) -> Option<Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>>> {
+    async fn try_cache_hit(cache: &RequestCache, cache_key: &str, request: &ProxyRequest, metrics: &Metrics, methods_for_metrics: &[String]) -> Option<ProxyResponse> {
         if let Some(cached) = cache.get(&request.chain, cache_key).await {
             for method_name in methods_for_metrics {
                 metrics.add_cache_hit(request.chain.as_ref(), method_name);
@@ -205,67 +192,13 @@ impl ProxyRequestService {
             );
 
             let proxy_headers = ResponseBuilder::create_proxy_headers(request.id.as_str(), request.elapsed());
-            Some(Ok(ResponseBuilder::build_cached_with_headers(cached, proxy_headers)))
+            Some(ResponseBuilder::build_cached_with_headers(cached, proxy_headers))
         } else {
             for method_name in methods_for_metrics {
                 metrics.add_cache_miss(request.chain.as_ref(), method_name);
             }
             None
         }
-    }
-
-    async fn store_cache(status: u16, cache_ttl: Duration, cache_key: String, body_bytes: Vec<u8>, info: CacheStoreInfo, cache: RequestCache) {
-        let CacheStoreInfo {
-            id,
-            chain,
-            host,
-            method,
-            path,
-            elapsed,
-            content_type,
-        } = info;
-        let body_size = body_bytes.len();
-        let cached = CachedResponse::new(body_bytes, status, content_type);
-
-        cache.set(&chain, cache_key, cached, cache_ttl).await;
-
-        info_with_fields!(
-            "Cache SET",
-            id = id.as_str(),
-            chain = chain.as_ref(),
-            host = &host,
-            method = method.as_str(),
-            path = &path,
-            ttl_ms = cache_ttl.as_millis(),
-            size_bytes = body_size,
-            latency = DurationMs(elapsed),
-        );
-    }
-
-    async fn proxy_pass_response(
-        response: reqwest::Response,
-        forward_headers: &HashSet<HeaderName>,
-        additional_headers: HeaderMap,
-    ) -> Result<(ProxyResponse, Vec<u8>), Box<dyn std::error::Error + Send + Sync>> {
-        let resp_headers = response.headers().clone();
-        let status = response.status().as_u16();
-        let body = response.bytes().await?.to_vec();
-
-        let mut headers = RequestBuilder::filter_headers(&resp_headers, forward_headers);
-        headers.extend(additional_headers);
-
-        Ok((ProxyResponse::new(status, headers, body.clone()), body))
-    }
-
-    async fn proxy_pass_get_data(
-        method: Method,
-        body: Vec<u8>,
-        url: RequestUrl,
-        client: &reqwest::Client,
-        headers: HeaderMap,
-    ) -> Result<reqwest::Response, Box<dyn std::error::Error + Send + Sync>> {
-        let request = RequestBuilder::build(&method, &url, body, headers)?;
-        Ok(client.execute(request).await?)
     }
 }
 

--- a/core/apps/dynode/src/proxy/service.rs
+++ b/core/apps/dynode/src/proxy/service.rs
@@ -1,6 +1,6 @@
 use crate::cache::{CacheProvider, RequestCache};
 use crate::config::{ChainConfig, HeadersConfig, Url};
-use crate::jsonrpc_types::{JsonRpcRequest, JsonRpcResponse, RequestType};
+use crate::jsonrpc_types::{JsonRpcRequest, RequestType};
 use crate::metrics::Metrics;
 use crate::proxy::CachedResponse;
 use crate::proxy::jsonrpc::JsonRpcHandler;
@@ -27,7 +27,7 @@ struct CacheStoreInfo {
     method: String,
     path: String,
     elapsed: Duration,
-    request_type: RequestType,
+    content_type: String,
 }
 
 #[derive(Clone)]
@@ -110,17 +110,8 @@ impl ProxyRequestService {
         let url = RequestUrl::from_parts(resolved_url, &request.path_with_query);
         let headers = self.build_headers(url.url.host_str().unwrap_or_default(), &request.headers);
 
-        let cache_ttl = self.cache.should_cache_request(&chain, request_type);
-        let cache_key = cache_ttl.and_then(|_| request_type.cache_key(&request.host, &request.path_with_query));
-
         let methods_for_metrics = request_type.get_methods_for_metrics();
         self.metrics.add_proxy_request(request.chain.as_ref(), &methods_for_metrics);
-
-        if let Some(key) = &cache_key
-            && let Some(result) = Self::try_cache_hit(&self.cache, key, &request, &url, &self.metrics, request_type, &methods_for_metrics).await
-        {
-            return result;
-        }
 
         if let RequestType::JsonRpc(rpc_request) = request_type {
             return JsonRpcHandler::handle_request(
@@ -135,6 +126,14 @@ impl ProxyRequestService {
                 &self.broadcast_providers,
             )
             .await;
+        }
+
+        let cache_ttl = self.cache.should_cache_request(&chain, request_type);
+        let cache_key = cache_ttl.and_then(|_| request_type.cache_key(&request.host));
+        if let Some(key) = &cache_key
+            && let Some(result) = Self::try_cache_hit(&self.cache, key, &request, &self.metrics, &methods_for_metrics).await
+        {
+            return result;
         }
 
         let response = match Self::proxy_pass_get_data(request.method.clone(), request.body.clone(), url.clone(), &self.client, headers).await {
@@ -174,13 +173,11 @@ impl ProxyRequestService {
                 method: request.method.to_string(),
                 path: request.path.clone(),
                 elapsed: request.elapsed(),
-                request_type: request_type.clone(),
+                content_type: request_type.content_type().to_string(),
             };
             let cache_clone = self.cache.clone();
             tokio::spawn(async move {
-                if let Err(err) = Self::store_cache(status, ttl, key, body_bytes, store_info, cache_clone).await {
-                    gem_tracing::error_with_fields!("Failed to store cache", err.as_ref(),);
-                }
+                Self::store_cache(status, ttl, key, body_bytes, store_info, cache_clone).await;
             });
         }
 
@@ -191,9 +188,7 @@ impl ProxyRequestService {
         cache: &RequestCache,
         cache_key: &str,
         request: &ProxyRequest,
-        url: &RequestUrl,
         metrics: &Metrics,
-        request_type: &RequestType,
         methods_for_metrics: &[String],
     ) -> Option<Result<ProxyResponse, Box<dyn std::error::Error + Send + Sync>>> {
         if let Some(cached) = cache.get(&request.chain, cache_key).await {
@@ -210,20 +205,7 @@ impl ProxyRequestService {
             );
 
             let proxy_headers = ResponseBuilder::create_proxy_headers(request.id.as_str(), request.elapsed());
-            let status = cached.status;
-
-            let response = match request_type {
-                RequestType::JsonRpc(JsonRpcRequest::Single(original_call)) => {
-                    let data = cached.to_jsonrpc_response(original_call);
-                    ResponseBuilder::build_with_headers(data, cached.status, &cached.content_type, proxy_headers).map(ProxyResponse::into_cached)
-                }
-                RequestType::Regular { .. } => Ok(ResponseBuilder::build_cached_with_headers(cached.clone(), proxy_headers)),
-                RequestType::JsonRpc(JsonRpcRequest::Batch(_)) => return None,
-            };
-
-            Self::add_proxy_response_metrics(metrics, request, methods_for_metrics, url.url.host_str().unwrap_or_default(), status);
-
-            Some(response)
+            Some(Ok(ResponseBuilder::build_cached_with_headers(cached, proxy_headers)))
         } else {
             for method_name in methods_for_metrics {
                 metrics.add_cache_miss(request.chain.as_ref(), method_name);
@@ -232,41 +214,32 @@ impl ProxyRequestService {
         }
     }
 
-    async fn store_cache(
-        status: u16,
-        cache_ttl: Duration,
-        cache_key: String,
-        body_bytes: Vec<u8>,
-        info: CacheStoreInfo,
-        cache: RequestCache,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let content_type = info.request_type.content_type().to_string();
+    async fn store_cache(status: u16, cache_ttl: Duration, cache_key: String, body_bytes: Vec<u8>, info: CacheStoreInfo, cache: RequestCache) {
+        let CacheStoreInfo {
+            id,
+            chain,
+            host,
+            method,
+            path,
+            elapsed,
+            content_type,
+        } = info;
         let body_size = body_bytes.len();
+        let cached = CachedResponse::new(body_bytes, status, content_type);
 
-        let cached = match &info.request_type {
-            RequestType::JsonRpc(_) => {
-                let json_response = serde_json::from_slice::<JsonRpcResponse>(&body_bytes)?;
-                let result_bytes = serde_json::to_string(&json_response.result).unwrap_or_default().into_bytes();
-                CachedResponse::new(result_bytes, status, content_type, cache_ttl)
-            }
-            RequestType::Regular { .. } => CachedResponse::new(body_bytes, status, content_type, cache_ttl),
-        };
-
-        cache.set(&info.chain, cache_key, cached, cache_ttl).await;
+        cache.set(&chain, cache_key, cached, cache_ttl).await;
 
         info_with_fields!(
             "Cache SET",
-            id = info.id.as_str(),
-            chain = info.chain.as_ref(),
-            host = &info.host,
-            method = info.method.as_str(),
-            path = &info.path,
+            id = id.as_str(),
+            chain = chain.as_ref(),
+            host = &host,
+            method = method.as_str(),
+            path = &path,
             ttl_ms = cache_ttl.as_millis(),
             size_bytes = body_size,
-            latency = DurationMs(info.elapsed),
+            latency = DurationMs(elapsed),
         );
-
-        Ok(())
     }
 
     async fn proxy_pass_response(
@@ -300,7 +273,7 @@ impl ProxyRequestService {
 mod tests {
     use super::*;
     use crate::cache::RequestCache;
-    use crate::config::{CacheConfig, ChainTypesConfig, HeadersConfig, MetricsConfig};
+    use crate::config::{CacheConfig, HeadersConfig, MetricsConfig};
     use crate::metrics::Metrics;
     use crate::proxy::constants::JSON_CONTENT_TYPE;
     use primitives::Chain;
@@ -313,7 +286,7 @@ mod tests {
         let metrics = Metrics::new(MetricsConfig::default());
         ProxyRequestService::new(
             metrics.clone(),
-            RequestCache::new(CacheConfig::default(), &ChainTypesConfig::default(), std::iter::empty()),
+            RequestCache::new(CacheConfig::default(), std::iter::empty()),
             gem_client::reqwest_client(),
             headers_config,
             DynodeBroadcastWebhookClient::disabled(),

--- a/core/apps/dynode/src/proxy/types.rs
+++ b/core/apps/dynode/src/proxy/types.rs
@@ -1,62 +1,12 @@
-use crate::jsonrpc_types::JsonRpcCall;
-use std::str::from_utf8;
-use std::time::Duration;
-
 #[derive(Debug, Clone)]
 pub struct CachedResponse {
     pub body: Vec<u8>,
     pub status: u16,
     pub content_type: String,
-    pub ttl: Duration,
 }
 
 impl CachedResponse {
-    pub fn new(body: Vec<u8>, status: u16, content_type: String, ttl: Duration) -> Self {
-        Self { body, status, content_type, ttl }
-    }
-
-    pub fn to_jsonrpc_response(&self, original_call: &JsonRpcCall) -> Vec<u8> {
-        let result_str = from_utf8(&self.body).unwrap_or("null");
-        format!(r#"{{"jsonrpc":"{}","result":{},"id":{}}}"#, original_call.jsonrpc, result_str, original_call.id).into_bytes()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::proxy::constants::JSON_CONTENT_TYPE;
-    use primitives::MINUTE;
-    use reqwest::StatusCode;
-
-    #[test]
-    fn test_to_jsonrpc_response() {
-        let response = CachedResponse::new(br#"{"value":123}"#.to_vec(), StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string(), MINUTE);
-        let call = JsonRpcCall {
-            jsonrpc: "2.0".to_string(),
-            method: "eth_blockNumber".to_string(),
-            params: serde_json::json!([]),
-            id: 42,
-        };
-
-        let result = response.to_jsonrpc_response(&call);
-        let result_str = from_utf8(&result).unwrap();
-
-        assert_eq!(result_str, r#"{"jsonrpc":"2.0","result":{"value":123},"id":42}"#);
-    }
-
-    #[test]
-    fn test_to_jsonrpc_response_invalid_utf8() {
-        let response = CachedResponse::new(vec![0xff, 0xfe], StatusCode::OK.as_u16(), JSON_CONTENT_TYPE.to_string(), MINUTE);
-        let call = JsonRpcCall {
-            jsonrpc: "2.0".to_string(),
-            method: "test".to_string(),
-            params: serde_json::json!([]),
-            id: 1,
-        };
-
-        let result = response.to_jsonrpc_response(&call);
-        let result_str = from_utf8(&result).unwrap();
-
-        assert_eq!(result_str, r#"{"jsonrpc":"2.0","result":null,"id":1}"#);
+    pub fn new(body: Vec<u8>, status: u16, content_type: String) -> Self {
+        Self { body, status, content_type }
     }
 }

--- a/core/apps/dynode/src/testkit/jsonrpc_mock.rs
+++ b/core/apps/dynode/src/testkit/jsonrpc_mock.rs
@@ -1,0 +1,18 @@
+use serde_json::{Value, json};
+
+use crate::jsonrpc_types::JsonRpcCall;
+
+impl JsonRpcCall {
+    pub fn mock(id: u64, method: &str) -> Self {
+        Self::mock_with_params(id, method, json!([]))
+    }
+
+    pub fn mock_with_params(id: u64, method: &str, params: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            method: method.to_string(),
+            params,
+            id,
+        }
+    }
+}

--- a/core/apps/dynode/src/testkit/mod.rs
+++ b/core/apps/dynode/src/testkit/mod.rs
@@ -1,3 +1,4 @@
 pub mod config;
+mod jsonrpc_mock;
 #[cfg(test)]
 pub(crate) mod sync;

--- a/core/crates/primitives/src/node_config.rs
+++ b/core/crates/primitives/src/node_config.rs
@@ -39,7 +39,7 @@ pub fn get_nodes_for_chain(chain: Chain) -> Vec<Node> {
         ],
         Chain::Solana => vec![Node::new("https://api.mainnet-beta.solana.com", NodePriority::High)],
         Chain::Polygon => vec![
-            Node::new("https://polygon.llamarpc.com", NodePriority::High),
+            Node::new("https://polygon.drpc.org", NodePriority::High),
             Node::new("https://polygon-rpc.com", NodePriority::High),
         ],
         Chain::Thorchain => vec![Node::new("https://thornode.thorchain.liquify.com", NodePriority::High)],

--- a/core/crates/serde_serializers/src/lib.rs
+++ b/core/crates/serde_serializers/src/lib.rs
@@ -17,6 +17,7 @@ pub use duration::{deserialize as deserialize_duration, deserialize_option as de
 pub mod f64;
 pub use f64::{deserialize_f64_from_str, deserialize_option_f64_from_str, serialize_f64};
 pub mod hex_bytes;
+pub mod size;
 pub mod u64;
 pub use u64::{deserialize_option_u64_from_str, deserialize_option_u64_from_str_or_int, deserialize_u64_from_str, deserialize_u64_from_str_or_int, serialize_u64};
 pub mod u128;

--- a/core/crates/serde_serializers/src/size.rs
+++ b/core/crates/serde_serializers/src/size.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Deserializer};
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    parse_size(&value).map_err(serde::de::Error::custom)
+}
+
+fn parse_size(value: &str) -> Result<usize, String> {
+    let value = value.trim();
+    let unit_start = value.find(|character: char| !character.is_ascii_digit()).unwrap_or(value.len());
+    let (number, unit) = value.split_at(unit_start);
+
+    if number.is_empty() {
+        return Err("no number found in size".to_string());
+    }
+
+    let number = number.parse::<u64>().map_err(|_| format!("invalid size: {number}"))?;
+    let multiplier: u64 = match unit.trim().to_ascii_uppercase().as_str() {
+        "" | "B" => 1,
+        "KB" => 1_000,
+        "MB" => 1_000_000,
+        "GB" => 1_000_000_000,
+        "TB" => 1_000_000_000_000,
+        "KIB" => 1_024,
+        "MIB" => 1_048_576,
+        "GIB" => 1_073_741_824,
+        "TIB" => 1_099_511_627_776,
+        unit => return Err(format!("unknown size unit '{unit}', supported: B, KB, MB, GB, TB, KiB, MiB, GiB, TiB")),
+    };
+
+    let bytes = number.checked_mul(multiplier).ok_or_else(|| "size exceeds u64 limit".to_string())?;
+    usize::try_from(bytes).map_err(|_| "size exceeds platform limit".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_size() {
+        assert_eq!(parse_size("1 B").unwrap(), 1);
+        assert_eq!(parse_size("64 MB").unwrap(), 64_000_000);
+        assert_eq!(parse_size("1GB").unwrap(), 1_000_000_000);
+        assert_eq!(parse_size("2 GiB").unwrap(), 2_147_483_648);
+        assert_eq!(parse_size("1 kib").unwrap(), 1_024);
+        assert!(parse_size("").is_err());
+        assert!(parse_size("GB").is_err());
+        assert!(parse_size("1 XB").is_err());
+        assert!(parse_size("1.5 GB").is_err());
+        assert!(parse_size(&format!("{} TB", usize::MAX)).is_err());
+    }
+}

--- a/core/gemstone/tests/ios/GemTest/GemTest/Networking/Provider.swift
+++ b/core/gemstone/tests/ios/GemTest/GemTest/Networking/Provider.swift
@@ -10,14 +10,14 @@ public actor NativeProvider {
 
     init(session: URLSession = .shared) {
         self.nodeConfig = [
-            "ethereum": URL(string: "https://eth.llamarpc.com")!,
-            "optimism": URL(string: "https://optimism.llamarpc.com")!,
+            "ethereum": URL(string: "https://ethereum.publicnode.com")!,
+            "optimism": URL(string: "https://mainnet.optimism.io")!,
             "thorchain": URL(string: "https://thornode.ninerealms.com")!,
             "solana": URL(string: "https://solana-rpc.publicnode.com")!,
-            "smartchain": URL(string: "https://binance.llamarpc.com")!,
-            "arbitrum": URL(string: "https://arbitrum.llamarpc.com")!,
-            "base": URL(string: "https://base.llamarpc.com")!,
-            "polygon": URL(string: "https://polygon.llamarpc.com")!,
+            "smartchain": URL(string: "https://bsc-dataseed.bnbchain.org")!,
+            "arbitrum": URL(string: "https://arb1.arbitrum.io/rpc")!,
+            "base": URL(string: "https://mainnet.base.org")!,
+            "polygon": URL(string: "https://polygon.drpc.org")!,
             "sui": URL(string: "https://fullnode.mainnet.sui.io")!,
             "abstract": URL(string: "https://api.mainnet.abs.xyz")!,
             "unichain": URL(string: "https://mainnet.unichain.org")!,

--- a/ios/Packages/Validators/Tests/URLTextValidatorTests.swift
+++ b/ios/Packages/Validators/Tests/URLTextValidatorTests.swift
@@ -6,9 +6,9 @@ import Testing
 struct URLTextValidatorTests {
     @Test
     func validate() {
-        #expect(throws: Never.self) { try URLTextValidator().validate("https://eth.llamarpc.com") }
+        #expect(throws: Never.self) { try URLTextValidator().validate("https://ethereum.publicnode.com") }
         #expect(throws: Never.self) { try URLTextValidator().validate("https://eth-mainnet.rpcfast.com?api_key=test") }
-        #expect(throws: Never.self) { try URLTextValidator().validate("eth.llamarpc.com") }
+        #expect(throws: Never.self) { try URLTextValidator().validate("ethereum.publicnode.com") }
 
         #expect(throws: URLValidationError.self) { try URLTextValidator().validate("http://example.com") }
         #expect(throws: URLValidationError.self) { try URLTextValidator().validate("ws://example.com") }


### PR DESCRIPTION
## Summary

- move cache policy into a dedicated `cache.yml` loaded by Dynode
- model each chain type with generic `rules` and optional `contracts`
- store contract addresses in `HashSet<String>` and method TTLs in `HashMap<String, Duration>`
- normalize strings for constant-time, case-insensitive lookup without byte decoders
- add reusable human-readable byte sizes and configure `max_memory: 2GB`
- support partial JSON-RPC batch cache hits while forwarding only misses upstream and restoring response order
- keep dynamic calls uncached and remove duplicated request/cache state

## Why

Swapper pool discovery repeatedly resolves immutable Uniswap V3 pool addresses through nodes. Dynode previously matched JSON-RPC caching only by method, which was too broad for safe `eth_call` caching and could not reuse individual entries inside batches.

Contract policy now lives with its chain type instead of in an EVM-specific top-level field. The schema uses generic address and method strings, so another chain type can adopt the same configuration shape when it gains matching support. The current matcher only accepts `eth_call` at `latest`, with an allowlisted address and method. Cache storage remains isolated per request chain.

## V3 and V4

Uniswap V3 `getPool` is static and safe for Dynode caching. Uniswap V4 route discovery calls `StateView.getSlot0`, whose response includes live price and tick data, so its existence result stays in the Swapper domain cache instead of Dynode.

Companion deployment PR: gemwalletcom/infra#19.

## Validation

- `cargo test -p dynode`
- `cargo clippy -p dynode --all-targets -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
- companion infra YAML schema check
- companion infra: `ansible-playbook --syntax-check dynode.yml`
- companion infra: `ansible-playbook --syntax-check api.yml`