### PR TITLE
Remove AssetsRepository pass-through service forwarders

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetChartDataImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetChartDataImpl.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.data.coordinators.asset
 
 import com.gemwallet.android.application.assets.coordinators.GetAssetChartData
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.CurrencyRatesService
 import com.gemwallet.android.data.services.gemapi.GemApiClient
 import com.gemwallet.android.ext.toIdentifier
 import com.wallet.core.primitives.AssetId
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.firstOrNull
 class GetAssetChartDataImpl(
     private val gemApiClient: GemApiClient,
     private val assetsRepository: AssetsRepository,
+    private val currencyRatesService: CurrencyRatesService,
 ) : GetAssetChartData {
 
     override suspend fun getAssetChartData(
@@ -25,7 +27,7 @@ class GetAssetChartDataImpl(
             assetsRepository.updateAssetMarket(assetId, it, currency)
         }
 
-        val rate = assetsRepository.getCurrencyRate(currency).firstOrNull()?.rate?.toFloat() ?: return emptyList()
+        val rate = currencyRatesService.getCurrencyRate(currency).firstOrNull()?.rate?.toFloat() ?: return emptyList()
         return chart.prices
             .map { it.copy(value = it.value * rate) }
             .sortedBy { it.timestamp }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetPortfolioDataImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetPortfolioDataImpl.kt
@@ -4,6 +4,7 @@ import com.gemwallet.android.application.assets.coordinators.GetPortfolioData
 import com.gemwallet.android.application.assets.coordinators.walletChartPeriods
 import com.gemwallet.android.blockchain.services.PerpetualService
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.CurrencyRatesService
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
 import com.gemwallet.android.ext.hyperliquidAccount
@@ -28,6 +29,7 @@ import java.math.BigInteger
 class GetPortfolioDataImpl(
     private val gemDeviceApiClient: GemDeviceApiClient,
     private val assetsRepository: AssetsRepository,
+    private val currencyRatesService: CurrencyRatesService,
     private val perpetualService: PerpetualService,
     private val sessionRepository: SessionRepository,
 ) : GetPortfolioData {
@@ -42,7 +44,7 @@ class GetPortfolioDataImpl(
     }
 
     private suspend fun getWalletData(period: ChartPeriod, currency: Currency): PortfolioData {
-        val rate = checkNotNull(assetsRepository.getCurrencyRate(currency).firstOrNull()?.rate) {
+        val rate = checkNotNull(currencyRatesService.getCurrencyRate(currency).firstOrNull()?.rate) {
             "Missing currency rate for ${currency.string}"
         }
         val assets = assetsRepository.getAssetsInfo().firstOrNull().orEmpty()

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetSearchListsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetSearchListsImpl.kt
@@ -1,13 +1,13 @@
 package com.gemwallet.android.data.coordinators.asset
 
 import com.gemwallet.android.application.assets.coordinators.GetSearchLists
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsSearchService
 import com.wallet.core.primitives.AssetList
 import kotlinx.coroutines.flow.Flow
 
 class GetSearchListsImpl(
-    private val assetsRepository: AssetsRepository,
+    private val searchService: AssetsSearchService,
 ) : GetSearchLists {
     override fun getSearchLists(query: String): Flow<List<AssetList>> =
-        assetsRepository.searchLists(query)
+        searchService.searchLists(query)
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/ClearRecentAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/ClearRecentAssetsImpl.kt
@@ -1,7 +1,7 @@
 package com.gemwallet.android.data.coordinators.asset_select
 
 import com.gemwallet.android.application.asset_select.coordinators.ClearRecentAssets
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.RecentAssetsService
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.model.RecentType
 import kotlinx.coroutines.flow.filterNotNull
@@ -9,10 +9,10 @@ import kotlinx.coroutines.flow.first
 
 class ClearRecentAssetsImpl(
     private val sessionRepository: SessionRepository,
-    private val assetsRepository: AssetsRepository,
+    private val recentAssetsService: RecentAssetsService,
 ) : ClearRecentAssets {
     override suspend fun invoke(types: List<RecentType>) {
         val wallet = sessionRepository.session().filterNotNull().first().wallet
-        assetsRepository.clearRecentAssets(wallet.id, types)
+        recentAssetsService.clearRecentAssets(wallet.id, types)
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/GetRecentAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/GetRecentAssetsImpl.kt
@@ -1,14 +1,14 @@
 package com.gemwallet.android.data.coordinators.asset_select
 
 import com.gemwallet.android.application.asset_select.coordinators.GetRecentAssets
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.RecentAssetsService
 import com.gemwallet.android.model.RecentAsset
 import com.gemwallet.android.model.RecentAssetsRequest
 import kotlinx.coroutines.flow.Flow
 
 class GetRecentAssetsImpl(
-    private val assetsRepository: AssetsRepository,
+    private val recentAssetsService: RecentAssetsService,
 ) : GetRecentAssets {
     override fun invoke(request: RecentAssetsRequest): Flow<List<RecentAsset>> =
-        assetsRepository.getRecentAssets(request)
+        recentAssetsService.getRecentAssets(request)
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SearchListAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SearchListAssetsImpl.kt
@@ -1,13 +1,13 @@
 package com.gemwallet.android.data.coordinators.asset_select
 
 import com.gemwallet.android.application.asset_select.coordinators.SearchListAssets
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsSearchService
 import com.gemwallet.android.model.AssetInfo
 import kotlinx.coroutines.flow.Flow
 
 class SearchListAssetsImpl(
-    private val assetsRepository: AssetsRepository,
+    private val searchService: AssetsSearchService,
 ) : SearchListAssets {
     override fun invoke(listId: String, limit: Int): Flow<List<AssetInfo>> =
-        assetsRepository.searchListAssets(listId, limit)
+        searchService.searchListAssets(listId, limit)
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SearchSelectAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/SearchSelectAssetsImpl.kt
@@ -1,14 +1,14 @@
 package com.gemwallet.android.data.coordinators.asset_select
 
 import com.gemwallet.android.application.asset_select.coordinators.SearchSelectAssets
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsSearchService
 import com.gemwallet.android.model.AssetInfo
 import com.wallet.core.primitives.AssetTag
 import kotlinx.coroutines.flow.Flow
 
 class SearchSelectAssetsImpl(
-    private val assetsRepository: AssetsRepository,
+    private val searchService: AssetsSearchService,
 ) : SearchSelectAssets {
     override fun invoke(query: String, tags: List<AssetTag>, limit: Int): Flow<List<AssetInfo>> =
-        assetsRepository.search(query, tags, false, limit)
+        searchService.search(query, tags, false, limit)
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/UpdateRecentAssetImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset_select/UpdateRecentAssetImpl.kt
@@ -1,7 +1,7 @@
 package com.gemwallet.android.data.coordinators.asset_select
 
 import com.gemwallet.android.application.asset_select.coordinators.UpdateRecentAsset
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.RecentAssetsService
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.model.RecentType
 import com.wallet.core.primitives.AssetId
@@ -10,10 +10,10 @@ import kotlinx.coroutines.flow.first
 
 class UpdateRecentAssetImpl(
     private val sessionRepository: SessionRepository,
-    private val assetsRepository: AssetsRepository,
+    private val recentAssetsService: RecentAssetsService,
 ) : UpdateRecentAsset {
     override suspend fun invoke(assetId: AssetId, type: RecentType) {
         val wallet = sessionRepository.session().filterNotNull().first().wallet
-        assetsRepository.addRecentActivity(assetId, wallet.id.id, type)
+        recentAssetsService.addRecentActivity(assetId, wallet.id.id, type)
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/confirm/ConfirmTransactionImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/confirm/ConfirmTransactionImpl.kt
@@ -5,7 +5,7 @@ import com.gemwallet.android.application.confirm.coordinators.ConfirmTransaction
 import com.gemwallet.android.blockchain.services.BroadcastService
 import com.gemwallet.android.blockchain.services.GemSignTransactionOperator
 import com.gemwallet.android.cases.transactions.CreateTransaction
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.RecentAssetsService
 import com.gemwallet.android.domains.confirm.ConfirmError
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.ConfirmParams
@@ -31,7 +31,7 @@ class ConfirmTransactionImpl(
     private val signTransactionOperator: GemSignTransactionOperator,
     private val broadcastService: BroadcastService,
     private val createTransactionsCase: CreateTransaction,
-    private val assetsRepository: AssetsRepository,
+    private val recentAssetsService: RecentAssetsService,
 ) : ConfirmTransaction {
 
     override suspend fun invoke(
@@ -128,7 +128,7 @@ class ConfirmTransactionImpl(
             null
         }
         try {
-            assetsRepository.addRecentActivity(assetInfo.id(), walletId, type, toAssetId)
+            recentAssetsService.addRecentActivity(assetInfo.id(), walletId, type, toAssetId)
         } catch (_: Throwable) {}
     }
 

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetModule.kt
@@ -59,6 +59,8 @@ import com.gemwallet.android.data.coordinators.asset.SyncAssetsImpl
 import com.gemwallet.android.data.coordinators.asset.ToggleAssetPinImpl
 import com.gemwallet.android.data.coordinators.asset.ToggleHideBalancesImpl
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsSearchService
+import com.gemwallet.android.data.repositories.assets.CurrencyRatesService
 import com.gemwallet.android.data.repositories.config.UserConfig
 import com.gemwallet.android.data.repositories.perpetual.ObservePerpetualWallet
 import com.gemwallet.android.data.repositories.perpetual.PerpetualRepository
@@ -98,8 +100,8 @@ object AssetModule {
 
     @Provides
     @Singleton
-    fun provideGetSearchLists(assetsRepository: AssetsRepository): GetSearchLists =
-        GetSearchListsImpl(assetsRepository)
+    fun provideGetSearchLists(searchService: AssetsSearchService): GetSearchLists =
+        GetSearchListsImpl(searchService)
 
     @Provides
     @Singleton
@@ -154,9 +156,11 @@ object AssetModule {
     fun provideGetAssetChartData(
         gemApiClient: GemApiClient,
         assetsRepository: AssetsRepository,
+        currencyRatesService: CurrencyRatesService,
     ): GetAssetChartData = GetAssetChartDataImpl(
         gemApiClient = gemApiClient,
         assetsRepository = assetsRepository,
+        currencyRatesService = currencyRatesService,
     )
 
     @Provides
@@ -164,11 +168,13 @@ object AssetModule {
     fun provideGetPortfolioData(
         gemDeviceApiClient: GemDeviceApiClient,
         assetsRepository: AssetsRepository,
+        currencyRatesService: CurrencyRatesService,
         perpetualService: PerpetualService,
         sessionRepository: SessionRepository,
     ): GetPortfolioData = GetPortfolioDataImpl(
         gemDeviceApiClient = gemDeviceApiClient,
         assetsRepository = assetsRepository,
+        currencyRatesService = currencyRatesService,
         perpetualService = perpetualService,
         sessionRepository = sessionRepository,
     )

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetSelectModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AssetSelectModule.kt
@@ -16,6 +16,8 @@ import com.gemwallet.android.data.coordinators.asset_select.SearchSelectAssetsIm
 import com.gemwallet.android.data.coordinators.asset_select.SwitchAssetVisibilityImpl
 import com.gemwallet.android.data.coordinators.asset_select.UpdateRecentAssetImpl
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsSearchService
+import com.gemwallet.android.data.repositories.assets.RecentAssetsService
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import dagger.Module
 import dagger.Provides
@@ -30,14 +32,14 @@ object AssetSelectModule {
     @Provides
     @Singleton
     fun provideSearchSelectAssets(
-        assetsRepository: AssetsRepository,
-    ): SearchSelectAssets = SearchSelectAssetsImpl(assetsRepository)
+        searchService: AssetsSearchService,
+    ): SearchSelectAssets = SearchSelectAssetsImpl(searchService)
 
     @Provides
     @Singleton
     fun provideSearchListAssets(
-        assetsRepository: AssetsRepository,
-    ): SearchListAssets = SearchListAssetsImpl(assetsRepository)
+        searchService: AssetsSearchService,
+    ): SearchListAssets = SearchListAssetsImpl(searchService)
 
     @Provides
     @Singleton
@@ -48,8 +50,8 @@ object AssetSelectModule {
     @Provides
     @Singleton
     fun provideGetRecentAssets(
-        assetsRepository: AssetsRepository,
-    ): GetRecentAssets = GetRecentAssetsImpl(assetsRepository)
+        recentAssetsService: RecentAssetsService,
+    ): GetRecentAssets = GetRecentAssetsImpl(recentAssetsService)
 
     @Provides
     @Singleton
@@ -62,13 +64,13 @@ object AssetSelectModule {
     @Singleton
     fun provideUpdateRecentAsset(
         sessionRepository: SessionRepository,
-        assetsRepository: AssetsRepository,
-    ): UpdateRecentAsset = UpdateRecentAssetImpl(sessionRepository, assetsRepository)
+        recentAssetsService: RecentAssetsService,
+    ): UpdateRecentAsset = UpdateRecentAssetImpl(sessionRepository, recentAssetsService)
 
     @Provides
     @Singleton
     fun provideClearRecentAssets(
         sessionRepository: SessionRepository,
-        assetsRepository: AssetsRepository,
-    ): ClearRecentAssets = ClearRecentAssetsImpl(sessionRepository, assetsRepository)
+        recentAssetsService: RecentAssetsService,
+    ): ClearRecentAssets = ClearRecentAssetsImpl(sessionRepository, recentAssetsService)
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/ConfirmModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/ConfirmModule.kt
@@ -11,7 +11,7 @@ import com.gemwallet.android.cases.transactions.CreateTransaction
 import com.gemwallet.android.data.coordinators.confirm.BuildConfirmPropertiesImpl
 import com.gemwallet.android.data.coordinators.confirm.ConfirmTransactionImpl
 import com.gemwallet.android.data.coordinators.confirm.ValidateBalanceImpl
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.RecentAssetsService
 import com.gemwallet.android.data.repositories.stake.StakeRepository
 import dagger.Module
 import dagger.Provides
@@ -34,13 +34,13 @@ object ConfirmModule {
         signTransactionOperator: GemSignTransactionOperator,
         broadcastService: BroadcastService,
         createTransactionsCase: CreateTransaction,
-        assetsRepository: AssetsRepository,
+        recentAssetsService: RecentAssetsService,
     ): ConfirmTransaction = ConfirmTransactionImpl(
         passwordStore,
         signTransactionOperator,
         broadcastService,
         createTransactionsCase,
-        assetsRepository,
+        recentAssetsService,
     )
 
     @Provides

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/FiatModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/FiatModule.kt
@@ -23,6 +23,7 @@ import com.gemwallet.android.data.coordinators.fiat.GetSellableFiatAssetsImpl
 import com.gemwallet.android.data.coordinators.fiat.ObserveFiatTransactionsImpl
 import com.gemwallet.android.data.coordinators.fiat.SyncFiatAssetsImpl
 import com.gemwallet.android.data.coordinators.fiat.SyncFiatTransactionsImpl
+import com.gemwallet.android.data.repositories.assets.AssetsAvailabilityService
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.service.store.ConfigStore
@@ -105,7 +106,7 @@ object FiatModule {
         getRemoteConfig: GetRemoteConfig,
         getBuyableFiatAssets: GetBuyableFiatAssets,
         getSellableFiatAssets: GetSellableFiatAssets,
-        assetsRepository: AssetsRepository,
+        availabilityService: AssetsAvailabilityService,
         prefetchAssets: PrefetchAssets,
     ): SyncFiatAssets {
         return SyncFiatAssetsImpl(
@@ -113,7 +114,7 @@ object FiatModule {
             getRemoteConfig = getRemoteConfig,
             getBuyableFiatAssets = getBuyableFiatAssets,
             getSellableFiatAssets = getSellableFiatAssets,
-            assetsRepository = assetsRepository,
+            availabilityService = availabilityService,
             prefetchAssets = prefetchAssets,
         )
     }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/SwapModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/SwapModule.kt
@@ -21,7 +21,9 @@ import com.gemwallet.android.data.coordinators.swap.GetSwapSupportedImpl
 import com.gemwallet.android.data.coordinators.swap.RequestSwapQuotesImpl
 import com.gemwallet.android.data.coordinators.swap.SearchSwapAssetsImpl
 import com.gemwallet.android.data.coordinators.swap.SyncSwapAssetsImpl
+import com.gemwallet.android.data.repositories.assets.AssetsAvailabilityService
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsSearchService
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.service.store.ConfigStore
 import com.gemwallet.android.data.services.gemapi.GemApiClient
@@ -106,10 +108,10 @@ object SwapModule {
     @Singleton
     @Provides
     fun provideSearchSwapAssets(
-        assetsRepository: AssetsRepository,
+        searchService: AssetsSearchService,
         getSwapSupported: GetSwapSupported,
     ): SearchSwapAssets = SearchSwapAssetsImpl(
-        assetsRepository = assetsRepository,
+        searchService = searchService,
         getSwapSupported = getSwapSupported,
     )
 
@@ -128,12 +130,14 @@ object SwapModule {
         getRemoteConfig: GetRemoteConfig,
         getSwapAssets: GetSwapAssets,
         assetsRepository: AssetsRepository,
+        availabilityService: AssetsAvailabilityService,
         prefetchAssets: PrefetchAssets,
     ): SyncSwapAssets = SyncSwapAssetsImpl(
         configStore = configStore,
         getRemoteConfig = getRemoteConfig,
         getSwapAssets = getSwapAssets,
         assetsRepository = assetsRepository,
+        availabilityService = availabilityService,
         prefetchAssets = prefetchAssets,
     )
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/fiat/SyncFiatAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/fiat/SyncFiatAssetsImpl.kt
@@ -5,7 +5,7 @@ import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
 import com.gemwallet.android.application.fiat.coordinators.GetBuyableFiatAssets
 import com.gemwallet.android.application.fiat.coordinators.GetSellableFiatAssets
 import com.gemwallet.android.application.fiat.coordinators.SyncFiatAssets
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsAvailabilityService
 import com.gemwallet.android.data.service.store.ConfigStore
 import com.gemwallet.android.ext.toAssetId
 import kotlinx.coroutines.currentCoroutineContext
@@ -16,7 +16,7 @@ class SyncFiatAssetsImpl(
     private val getRemoteConfig: GetRemoteConfig,
     private val getBuyableFiatAssets: GetBuyableFiatAssets,
     private val getSellableFiatAssets: GetSellableFiatAssets,
-    private val assetsRepository: AssetsRepository,
+    private val availabilityService: AssetsAvailabilityService,
     private val prefetchAssets: PrefetchAssets,
 ) : SyncFiatAssets {
 
@@ -47,11 +47,11 @@ class SyncFiatAssetsImpl(
             }
 
             buyAssets?.let {
-                assetsRepository.updateBuyAvailable(it.assetIds)
+                availabilityService.updateBuyAvailable(it.assetIds)
                 configStore.putInt(FIAT_ON_RAMP_ASSETS_VERSION, it.version.toInt())
             }
             sellAssets?.let {
-                assetsRepository.updateSellAvailable(it.assetIds)
+                availabilityService.updateSellAvailable(it.assetIds)
                 configStore.putInt(FIAT_OFF_RAMP_ASSETS_VERSION, it.version.toInt())
             }
         } catch (_: Exception) {

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/swap/SearchSwapAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/swap/SearchSwapAssetsImpl.kt
@@ -2,7 +2,7 @@ package com.gemwallet.android.data.coordinators.swap
 
 import com.gemwallet.android.application.swap.coordinators.GetSwapSupported
 import com.gemwallet.android.application.swap.coordinators.SearchSwapAssets
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsSearchService
 import com.gemwallet.android.domains.swap.SwapItemType
 import com.gemwallet.android.ext.isSwapSupport
 import com.gemwallet.android.ext.toAssetId
@@ -23,7 +23,7 @@ import uniffi.gemstone.SwapperAssetList
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SearchSwapAssetsImpl(
-    private val assetsRepository: AssetsRepository,
+    private val searchService: AssetsSearchService,
     private val getSwapSupported: GetSwapSupported,
 ) : SearchSwapAssets {
 
@@ -49,7 +49,7 @@ class SearchSwapAssetsImpl(
             }
         }
         .flatMapLatest { supported ->
-            assetsRepository.swapSearch(
+            searchService.swapSearch(
                 wallet,
                 query,
                 supported.chains.mapNotNull { it.toChain() },

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/swap/SyncSwapAssetsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/swap/SyncSwapAssetsImpl.kt
@@ -4,6 +4,7 @@ import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
 import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
 import com.gemwallet.android.application.swap.coordinators.GetSwapAssets
 import com.gemwallet.android.application.swap.coordinators.SyncSwapAssets
+import com.gemwallet.android.data.repositories.assets.AssetsAvailabilityService
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.service.store.ConfigStore
 import com.gemwallet.android.ext.toAssetId
@@ -15,6 +16,7 @@ class SyncSwapAssetsImpl(
     private val getRemoteConfig: GetRemoteConfig,
     private val getSwapAssets: GetSwapAssets,
     private val assetsRepository: AssetsRepository,
+    private val availabilityService: AssetsAvailabilityService,
     private val prefetchAssets: PrefetchAssets,
 ) : SyncSwapAssets {
 
@@ -28,7 +30,7 @@ class SyncSwapAssetsImpl(
             val synced = swapAssets.assetIds.distinct().chunked(ASSET_BATCH_SIZE).map { batch ->
                 val assetIds = batch.mapNotNull(String::toAssetId)
                 prefetchAssets.prefetchAssets(assetIds)
-                assetsRepository.updateSwapAvailable(batch)
+                availabilityService.updateSwapAvailable(batch)
                 assetsRepository.hasAssets(assetIds).size == assetIds.size
             }
             if (synced.all { it }) {

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetChartDataImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/GetAssetChartDataImplTest.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.data.coordinators.asset
 
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.CurrencyRatesService
 import com.gemwallet.android.data.services.gemapi.GemApiClient
 import com.gemwallet.android.testkit.mockAsset
 import com.gemwallet.android.testkit.mockAssetMarket
@@ -23,10 +24,12 @@ class GetAssetChartDataImplTest {
 
     private val gemApiClient = mockk<GemApiClient>()
     private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
+    private val currencyRatesService = mockk<CurrencyRatesService>(relaxed = true)
 
     private val subject = GetAssetChartDataImpl(
         gemApiClient = gemApiClient,
         assetsRepository = assetsRepository,
+        currencyRatesService = currencyRatesService,
     )
 
     @Test
@@ -43,7 +46,7 @@ class GetAssetChartDataImplTest {
             totalVolumes = emptyList(),
         )
         coEvery { gemApiClient.getChart("bitcoin", "day") } returns chart
-        every { assetsRepository.getCurrencyRate(Currency.EUR) } returns flowOf(FiatRate("EUR", 2.0))
+        every { currencyRatesService.getCurrencyRate(Currency.EUR) } returns flowOf(FiatRate("EUR", 2.0))
 
         val result = subject.getAssetChartData(
             assetId = asset.id,
@@ -64,7 +67,7 @@ class GetAssetChartDataImplTest {
             totalVolumes = emptyList(),
         )
         coEvery { gemApiClient.getChart("bitcoin", "day") } returns chart
-        every { assetsRepository.getCurrencyRate(Currency.EUR) } returns flowOf(null)
+        every { currencyRatesService.getCurrencyRate(Currency.EUR) } returns flowOf(null)
 
         val result = subject.getAssetChartData(
             assetId = asset.id,

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/GetPortfolioDataImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/GetPortfolioDataImplTest.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.data.coordinators.asset
 
 import com.gemwallet.android.blockchain.services.PerpetualService
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.CurrencyRatesService
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.services.gemapi.GemDeviceApiClient
 import com.gemwallet.android.model.AssetBalance
@@ -33,12 +34,14 @@ class GetPortfolioDataImplTest {
 
     private val gemDeviceApiClient = mockk<GemDeviceApiClient>()
     private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
+    private val currencyRatesService = mockk<CurrencyRatesService>(relaxed = true)
     private val perpetualService = mockk<PerpetualService>(relaxed = true)
     private val sessionRepository = mockk<SessionRepository>(relaxed = true)
 
     private val subject = GetPortfolioDataImpl(
         gemDeviceApiClient = gemDeviceApiClient,
         assetsRepository = assetsRepository,
+        currencyRatesService = currencyRatesService,
         perpetualService = perpetualService,
         sessionRepository = sessionRepository,
     )
@@ -64,7 +67,7 @@ class GetPortfolioDataImplTest {
         val held = mockAssetInfo(asset = bitcoin, balance = AssetBalance.create(bitcoin, available = "1000"))
         val empty = mockAssetInfo(asset = ethereum, balance = AssetBalance.create(ethereum))
         every { assetsRepository.getAssetsInfo() } returns flowOf(listOf(held, empty))
-        every { assetsRepository.getCurrencyRate(Currency.EUR) } returns flowOf(FiatRate("EUR", 2.0))
+        every { currencyRatesService.getCurrencyRate(Currency.EUR) } returns flowOf(FiatRate("EUR", 2.0))
         coEvery { gemDeviceApiClient.getPortfolioAssets("day", any()) } returns portfolio()
 
         val result = subject.getPortfolioData(PortfolioType.Wallet, period = ChartPeriod.Day, currency = Currency.EUR)
@@ -85,7 +88,7 @@ class GetPortfolioDataImplTest {
         val bitcoin = mockAsset()
         every { assetsRepository.getAssetsInfo() } returns
             flowOf(listOf(mockAssetInfo(asset = bitcoin, balance = AssetBalance.create(bitcoin, available = "1"))))
-        every { assetsRepository.getCurrencyRate(Currency.EUR) } returns flowOf(FiatRate("EUR", 2.0))
+        every { currencyRatesService.getCurrencyRate(Currency.EUR) } returns flowOf(FiatRate("EUR", 2.0))
         val allTimeHigh = ChartValuePercentage(date = 10L, value = 99f, percentage = 5f)
         val allTimeLow = ChartValuePercentage(date = 20L, value = 10f, percentage = -3f)
         coEvery { gemDeviceApiClient.getPortfolioAssets(any(), any()) } returns
@@ -111,7 +114,7 @@ class GetPortfolioDataImplTest {
 
     @Test(expected = IllegalStateException::class)
     fun getPortfolioData_throwsWhenRateMissing() = runTest {
-        every { assetsRepository.getCurrencyRate(Currency.EUR) } returns flowOf(null)
+        every { currencyRatesService.getCurrencyRate(Currency.EUR) } returns flowOf(null)
 
         subject.getPortfolioData(PortfolioType.Wallet, period = ChartPeriod.Day, currency = Currency.EUR)
     }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/confirm/ConfirmTransactionImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/confirm/ConfirmTransactionImplTest.kt
@@ -4,7 +4,7 @@ import com.gemwallet.android.application.PasswordStore
 import com.gemwallet.android.blockchain.services.BroadcastService
 import com.gemwallet.android.blockchain.services.GemSignTransactionOperator
 import com.gemwallet.android.cases.transactions.CreateTransaction
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.RecentAssetsService
 import com.gemwallet.android.model.ConfirmParams
 import com.gemwallet.android.model.Fee
 import com.gemwallet.android.model.SignerParams
@@ -72,7 +72,7 @@ class ConfirmTransactionImplTest {
             signTransactionOperator = signer,
             broadcastService = broadcastService,
             createTransactionsCase = createTransaction,
-            assetsRepository = mockk<AssetsRepository>(relaxed = true),
+            recentAssetsService = mockk<RecentAssetsService>(relaxed = true),
         ).invoke(
             signerParams = SignerParams(
                 input = ConfirmParams.SwapParams(

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/fiat/SyncFiatAssetsImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/fiat/SyncFiatAssetsImplTest.kt
@@ -4,7 +4,7 @@ import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
 import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
 import com.gemwallet.android.application.fiat.coordinators.GetBuyableFiatAssets
 import com.gemwallet.android.application.fiat.coordinators.GetSellableFiatAssets
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsAvailabilityService
 import com.gemwallet.android.data.service.store.ConfigStore
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.Chain
@@ -26,7 +26,7 @@ class SyncFiatAssetsImplTest {
     private val getRemoteConfig = mockk<GetRemoteConfig>()
     private val getBuyableFiatAssets = mockk<GetBuyableFiatAssets>()
     private val getSellableFiatAssets = mockk<GetSellableFiatAssets>()
-    private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
+    private val availabilityService = mockk<AssetsAvailabilityService>(relaxed = true)
     private val prefetchAssets = mockk<PrefetchAssets>(relaxed = true)
 
     private val subject = SyncFiatAssetsImpl(
@@ -34,7 +34,7 @@ class SyncFiatAssetsImplTest {
         getRemoteConfig = getRemoteConfig,
         getBuyableFiatAssets = getBuyableFiatAssets,
         getSellableFiatAssets = getSellableFiatAssets,
-        assetsRepository = assetsRepository,
+        availabilityService = availabilityService,
         prefetchAssets = prefetchAssets,
     )
 
@@ -60,8 +60,8 @@ class SyncFiatAssetsImplTest {
                 )
             )
         }
-        coVerify { assetsRepository.updateBuyAvailable(listOf("bitcoin")) }
-        coVerify { assetsRepository.updateSellAvailable(listOf("ethereum")) }
+        coVerify { availabilityService.updateBuyAvailable(listOf("bitcoin")) }
+        coVerify { availabilityService.updateSellAvailable(listOf("ethereum")) }
         verify { configStore.putInt("fiat-on-ramp-assets-version", 5, "") }
         verify { configStore.putInt("fiat-off-ramp-assets-version", 7, "") }
     }
@@ -80,8 +80,8 @@ class SyncFiatAssetsImplTest {
         coVerify(exactly = 0) { getBuyableFiatAssets() }
         coVerify(exactly = 0) { getSellableFiatAssets() }
         coVerify(exactly = 0) { prefetchAssets.prefetchAssets(any()) }
-        coVerify(exactly = 0) { assetsRepository.updateBuyAvailable(any()) }
-        coVerify(exactly = 0) { assetsRepository.updateSellAvailable(any()) }
+        coVerify(exactly = 0) { availabilityService.updateBuyAvailable(any()) }
+        coVerify(exactly = 0) { availabilityService.updateSellAvailable(any()) }
     }
 
     @Test
@@ -98,8 +98,8 @@ class SyncFiatAssetsImplTest {
         subject()
 
         coVerify(exactly = 0) { prefetchAssets.prefetchAssets(any()) }
-        coVerify { assetsRepository.updateBuyAvailable(emptyList()) }
-        coVerify { assetsRepository.updateSellAvailable(emptyList()) }
+        coVerify { availabilityService.updateBuyAvailable(emptyList()) }
+        coVerify { availabilityService.updateSellAvailable(emptyList()) }
         verify { configStore.putInt("fiat-on-ramp-assets-version", 5, "") }
         verify { configStore.putInt("fiat-off-ramp-assets-version", 7, "") }
     }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/swap/SearchSwapAssetsImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/swap/SearchSwapAssetsImplTest.kt
@@ -1,7 +1,7 @@
 package com.gemwallet.android.data.coordinators.swap
 
 import com.gemwallet.android.application.swap.coordinators.GetSwapSupported
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsSearchService
 import com.gemwallet.android.domains.swap.SwapItemType
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.model.AssetBalance
@@ -45,7 +45,7 @@ class SearchSwapAssetsImplTest {
             metadata = swapableMetaData,
         )
 
-        val assetsRepository = mockk<AssetsRepository> {
+        val searchService = mockk<AssetsSearchService> {
             every {
                 swapSearch(
                     wallet = wallet,
@@ -63,7 +63,7 @@ class SearchSwapAssetsImplTest {
             )
         }
 
-        val subject = SearchSwapAssetsImpl(assetsRepository, getSwapSupported)
+        val subject = SearchSwapAssetsImpl(searchService, getSwapSupported)
 
         val result = subject.invoke(
             wallet = wallet,

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/swap/SyncSwapAssetsImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/swap/SyncSwapAssetsImplTest.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.data.coordinators.swap
 import com.gemwallet.android.application.assets.coordinators.PrefetchAssets
 import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
 import com.gemwallet.android.application.swap.coordinators.GetSwapAssets
+import com.gemwallet.android.data.repositories.assets.AssetsAvailabilityService
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.service.store.ConfigStore
 import com.wallet.core.primitives.AssetId
@@ -27,6 +28,7 @@ class SyncSwapAssetsImplTest {
     private val getRemoteConfig = mockk<GetRemoteConfig>()
     private val getSwapAssets = mockk<GetSwapAssets>()
     private val assetsRepository = mockk<AssetsRepository>(relaxed = true)
+    private val availabilityService = mockk<AssetsAvailabilityService>(relaxed = true)
     private val prefetchAssets = mockk<PrefetchAssets>(relaxed = true)
 
     private val subject = SyncSwapAssetsImpl(
@@ -34,6 +36,7 @@ class SyncSwapAssetsImplTest {
         getRemoteConfig = getRemoteConfig,
         getSwapAssets = getSwapAssets,
         assetsRepository = assetsRepository,
+        availabilityService = availabilityService,
         prefetchAssets = prefetchAssets,
     )
 
@@ -47,7 +50,7 @@ class SyncSwapAssetsImplTest {
         subject()
 
         coVerify { prefetchAssets.prefetchAssets(listOf(AssetId(Chain.Bitcoin), AssetId(Chain.Ethereum))) }
-        coVerify { assetsRepository.updateSwapAvailable(listOf("bitcoin", "ethereum")) }
+        coVerify { availabilityService.updateSwapAvailable(listOf("bitcoin", "ethereum")) }
         verify { configStore.putInt(SWAP_ASSETS_VERSION, 495776, "") }
     }
 
@@ -60,7 +63,7 @@ class SyncSwapAssetsImplTest {
 
         coVerify(exactly = 0) { getSwapAssets() }
         coVerify(exactly = 0) { prefetchAssets.prefetchAssets(any()) }
-        coVerify(exactly = 0) { assetsRepository.updateSwapAvailable(any()) }
+        coVerify(exactly = 0) { availabilityService.updateSwapAvailable(any()) }
         verify(exactly = 0) { configStore.putInt(SWAP_ASSETS_VERSION, any(), any()) }
     }
 
@@ -78,7 +81,7 @@ class SyncSwapAssetsImplTest {
         subject()
 
         coVerify { prefetchAssets.prefetchAssets(capture(prefetched)) }
-        coVerify { assetsRepository.updateSwapAvailable(capture(marked)) }
+        coVerify { availabilityService.updateSwapAvailable(capture(marked)) }
 
         assertTrue(prefetched.all { it.size <= SQLITE_VARIABLE_LIMIT })
         assertTrue(marked.all { it.size <= SQLITE_VARIABLE_LIMIT })
@@ -93,7 +96,7 @@ class SyncSwapAssetsImplTest {
 
         subject()
 
-        coVerify(exactly = 0) { assetsRepository.updateSwapAvailable(any()) }
+        coVerify(exactly = 0) { availabilityService.updateSwapAvailable(any()) }
         verify(exactly = 0) { configStore.putInt(SWAP_ASSETS_VERSION, any(), any()) }
     }
 
@@ -106,7 +109,7 @@ class SyncSwapAssetsImplTest {
 
         subject()
 
-        coVerify { assetsRepository.updateSwapAvailable(listOf("bitcoin", "ethereum")) }
+        coVerify { availabilityService.updateSwapAvailable(listOf("bitcoin", "ethereum")) }
         verify(exactly = 0) { configStore.putInt(SWAP_ASSETS_VERSION, any(), any()) }
     }
 

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/transaction/TransactionDetailsAggregateImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/transaction/TransactionDetailsAggregateImplTest.kt
@@ -808,8 +808,8 @@ class TransactionDetailsAggregateImplTest {
 
         val rate = swapAggregate.rate
         Assert.assertNotNull(rate)
-        Assert.assertTrue(rate!!.forward.startsWith("1 ETH"))
-        Assert.assertTrue(rate.reverse.startsWith("1 USDT"))
+        Assert.assertTrue(rate!!.rate.forward.startsWith("1 ETH"))
+        Assert.assertTrue(rate.rate.reverse.startsWith("1 USDT"))
 
         Assert.assertNull(createAggregate(createTransactionExtended(createTransaction())).rate)
     }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
@@ -29,19 +29,13 @@ import com.gemwallet.android.ext.toAssetId
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.model.AssetBalance
 import com.gemwallet.android.model.AssetInfo
-import com.gemwallet.android.model.NO_QUERY_LIMIT
-import com.gemwallet.android.model.RecentAsset
-import com.gemwallet.android.model.RecentAssetsRequest
-import com.gemwallet.android.model.RecentType
 import com.wallet.core.primitives.Account
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.AssetBasic
 import com.wallet.core.primitives.AssetFull
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.AssetLink
-import com.wallet.core.primitives.AssetList
 import com.wallet.core.primitives.AssetMarket
-import com.wallet.core.primitives.AssetTag
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.FiatRate
@@ -82,8 +76,6 @@ class AssetsRepository @Inject constructor(
     private val streamSubscriptionService: StreamSubscriptionService,
     private val availabilityService: AssetsAvailabilityService,
     private val currencyRatesService: CurrencyRatesService,
-    private val searchService: AssetsSearchService,
-    private val recentAssetsService: RecentAssetsService,
     private val updateBalances: UpdateBalances = UpdateBalances(balancesDao, balancesService),
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
 ) : GetAsset {
@@ -238,17 +230,6 @@ class AssetsRepository @Inject constructor(
         return searchTokensCase.search(assetId, currency)
     }
 
-    fun search(query: String, tags: List<AssetTag>, byAllWallets: Boolean, limit: Int = NO_QUERY_LIMIT): Flow<List<AssetInfo>> =
-        searchService.search(query, tags, byAllWallets, limit)
-
-    fun searchLists(query: String): Flow<List<AssetList>> = searchService.searchLists(query)
-
-    fun searchListAssets(listId: String, limit: Int = NO_QUERY_LIMIT): Flow<List<AssetInfo>> =
-        searchService.searchListAssets(listId, limit)
-
-    fun swapSearch(wallet: Wallet, query: String, byChains: List<Chain>, byAssets: List<AssetId>, tags: List<AssetTag>): Flow<List<AssetInfo>> =
-        searchService.swapSearch(wallet, query, byChains, byAssets, tags)
-
     /**
      * Check and add new coins and active tokens
      * */
@@ -398,12 +379,6 @@ class AssetsRepository @Inject constructor(
         assetsDao.setWalletAssetVisibility(walletId, assetIdIdentifier, visible)
     }
 
-    suspend fun updateBuyAvailable(assets: List<String>) = availabilityService.updateBuyAvailable(assets)
-
-    suspend fun updateSellAvailable(assets: List<String>) = availabilityService.updateSellAvailable(assets)
-
-    suspend fun updateSwapAvailable(assets: List<String>) = availabilityService.updateSwapAvailable(assets)
-
     fun getAssetLinks(id: AssetId): Flow<List<AssetLink>> {
         return assetsDao.getAssetLinks(id.toIdentifier())
             .toAssetLinksModel()
@@ -440,20 +415,6 @@ class AssetsRepository @Inject constructor(
             .mapNotNull { it.value }
             .flatten()
     }
-
-    fun getCurrencyRate(currency: Currency): Flow<FiatRate?> = currencyRatesService.getCurrencyRate(currency)
-
-    suspend fun addRecentActivity(
-        assetId: AssetId,
-        walletId: String,
-        type: RecentType,
-        toAssetId: AssetId? = null,
-    ) = recentAssetsService.addRecentActivity(assetId, walletId, type, toAssetId)
-
-    fun getRecentAssets(request: RecentAssetsRequest): Flow<List<RecentAsset>> = recentAssetsService.getRecentAssets(request)
-
-    suspend fun clearRecentAssets(walletId: WalletId, types: List<RecentType>) =
-        recentAssetsService.clearRecentAssets(walletId, types)
 }
 
 private fun DbAsset.toBasicUpdateRecord() = DbAssetBasicUpdate(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
@@ -13,9 +13,7 @@ import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
 import com.gemwallet.android.data.repositories.assets.AssetsAvailabilityService
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
-import com.gemwallet.android.data.repositories.assets.AssetsSearchService
 import com.gemwallet.android.data.repositories.assets.CurrencyRatesService
-import com.gemwallet.android.data.repositories.assets.RecentAssetsService
 import com.gemwallet.android.data.repositories.assets.UpdateBalances
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.stream.ExponentialReconnection
@@ -57,8 +55,6 @@ object AssetsModule {
         streamSubscriptionService: StreamSubscriptionService,
         availabilityService: AssetsAvailabilityService,
         currencyRatesService: CurrencyRatesService,
-        searchService: AssetsSearchService,
-        recentAssetsService: RecentAssetsService,
     ): AssetsRepository = AssetsRepository(
         assetsDao = assetsDao,
         balancesDao = balancesDao,
@@ -69,8 +65,6 @@ object AssetsModule {
         streamSubscriptionService = streamSubscriptionService,
         availabilityService = availabilityService,
         currencyRatesService = currencyRatesService,
-        searchService = searchService,
-        recentAssetsService = recentAssetsService,
     )
 
     @Provides

--- a/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/PriceAlertsSelectViewModel.kt
+++ b/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/PriceAlertsSelectViewModel.kt
@@ -6,7 +6,7 @@ import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
 import com.gemwallet.android.application.asset_select.coordinators.UpdateRecentAsset
 import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.cases.tokens.SearchTokensCase
-import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.assets.AssetsSearchService
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.features.asset_select.viewmodels.BaseAssetSelectViewModel
 import com.gemwallet.android.features.asset_select.viewmodels.models.SelectAssetFilters
@@ -26,7 +26,7 @@ class PriceAlertsSelectViewModel @Inject constructor(
     updateRecentAsset: UpdateRecentAsset,
     switchAssetVisibility: SwitchAssetVisibility,
     toggleAssetPin: ToggleAssetPin,
-    assetsRepository: AssetsRepository,
+    searchService: AssetsSearchService,
     searchTokensCase: SearchTokensCase,
 ) : BaseAssetSelectViewModel(
     getSession,
@@ -35,20 +35,20 @@ class PriceAlertsSelectViewModel @Inject constructor(
     switchAssetVisibility,
     toggleAssetPin,
     searchTokensCase,
-    PriceAlertSelectSearch(assetsRepository),
+    PriceAlertSelectSearch(searchService),
 ) {
     override val showRecents: Boolean get() = false
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
 open class PriceAlertSelectSearch(
-    private val assetsRepository: AssetsRepository,
+    private val searchService: AssetsSearchService,
 ) : SelectSearch {
 
     override fun items(filters: Flow<SelectAssetFilters?>): Flow<List<AssetInfo>> {
         return filters
             .flatMapLatest { filters ->
-                assetsRepository.search(
+                searchService.search(
                     filters?.query ?: "",
                     filters?.tag?.let { listOf(it) } ?: emptyList(),
                     true


### PR DESCRIPTION
AssetsRepository re-exported eleven methods of four services that live next to it, without adding any logic of its own.

Those methods are gone — callers now take the service they actually need instead of the whole assets repository. Behaviour is unchanged.

Also fixes two assertions in the transaction details test that no longer compiled after the swap rate change.