### PR TITLE
Fetch current wallet by id instead of scanning all wallets

### DIFF
--- a/ios/Packages/FeatureServices/WalletSessionService/Tests/WalletSessionServiceTests.swift
+++ b/ios/Packages/FeatureServices/WalletSessionService/Tests/WalletSessionServiceTests.swift
@@ -2,6 +2,8 @@
 
 import Primitives
 import PrimitivesTestKit
+import Store
+import StoreTestKit
 import Testing
 @testable import WalletSessionService
 import WalletSessionServiceTestKit
@@ -22,5 +24,29 @@ struct WalletSessionServiceTests {
 
         #expect(service.setCurrent(index: 999) == .none)
         #expect(service.currentWalletId == .none)
+    }
+
+    @Test
+    func currentWalletResolvesSelectedWalletAmongMany() throws {
+        let store = WalletStore.mock(db: .mockWithChains([.bitcoin, .ethereum]))
+        let first = Wallet.mock(
+            id: .mock(address: "0x1"),
+            name: "First",
+            accounts: [.mock(chain: .bitcoin, address: "bc1")],
+        )
+        let second = Wallet.mock(
+            id: .mock(address: "0x2"),
+            name: "Second",
+            accounts: [.mock(chain: .ethereum, address: "0x2")],
+        )
+        try store.addWallet(first)
+        try store.addWallet(second)
+        let service = WalletSessionService.mock(store: store)
+
+        service.setCurrent(walletId: second.id)
+
+        #expect(service.currentWallet?.id == second.id)
+        #expect(service.currentWallet?.name == "Second")
+        #expect(service.currentWallet?.accounts == second.accounts)
     }
 }

--- a/ios/Packages/FeatureServices/WalletSessionService/WalletSessionService.swift
+++ b/ios/Packages/FeatureServices/WalletSessionService/WalletSessionService.swift
@@ -19,7 +19,7 @@ public struct WalletSessionService: WalletSessionManageable {
 
     public var currentWallet: Wallet? {
         guard let currentWalletId else { return nil }
-        return wallets.first(where: { $0.id == currentWalletId })
+        return try? walletStore.getWallet(id: currentWalletId)
     }
 
     public var currentWalletId: Primitives.WalletId? {


### PR DESCRIPTION
Reading the current wallet loaded every wallet from the database together with all of their accounts, then kept just one and threw the rest away.

It is read from four screens that stay mounted the whole time, so this happened on every redraw on the main thread, and got heavier the more wallets and chains you have.

Now it asks the database for that one wallet directly. Nothing changes for the user.