### PR TITLE
Share chart selection gestures between line and candlestick charts

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/chart/ChartSelection.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/chart/ChartSelection.kt
@@ -1,0 +1,104 @@
+package com.gemwallet.android.ui.components.chart
+
+import android.os.Build
+import android.view.HapticFeedbackConstants
+import android.view.View
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalView
+
+private const val FADE_IN_MS = 150
+private const val FADE_OUT_MS = 200
+
+@Stable
+class ChartSelection internal constructor(private val view: View) {
+
+    private val fade = Animatable(0f)
+    private var lastHapticIndex by mutableIntStateOf(-1)
+
+    val alpha: Float
+        get() = fade.value
+
+    internal suspend fun fadeIn() = fade.animateTo(1f, animationSpec = tween(FADE_IN_MS))
+
+    internal suspend fun fadeOut() {
+        fade.animateTo(0f, animationSpec = tween(FADE_OUT_MS))
+        lastHapticIndex = -1
+    }
+
+    internal fun hapticOnStart(index: Int) {
+        hapticTick()
+        lastHapticIndex = index
+    }
+
+    internal fun hapticOnChange(index: Int) {
+        if (index != lastHapticIndex) {
+            hapticTick()
+            lastHapticIndex = index
+        }
+    }
+
+    private fun hapticTick() {
+        view.performHapticFeedback(
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) HapticFeedbackConstants.CLOCK_TICK
+            else HapticFeedbackConstants.VIRTUAL_KEY
+        )
+    }
+}
+
+@Composable
+fun rememberChartSelection(selectedIndex: Int?): ChartSelection {
+    val view = LocalView.current
+    val selection = remember(view) { ChartSelection(view) }
+    LaunchedEffect(selectedIndex) {
+        if (selectedIndex != null) selection.fadeIn() else selection.fadeOut()
+    }
+    return selection
+}
+
+fun Modifier.chartSelection(
+    selection: ChartSelection,
+    vararg keys: Any?,
+    indexAt: (Float) -> Int?,
+    onSelectionChanged: (Int?) -> Unit,
+): Modifier = this
+    .pointerInput(*keys) {
+        detectTapGestures(onPress = { touch ->
+            indexAt(touch.x)?.let { index ->
+                selection.hapticOnChange(index)
+                onSelectionChanged(index)
+            }
+            tryAwaitRelease()
+            onSelectionChanged(null)
+        })
+    }
+    .pointerInput(*keys) {
+        detectDragGestures(
+            onDragStart = { touch ->
+                indexAt(touch.x)?.let { index ->
+                    selection.hapticOnStart(index)
+                    onSelectionChanged(index)
+                }
+            },
+            onDrag = { change, _ ->
+                change.consume()
+                indexAt(change.position.x)?.let { index ->
+                    selection.hapticOnChange(index)
+                    onSelectionChanged(index)
+                }
+            },
+            onDragEnd = { onSelectionChanged(null) },
+            onDragCancel = { onSelectionChanged(null) },
+        )
+    }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/chart/GemCandlestickChart.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/chart/GemCandlestickChart.kt
@@ -1,19 +1,11 @@
 package com.gemwallet.android.ui.components.chart
 
-import android.os.Build
-import android.view.HapticFeedbackConstants
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -25,10 +17,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
@@ -79,8 +69,6 @@ private object CandlestickMetrics {
     val axisLabelSize = 11.sp
 
     const val SELECTION_LINE_ALPHA = 0.50f
-    const val FADE_IN_MS = 150
-    const val FADE_OUT_MS = 200
 }
 
 @Composable
@@ -93,7 +81,6 @@ fun GemCandlestickChart(
     if (model.candles.isEmpty()) return
 
     val density = LocalDensity.current
-    val view = LocalView.current
     val textMeasurer = rememberTextMeasurer()
 
     val upColor = ValueDirection.Up.color()
@@ -135,17 +122,7 @@ fun GemCandlestickChart(
     val rightAxisWidthPx = with(density) { CandlestickMetrics.rightAxisWidth.toPx() }
 
     var chartSize by remember { mutableStateOf(IntSize.Zero) }
-    var lastHapticIndex by remember { mutableIntStateOf(-1) }
-
-    val selectionAlpha = remember { Animatable(0f) }
-    LaunchedEffect(selectedIndex) {
-        if (selectedIndex != null) {
-            selectionAlpha.animateTo(1f, animationSpec = tween(CandlestickMetrics.FADE_IN_MS))
-        } else {
-            selectionAlpha.animateTo(0f, animationSpec = tween(CandlestickMetrics.FADE_OUT_MS))
-            lastHapticIndex = -1
-        }
-    }
+    val selection = rememberChartSelection(selectedIndex)
 
     Box(modifier = modifier.fillMaxSize().onSizeChanged { chartSize = it }) {
         if (chartSize.width <= 0 || chartSize.height <= 0) return@Box
@@ -176,34 +153,13 @@ fun GemCandlestickChart(
         Canvas(
             modifier = Modifier
                 .fillMaxSize()
-                .pointerInput(chartSize, model.candles.size) {
-                    detectTapGestures(onPress = { touch ->
-                        touchToIndex(touch.x)?.let { index ->
-                            if (index != lastHapticIndex) { haptic(view); lastHapticIndex = index }
-                            onSelectionChanged(index)
-                        }
-                        tryAwaitRelease()
-                        onSelectionChanged(null)
-                    })
-                }
-                .pointerInput(chartSize, model.candles.size) {
-                    detectDragGestures(
-                        onDragStart = { touch ->
-                            touchToIndex(touch.x)?.let { index ->
-                                haptic(view); lastHapticIndex = index; onSelectionChanged(index)
-                            }
-                        },
-                        onDrag = { change, _ ->
-                            change.consume()
-                            touchToIndex(change.position.x)?.let { index ->
-                                if (index != lastHapticIndex) { haptic(view); lastHapticIndex = index }
-                                onSelectionChanged(index)
-                            }
-                        },
-                        onDragEnd = { onSelectionChanged(null) },
-                        onDragCancel = { onSelectionChanged(null) },
-                    )
-                },
+                .chartSelection(
+                    selection = selection,
+                    chartSize,
+                    model.candles.size,
+                    indexAt = ::touchToIndex,
+                    onSelectionChanged = onSelectionChanged,
+                ),
         ) {
             drawYAxis(model.yTicks, plotLeft, plotRight, plotTop, plotBottom, gridGuidelineColor, gridDashEffect, textMeasurer, axisLabelStyle, labelPaddingPx)
             drawXAxisGridlines(model.xGridlineFractions, plotLeft, plotRight, plotTop, plotBottom, gridGuidelineColor, gridDashEffect)
@@ -245,7 +201,7 @@ fun GemCandlestickChart(
             )
             drawSelection(
                 selectedIndex = selectedIndex,
-                selectionAlpha = selectionAlpha.value,
+                selectionAlpha = selection.alpha,
                 candles = model.candles,
                 slotCenter = ::slotCenter,
                 valueToY = ::valueToY,
@@ -511,12 +467,5 @@ private fun DrawScope.drawBadgeLabel(
     drawText(
         textLayoutResult = measured,
         topLeft = Offset(anchorX + horizontalPaddingPx, topY + verticalPaddingPx),
-    )
-}
-
-private fun haptic(view: android.view.View) {
-    view.performHapticFeedback(
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) HapticFeedbackConstants.CLOCK_TICK
-        else HapticFeedbackConstants.VIRTUAL_KEY,
     )
 }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/chart/GemLineChart.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/chart/GemLineChart.kt
@@ -1,21 +1,13 @@
 package com.gemwallet.android.ui.components.chart
 
-import android.os.Build
-import android.view.HapticFeedbackConstants
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -30,10 +22,8 @@ import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
@@ -70,8 +60,6 @@ private object Metrics {
     const val FLAT_LINE_PADDING = 0.01f
     const val FLAT_LINE_MIN_RANGE = 0.01f
     const val RANGE_PADDING = 0.05f
-    const val FADE_IN_MS = 150
-    const val FADE_OUT_MS = 200
 }
 
 private object Alpha {
@@ -97,7 +85,6 @@ fun GemLineChart(
     if (points.size < 2) return
 
     val density = LocalDensity.current
-    val view = LocalView.current
     val textMeasurer = rememberTextMeasurer()
     val isDark = isSystemInDarkTheme()
 
@@ -124,17 +111,7 @@ fun GemLineChart(
     }
 
     var chartSize by remember { mutableStateOf(IntSize.Zero) }
-    var lastHapticIndex by remember { mutableIntStateOf(-1) }
-
-    val selectionAlpha = remember { Animatable(0f) }
-    LaunchedEffect(selectedIndex) {
-        if (selectedIndex != null) {
-            selectionAlpha.animateTo(1f, animationSpec = tween(Metrics.FADE_IN_MS))
-        } else {
-            selectionAlpha.animateTo(0f, animationSpec = tween(Metrics.FADE_OUT_MS))
-            lastHapticIndex = -1
-        }
-    }
+    val selection = rememberChartSelection(selectedIndex)
 
     val labelStyle = TextStyle(
         color = MaterialTheme.colorScheme.secondary,
@@ -162,34 +139,12 @@ fun GemLineChart(
             Canvas(
                 modifier = Modifier
                     .fillMaxSize()
-                    .pointerInput(points) {
-                        detectTapGestures(onPress = { touch ->
-                            findClosestIndex(points, touch.x, curveLeft, curveWidth)?.let { index ->
-                                if (index != lastHapticIndex) { haptic(view); lastHapticIndex = index }
-                                onSelectionChanged(index)
-                            }
-                            tryAwaitRelease()
-                            onSelectionChanged(null)
-                        })
-                    }
-                    .pointerInput(points) {
-                        detectDragGestures(
-                            onDragStart = { touch ->
-                                findClosestIndex(points, touch.x, curveLeft, curveWidth)?.let { index ->
-                                    haptic(view); lastHapticIndex = index; onSelectionChanged(index)
-                                }
-                            },
-                            onDrag = { change, _ ->
-                                change.consume()
-                                findClosestIndex(points, change.position.x, curveLeft, curveWidth)?.let { index ->
-                                    if (index != lastHapticIndex) { haptic(view); lastHapticIndex = index }
-                                    onSelectionChanged(index)
-                                }
-                            },
-                            onDragEnd = { onSelectionChanged(null) },
-                            onDragCancel = { onSelectionChanged(null) },
-                        )
-                    }
+                    .chartSelection(
+                        selection = selection,
+                        points,
+                        indexAt = { touchX -> findClosestIndex(points, touchX, curveLeft, curveWidth) },
+                        onSelectionChanged = onSelectionChanged,
+                    )
             ) {
                 val screenPoints = renderPoints.map { point ->
                     Offset(renderScreenX(point.x), valueToScreenY(point.y))
@@ -212,7 +167,7 @@ fun GemLineChart(
                 if (selectedIndex != null && selectedIndex in points.indices) {
                     drawSelectionIndicator(
                         Offset(curveScreenX(selectedIndex, points.size), valueToScreenY(points[selectedIndex].y)),
-                        canvasHeight, selectionAlpha.value, lineColor, lineWidthPx, selectionDotRadiusPx, dashLengthPx, glowExtraPx,
+                        canvasHeight, selection.alpha, lineColor, lineWidthPx, selectionDotRadiusPx, dashLengthPx, glowExtraPx,
                     )
                 }
             }
@@ -412,10 +367,3 @@ private fun findClosestIndex(points: List<ChartPoint>, touchX: Float, curveLeft:
     points.indices.minByOrNull { index ->
         abs(curveLeft + indexToX(index, points.size, curveWidth) - touchX)
     }
-
-private fun haptic(view: android.view.View) {
-    view.performHapticFeedback(
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) HapticFeedbackConstants.CLOCK_TICK
-        else HapticFeedbackConstants.VIRTUAL_KEY
-    )
-}


### PR DESCRIPTION
The price chart and the perpetuals candlestick chart each had their own copy of the same touch-selection code — the tap and drag handling, the haptic feedback, and the fade animation.

Both now use one shared implementation. No visible change.