### PR TITLE
Fix Celestia staking APR and lock time

### DIFF
--- a/core/crates/gem_cosmos/src/models/block.rs
+++ b/core/crates/gem_cosmos/src/models/block.rs
@@ -44,6 +44,12 @@ pub struct InflationResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnnualProvisionsResponse {
+    #[serde(deserialize_with = "deserialize_f64_from_str")]
+    pub annual_provisions: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SupplyResponse {
     pub amount: SupplyAmount,
 }

--- a/core/crates/gem_cosmos/src/models/staking_osmosis.rs
+++ b/core/crates/gem_cosmos/src/models/staking_osmosis.rs
@@ -12,6 +12,12 @@ pub struct OsmosisMintParams {
     pub distribution_proportions: OsmosisDistributionProportions,
 }
 
+impl OsmosisMintParams {
+    pub fn epochs_per_year(&self) -> f64 {
+        if self.epoch_identifier == "day" { 365.0 } else { 52.0 }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OsmosisDistributionProportions {
     #[serde(deserialize_with = "deserialize_f64_from_str")]

--- a/core/crates/gem_cosmos/src/provider/staking.rs
+++ b/core/crates/gem_cosmos/src/provider/staking.rs
@@ -7,7 +7,7 @@ use gem_client::Client;
 use primitives::{DelegationBase, DelegationValidator, chain_cosmos::CosmosChain};
 
 use crate::{
-    provider::staking_mapper::{calculate_network_apy_cosmos, calculate_network_apy_osmosis, map_staking_delegations, map_staking_validators},
+    provider::staking_mapper::{calculate_network_apy, map_staking_delegations, map_staking_validators},
     rpc::client::CosmosClient,
 };
 
@@ -20,14 +20,20 @@ impl<C: Client> ChainStaking for CosmosClient<C> {
             CosmosChain::Cosmos | CosmosChain::Injective => {
                 let denom = chain.denom();
                 let (inflation, supply, staking_pool) = try_join!(self.get_inflation(), self.get_supply_by_denom(denom.as_ref()), self.get_staking_pool())?;
-                Ok(calculate_network_apy_cosmos(inflation, supply, staking_pool))
+                let annual_rewards = inflation.inflation * supply.amount.amount;
+
+                Ok(Some(calculate_network_apy(annual_rewards, staking_pool.pool.bonded_tokens)))
             }
             CosmosChain::Osmosis => {
                 let (mint_params, epoch_provisions, staking_pool) = try_join!(self.get_osmosis_mint_params(), self.get_osmosis_epoch_provisions(), self.get_staking_pool())?;
+                let annual_rewards = epoch_provisions.epoch_provisions * mint_params.params.epochs_per_year() * mint_params.params.distribution_proportions.staking;
 
-                Ok(calculate_network_apy_osmosis(mint_params, epoch_provisions, staking_pool))
+                Ok(Some(calculate_network_apy(annual_rewards, staking_pool.pool.bonded_tokens)))
             }
-            CosmosChain::Celestia => Ok(Some(10.55)),
+            CosmosChain::Celestia => {
+                let (annual_provisions, staking_pool) = try_join!(self.get_celestia_annual_provisions(), self.get_staking_pool())?;
+                Ok(Some(calculate_network_apy(annual_provisions.annual_provisions, staking_pool.pool.bonded_tokens)))
+            }
             CosmosChain::Sei => Ok(Some(5.62)),
         }
     }
@@ -75,8 +81,18 @@ impl<C: Client> ChainStaking for CosmosClient<C> {
 
 #[cfg(all(test, feature = "chain_integration_tests"))]
 mod chain_integration_tests {
-    use crate::provider::testkit::{create_cosmos_test_client, create_osmosis_test_client};
+    use crate::provider::testkit::{create_celestia_test_client, create_cosmos_test_client, create_osmosis_test_client};
     use chain_traits::ChainStaking;
+
+    #[tokio::test]
+    async fn test_get_celestia_staking_apy() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let client = create_celestia_test_client();
+        let apy = client.get_staking_apy().await?.unwrap();
+
+        assert!(apy > 0.0 && apy < 100.0);
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_get_osmosis_staking_apy() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/core/crates/gem_cosmos/src/provider/staking_mapper.rs
+++ b/core/crates/gem_cosmos/src/provider/staking_mapper.rs
@@ -1,52 +1,25 @@
-use crate::constants::BOND_STATUS_BONDED;
-use crate::models::staking::{Delegations, Rewards, StakingPoolResponse, UnbondingDelegations, Validator};
-use crate::models::{InflationResponse, OsmosisEpochProvisionsResponse, OsmosisMintParamsResponse, SupplyResponse};
+use std::{collections::HashMap, str::FromStr};
+
 use num_bigint::BigUint;
-use std::str::FromStr;
-
-#[cfg(test)]
-use crate::models::staking::{StakingPool, ValidatorCommission, ValidatorCommissionRates, ValidatorDescription, ValidatorsResponse};
-
-#[cfg(test)]
-use crate::models::{OsmosisDistributionProportions, OsmosisMintParams, SupplyAmount};
-
 use number_formatter::BigNumberFormatter;
 use primitives::chain_cosmos::CosmosChain;
 use primitives::{DelegationBase, DelegationState, DelegationValidator};
-use std::collections::HashMap;
 
-/// Convert string amounts to BigUint, handling parsing errors gracefully
+use crate::constants::BOND_STATUS_BONDED;
+use crate::models::staking::{Delegations, Rewards, UnbondingDelegations, Validator};
+#[cfg(test)]
+use crate::models::staking::{StakingPoolResponse, ValidatorCommission, ValidatorCommissionRates, ValidatorDescription, ValidatorsResponse};
+
 fn parse_to_biguint(value: &str) -> BigUint {
     BigUint::from_str(value).unwrap_or_default()
 }
 
-pub fn calculate_network_apy_cosmos(inflation: InflationResponse, supply: SupplyResponse, staking_pool: StakingPoolResponse) -> Option<f64> {
-    let bonded_tokens = staking_pool.pool.bonded_tokens;
-
+pub fn calculate_network_apy(annual_rewards: f64, bonded_tokens: f64) -> f64 {
     if bonded_tokens == 0.0 {
-        return Some(0.0);
+        return 0.0;
     }
 
-    let network_apy = inflation.inflation * (supply.amount.amount / bonded_tokens);
-    Some(network_apy * 100.0)
-}
-
-pub fn calculate_network_apy_osmosis(mint_params: OsmosisMintParamsResponse, epoch_provisions: OsmosisEpochProvisionsResponse, staking_pool: StakingPoolResponse) -> Option<f64> {
-    let epoch_provisions = epoch_provisions.epoch_provisions;
-    let staking_distribution = mint_params.params.distribution_proportions.staking;
-    let bonded_tokens = staking_pool.pool.bonded_tokens;
-
-    if bonded_tokens == 0.0 {
-        return Some(0.0);
-    }
-
-    let epochs_per_year = if mint_params.params.epoch_identifier == "day" { 365.0 } else { 52.0 };
-
-    let annual_issuance = epoch_provisions * epochs_per_year;
-    let annual_staking_rewards = annual_issuance * staking_distribution;
-    let staking_apy = (annual_staking_rewards / bonded_tokens) * 100.0;
-
-    Some(staking_apy)
+    (annual_rewards / bonded_tokens) * 100.0
 }
 
 pub fn map_staking_validators(validators: Vec<Validator>, chain: CosmosChain, apy: Option<f64>) -> Vec<DelegationValidator> {
@@ -225,7 +198,7 @@ mod tests {
             },
         };
 
-        let result = map_staking_validators(vec![validator], CosmosChain::Celestia, Some(10.55));
+        let result = map_staking_validators(vec![validator], CosmosChain::Celestia, Some(5.0));
 
         assert_eq!(result.len(), 1);
         let validator = &result[0];
@@ -238,52 +211,11 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_network_apy_cosmos() {
-        let inflation = InflationResponse { inflation: 0.10 };
-        let supply = SupplyResponse {
-            amount: SupplyAmount {
-                denom: "uatom".to_string(),
-                amount: 498707607433890.0,
-            },
-        };
-        let staking_pool = StakingPoolResponse {
-            pool: StakingPool {
-                bonded_tokens: 294464180546813.0,
-                not_bonded_tokens: 14480963444282.0,
-            },
-        };
+    fn test_calculate_network_apy() {
+        let staking_pool = StakingPoolResponse::mock();
+        assert_eq!(calculate_network_apy(50.0, staking_pool.pool.bonded_tokens), 50.0);
 
-        let result = calculate_network_apy_cosmos(inflation, supply, staking_pool);
-
-        assert!(result.is_some());
-        let apy = result.unwrap();
-
-        assert_eq!(apy.to_bits(), 0x4030efa48809e989);
-    }
-
-    #[test]
-    fn test_calculate_network_apy_osmosis() {
-        let mint_params = OsmosisMintParamsResponse {
-            params: OsmosisMintParams {
-                epoch_identifier: "week".to_string(),
-                distribution_proportions: OsmosisDistributionProportions { staking: 0.5 },
-            },
-        };
-
-        let epoch_provisions = OsmosisEpochProvisionsResponse { epoch_provisions: 1.0 };
-
-        let staking_pool = StakingPoolResponse {
-            pool: StakingPool {
-                bonded_tokens: 50.0,
-                not_bonded_tokens: 0.0,
-            },
-        };
-
-        let result = calculate_network_apy_osmosis(mint_params, epoch_provisions, staking_pool);
-
-        assert!(result.is_some());
-        let apy = result.unwrap();
-
-        assert_eq!(apy, 52.0);
+        let staking_pool = StakingPoolResponse::mock_with_bonded_tokens(0.0);
+        assert_eq!(calculate_network_apy(50.0, staking_pool.pool.bonded_tokens), 0.0);
     }
 }

--- a/core/crates/gem_cosmos/src/provider/testkit.rs
+++ b/core/crates/gem_cosmos/src/provider/testkit.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use crate::models::TransactionResponse;
+use crate::models::{StakingPool, StakingPoolResponse, TransactionResponse};
 #[cfg(all(test, feature = "chain_integration_tests"))]
 use crate::rpc::client::CosmosClient;
 #[cfg(all(test, feature = "chain_integration_tests"))]
@@ -25,6 +25,22 @@ impl TransactionResponse {
 
     pub fn mock_reverted_transfer_spam() -> Self {
         serde_json::from_str(include_str!("../../testdata/reverted_transfer_spam.json")).unwrap()
+    }
+}
+
+#[cfg(test)]
+impl StakingPoolResponse {
+    pub fn mock() -> Self {
+        Self::mock_with_bonded_tokens(100.0)
+    }
+
+    pub fn mock_with_bonded_tokens(bonded_tokens: f64) -> Self {
+        Self {
+            pool: StakingPool {
+                bonded_tokens,
+                not_bonded_tokens: 0.0,
+            },
+        }
     }
 }
 

--- a/core/crates/gem_cosmos/src/rpc/client.rs
+++ b/core/crates/gem_cosmos/src/rpc/client.rs
@@ -5,8 +5,8 @@ use crate::models::account::Balances;
 use crate::models::staking::{Delegations, Rewards, UnbondingDelegations};
 use crate::models::{Account, AccountResponse, BroadcastRequest, BroadcastResponse, InjectiveAccount};
 use crate::models::{
-    BlockResponse, InflationResponse, OsmosisEpochProvisionsResponse, OsmosisMintParamsResponse, StakingPoolResponse, SupplyResponse, TransactionResponse, TransactionsResponse,
-    ValidatorsResponse,
+    AnnualProvisionsResponse, BlockResponse, InflationResponse, OsmosisEpochProvisionsResponse, OsmosisMintParamsResponse, StakingPoolResponse, SupplyResponse,
+    TransactionResponse, TransactionsResponse, ValidatorsResponse,
 };
 use chain_traits::{ChainAccount, ChainAddressStatus, ChainPerpetual, ChainSimulation, ChainTraits};
 use gem_client::{Client, ClientExt};
@@ -78,6 +78,10 @@ impl<C: Client> CosmosClient<C> {
 
     pub async fn get_inflation(&self) -> Result<InflationResponse, Box<dyn Error + Send + Sync>> {
         Ok(self.client.get("/cosmos/mint/v1beta1/inflation").await?)
+    }
+
+    pub async fn get_celestia_annual_provisions(&self) -> Result<AnnualProvisionsResponse, Box<dyn Error + Send + Sync>> {
+        Ok(self.client.get("/cosmos/mint/v1beta1/annual_provisions").await?)
     }
 
     pub async fn get_supply_by_denom(&self, denom: &str) -> Result<SupplyResponse, Box<dyn Error + Send + Sync>> {

--- a/core/crates/primitives/src/chain_config.rs
+++ b/core/crates/primitives/src/chain_config.rs
@@ -668,7 +668,7 @@ static CHAIN_CONFIGS: LazyLock<Vec<ChainConfig>> = LazyLock::new(|| {
             is_utxo: false,
             evm: None,
             stake: Some(StakeChainConfig {
-                lock_time: 1_814_400,
+                lock_time: 1_209_600,
                 min_stake_amount: 0,
                 change_amount_on_unstake: true,
                 can_redelegate: true,


### PR DESCRIPTION
## Summary

- calculate Celestia staking APR dynamically from annual provisions and bonded tokens instead of using the stale hardcoded value
- share the primitive APR calculation across Cosmos-family staking paths while keeping chain-specific annual reward inputs at their call sites
- move the Osmosis epoch cadence behavior onto its mint parameters model
- correct Celestia's unstaking lock time from 21 days to 14 days

## Root cause

Celestia used a hardcoded staking rate that no longer reflected current network issuance and bonded supply. Its chain configuration also retained the former 21-day unstaking period.

## Impact

Celestia validator APR now follows current on-chain mint and staking-pool data, and the wallet displays the correct 14-day unstaking duration. This is an internal shared-Core change with no FFI or generated model changes.

## Validation

- `just test gem_cosmos` - 40 passed
- `cargo test -p primitives` - 216 passed
- live Celestia staking APR integration test - passed
- `cargo clippy -p gem_cosmos -p primitives --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
