### PR TITLE
Fix biometric prompt crash on cold start

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/SystemAuthenticator.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/SystemAuthenticator.kt
@@ -7,7 +7,9 @@ import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.LifecycleDestroyedException
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.withResumed
 import com.gemwallet.android.model.AuthRequest
 import com.gemwallet.android.model.AuthState
 import com.gemwallet.android.model.requiresConfirmation
@@ -28,6 +30,7 @@ internal class SystemAuthenticator(
     private lateinit var biometricPrompt: BiometricPrompt
     private var initialAuthRetry: Job? = null
     private var activeAuthTimeout: Job? = null
+    private var pendingAuthenticate: Job? = null
 
     val enrollmentMissing = _enrollmentMissing.asStateFlow()
 
@@ -54,7 +57,15 @@ internal class SystemAuthenticator(
     }
 
     fun authenticate() {
-        biometricPrompt.authenticate(buildPrompt(authRequests.activeRequiresConfirmation()))
+        pendingAuthenticate?.cancel()
+        pendingAuthenticate = activity.lifecycleScope.launch {
+            try {
+                activity.lifecycle.withResumed {
+                    biometricPrompt.authenticate(buildPrompt(authRequests.activeRequiresConfirmation()))
+                }
+            } catch (_: LifecycleDestroyedException) {
+            }
+        }
     }
 
     private fun buildPrompt(requiresConfirmation: Boolean): BiometricPrompt.PromptInfo =
@@ -101,6 +112,7 @@ internal class SystemAuthenticator(
     fun cancel() {
         initialAuthRetry?.cancel()
         activeAuthTimeout?.cancel()
+        pendingAuthenticate?.cancel()
         runCatching { biometricPrompt.cancelAuthentication() }
     }
 


### PR DESCRIPTION
Fixes a production crash (Play Console: 16 users / 26 events over 28 days, mostly on slower budget devices) where the biometric prompt could throw on app cold start.

The auth prompt was triggered before the app was fully ready, which occasionally raced Android's own setup for the prompt and crashed. Now it waits until the app is truly ready before showing the prompt, and does nothing if the app closes before that.