### PR TITLE
Fix Android price alert parity gaps with iOS

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/EnableDevicePushImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/EnableDevicePushImpl.kt
@@ -1,0 +1,16 @@
+package com.gemwallet.android.data.coordinators.device
+
+import com.gemwallet.android.application.device.coordinators.EnableDevicePush
+import com.gemwallet.android.cases.device.SwitchPushEnabled
+import com.gemwallet.android.data.repositories.wallets.WalletsRepository
+import kotlinx.coroutines.flow.firstOrNull
+
+class EnableDevicePushImpl(
+    private val switchPushEnabled: SwitchPushEnabled,
+    private val walletsRepository: WalletsRepository,
+) : EnableDevicePush {
+
+    override suspend fun invoke() {
+        switchPushEnabled.switchPushEnabled(true, walletsRepository.getAll().firstOrNull() ?: emptyList())
+    }
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/DeviceModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/DeviceModule.kt
@@ -1,8 +1,12 @@
 package com.gemwallet.android.data.coordinators.di
 
 import com.gemwallet.android.application.SecurityStore
+import com.gemwallet.android.application.device.coordinators.EnableDevicePush
 import com.gemwallet.android.application.device.coordinators.GetDeviceId
+import com.gemwallet.android.cases.device.SwitchPushEnabled
+import com.gemwallet.android.data.coordinators.device.EnableDevicePushImpl
 import com.gemwallet.android.data.coordinators.device.GetDeviceIdImpl
+import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,4 +19,11 @@ object DeviceModule {
     @Provides
     @Singleton
     fun provideDeviceId(securityStore: SecurityStore<Any>): GetDeviceId = GetDeviceIdImpl(securityStore)
+
+    @Provides
+    @Singleton
+    fun provideEnableDevicePush(
+        switchPushEnabled: SwitchPushEnabled,
+        walletsRepository: WalletsRepository,
+    ): EnableDevicePush = EnableDevicePushImpl(switchPushEnabled, walletsRepository)
 }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/device/EnableDevicePushImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/device/EnableDevicePushImplTest.kt
@@ -1,0 +1,43 @@
+package com.gemwallet.android.data.coordinators.device
+
+import com.gemwallet.android.cases.device.SwitchPushEnabled
+import com.gemwallet.android.data.repositories.wallets.WalletsRepository
+import com.wallet.core.primitives.Wallet
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class EnableDevicePushImplTest {
+
+    @Test
+    fun invoke_switchesPushEnabledWithCurrentWallets() = runBlocking {
+        val wallets = listOf(mockk<Wallet>())
+        val walletsRepository = mockk<WalletsRepository> {
+            coEvery { getAll() } returns flowOf(wallets)
+        }
+        val switchPushEnabled = mockk<SwitchPushEnabled> {
+            coEvery { switchPushEnabled(any(), any()) } returns Unit
+        }
+
+        EnableDevicePushImpl(switchPushEnabled, walletsRepository).invoke()
+
+        coVerify(exactly = 1) { switchPushEnabled.switchPushEnabled(true, wallets) }
+    }
+
+    @Test
+    fun invoke_withNoWallets_switchesPushEnabledWithEmptyList() = runBlocking {
+        val walletsRepository = mockk<WalletsRepository> {
+            coEvery { getAll() } returns flowOf(emptyList())
+        }
+        val switchPushEnabled = mockk<SwitchPushEnabled> {
+            coEvery { switchPushEnabled(any(), any()) } returns Unit
+        }
+
+        EnableDevicePushImpl(switchPushEnabled, walletsRepository).invoke()
+
+        coVerify(exactly = 1) { switchPushEnabled.switchPushEnabled(true, emptyList()) }
+    }
+}

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/AssetDetailsScene.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/AssetDetailsScene.kt
@@ -51,6 +51,7 @@ internal fun AssetDetailsScene(
     transactions: List<TransactionDataAggregate>,
     priceAlertEnabled: Boolean,
     priceAlertsCount: Int,
+    requestNotificationPermission: (() -> Unit) -> Unit,
     isRefreshing: Boolean,
     isOperationEnabled: Boolean,
     onAction: (AssetDetailsAction) -> Unit,
@@ -88,6 +89,7 @@ internal fun AssetDetailsScene(
                 uiState = uiState,
                 priceAlertEnabled = priceAlertEnabled,
                 snackBar = snackBar,
+                requestNotificationPermission = requestNotificationPermission,
                 onPriceAlert = { onAction(AssetDetailsAction.TogglePriceAlert(it)) },
             )
         },

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/AssetDetailsScreen.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/AssetDetailsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.rememberNotificationPermissionGate
 import com.gemwallet.android.ui.components.screen.LoadingScene
 import com.gemwallet.android.features.asset.viewmodels.details.viewmodels.AssetDetailsViewModel
 
@@ -20,6 +21,7 @@ fun AssetDetailsScreen(
     val priceAlertsCount by viewModel.priceAlertsCount.collectAsStateWithLifecycle()
     val uiModel by viewModel.uiModel.collectAsStateWithLifecycle()
     val isOperationEnabled by viewModel.isOperationEnabled.collectAsStateWithLifecycle()
+    val requestNotificationPermission = rememberNotificationPermissionGate(onGranted = viewModel::onPushNotificationGranted)
 
     if (uiModel != null) {
         AssetDetailsScene(
@@ -29,6 +31,7 @@ fun AssetDetailsScreen(
             priceAlertsCount = priceAlertsCount,
             isRefreshing = isRefreshing,
             isOperationEnabled = isOperationEnabled,
+            requestNotificationPermission = requestNotificationPermission,
             onAction = { action ->
                 when (action) {
                     AssetDetailsAction.Refresh -> viewModel.refresh()

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/components/AssetDetailsMenu.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/components/AssetDetailsMenu.kt
@@ -34,6 +34,7 @@ fun RowScope.AssetDetailsMenu(
     uiState: AssetInfoUIModel,
     priceAlertEnabled: Boolean,
     snackBar: SnackbarHostState,
+    requestNotificationPermission: (() -> Unit) -> Unit,
     onPriceAlert: (AssetId) -> Unit,
 ) {
     val context = LocalContext.current
@@ -53,10 +54,18 @@ fun RowScope.AssetDetailsMenu(
         context.shareText(subject = subject, text = shareUrl, chooserTitle = shareTitle)
     }
 
+    val enablePriceAlert = fun () {
+        onPriceAlert(uiState.asset.id)
+        scope.launch { snackBar.showSnackbar(priceAlertToastMessage, R.drawable.ic_notifications) }
+    }
+
     IconButton(
         onClick = {
-            onPriceAlert(uiState.asset.id)
-            scope.launch { snackBar.showSnackbar(priceAlertToastMessage, R.drawable.ic_notifications) }
+            if (priceAlertEnabled) {
+                enablePriceAlert()
+            } else {
+                requestNotificationPermission(enablePriceAlert)
+            }
         }
     ) {
         if (priceAlertEnabled) {

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
@@ -7,6 +7,7 @@ import com.gemwallet.android.application.assets.coordinators.EnableAsset
 import com.gemwallet.android.application.assets.coordinators.GetChainAssetInfo
 import com.gemwallet.android.application.assets.coordinators.SyncAssetInfo
 import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
+import com.gemwallet.android.application.device.coordinators.EnableDevicePush
 import com.gemwallet.android.application.pricealerts.coordinators.GetAssetPriceAlertState
 import com.gemwallet.android.application.pricealerts.coordinators.GetPriceAlerts
 import com.gemwallet.android.application.pricealerts.coordinators.HasAssetPriceAlerts
@@ -61,6 +62,7 @@ class AssetDetailsViewModel @Inject constructor(
     private val hasAssetPriceAlerts: HasAssetPriceAlerts,
     private val updatePriceAlerts: UpdatePriceAlerts,
     private val getPriceAlerts: GetPriceAlerts,
+    private val enableDevicePush: EnableDevicePush,
     private val getCurrentBlockExplorer: GetCurrentBlockExplorer,
     private val hasMultiSign: HasMultiSign,
     private val syncAssetTransactions: SyncAssetTransactions,
@@ -177,6 +179,10 @@ class AssetDetailsViewModel @Inject constructor(
     fun enablePriceAlert(assetId: AssetId) = viewModelScope.launch {
         val enabled = priceAlertEnabled.value ?: return@launch
         setAssetPriceAlertEnabled(assetId, !enabled)
+    }
+
+    fun onPushNotificationGranted() = viewModelScope.launch(Dispatchers.IO) {
+        enableDevicePush()
     }
 
     fun pin() = viewModelScope.launch(Dispatchers.IO) {

--- a/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertTargetNavScreen.kt
+++ b/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertTargetNavScreen.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.features.settings.price_alerts.viewmodels.PriceAlertTargetViewModel
 import com.gemwallet.android.features.settings.price_alerts.viewmodels.models.PriceAlertConfirmResult
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.rememberNotificationPermissionGate
 import com.wallet.core.primitives.PriceAlertDirection
 import com.wallet.core.primitives.PriceAlertNotificationType
 
@@ -20,9 +21,9 @@ fun PriceAlertTargetNavScreen(
     val resources = LocalResources.current
     val currency by viewModel.currency.collectAsStateWithLifecycle()
     val currentPriceFormatted by viewModel.currentPrice.collectAsStateWithLifecycle()
-    val currentPriceValue by viewModel.currentPriceValue.collectAsStateWithLifecycle()
     val type by viewModel.type.collectAsStateWithLifecycle()
     val direction by viewModel.direction.collectAsStateWithLifecycle()
+    val resolvedDirection by viewModel.resolvedDirection.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
     val priceSuggestions by viewModel.priceSuggestions.collectAsStateWithLifecycle()
     val percentageSuggestions by viewModel.percentageSuggestions.collectAsStateWithLifecycle()
@@ -31,12 +32,14 @@ fun PriceAlertTargetNavScreen(
     val priceState by viewModel.priceState.collectAsStateWithLifecycle()
     val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
 
+    val requestNotificationPermission = rememberNotificationPermissionGate(onGranted = viewModel::onPushNotificationGranted)
+
     PriceAlertTargetScene(
         value = viewModel.value,
         type = type,
         direction = direction,
+        resolvedDirection = resolvedDirection,
         currency = currency,
-        currentPriceValue = currentPriceValue,
         currentPriceFormatted = currentPriceFormatted,
         priceSuggestions = priceSuggestions,
         percentageSuggestions = percentageSuggestions,
@@ -50,10 +53,12 @@ fun PriceAlertTargetNavScreen(
         onDirection = viewModel::onDirection,
         onConfirm = {
             val result = viewModel.onConfirm()
-            if (result != null) {
-                onComplete(result.toMessage(resources))
-            } else {
-                onCancel()
+            requestNotificationPermission {
+                if (result != null) {
+                    onComplete(result.toMessage(resources))
+                } else {
+                    onCancel()
+                }
             }
         },
         onCancel = onCancel,

--- a/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertTargetScene.kt
+++ b/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertTargetScene.kt
@@ -69,8 +69,8 @@ fun PriceAlertTargetScene(
     value: TextFieldState = rememberTextFieldState(),
     type: PriceAlertNotificationType,
     direction: PriceAlertDirection,
+    resolvedDirection: PriceAlertDirection?,
     currency: Currency,
-    currentPriceValue: Double,
     currentPriceFormatted: String,
     priceSuggestions: List<Pair<String, String>> = emptyList(),
     percentageSuggestions: List<Int> = listOf(5, 10, 15),
@@ -153,16 +153,10 @@ fun PriceAlertTargetScene(
                 Text(
                     text = when (type) {
                         PriceAlertNotificationType.Auto -> ""
-                        PriceAlertNotificationType.Price -> {
-                            val inputPrice = try {
-                                value.text.toString().toDouble()
-                            } catch (_: Throwable) { 0.0 }
-                            when {
-                                inputPrice == 0.0 -> stringResource(R.string.price_alerts_set_alert_set_target_price)
-                                inputPrice < currentPriceValue -> stringResource(R.string.price_alerts_set_alert_price_under)
-                                inputPrice > currentPriceValue -> stringResource(R.string.price_alerts_set_alert_price_over)
-                                else -> stringResource(R.string.price_alerts_set_alert_set_target_price)
-                            }
+                        PriceAlertNotificationType.Price -> when (resolvedDirection) {
+                            null -> stringResource(R.string.price_alerts_set_alert_set_target_price)
+                            PriceAlertDirection.Down -> stringResource(R.string.price_alerts_set_alert_price_under)
+                            PriceAlertDirection.Up -> stringResource(R.string.price_alerts_set_alert_price_over)
                         }
 
                         PriceAlertNotificationType.PricePercentChange -> when (direction) {
@@ -219,7 +213,7 @@ fun PriceAlertTargetScene(
                             textAlign = TextAlign.Center,
                             color = if (value.text.isEmpty()) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.onSurface
                         ),
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal, imeAction = ImeAction.Next),
                         interactionSource = interactionSource,
                         cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                         outputTransformation = OutputTransformation {
@@ -276,7 +270,7 @@ fun PriceAlertTargetScenePricePreview() {
             type = PriceAlertNotificationType.Price,
             currency = Currency.USD,
             currentPriceFormatted = "$901.80",
-            currentPriceValue = 901.8,
+            resolvedDirection = PriceAlertDirection.Up,
             priceSuggestions = listOf("$850" to "850", "$950" to "950"),
             percentageSuggestions = listOf(3, 6, 9),
             error = null,
@@ -299,7 +293,7 @@ fun PriceAlertTargetScenePercentagePreview() {
             type = PriceAlertNotificationType.PricePercentChange,
             currency = Currency.USD,
             currentPriceFormatted = "$901.80",
-            currentPriceValue = 901.8,
+            resolvedDirection = PriceAlertDirection.Up,
             priceSuggestions = listOf("$850" to "850", "$950" to "950"),
             percentageSuggestions = listOf(3, 6, 9),
             error = null,

--- a/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertsNavScreen.kt
+++ b/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertsNavScreen.kt
@@ -12,6 +12,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.rememberNotificationPermissionGate
 import com.gemwallet.android.ui.components.screen.rememberSnackbarState
 import com.gemwallet.android.ui.components.screen.showSnackbar
 import com.gemwallet.android.features.settings.price_alerts.viewmodels.PriceAlertViewModel
@@ -36,6 +37,7 @@ fun PriceAlertsNavScreen(
     )
 
     var selectingAsset by remember { mutableStateOf(false) }
+    val requestNotificationPermission = rememberNotificationPermissionGate(onGranted = viewModel::onPushNotificationGranted)
 
     val data by viewModel.data.collectAsStateWithLifecycle()
     val assetInfo by viewModel.assetInfo.collectAsStateWithLifecycle()
@@ -46,11 +48,13 @@ fun PriceAlertsNavScreen(
         when (selecting) {
             true -> PriceAlertSelectScreen(
                 onCancel = { selectingAsset = false },
-                onSelect = {
-                    viewModel.includeAsset(it) { asset ->
-                        val message = resources.getString(R.string.price_alerts_enabled_for, asset.name)
-                        scope.launch {
-                            snackbar.showSnackbar(message, R.drawable.ic_notifications)
+                onSelect = { assetId ->
+                    requestNotificationPermission {
+                        viewModel.includeAsset(assetId) { asset ->
+                            val message = resources.getString(R.string.price_alerts_enabled_for, asset.name)
+                            scope.launch {
+                                snackbar.showSnackbar(message, R.drawable.ic_notifications)
+                            }
                         }
                     }
                     selectingAsset = false
@@ -65,8 +69,16 @@ fun PriceAlertsNavScreen(
                 snackbar = snackbar,
                 onAction = { action ->
                     when (action) {
-                        is PriceAlertAction.TogglePriceAlerts -> viewModel.togglePriceAlerts(action.enabled)
-                        is PriceAlertAction.ToggleAutoAlert -> viewModel.toggleAutoAlert(action.enabled)
+                        is PriceAlertAction.TogglePriceAlerts -> if (action.enabled) {
+                            requestNotificationPermission { viewModel.togglePriceAlerts(true) }
+                        } else {
+                            viewModel.togglePriceAlerts(false)
+                        }
+                        is PriceAlertAction.ToggleAutoAlert -> if (action.enabled) {
+                            requestNotificationPermission { viewModel.toggleAutoAlert(true) }
+                        } else {
+                            viewModel.toggleAutoAlert(false)
+                        }
                         is PriceAlertAction.Exclude -> viewModel.excludeAsset(action.id)
                         PriceAlertAction.Refresh -> viewModel.refresh()
                         PriceAlertAction.Add -> selectingAsset = true
@@ -78,5 +90,4 @@ fun PriceAlertsNavScreen(
             )
         }
     }
-
 }

--- a/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/PriceAlertTargetViewModel.kt
+++ b/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/PriceAlertTargetViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.device.coordinators.EnableDevicePush
 import com.gemwallet.android.application.pricealerts.coordinators.IncludePriceAlert
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.domains.pricealerts.direction
@@ -13,6 +14,7 @@ import com.gemwallet.android.domains.percentage.formatAsPercentage
 import com.gemwallet.android.domains.price.ValueDirection
 import com.gemwallet.android.domains.price.toValueDirection
 import com.gemwallet.android.model.CurrencyFormatter
+import com.gemwallet.android.model.NumericFormatter
 import com.gemwallet.android.features.settings.price_alerts.viewmodels.models.PriceAlertConfirmResult
 import com.gemwallet.android.features.settings.price_alerts.viewmodels.models.PriceAlertTargetError
 import com.gemwallet.android.ui.models.ButtonState
@@ -41,10 +43,12 @@ import javax.inject.Inject
 class PriceAlertTargetViewModel @Inject constructor(
     private val assetsRepository: AssetsRepository,
     private val includePriceAlert: IncludePriceAlert,
+    private val enableDevicePush: EnableDevicePush,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
     private val priceAlertFormatter = PriceAlertFormatter()
+    private val numericFormatter = NumericFormatter()
     private val suggestionOffsetPercent = 5.0
 
     val value = TextFieldState()
@@ -83,25 +87,38 @@ class PriceAlertTargetViewModel @Inject constructor(
         priceAlertFormatter.percentageSuggestions(price)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, listOf(5, 10, 15))
 
-    val error: StateFlow<PriceAlertTargetError?> = snapshotFlow { value.text }.map {
-        val value = try { it.toString().toDouble() } catch (_: Throwable) { 0.0 }
-        if (value <= 0.0) {
-            PriceAlertTargetError.Zero
-        } else {
-            null
-        }
-    }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
-
-    val buttonState: StateFlow<ButtonState> = error
-        .map { buttonState(enabled = it == null) }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, buttonState(enabled = error.value == null))
-
     private val _direction = MutableStateFlow(PriceAlertDirection.Up)
     val direction: StateFlow<PriceAlertDirection> = _direction
 
     private val _type = MutableStateFlow(PriceAlertNotificationType.Price)
     val type: StateFlow<PriceAlertNotificationType> = _type
+
+    private data class ResolvedInput(val inputValue: Double, val direction: PriceAlertDirection?)
+
+    private val resolvedInput: StateFlow<ResolvedInput> = combine(
+        snapshotFlow { value.text }, currentPriceValue, _type, _direction,
+    ) { text, currentPrice, type, selectedDirection ->
+        val inputValue = numericFormatter.double(text.toString()) ?: 0.0
+        val direction = if (inputValue <= 0.0) null else type.direction(currentPrice, inputValue, selectedDirection)
+        ResolvedInput(inputValue, direction)
+    }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ResolvedInput(0.0, null))
+
+    val resolvedDirection: StateFlow<PriceAlertDirection?> = resolvedInput.map { it.direction }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val error: StateFlow<PriceAlertTargetError?> = resolvedInput.map {
+        when {
+            it.inputValue <= 0.0 -> PriceAlertTargetError.Zero
+            it.direction == null -> PriceAlertTargetError.Undecided
+            else -> null
+        }
+    }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, PriceAlertTargetError.Zero)
+
+    val buttonState: StateFlow<ButtonState> = error
+        .map { buttonState(enabled = it == null) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, buttonState(enabled = error.value == null))
 
     fun onDirection(direction: PriceAlertDirection) {
         _direction.update { direction }
@@ -112,13 +129,9 @@ class PriceAlertTargetViewModel @Inject constructor(
     }
 
     fun onConfirm(): PriceAlertConfirmResult? {
-        val inputValue = try {
-            value.text.toString().toDouble()
-        } catch (_: Throwable) {
-            return null
-        }
+        val inputValue = numericFormatter.double(value.text.toString()) ?: return null
         val type = type.value
-        val direction = type.direction(currentPriceValue.value, inputValue, direction.value)
+        val direction = resolvedInput.value.direction ?: return null
         val price = if (type == PriceAlertNotificationType.Price) inputValue else null
         val percentage = if (type == PriceAlertNotificationType.PricePercentChange) inputValue else null
         viewModelScope.launch(Dispatchers.IO) {
@@ -130,8 +143,11 @@ class PriceAlertTargetViewModel @Inject constructor(
                 direction = direction,
             )
         }
-        direction ?: return null
         return PriceAlertConfirmResult(type, direction, type.formatAmount(inputValue, currency.value))
+    }
+
+    fun onPushNotificationGranted() = viewModelScope.launch(Dispatchers.IO) {
+        enableDevicePush()
     }
 
 }

--- a/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/PriceAlertViewModel.kt
+++ b/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/PriceAlertViewModel.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.features.settings.price_alerts.viewmodels
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.device.coordinators.EnableDevicePush
 import com.gemwallet.android.application.pricealerts.coordinators.ExcludePriceAlert
 import com.gemwallet.android.application.pricealerts.coordinators.GetAssetPriceAlertState
 import com.gemwallet.android.application.pricealerts.coordinators.GetPriceAlerts
@@ -41,6 +42,7 @@ class PriceAlertViewModel @Inject constructor(
     private val assetsRepository: AssetsRepository,
     private val includePriceAlert: IncludePriceAlert,
     private val excludePriceAlert: ExcludePriceAlert,
+    private val enableDevicePush: EnableDevicePush,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -106,6 +108,10 @@ class PriceAlertViewModel @Inject constructor(
         viewModelScope.launch {
             setPriceAlertsEnabled(enable)
         }
+    }
+
+    fun onPushNotificationGranted() = viewModelScope.launch(Dispatchers.IO) {
+        enableDevicePush()
     }
 
     fun toggleAutoAlert(enabled: Boolean) = viewModelScope.launch(Dispatchers.IO) {

--- a/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/models/PriceAlertTargetError.kt
+++ b/android/features/settings/price_alerts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/viewmodels/models/PriceAlertTargetError.kt
@@ -3,4 +3,5 @@ package com.gemwallet.android.features.settings.price_alerts.viewmodels.models
 sealed class PriceAlertTargetError : Exception() {
     object Zero : PriceAlertTargetError()
     object NotNumber : PriceAlertTargetError()
+    object Undecided : PriceAlertTargetError()
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/device/coordinators/EnableDevicePush.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/device/coordinators/EnableDevicePush.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.application.device.coordinators
+
+interface EnableDevicePush {
+    suspend operator fun invoke()
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/pricealerts/PriceAlertNotificationTypeExt.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/pricealerts/PriceAlertNotificationTypeExt.kt
@@ -10,8 +10,12 @@ fun PriceAlertNotificationType.direction(
     inputValue: Double,
     selectedDirection: PriceAlertDirection,
 ): PriceAlertDirection? = when (this) {
-    PriceAlertNotificationType.Price ->
-        if (currentPrice > inputValue) PriceAlertDirection.Down else PriceAlertDirection.Up
+    PriceAlertNotificationType.Price -> when {
+        currentPrice <= 0.0 -> null
+        inputValue > currentPrice -> PriceAlertDirection.Up
+        inputValue < currentPrice -> PriceAlertDirection.Down
+        else -> null
+    }
     PriceAlertNotificationType.PricePercentChange -> selectedDirection
     PriceAlertNotificationType.Auto -> null
 }

--- a/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/pricealerts/PriceAlertNotificationTypeExtTest.kt
+++ b/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/pricealerts/PriceAlertNotificationTypeExtTest.kt
@@ -1,0 +1,44 @@
+package com.gemwallet.android.domains.pricealerts
+
+import com.wallet.core.primitives.PriceAlertDirection
+import com.wallet.core.primitives.PriceAlertNotificationType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PriceAlertNotificationTypeExtTest {
+
+    @Test
+    fun `price direction is null when target equals current price`() {
+        assertNull(PriceAlertNotificationType.Price.direction(currentPrice = 100.0, inputValue = 100.0, selectedDirection = PriceAlertDirection.Up))
+    }
+
+    @Test
+    fun `price direction is null when there is no current price yet`() {
+        assertNull(PriceAlertNotificationType.Price.direction(currentPrice = 0.0, inputValue = 100.0, selectedDirection = PriceAlertDirection.Up))
+    }
+
+    @Test
+    fun `price direction is up when target is above current price`() {
+        assertEquals(
+            PriceAlertDirection.Up,
+            PriceAlertNotificationType.Price.direction(currentPrice = 100.0, inputValue = 150.0, selectedDirection = PriceAlertDirection.Down),
+        )
+    }
+
+    @Test
+    fun `price direction is down when target is below current price`() {
+        assertEquals(
+            PriceAlertDirection.Down,
+            PriceAlertNotificationType.Price.direction(currentPrice = 100.0, inputValue = 50.0, selectedDirection = PriceAlertDirection.Up),
+        )
+    }
+
+    @Test
+    fun `percent change direction always follows the selected direction`() {
+        assertEquals(
+            PriceAlertDirection.Down,
+            PriceAlertNotificationType.PricePercentChange.direction(currentPrice = 0.0, inputValue = 5.0, selectedDirection = PriceAlertDirection.Down),
+        )
+    }
+}

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/NotificationPermissionGate.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/NotificationPermissionGate.kt
@@ -1,0 +1,27 @@
+package com.gemwallet.android.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+@Composable
+fun rememberNotificationPermissionGate(onGranted: () -> Unit = {}): (() -> Unit) -> Unit {
+    var requesting by remember { mutableStateOf(false) }
+
+    if (requesting) {
+        PushRequest(
+            onNotificationEnable = {
+                requesting = false
+                onGranted()
+            },
+            onDismiss = { requesting = false },
+        )
+    }
+
+    return { action ->
+        action()
+        requesting = true
+    }
+}

--- a/ios/Packages/FeatureServices/PriceAlertService/PriceAlertService.swift
+++ b/ios/Packages/FeatureServices/PriceAlertService/PriceAlertService.swift
@@ -83,10 +83,8 @@ public struct PriceAlertService: Sendable {
     }
 
     public func enablePriceAlerts() async throws {
-        if !preferences.isPriceAlertsEnabled {
-            preferences.isPriceAlertsEnabled = true
-            try await deviceService.update()
-        }
+        preferences.isPriceAlertsEnabled = true
+        try await deviceService.update()
     }
 
     public func delete(priceAlerts: [PriceAlert]) async throws {

--- a/ios/Packages/FeatureServices/PriceAlertService/Tests/PriceAlertServiceTests.swift
+++ b/ios/Packages/FeatureServices/PriceAlertService/Tests/PriceAlertServiceTests.swift
@@ -72,8 +72,10 @@ struct PriceAlertServiceTests {
         let store = try createStore()
         let preferences = Preferences.mock()
         let pushNotificationService = PushNotificationEnablerMock()
+        let deviceService = DeviceServiceMock()
         let service = PriceAlertService.mock(
             store: store,
+            deviceService: deviceService,
             preferences: preferences,
             pushNotificationService: pushNotificationService,
         )
@@ -83,6 +85,24 @@ struct PriceAlertServiceTests {
         #expect(pushNotificationService.didRequestPermissions)
         #expect(preferences.isPriceAlertsEnabled)
         #expect(try store.getPriceAlerts().count == 1)
+        #expect(await deviceService.updateCalls == 1)
+    }
+
+    @Test
+    func enableAlertSyncsDeviceWhenPriceAlertsAlreadyEnabled() async throws {
+        let store = try createStore()
+        let preferences = Preferences.mock()
+        preferences.isPriceAlertsEnabled = true
+        let deviceService = DeviceServiceMock()
+        let service = PriceAlertService.mock(
+            store: store,
+            deviceService: deviceService,
+            preferences: preferences,
+        )
+
+        try await service.enable(priceAlert: .mock(assetId: .mock(.bitcoin)))
+
+        #expect(await deviceService.updateCalls == 1)
     }
 
     // MARK: - Private methods


### PR DESCRIPTION
Fixes three Android-only gaps in the price alert flow: the target price field now opens a decimal keyboard, the confirm button stays disabled when the direction is undecided (target equals current price, or no price yet), and enabling a price alert now asks for notification permission on every path instead of never asking.

While testing, also found and fixed a related gap on both platforms: enabling a price alert didn't guarantee the device was actually registered for push with the backend, so an alert could show as "on" while never being able to notify.

Closes #805