### PR TITLE
Consolidate select-asset flow rules into SelectAssetFlow

### DIFF
--- a/ios/Features/Assets/Sources/Scenes/SelectAssetScene.swift
+++ b/ios/Features/Assets/Sources/Scenes/SelectAssetScene.swift
@@ -76,15 +76,10 @@ public struct SelectAssetScene: View {
                     models: model.recentModels,
                     onSelectRecents: model.onSelectRecents,
                 ) { assetModel in
-                    switch model.selectType {
-                    case .send, .receive, .buy, .swap:
-                        Button {
-                            model.onSelectRecent(assetModel.asset)
-                        } label: {
-                            AssetChipView(model: assetModel)
-                        }
-                    case .manage, .priceAlert, .deposit, .withdraw:
-                        EmptyView()
+                    Button {
+                        model.onSelectRecent(assetModel.asset)
+                    } label: {
+                        AssetChipView(model: assetModel)
                     }
                 }
             }
@@ -125,34 +120,21 @@ public struct SelectAssetScene: View {
 
     func assetsList(assets: [AssetData]) -> some View {
         ForEach(assets) { assetData in
-            switch model.selectType {
-            case .buy, .receive, .send, .deposit, .withdraw:
-                NavigationCustomLink(
-                    with: ListAssetItemSelectionView(
-                        assetData: model.displayAssetData(assetData),
-                        currencyCode: model.currencyCode,
-                        type: model.selectType.listType,
-                        action: model.onAssetAction,
-                    ),
-                ) {
+            let itemView = ListAssetItemSelectionView(
+                assetData: model.displayAssetData(assetData),
+                currencyCode: model.currencyCode,
+                type: model.flow.listType,
+                action: model.onAssetAction,
+            )
+            switch model.flow.rowSelection {
+            case .navigate:
+                NavigationCustomLink(with: itemView) {
                     model.onSelectAsset(assetData)
                 }
-            case .manage:
-                ListAssetItemSelectionView(
-                    assetData: assetData,
-                    currencyCode: model.currencyCode,
-                    type: model.selectType.listType,
-                    action: model.onAssetAction,
-                )
-            case .swap, .priceAlert:
-                NavigationCustomLink(
-                    with: ListAssetItemSelectionView(
-                        assetData: assetData,
-                        currencyCode: model.currencyCode,
-                        type: model.selectType.listType,
-                        action: model.onAssetAction,
-                    ),
-                ) {
+            case .toggle:
+                itemView
+            case .select:
+                NavigationCustomLink(with: itemView) {
                     model.selectAsset(asset: assetData.asset)
                 }
             }

--- a/ios/Features/Assets/Sources/Types/SelectAssetFlow.swift
+++ b/ios/Features/Assets/Sources/Types/SelectAssetFlow.swift
@@ -1,0 +1,169 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import GemstonePrimitives
+import Localization
+import Primitives
+import PrimitivesComponents
+import Store
+
+public struct SelectAssetFlow: Sendable {
+    public enum RowSelection: Sendable, Equatable {
+        case navigate
+        case toggle
+        case select
+    }
+
+    public enum SelectionEffect: Sendable, Equatable {
+        case enablePriceAlert
+        case recordRecent
+        case none
+    }
+
+    public struct Capabilities: OptionSet, Sendable {
+        public let rawValue: Int
+
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        public static let networkSearch = Capabilities(rawValue: 1 << 0)
+        public static let chainFilter = Capabilities(rawValue: 1 << 1)
+        public static let recents = Capabilities(rawValue: 1 << 2)
+        public static let popularSection = Capabilities(rawValue: 1 << 3)
+        public static let balanceFilter = Capabilities(rawValue: 1 << 4)
+        public static let addCustomToken = Capabilities(rawValue: 1 << 5)
+        public static let depositAssetDisplay = Capabilities(rawValue: 1 << 6)
+    }
+
+    public let title: String
+    public let assetsSectionTitle: String
+    public let listType: AssetListType
+    public let defaultFilters: [AssetsRequestFilter]
+    public let rowSelection: RowSelection
+    public let selectionEffect: SelectionEffect
+    public let capabilities: Capabilities
+
+    init(
+        title: String,
+        assetsSectionTitle: String = Localized.Assets.title,
+        listType: AssetListType,
+        defaultFilters: [AssetsRequestFilter],
+        rowSelection: RowSelection,
+        selectionEffect: SelectionEffect = .none,
+        capabilities: Capabilities = [],
+    ) {
+        self.title = title
+        self.assetsSectionTitle = assetsSectionTitle
+        self.listType = listType
+        self.defaultFilters = defaultFilters
+        self.rowSelection = rowSelection
+        self.selectionEffect = selectionEffect
+        self.capabilities = capabilities
+    }
+}
+
+// MARK: - Models extensions
+
+public extension SelectAssetType {
+    var flow: SelectAssetFlow {
+        switch self {
+        case .send:
+            SelectAssetFlow(
+                title: Localized.Wallet.send,
+                listType: .view,
+                defaultFilters: [.enabled, .hasBalance],
+                rowSelection: .navigate,
+                capabilities: [.chainFilter, .recents],
+            )
+        case let .receive(type):
+            switch type {
+            case .asset:
+                SelectAssetFlow(
+                    title: Localized.Wallet.receive,
+                    listType: .copy(.asset),
+                    defaultFilters: [.enabled],
+                    rowSelection: .navigate,
+                    capabilities: [.networkSearch, .chainFilter, .recents],
+                )
+            case .collection:
+                SelectAssetFlow(
+                    title: Localized.Wallet.receiveCollection,
+                    assetsSectionTitle: Localized.Settings.Networks.title,
+                    listType: .copy(.collection),
+                    defaultFilters: [
+                        .enabled,
+                        .chainsOrAssets([], Chain.allCases.filter(\.isNFTSupported).map(\.rawValue)),
+                    ],
+                    rowSelection: .navigate,
+                    capabilities: [.networkSearch, .recents],
+                )
+            }
+        case .buy:
+            SelectAssetFlow(
+                title: Localized.Wallet.buy,
+                listType: .view,
+                defaultFilters: [.enabled, .buyable],
+                rowSelection: .navigate,
+                capabilities: [.networkSearch, .chainFilter, .recents, .popularSection],
+            )
+        case let .swap(type):
+            switch type {
+            case .pay:
+                SelectAssetFlow(
+                    title: Localized.Swap.youPay,
+                    listType: .view,
+                    defaultFilters: [.enabled, .swappable, .hasBalance],
+                    rowSelection: .select,
+                    selectionEffect: .recordRecent,
+                    capabilities: [.chainFilter, .recents],
+                )
+            case let .receive(chains, assetIds):
+                SelectAssetFlow(
+                    title: Localized.Swap.youReceive,
+                    listType: .view,
+                    defaultFilters: [
+                        .enabled,
+                        .chainsOrAssets(chains.map(\.rawValue), assetIds.map(\.identifier)),
+                        .swappable,
+                    ],
+                    rowSelection: .select,
+                    selectionEffect: .recordRecent,
+                    capabilities: [.networkSearch, .chainFilter, .recents],
+                )
+            }
+        case .manage:
+            SelectAssetFlow(
+                title: Localized.Wallet.manageTokenList,
+                listType: .manage,
+                defaultFilters: [.enabled],
+                rowSelection: .toggle,
+                capabilities: [.networkSearch, .chainFilter, .balanceFilter, .addCustomToken],
+            )
+        case .priceAlert:
+            SelectAssetFlow(
+                title: Localized.Assets.selectAsset,
+                listType: .price,
+                defaultFilters: [.enabled, .priceAlerts],
+                rowSelection: .select,
+                selectionEffect: .enablePriceAlert,
+                capabilities: [.networkSearch, .chainFilter, .popularSection],
+            )
+        case .deposit:
+            SelectAssetFlow(
+                title: Localized.Wallet.deposit,
+                listType: .view,
+                defaultFilters: [.chainsOrAssets([], [PerpetualConfig.depositAssetId])],
+                rowSelection: .navigate,
+            )
+        case .withdraw:
+            SelectAssetFlow(
+                title: Localized.Wallet.withdraw,
+                listType: .view,
+                defaultFilters: [.chainsOrAssets([], [Asset.hypercoreUSDC().id.identifier])],
+                rowSelection: .navigate,
+                capabilities: [.depositAssetDisplay],
+            )
+        }
+    }
+}

--- a/ios/Features/Assets/Sources/ViewModels/AssetsFilterViewModel.swift
+++ b/ios/Features/Assets/Sources/ViewModels/AssetsFilterViewModel.swift
@@ -1,7 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Components
-import GemstonePrimitives
 import Localization
 import Primitives
 import PrimitivesComponents
@@ -40,39 +39,11 @@ public struct AssetsFilterViewModel: Sendable, Equatable {
     }
 
     public var defaultFilters: [AssetsRequestFilter] {
-        switch type {
-        case .send: [.enabled, .hasBalance]
-        case let .receive(type):
-            switch type {
-            case .asset: [.enabled]
-            case .collection: [.enabled, .chainsOrAssets([], Chain.allCases.filter(\.isNFTSupported).map(\.rawValue))]
-            }
-        case .buy: [.enabled, .buyable]
-        case let .swap(type):
-            switch type {
-            case .pay: [.enabled, .swappable, .hasBalance]
-            case let .receive(chains, assetIds):
-                [
-                    .enabled,
-                    .chainsOrAssets(
-                        chains.map(\.rawValue),
-                        assetIds.map(\.identifier),
-                    ),
-                    .swappable,
-                ]
-            }
-        case .manage: [.enabled]
-        case .priceAlert: [.enabled, .priceAlerts]
-        case .deposit: [.chainsOrAssets([], [PerpetualConfig.depositAssetId])]
-        case .withdraw: [.chainsOrAssets([], [Asset.hypercoreUSDC().id.identifier])]
-        }
+        type.flow.defaultFilters
     }
 
     var showHasBalanceToggle: Bool {
-        switch type {
-        case .send, .receive, .buy, .swap, .priceAlert, .deposit, .withdraw: false
-        case .manage: true
-        }
+        type.flow.capabilities.contains(.balanceFilter)
     }
 
     var title: String {

--- a/ios/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
+++ b/ios/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
@@ -20,6 +20,7 @@ import SwiftUI
 public final class SelectAssetViewModel {
     let preferences: Preferences
     let selectType: SelectAssetType
+    let flow: SelectAssetFlow
     let searchService: AssetSearchService
     let assetsEnabler: any AssetsEnabler
     let priceAlertService: PriceAlertService
@@ -70,6 +71,7 @@ public final class SelectAssetViewModel {
         self.assetsEnabler = assetsEnabler
         self.priceAlertService = priceAlertService
         self.activityService = activityService
+        flow = selectType.flow
         onSelectAssetAction = selectAssetAction
 
         let filter = AssetsFilterViewModel(
@@ -95,32 +97,11 @@ public final class SelectAssetViewModel {
     }
 
     var title: String {
-        switch selectType {
-        case .send: Localized.Wallet.send
-        case let .receive(type):
-            switch type {
-            case .asset: Localized.Wallet.receive
-            case .collection: Localized.Wallet.receiveCollection
-            }
-        case .buy: Localized.Wallet.buy
-        case let .swap(type):
-            switch type {
-            case .pay: Localized.Swap.youPay
-            case .receive: Localized.Swap.youReceive
-            }
-        case .manage: Localized.Wallet.manageTokenList
-        case .priceAlert: Localized.Assets.selectAsset
-        case .deposit: Localized.Wallet.deposit
-        case .withdraw: Localized.Wallet.withdraw
-        }
+        flow.title
     }
 
     var sections: AssetsSections {
-        AssetsSections.from(assets, enablePopular: enablePopularSection)
-    }
-
-    var enablePopularSection: Bool {
-        [.buy, .priceAlert].contains(selectType)
+        AssetsSections.from(assets, enablePopular: flow.capabilities.contains(.popularSection))
     }
 
     var showPopularSection: Bool {
@@ -152,42 +133,19 @@ public final class SelectAssetViewModel {
     }
 
     var assetsTitle: String {
-        switch selectType {
-        case .send, .buy, .swap, .manage, .priceAlert, .deposit, .withdraw, .receive(.asset):
-            Localized.Assets.title
-        case .receive(.collection):
-            Localized.Settings.Networks.title
-        }
+        flow.assetsSectionTitle
     }
 
     public var showAddToken: Bool {
-        selectType == .manage && wallet.hasTokenSupport && !filterModel.chainsFilter.isEmpty
+        flow.capabilities.contains(.addCustomToken) && wallet.hasTokenSupport && filterModel.chainsFilter.hasChains
     }
 
     public var showFilter: Bool {
-        switch selectType {
-        case let .receive(type):
-            switch type {
-            case .asset:
-                wallet.isMultiCoins && !filterModel.chainsFilter.isEmpty
-            case .collection: false
-            }
-        case .buy, .manage, .priceAlert, .send, .swap:
-            wallet.isMultiCoins && !filterModel.chainsFilter.isEmpty
-        case .deposit, .withdraw: false
-        }
+        flow.capabilities.contains(.chainFilter) && wallet.isMultiCoins && filterModel.chainsFilter.hasChains
     }
 
     var isNetworkSearchEnabled: Bool {
-        switch selectType {
-        case .manage, .receive, .buy, .priceAlert: true
-        case let .swap(type):
-            switch type {
-            case .pay: false
-            case .receive: true
-            }
-        case .send, .deposit, .withdraw: false
-        }
+        flow.capabilities.contains(.networkSearch)
     }
 
     var showTags: Bool {
@@ -203,10 +161,7 @@ public final class SelectAssetViewModel {
     }
 
     var showRecents: Bool {
-        switch selectType {
-        case .send, .receive, .buy, .swap: searchModel.searchableQuery.isEmpty && recents.isNotEmpty
-        case .manage, .priceAlert, .deposit, .withdraw: false
-        }
+        flow.capabilities.contains(.recents) && searchModel.searchableQuery.isEmpty && recents.isNotEmpty
     }
 
     var recentModels: [AssetViewModel] {
@@ -231,14 +186,14 @@ extension SelectAssetViewModel {
     }
 
     func selectAsset(asset: Asset) {
-        switch selectType {
-        case .priceAlert:
+        switch flow.selectionEffect {
+        case .enablePriceAlert:
             Task {
                 await setPriceAlert(assetId: asset.id, enabled: true)
             }
-        case .swap:
+        case .recordRecent:
             updateRecent(assetId: asset.id)
-        case .manage, .send, .receive, .buy, .deposit, .withdraw:
+        case .none:
             break
         }
         onSelectAssetAction?(asset)
@@ -257,14 +212,15 @@ extension SelectAssetViewModel {
     }
 
     func handleAction(assetId: AssetId, enabled: Bool) async {
-        switch selectType {
-        case .manage:
+        switch flow.rowSelection {
+        case .toggle:
             do {
                 try await assetsEnabler.enableAssets(wallet: wallet, assetIds: [assetId], enabled: enabled)
             } catch {
                 debugLog("SelectAssetViewModel handleAction error: \(error)")
             }
-        case .send, .receive, .buy, .swap, .priceAlert, .deposit, .withdraw: break
+        case .navigate, .select:
+            break
         }
     }
 
@@ -332,7 +288,7 @@ extension SelectAssetViewModel {
     }
 
     func displayAssetData(_ assetData: AssetData) -> AssetData {
-        guard selectType == .withdraw else { return assetData }
+        guard flow.capabilities.contains(.depositAssetDisplay) else { return assetData }
         return AssetData(
             asset: PerpetualConfig.depositAsset,
             balance: assetData.balance,
@@ -344,12 +300,12 @@ extension SelectAssetViewModel {
     }
 
     public func onSelectRecent(_ asset: Asset) {
-        switch selectType {
-        case .send, .receive, .buy:
+        switch flow.rowSelection {
+        case .navigate:
             assetSelection = .recent(SelectAssetInput(type: selectType, assetAddress: assetAddress(for: asset)))
-        case .swap:
+        case .select:
             onSelectAssetAction?(asset)
-        case .manage, .priceAlert, .deposit, .withdraw:
+        case .toggle:
             break
         }
         isPresentingRecents = false
@@ -409,22 +365,5 @@ extension SelectAssetViewModel {
     private func handle(error: any Error) {
         state.setError(error)
         debugLog("SelectAssetScene scene error: \(error)")
-    }
-}
-
-// MARK: - Models extensions
-
-extension SelectAssetType {
-    var listType: AssetListType {
-        switch self {
-        case .send,
-             .buy,
-             .swap,
-             .deposit,
-             .withdraw: .view
-        case let .receive(type): .copy(type)
-        case .manage: .manage
-        case .priceAlert: .price
-        }
     }
 }

--- a/ios/Features/Assets/TestKit/SelectAssetViewModel+AssetsTestKit.swift
+++ b/ios/Features/Assets/TestKit/SelectAssetViewModel+AssetsTestKit.swift
@@ -3,6 +3,7 @@
 import ActivityServiceTestKit
 @testable import Assets
 import AssetsServiceTestKit
+import BalanceService
 import BalanceServiceTestKit
 import Components
 import Foundation
@@ -18,12 +19,13 @@ public extension SelectAssetViewModel {
         selectType: SelectAssetType = .manage,
         assets: [AssetData] = [],
         state: StateViewType<[AssetBasic]> = .noData,
+        assetsEnabler: any AssetsEnabler = .mock(),
     ) -> SelectAssetViewModel {
         let model = SelectAssetViewModel(
             wallet: wallet,
             selectType: selectType,
             searchService: .mock(),
-            assetsEnabler: .mock(),
+            assetsEnabler: assetsEnabler,
             priceAlertService: .mock(),
             activityService: .mock(),
         )

--- a/ios/Features/Assets/Tests/AssetsTests/SelectAssetFlowTests.swift
+++ b/ios/Features/Assets/Tests/AssetsTests/SelectAssetFlowTests.swift
@@ -1,0 +1,80 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+@testable import Assets
+import Primitives
+import Store
+import Testing
+
+struct SelectAssetFlowTests {
+    @Test
+    func rowSelection() {
+        #expect(SelectAssetType.send.flow.rowSelection == .navigate)
+        #expect(SelectAssetType.receive(.asset).flow.rowSelection == .navigate)
+        #expect(SelectAssetType.receive(.collection).flow.rowSelection == .navigate)
+        #expect(SelectAssetType.buy.flow.rowSelection == .navigate)
+        #expect(SelectAssetType.deposit.flow.rowSelection == .navigate)
+        #expect(SelectAssetType.withdraw.flow.rowSelection == .navigate)
+        #expect(SelectAssetType.manage.flow.rowSelection == .toggle)
+        #expect(SelectAssetType.swap(.pay).flow.rowSelection == .select)
+        #expect(SelectAssetType.swap(.receive(chains: [], assetIds: [])).flow.rowSelection == .select)
+        #expect(SelectAssetType.priceAlert.flow.rowSelection == .select)
+    }
+
+    @Test
+    func selectionEffect() {
+        #expect(SelectAssetType.priceAlert.flow.selectionEffect == .enablePriceAlert)
+        #expect(SelectAssetType.swap(.pay).flow.selectionEffect == .recordRecent)
+        #expect(SelectAssetType.swap(.receive(chains: [], assetIds: [])).flow.selectionEffect == .recordRecent)
+    }
+
+    @Test
+    func capabilities() {
+        #expect(SelectAssetType.send.flow.capabilities == [.chainFilter, .recents])
+        #expect(SelectAssetType.receive(.asset).flow.capabilities == [.networkSearch, .chainFilter, .recents])
+        #expect(SelectAssetType.receive(.collection).flow.capabilities == [.networkSearch, .recents])
+        #expect(SelectAssetType.buy.flow.capabilities == [.networkSearch, .chainFilter, .recents, .popularSection])
+        #expect(SelectAssetType.swap(.pay).flow.capabilities == [.chainFilter, .recents])
+        #expect(SelectAssetType.swap(.receive(chains: [], assetIds: [])).flow.capabilities == [.networkSearch, .chainFilter, .recents])
+        #expect(SelectAssetType.manage.flow.capabilities == [.networkSearch, .chainFilter, .balanceFilter, .addCustomToken])
+        #expect(SelectAssetType.priceAlert.flow.capabilities == [.networkSearch, .chainFilter, .popularSection])
+        #expect(SelectAssetType.deposit.flow.capabilities.isEmpty == true)
+        #expect(SelectAssetType.withdraw.flow.capabilities == [.depositAssetDisplay])
+    }
+
+    @Test
+    func defaultFilters() {
+        #expect(SelectAssetType.send.flow.defaultFilters == [.enabled, .hasBalance])
+        #expect(SelectAssetType.receive(.asset).flow.defaultFilters == [.enabled])
+        #expect(SelectAssetType.buy.flow.defaultFilters == [.enabled, .buyable])
+        #expect(SelectAssetType.swap(.pay).flow.defaultFilters == [.enabled, .swappable, .hasBalance])
+        #expect(SelectAssetType.manage.flow.defaultFilters == [.enabled])
+        #expect(SelectAssetType.priceAlert.flow.defaultFilters == [.enabled, .priceAlerts])
+    }
+
+    @Test
+    func collectionFiltersRestrictToNftChains() {
+        let filters = SelectAssetType.receive(.collection).flow.defaultFilters
+        let chains = filters.flatMap { filter -> [String] in
+            guard case let .chainsOrAssets(_, assets) = filter else { return [] }
+            return assets
+        }
+
+        #expect(filters.contains(.enabled) == true)
+        #expect(chains.contains(Chain.ethereum.rawValue) == true)
+        #expect(chains.contains(Chain.bitcoin.rawValue) == false)
+    }
+
+    @Test
+    func swapReceiveFiltersCarryPairConstraints() {
+        let filters = SelectAssetType.swap(.receive(
+            chains: [.ethereum],
+            assetIds: [AssetId(chain: .smartChain, tokenId: "0x123")],
+        )).flow.defaultFilters
+
+        #expect(filters == [
+            .enabled,
+            .chainsOrAssets(["ethereum"], ["smartchain_0x123"]),
+            .swappable,
+        ])
+    }
+}

--- a/ios/Features/Assets/Tests/AssetsTests/SelectAssetViewModelTests.swift
+++ b/ios/Features/Assets/Tests/AssetsTests/SelectAssetViewModelTests.swift
@@ -2,6 +2,7 @@
 
 @testable import Assets
 import AssetsTestKit
+import BalanceServiceTestKit
 import Primitives
 import PrimitivesTestKit
 import Testing
@@ -27,5 +28,42 @@ struct SelectAssetViewModelTests {
         let pinnedAsset = AssetData.mock(metadata: .mock(isPinned: true))
         #expect(SelectAssetViewModel.mock(assets: [], state: .loading).showLoading == true)
         #expect(SelectAssetViewModel.mock(assets: [pinnedAsset], state: .loading).showLoading == false)
+    }
+
+    @Test
+    func filterAndAddTokenRequireFlowAndWalletSupport() {
+        let walletWithTokens = Wallet.mock(accounts: [.mock(chain: .ethereum)])
+        let walletWithoutTokens = Wallet.mock(accounts: [.mock(chain: .bitcoin)])
+        let singleChainWallet = Wallet.mock(type: .single, accounts: [.mock(chain: .ethereum)])
+
+        #expect(SelectAssetViewModel.mock(wallet: walletWithTokens, selectType: .manage).showAddToken == true)
+        #expect(SelectAssetViewModel.mock(wallet: walletWithTokens, selectType: .send).showAddToken == false)
+        #expect(SelectAssetViewModel.mock(wallet: walletWithoutTokens, selectType: .manage).showAddToken == false)
+
+        #expect(SelectAssetViewModel.mock(wallet: walletWithTokens, selectType: .manage).showFilter == true)
+        #expect(SelectAssetViewModel.mock(wallet: walletWithTokens, selectType: .deposit).showFilter == false)
+        #expect(SelectAssetViewModel.mock(wallet: singleChainWallet, selectType: .manage).showFilter == false)
+    }
+
+    @Test
+    func toggleFlowEnablesAssets() async {
+        await confirmation { enabledAssets in
+            let enabler: AssetsEnablerMock = .mock(onEnableAssets: { _, assetIds, enabled in
+                #expect(assetIds == [.mock()])
+                #expect(enabled == true)
+                enabledAssets()
+            })
+            await SelectAssetViewModel.mock(selectType: .manage, assetsEnabler: enabler)
+                .handleAction(assetId: .mock(), enabled: true)
+        }
+    }
+
+    @Test
+    func nonToggleFlowNeverEnablesAssets() async {
+        await confirmation(expectedCount: 0) { enabledAssets in
+            let enabler: AssetsEnablerMock = .mock(onEnableAssets: { _, _, _ in enabledAssets() })
+            await SelectAssetViewModel.mock(selectType: .receive(.asset), assetsEnabler: enabler)
+                .handleAction(assetId: .mock(), enabled: true)
+        }
     }
 }

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/ChainsFilterViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/ChainsFilterViewModel.swift
@@ -21,7 +21,7 @@ public struct ChainsFilterViewModel: Sendable, Equatable {
         !selectedChains.isEmpty
     }
 
-    public var isEmpty: Bool {
-        allChains.isEmpty
+    public var hasChains: Bool {
+        allChains.isNotEmpty
     }
 }


### PR DESCRIPTION
The select-asset screen is used by eight different flows — send, receive, buy, swap, manage, price alerts, deposit and withdraw. Each flow's rules were spread across sixteen places, so changing one flow or adding a new one meant hunting through the view model, the screen and the filter model.

Now every flow describes itself in one place. Nothing changes for the user.