### PR TITLE
Fix crash on malformed transaction amount

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionDetailsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionDetailsImpl.kt
@@ -147,44 +147,50 @@ class TransactionDetailsAggregateImpl(
                 }
 
                 else -> {
-                    val value = Crypto(data.transaction.value.toBigInteger())
-                    val fiat = data.price?.price?.let {
-                        CryptoFiatConverter.toFiatString(value, asset.decimals, it, currency)
-                    } ?: ""
+                    val atomicValue = data.transaction.value.toBigIntegerOrNull()
+                    if (atomicValue == null) {
+                        TransactionDetailsValue.Amount.None
+                    } else {
+                        val value = Crypto(atomicValue)
+                        val fiat = data.price?.price?.let {
+                            CryptoFiatConverter.toFiatString(value, asset.decimals, it, currency)
+                        } ?: ""
 
-                    val formatter = ValueFormatter(style = ValueFormatter.Style.Full)
+                        val formatter = ValueFormatter(style = ValueFormatter.Style.Full)
 
-                    val (amount, equivalent) = when (data.transaction.type) {
-                        TransactionType.StakeDelegate,
-                        TransactionType.StakeUndelegate,
-                        TransactionType.StakeRewards,
-                        TransactionType.StakeRedelegate,
-                        TransactionType.StakeWithdraw,
-                        TransactionType.EarnWithdraw,
-                        TransactionType.EarnDeposit,
-                        TransactionType.Swap,
-                        TransactionType.StakeFreeze,
-                        TransactionType.StakeUnfreeze -> Pair(formatter.string(value.atomicValue, asset), fiat)
-                        TransactionType.Transfer -> Pair(
-                            AmountSign(data.transaction.direction).format(formatter.string(value.atomicValue, asset)),
-                            fiat,
-                        )
-                        TransactionType.TransferNFT,
-                        TransactionType.AssetActivation,
-                        TransactionType.SmartContractCall,
-                        TransactionType.PerpetualOpenPosition,
-                        TransactionType.PerpetualClosePosition,
-                        TransactionType.PerpetualModifyPosition,
-                        TransactionType.TokenApproval -> Pair(data.asset.symbol, null)
+                        val (amount, equivalent) = when (data.transaction.type) {
+                            TransactionType.StakeDelegate,
+                            TransactionType.StakeUndelegate,
+                            TransactionType.StakeRewards,
+                            TransactionType.StakeRedelegate,
+                            TransactionType.StakeWithdraw,
+                            TransactionType.EarnWithdraw,
+                            TransactionType.EarnDeposit,
+                            TransactionType.Swap,
+                            TransactionType.StakeFreeze,
+                            TransactionType.StakeUnfreeze -> Pair(formatter.string(value.atomicValue, asset), fiat)
+                            TransactionType.Transfer -> Pair(
+                                AmountSign(data.transaction.direction).format(formatter.string(value.atomicValue, asset)),
+                                fiat,
+                            )
+                            TransactionType.TransferNFT,
+                            TransactionType.AssetActivation,
+                            TransactionType.SmartContractCall,
+                            TransactionType.PerpetualOpenPosition,
+                            TransactionType.PerpetualClosePosition,
+                            TransactionType.PerpetualModifyPosition,
+                            TransactionType.TokenApproval -> Pair(data.asset.symbol, null)
+                        }
+                        TransactionDetailsValue.Amount.Plain(data.asset, amount, equivalent)
                     }
-                    TransactionDetailsValue.Amount.Plain(data.asset, amount, equivalent)
                 }
             }
         }
 
-    override val fee: TransactionDetailsValue.Fee
+    override val fee: TransactionDetailsValue.Fee?
         get() {
-            val fee = Crypto(data.transaction.fee.toBigInteger())
+            val atomicValue = data.transaction.fee.toBigIntegerOrNull() ?: return null
+            val fee = Crypto(atomicValue)
             val feeCrypto = ValueFormatter(style = ValueFormatter.Style.Full)
                 .string(fee.atomicValue, data.feeAsset)
             val feeFiat = data.feePrice?.price?.let {
@@ -292,7 +298,7 @@ class TransactionDetailsAggregateImpl(
                     )
                 )
             )
-            add(ValueGroup(listOf(fee)))
+            fee?.let { add(ValueGroup(listOf(it))) }
             add(ValueGroup(listOf(explorer)))
         }
 

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionsImpl.kt
@@ -111,9 +111,11 @@ class TransactionDataAggregateImpl(
                 AmountSign.Incoming.format(formatter.string(value, asset))
             } ?: ""
         }
-        TransactionType.PerpetualOpenPosition -> CurrencyFormatter(type = CurrencyFormatter.Type.Fiat, currency = Currency.USD).string(
-            CryptoFiatConverter.toFiat(Crypto(data.transaction.value), HypercoreUSDC.decimals, price = 1.0).atomicValue,
-        )
+        TransactionType.PerpetualOpenPosition -> data.transaction.value.toBigIntegerOrNull()?.let {
+            CurrencyFormatter(type = CurrencyFormatter.Type.Fiat, currency = Currency.USD).string(
+                CryptoFiatConverter.toFiat(Crypto(it), HypercoreUSDC.decimals, price = 1.0).atomicValue,
+            )
+        } ?: ""
         TransactionType.PerpetualClosePosition -> pnl?.let {
             PriceChangeFormatter(CurrencyFormatter(type = CurrencyFormatter.Type.Fiat, currency = Currency.USD)).string(it)
         } ?: ""
@@ -125,8 +127,8 @@ class TransactionDataAggregateImpl(
         TransactionType.StakeDelegate,
         TransactionType.EarnDeposit,
         TransactionType.StakeFreeze,
-        TransactionType.StakeUnfreeze -> getFormattedValue()
-        TransactionType.Transfer -> AmountSign(data.transaction.direction).format(getFormattedValue())
+        TransactionType.StakeUnfreeze -> getFormattedValue() ?: ""
+        TransactionType.Transfer -> getFormattedValue()?.let { AmountSign(data.transaction.direction).format(it) } ?: ""
         TransactionType.TokenApproval -> data.asset.symbol
         TransactionType.TransferNFT,
         TransactionType.AssetActivation,
@@ -173,8 +175,8 @@ class TransactionDataAggregateImpl(
         return value.toBigIntegerOrNull()?.let { Pair(it, asset) }
     }
 
-    private fun getFormattedValue(): String =
-        formatter.string(data.transaction.value.toBigInteger(), data.asset)
+    private fun getFormattedValue(): String? =
+        data.transaction.value.toBigIntegerOrNull()?.let { formatter.string(it, data.asset) }
 
     private companion object {
         val formatter = ValueFormatter(style = ValueFormatter.Style.Short)

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/transaction/TransactionDataAggregateImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/transaction/TransactionDataAggregateImplTest.kt
@@ -434,6 +434,19 @@ class TransactionDataAggregateImplTest {
     }
 
     @Test
+    fun testValue_malformedTransferValue() {
+        val transaction = createTransaction(
+            type = TransactionType.Transfer,
+            direction = TransactionDirection.Outgoing,
+            value = "54.108086",
+        )
+        val extended = createTransactionExtended(transaction, asset = btcAsset)
+        val aggregate = createAggregate(extended)
+
+        assertEquals("", aggregate.value)
+    }
+
+    @Test
     fun testValue_smallAmount() {
         val transaction = createTransaction(
             type = TransactionType.Transfer,

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/transaction/TransactionDetailsAggregateImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/transaction/TransactionDetailsAggregateImplTest.kt
@@ -207,6 +207,18 @@ class TransactionDetailsAggregateImplTest {
     }
 
     @Test
+    fun testAmountPlain_malformedValue() {
+        val transaction = createTransaction(
+            type = TransactionType.Transfer,
+            value = "54.108086",
+        )
+        val extended = createTransactionExtended(transaction, asset = btcAsset, price = null)
+        val aggregate = createAggregate(extended)
+
+        Assert.assertTrue(aggregate.amount is TransactionDetailsValue.Amount.None)
+    }
+
+    @Test
     fun testAmountSwap_withValidMetadata() {
         val bnbAsset = mockAsset(
             chain = Chain.SmartChain,
@@ -707,7 +719,7 @@ class TransactionDetailsAggregateImplTest {
         val extended = createTransactionExtended(transaction, asset = btcAsset, feePrice = feePrice)
         val aggregate = createAggregate(extended)
 
-        val fee = aggregate.fee
+        val fee = requireNotNull(aggregate.fee)
         Assert.assertEquals(btcAsset, fee.asset)
         Assert.assertEquals("0.00001 BTC", fee.value)
         Assert.assertEquals("\$0.5", fee.equivalent)
@@ -726,7 +738,7 @@ class TransactionDetailsAggregateImplTest {
         val extended = createTransactionExtended(transaction, asset = btcAsset, feePrice = feePrice)
         val aggregate = createAggregate(extended)
 
-        val fee = aggregate.fee
+        val fee = requireNotNull(aggregate.fee)
         Assert.assertEquals("0.00001 BTC", fee.value)
         Assert.assertEquals("\$0.0000428", fee.equivalent)
     }
@@ -739,10 +751,21 @@ class TransactionDetailsAggregateImplTest {
         val extended = createTransactionExtended(transaction, asset = btcAsset, feePrice = null)
         val aggregate = createAggregate(extended)
 
-        val fee = aggregate.fee
+        val fee = requireNotNull(aggregate.fee)
         Assert.assertEquals(btcAsset, fee.asset)
         Assert.assertEquals("0.00001 BTC", fee.value)
         Assert.assertEquals("", fee.equivalent)
+    }
+
+    @Test
+    fun testFee_malformedValue() {
+        val transaction = createTransaction(
+            fee = "0.006671888",
+        )
+        val extended = createTransactionExtended(transaction, asset = btcAsset, feePrice = null)
+        val aggregate = createAggregate(extended)
+
+        Assert.assertNull(aggregate.fee)
     }
 
     @Test
@@ -757,7 +780,7 @@ class TransactionDetailsAggregateImplTest {
         )
         val aggregate = createAggregate(extended)
 
-        val fee = aggregate.fee
+        val fee = requireNotNull(aggregate.fee)
         Assert.assertEquals(ethAsset, fee.asset)
         Assert.assertEquals("0.001 ETH", fee.value)
         Assert.assertEquals("", fee.equivalent)

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/transaction/aggregates/TransactionDetailsAggregate.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/transaction/aggregates/TransactionDetailsAggregate.kt
@@ -21,7 +21,7 @@ interface TransactionDetailsAggregate {
     val currency: Currency
 
     val amount: TransactionDetailsValue.Amount
-    val fee: TransactionDetailsValue.Fee
+    val fee: TransactionDetailsValue.Fee?
     val date: TransactionDetailsValue.Date
     val status: TransactionDetailsValue.Status
     val rate: TransactionDetailsValue.Rate?


### PR DESCRIPTION
Fixes a crash when a transaction's amount or fee comes back in an unexpected format. Instead of crashing, the app now just hides that value.