### PR TITLE
Extract shared PullToRefreshBox component

### DIFF
--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
@@ -10,15 +10,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -28,6 +24,7 @@ import com.gemwallet.android.ui.components.empty.EmptyContentType
 import com.gemwallet.android.ui.components.empty.EmptyContentView
 import com.gemwallet.android.ui.components.filters.TransactionsFilter
 import com.gemwallet.android.ui.components.list_item.transaction.transactionsList
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.models.TransactionTypeFilter
@@ -45,7 +42,6 @@ internal fun TransactionsScene(
     showReceiveAction: Boolean,
     onAction: (TransactionsListAction) -> Unit,
 ) {
-    val pullToRefreshState = rememberPullToRefreshState()
     var showFilters by remember { mutableStateOf(false) }
 
     Scene(
@@ -66,18 +62,8 @@ internal fun TransactionsScene(
         navigationBarPadding = false,
     ) {
         PullToRefreshBox(
-            modifier = Modifier,
             isRefreshing = isRefreshing,
             onRefresh = { onAction(TransactionsListAction.Refresh) },
-            state = pullToRefreshState,
-            indicator = {
-                PullToRefreshDefaults.Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = isRefreshing,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background,
-                )
-            },
         ) {
             if (transactions.isEmpty()) {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/chart/AssetChartScene.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/chart/AssetChartScene.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -43,6 +41,7 @@ import com.gemwallet.android.ui.components.list_item.property.PropertyDataText
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyTitleText
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.components.screen.rememberSnackbarState
 import com.gemwallet.android.ui.models.ListPosition
@@ -77,7 +76,6 @@ fun AssetChartScene(
     val title by viewModel.title.collectAsStateWithLifecycle()
     val priceAlertsCount by viewModel.priceAlertsCount.collectAsStateWithLifecycle()
     val isChartRefreshing by chartViewModel.isRefreshing.collectAsStateWithLifecycle()
-    val pullToRefreshState = rememberPullToRefreshState()
     val snackbar = rememberSnackbarState(
         message = toastMessage,
         iconRes = R.drawable.ic_notifications,
@@ -96,14 +94,7 @@ fun AssetChartScene(
             onRefresh = {
                 chartViewModel.refresh()
             },
-            state = pullToRefreshState,
-            indicator = {
-                PullToRefreshDefaults.Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = isChartRefreshing,
-                    state = pullToRefreshState,
-                )
-            },
+            containerColor = PullToRefreshDefaults.containerColor,
         ) {
             LazyColumn {
                 item { Chart(chartViewModel) }

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/chart/PortfolioChartScene.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/chart/PortfolioChartScene.kt
@@ -9,9 +9,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -27,6 +25,7 @@ import com.gemwallet.android.features.asset.viewmodels.chart.models.portfolioCha
 import com.gemwallet.android.features.asset.viewmodels.chart.viewmodels.PortfolioChartViewModel
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.TabsBar
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.models.StateViewType
@@ -47,7 +46,6 @@ fun PortfolioChartScene(
     val selectedChartType by viewModel.selectedChartType.collectAsStateWithLifecycle()
     val state by viewModel.chartUIState.collectAsStateWithLifecycle()
     val showChartTypePicker = selectedType == PortfolioType.Perpetuals
-    val pullToRefreshState = rememberPullToRefreshState()
 
     Scene(
         titleContent = {
@@ -67,14 +65,7 @@ fun PortfolioChartScene(
         PullToRefreshBox(
             isRefreshing = isRefreshing,
             onRefresh = viewModel::refresh,
-            state = pullToRefreshState,
-            indicator = {
-                PullToRefreshDefaults.Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = isRefreshing,
-                    state = pullToRefreshState,
-                )
-            },
+            containerColor = PullToRefreshDefaults.containerColor,
         ) {
             LazyColumn {
                 item { PortfolioChart(viewModel) }

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/AssetDetailsScene.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/AssetDetailsScene.kt
@@ -4,12 +4,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -26,6 +22,7 @@ import com.gemwallet.android.ui.components.list_item.energyItem
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
 import com.gemwallet.android.ui.components.list_item.transaction.transactionsList
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.components.screen.showSnackbar
 import kotlinx.coroutines.launch
@@ -56,7 +53,6 @@ internal fun AssetDetailsScene(
     isOperationEnabled: Boolean,
     onAction: (AssetDetailsAction) -> Unit,
 ) {
-    val pullToRefreshState = rememberPullToRefreshState()
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     val snackBar = remember { SnackbarHostState() }
@@ -100,15 +96,6 @@ internal fun AssetDetailsScene(
             modifier = Modifier.fillMaxSize(),
             isRefreshing = isRefreshing,
             onRefresh = { onAction(AssetDetailsAction.Refresh) },
-            state = pullToRefreshState,
-            indicator = {
-                PullToRefreshDefaults.Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = isRefreshing,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background
-                )
-            }
         ) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize()

--- a/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsResultsScreen.kt
+++ b/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsResultsScreen.kt
@@ -2,16 +2,11 @@ package com.gemwallet.android.features.assets.views
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -29,6 +24,7 @@ import com.gemwallet.android.ui.components.list_item.assetPriceSupport
 import com.gemwallet.android.ui.components.list_item.getBalanceInfo
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
 import com.gemwallet.android.ui.components.screen.AssetToastEffect
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.AssetsGroupType
 import com.wallet.core.primitives.AssetId
@@ -63,8 +59,6 @@ fun AssetsResultsScreen(
             onAddToWallet = viewModel::onAddToWallet,
         )
     }
-    val pullToRefreshState = rememberPullToRefreshState()
-
     Scene(
         title = viewModel.title,
         snackbar = snackbar,
@@ -74,15 +68,6 @@ fun AssetsResultsScreen(
             modifier = Modifier.fillMaxSize(),
             isRefreshing = isRefreshing,
             onRefresh = viewModel::refresh,
-            state = pullToRefreshState,
-            indicator = {
-                Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = isRefreshing,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background,
-                )
-            },
         ) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 if (pinned.isNotEmpty()) {

--- a/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsScreen.kt
+++ b/android/features/assets/presents/src/main/kotlin/com/gemwallet/android/features/assets/views/AssetsScreen.kt
@@ -19,9 +19,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -56,6 +53,7 @@ import com.gemwallet.android.features.update_app.presents.InAppUpdateBanner
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.AssetContextActions
 import com.gemwallet.android.ui.components.screen.AssetToastEffect
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.SnackbarHost
 import com.gemwallet.android.ui.models.AssetsGroupType
 import com.gemwallet.android.ui.open
@@ -117,20 +115,10 @@ fun AssetsScreen(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         containerColor = MaterialTheme.colorScheme.surface,
     ) {
-        val pullToRefreshState = rememberPullToRefreshState()
         PullToRefreshBox(
             modifier = Modifier.padding(top = it.calculateTopPadding()),
             isRefreshing = isRefreshing,
             onRefresh = viewModel::onRefresh,
-            state = pullToRefreshState,
-            indicator = {
-                Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = isRefreshing,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background
-                )
-            }
         ) {
             val longPressedAsset = remember { mutableStateOf<AssetId?>(null) }
             val assetActions = remember(viewModel) {

--- a/android/features/buy/presents/src/main/kotlin/com/gemwallet/android/features/buy/views/FiatTransactionsScene.kt
+++ b/android/features/buy/presents/src/main/kotlin/com/gemwallet/android/features/buy/views/FiatTransactionsScene.kt
@@ -2,12 +2,7 @@ package com.gemwallet.android.features.buy.views
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -15,6 +10,7 @@ import androidx.compose.ui.res.stringResource
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.empty.EmptyContentType
 import com.gemwallet.android.ui.components.empty.EmptyContentView
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.open
 import com.wallet.core.primitives.FiatTransactionAssetData
@@ -26,8 +22,6 @@ fun FiatTransactionsScene(
     onClose: () -> Unit,
     onRefresh: () -> Unit,
 ) {
-    val pullToRefreshState = rememberPullToRefreshState()
-
     Scene(
         title = stringResource(id = R.string.activity_title),
         onClose = onClose,
@@ -37,15 +31,6 @@ fun FiatTransactionsScene(
         PullToRefreshBox(
             isRefreshing = isRefreshing,
             onRefresh = onRefresh,
-            state = pullToRefreshState,
-            indicator = {
-                PullToRefreshDefaults.Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = isRefreshing,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background,
-                )
-            }
         ) {
             if (transactions.isEmpty()) {
                 EmptyContentView(type = EmptyContentType.Activity(), modifier = Modifier.fillMaxSize())

--- a/android/features/earn/stake/presents/src/main/kotlin/com/gemwallet/android/features/stake/presents/StakeScene.kt
+++ b/android/features/earn/stake/presents/src/main/kotlin/com/gemwallet/android/features/stake/presents/StakeScene.kt
@@ -14,11 +14,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -47,6 +43,7 @@ import com.gemwallet.android.ui.components.list_item.SubheaderItem
 import com.gemwallet.android.ui.components.list_item.energyItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.models.actions.AmountTransactionAction
@@ -66,7 +63,6 @@ internal fun StakeScene(
     amountAction: AmountTransactionAction,
     onAction: (StakeSceneAction) -> Unit,
 ) {
-    val pullToRefreshState = rememberPullToRefreshState()
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
 
@@ -82,18 +78,8 @@ internal fun StakeScene(
         },
     ) {
         PullToRefreshBox(
-            modifier = Modifier,
             isRefreshing = inSync,
             onRefresh = { onAction(StakeSceneAction.Refresh) },
-            state = pullToRefreshState,
-            indicator = {
-                Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = inSync,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background
-                )
-            }
         ) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 item {

--- a/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
+++ b/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
@@ -12,15 +12,10 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -40,6 +35,7 @@ import com.gemwallet.android.ui.components.empty.EmptyContentView
 import com.gemwallet.android.ui.components.list_item.LinkItem
 import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
 import com.gemwallet.android.ui.components.list_item.property.PropertyDataText
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.models.ListPosition
@@ -95,7 +91,6 @@ fun NftListNavScreen(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun NftListScene(
     items: List<NftItemUIModel>,
@@ -109,8 +104,6 @@ internal fun NftListScene(
     listState: LazyGridState = rememberLazyGridState(),
     onAction: (NftListAction) -> Unit,
 ) {
-    val pullToRefreshState = rememberPullToRefreshState()
-
     Scene(
         title = title,
         navigationBarPadding = false,
@@ -134,15 +127,6 @@ internal fun NftListScene(
             modifier = Modifier.fillMaxSize(),
             isRefreshing = isRefreshing,
             onRefresh = { onAction(NftListAction.Refresh) },
-            state = pullToRefreshState,
-            indicator = {
-                Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = isRefreshing,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background,
-                )
-            },
         ) {
             val currentError = error
             if (currentError != null) {

--- a/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/market/PerpetualMarketScene.kt
+++ b/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/market/PerpetualMarketScene.kt
@@ -16,9 +16,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -47,6 +44,7 @@ import com.gemwallet.android.ui.components.list_head.AmountListHead
 import com.gemwallet.android.ui.components.list_item.PinnedAssetsHeaderItem
 import com.gemwallet.android.ui.components.list_item.SubheaderItem
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.models.AssetsGroupType
@@ -80,7 +78,6 @@ internal fun PerpetualMarketScene(
     query: TextFieldState,
     onAction: (PerpetualMarketAction) -> Unit,
 ) {
-    val pullToRefreshState = rememberPullToRefreshState()
     val longPressedAsset = remember { mutableStateOf<PerpetualId?>(null) }
     var isSearching by rememberSaveable { mutableStateOf(false) }
     val showRecents = isSearching && query.text.isEmpty() && recent.isNotEmpty()
@@ -116,15 +113,6 @@ internal fun PerpetualMarketScene(
         PullToRefreshBox(
             isRefreshing = sceneState.isRefreshing,
             onRefresh = { onAction(PerpetualMarketAction.Refresh) },
-            state = pullToRefreshState,
-            indicator = {
-                Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = sceneState.isRefreshing,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background
-                )
-            }
         ) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize()

--- a/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/position/PerpetualPositionScene.kt
+++ b/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/position/PerpetualPositionScene.kt
@@ -2,16 +2,11 @@ package com.gemwallet.android.features.perpetual.views.position
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,6 +22,7 @@ import com.gemwallet.android.features.perpetual.views.components.perpetualInfo
 import com.gemwallet.android.features.perpetual.views.components.positionProperties
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.transaction.transactionsList
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.StateViewType
 import com.gemwallet.android.ui.theme.WalletTheme
@@ -53,7 +49,6 @@ internal fun PerpetualPositionScene(
     onAction: (PerpetualDetailsAction) -> Unit,
 ) {
     var showModifyDialog by remember { mutableStateOf(false) }
-    val pullToRefreshState = rememberPullToRefreshState()
 
     Scene(
         title = perpetual?.name ?: stringResource(R.string.perpetuals_title),
@@ -62,15 +57,6 @@ internal fun PerpetualPositionScene(
         PullToRefreshBox(
             isRefreshing = isRefreshing,
             onRefresh = { onAction(PerpetualDetailsAction.Refresh) },
-            state = pullToRefreshState,
-            indicator = {
-                Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = isRefreshing,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background,
-                )
-            },
         ) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize()

--- a/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/ReferralScene.kt
+++ b/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/ReferralScene.kt
@@ -14,9 +14,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -37,6 +34,7 @@ import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.buttons.mainActionButtonColors
 import com.gemwallet.android.ui.components.clickable
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.components.screen.showSnackbar
 import com.gemwallet.android.ui.shareText
@@ -88,7 +86,6 @@ fun ReferralScene(
     val joinText = stringResource(R.string.rewards_share_text, link)
     val shareTitle = stringResource(id = R.string.common_share, link)
 
-    val pullToRefreshState = rememberPullToRefreshState()
     var getStartedDialogShow by remember(rewards) { mutableStateOf(false) }
     var codeDialogShow by remember(referralCode, inSync) { mutableStateOf(referralCode != null && inSync == SyncType.None) }
     var referralCode by remember(referralCode) { mutableStateOf(referralCode) }
@@ -143,15 +140,6 @@ fun ReferralScene(
         PullToRefreshBox(
             isRefreshing = inSync != SyncType.None,
             onRefresh = onRefresh,
-            state = pullToRefreshState,
-            indicator = {
-                Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = inSync != SyncType.None,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background
-                )
-            }
         ) {
             LazyColumn {
                 referralHead(

--- a/android/features/settings/networks/presents/src/main/kotlin/com/gemwallet/android/features/settings/networks/presents/NetworkScene.kt
+++ b/android/features/settings/networks/presents/src/main/kotlin/com/gemwallet/android/features/settings/networks/presents/NetworkScene.kt
@@ -17,15 +17,11 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
@@ -38,6 +34,7 @@ import com.gemwallet.android.ui.components.list_item.SubheaderItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyTitleText
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.models.ListPosition
@@ -64,22 +61,9 @@ internal fun NetworkScene(
         },
         onClose = { onAction(NetworkAction.Cancel) },
     ) {
-        val pullToRefreshState = rememberPullToRefreshState()
         PullToRefreshBox(
             isRefreshing = false,
             onRefresh = { onAction(NetworkAction.Refresh) },
-            state = pullToRefreshState,
-            enabled = true,
-            indicator = {
-                if (pullToRefreshState.distanceFraction > 0f) {
-                    Indicator(
-                        modifier = Modifier.align(Alignment.TopCenter),
-                        isRefreshing = false,
-                        state = pullToRefreshState,
-                        containerColor = MaterialTheme.colorScheme.background,
-                    )
-                }
-            },
         ) {
             LazyColumn {
                 item {

--- a/android/features/settings/networks/presents/src/main/kotlin/com/gemwallet/android/features/settings/networks/presents/ServiceStatusScene.kt
+++ b/android/features/settings/networks/presents/src/main/kotlin/com/gemwallet/android/features/settings/networks/presents/ServiceStatusScene.kt
@@ -4,21 +4,16 @@ package com.gemwallet.android.features.settings.networks.presents
 
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.features.settings.networks.viewmodels.ServiceStatusViewModel
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 
 @Composable
@@ -34,21 +29,9 @@ fun ServiceStatusScene(
         title = stringResource(R.string.transaction_status),
         onClose = onCancel,
     ) {
-        val pullToRefreshState = rememberPullToRefreshState()
         PullToRefreshBox(
             isRefreshing = false,
             onRefresh = viewModel::fetch,
-            state = pullToRefreshState,
-            indicator = {
-                if (pullToRefreshState.distanceFraction > 0f) {
-                    Indicator(
-                        modifier = Modifier.align(Alignment.TopCenter),
-                        isRefreshing = false,
-                        state = pullToRefreshState,
-                        containerColor = MaterialTheme.colorScheme.background,
-                    )
-                }
-            },
         ) {
             LazyColumn {
                 itemsPositioned(state.rows) { position, item ->

--- a/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertScene.kt
+++ b/android/features/settings/price_alerts/presents/src/main/kotlin/com/gemwallet/android/features/settings/price_alerts/presents/PriceAlertScene.kt
@@ -24,16 +24,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
@@ -48,6 +44,7 @@ import com.gemwallet.android.ui.components.list_item.SubheaderItem
 import com.gemwallet.android.ui.components.list_item.SwipeableItemWithActions
 import com.gemwallet.android.ui.components.list_item.SwitchProperty
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
+import com.gemwallet.android.ui.components.screen.PullToRefreshBox
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.theme.headerIconSize
@@ -68,7 +65,6 @@ internal fun PriceAlertScene(
     onAction: (PriceAlertAction) -> Unit,
 ) {
     val revealable = remember { mutableStateOf<Int?>(null) }
-    val pullToRefreshState = rememberPullToRefreshState()
     Scene(
         title = stringResource(R.string.settings_price_alerts_title),
         actions = @Composable {
@@ -88,15 +84,6 @@ internal fun PriceAlertScene(
             modifier = Modifier.fillMaxSize(),
             isRefreshing = syncState,
             onRefresh = { onAction(PriceAlertAction.Refresh) },
-            state = pullToRefreshState,
-            indicator = {
-                Indicator(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    isRefreshing = syncState,
-                    state = pullToRefreshState,
-                    containerColor = MaterialTheme.colorScheme.background
-                )
-            }
         ) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 if (isAssetView) {

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/PullToRefreshBox.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/PullToRefreshBox.kt
@@ -1,0 +1,37 @@
+package com.gemwallet.android.ui.components.screen
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun PullToRefreshBox(
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+    state: PullToRefreshState = rememberPullToRefreshState(),
+    containerColor: Color = MaterialTheme.colorScheme.background,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    androidx.compose.material3.pulltorefresh.PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        modifier = modifier,
+        state = state,
+        indicator = {
+            PullToRefreshDefaults.Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                isRefreshing = isRefreshing,
+                state = state,
+                containerColor = containerColor,
+            )
+        },
+        content = content,
+    )
+}


### PR DESCRIPTION
Pull-to-refresh was written out by hand on 15 screens, each with its own copy of the indicator. Now there is one shared component in the UI module and every screen uses it.

No visible changes.