### PR TITLE
Hide Balance: consistent masking across Asset, Transactions, Portfolio

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetActiveAssetsInfoImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetActiveAssetsInfoImpl.kt
@@ -7,6 +7,7 @@ import com.gemwallet.android.domains.asset.aggregates.AssetPriceDataAggregate
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.ValueFormatter
+import com.gemwallet.android.model.masked
 import com.wallet.core.primitives.Currency
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -30,20 +31,14 @@ internal fun AssetInfo.toAssetInfoDataAggregate(
     val priceValue = assetPrice?.price?.takeIf(Double::isFinite)
     val changePercentage = assetPrice?.priceChangePercentage24h?.takeIf(Double::isFinite)
     val assetBalance = balance
-    val formattedBalance = if (hideBalance) {
-        "*****"
-    } else {
-        ValueFormatter(style = ValueFormatter.Style.Short)
-            .string(BigDecimal.valueOf(assetBalance.totalAmount), asset.symbol)
-    }
-    val balanceEquivalent = if (hideBalance) {
-        "*****"
-    } else {
-        priceValue
-            ?.takeUnless { it == 0.0 }
-            ?.let { CurrencyFormatter(currency = currency).string(assetBalance.totalAmount * it) }
-            .orEmpty()
-    }
+    val formattedBalance = ValueFormatter(style = ValueFormatter.Style.Short)
+        .string(BigDecimal.valueOf(assetBalance.totalAmount), asset.symbol)
+        .masked(hideBalance)
+    val balanceEquivalent = priceValue
+        ?.takeUnless { it == 0.0 }
+        ?.let { CurrencyFormatter(currency = currency).string(assetBalance.totalAmount * it) }
+        .orEmpty()
+        .masked(hideBalance)
     val price = assetPrice?.let {
         AssetPriceDataAggregate(
             currency = currency,

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionDetailsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionDetailsImpl.kt
@@ -26,6 +26,8 @@ import com.gemwallet.android.model.CryptoFiatConverter
 import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.TransactionExtended
 import com.gemwallet.android.model.ValueFormatter
+import com.gemwallet.android.model.masked
+import com.gemwallet.android.model.maskedOrNull
 import com.wallet.core.primitives.AddressType
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.BlockExplorerLink
@@ -60,7 +62,7 @@ class GetTransactionDetailsImpl(
     private val createExplorer: (String) -> Explorer = ::Explorer,
 ) : GetTransactionDetails {
 
-    override fun getTransactionDetails(id: TransactionId): Flow<TransactionDetailsAggregate?> {
+    override fun getTransactionDetails(id: TransactionId, hideBalance: Boolean): Flow<TransactionDetailsAggregate?> {
         return combine(
             sessionRepository.session().filterNotNull(),
             transactionRepository.getTransaction(id),
@@ -82,6 +84,7 @@ class GetTransactionDetailsImpl(
                         associatedAssets = assets,
                         explorer = explorerInfo,
                         currency = session.currency,
+                        hideBalance = hideBalance,
                         swapProvider = swapProvider,
                         swapMetadata = swapMetadata,
                         senderExplorerLink = BlockExplorerLink(
@@ -106,6 +109,7 @@ class TransactionDetailsAggregateImpl(
     swapMetadata: TransactionSwapMetadata? = null,
     override val explorer: TransactionDetailsValue.Explorer,
     override val currency: Currency,
+    private val hideBalance: Boolean = false,
     private val swapProvider: SwapperProviderType? = null,
     private val senderExplorerLink: BlockExplorerLink? = null,
     private val recipientExplorerLink: BlockExplorerLink? = null,
@@ -177,7 +181,12 @@ class TransactionDetailsAggregateImpl(
                         TransactionType.PerpetualModifyPosition,
                         TransactionType.TokenApproval -> Pair(data.asset.symbol, null)
                     }
-                    TransactionDetailsValue.Amount.Plain(data.asset, amount, equivalent)
+                    val isAmount = data.transaction.type != TransactionType.TokenApproval
+                    TransactionDetailsValue.Amount.Plain(
+                        data.asset,
+                        amount.masked(hideBalance && isAmount),
+                        equivalent.maskedOrNull(hideBalance && isAmount),
+                    )
                 }
             }
         }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/GetTransactionsImpl.kt
@@ -20,6 +20,8 @@ import com.gemwallet.android.model.TransactionExtended
 import com.gemwallet.android.model.ValueFormatter
 import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.PriceChangeFormatter
+import com.gemwallet.android.model.masked
+import com.gemwallet.android.model.maskedOrNull
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.PerpetualDirection
@@ -52,14 +54,16 @@ class GetTransactionsImpl(
 
     override fun getTransactions(
         filters: List<TransactionsRequestFilter>,
+        hideBalance: Boolean,
     ): Flow<List<TransactionDataAggregate>> = transactionsRepository.getTransactions(filters)
-        .map { items -> items.map { TransactionDataAggregateImpl(it) } }
+        .map { items -> items.map { TransactionDataAggregateImpl(it, hideBalance) } }
         .flowOn(Dispatchers.IO)
 }
 
 @Stable
 class TransactionDataAggregateImpl(
     private val data: TransactionExtended,
+    private val hideBalance: Boolean = false,
 ) : TransactionDataAggregate {
 
     override val id: TransactionId = data.transaction.id
@@ -105,7 +109,12 @@ class TransactionDataAggregateImpl(
             -> ""
     }
 
-    override val value: String get() = when (data.transaction.type) {
+    override val value: String get() = rawValue.let {
+        val isAmount = data.transaction.type != TransactionType.TokenApproval
+        it.masked(hideBalance && isAmount && it.isNotEmpty())
+    }
+
+    private val rawValue: String get() = when (data.transaction.type) {
         TransactionType.Swap -> {
             getSwapValue(true)?.let { (value, asset) ->
                 AmountSign.Incoming.format(formatter.string(value, asset))
@@ -135,7 +144,9 @@ class TransactionDataAggregateImpl(
             -> ""
     }
 
-    override val equivalentValue: String? get() = when (data.transaction.type) {
+    override val equivalentValue: String? get() = rawEquivalentValue.maskedOrNull(hideBalance)
+
+    private val rawEquivalentValue: String? get() = when (data.transaction.type) {
         TransactionType.Swap -> getSwapValue(false)?.let { (value, asset) ->
             AmountSign.Outgoing.format(formatter.string(value, asset))
         }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/AssetInfoDataAggregateImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/AssetInfoDataAggregateImplTest.kt
@@ -4,6 +4,7 @@ import com.gemwallet.android.domains.price.ValueDirection
 import com.gemwallet.android.model.AssetBalance
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.AssetPriceInfo
+import com.gemwallet.android.model.HIDDEN_BALANCE_MASK
 import com.wallet.core.primitives.Account
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.AssetId
@@ -77,7 +78,7 @@ class AssetInfoDataAggregateImplTest {
         )
         val aggregate = assetInfo.toAssetInfoDataAggregate(hideBalance = true)
 
-        assertEquals("*****", aggregate.balance)
+        assertEquals(HIDDEN_BALANCE_MASK, aggregate.balance)
     }
 
     @Test
@@ -110,7 +111,7 @@ class AssetInfoDataAggregateImplTest {
         )
         val aggregate = assetInfo.toAssetInfoDataAggregate(hideBalance = true)
 
-        assertEquals("*****", aggregate.balanceEquivalent)
+        assertEquals(HIDDEN_BALANCE_MASK, aggregate.balanceEquivalent)
     }
 
     @Test

--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsNavScreen.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsNavScreen.kt
@@ -18,6 +18,7 @@ fun TransactionDetailsNavScreen(
     viewModel: TransactionDetailsViewModel = hiltViewModel(),
 ) {
     val transaction by viewModel.data.collectAsStateWithLifecycle()
+    val hideBalance by viewModel.hideBalance.collectAsStateWithLifecycle()
     var isShowFeeDetails by remember { mutableStateOf(false) }
     val context = LocalContext.current
 
@@ -36,6 +37,7 @@ fun TransactionDetailsNavScreen(
 
     TransactionDetailsScene(
         data = model,
+        hideBalance = hideBalance,
         onAction = {
             when (it) {
                 TransactionDetailsAction.Share -> onShare(model.explorer.url, model.explorer.name)

--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/TransactionDetailsScene.kt
@@ -38,6 +38,7 @@ import com.wallet.core.primitives.TransactionType
 @Composable
 internal fun TransactionDetailsScene(
     data: TransactionDetailsAggregate,
+    hideBalance: Boolean,
     onAction: (TransactionDetailsAction) -> Unit,
 ) {
     Scene(
@@ -72,6 +73,7 @@ internal fun TransactionDetailsScene(
                             toAsset = item.toAsset,
                             toValue = item.toValue,
                             currency = item.currency,
+                            hideBalance = hideBalance,
                             onSwapClick = {
                                 onAction(
                                     TransactionDetailsAction.OpenSwap(
@@ -107,7 +109,7 @@ internal fun TransactionDetailsScene(
                         is TransactionDetailsValue.Price -> PropertyItem(R.string.asset_price, item.data, listPosition = position)
                         is TransactionDetailsValue.Status -> TransactionStatusProperty(data.asset, item, position)
                         is TransactionDetailsValue.Rate -> AssetRatePropertyItem(item.rate, position)
-                        is TransactionDetailsValue.SwapProgress -> SwapProgressItem(item)
+                        is TransactionDetailsValue.SwapProgress -> SwapProgressItem(item, hideBalance)
                         is TransactionDetailsValue.SwapAgain -> MainActionButton(
                             title = stringResource(R.string.transaction_swap_again),
                             modifier = Modifier.padding(horizontal = padding16, vertical = paddingSmall),

--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/components/SwapProgressItem.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/details/components/SwapProgressItem.kt
@@ -30,6 +30,7 @@ import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.transaction.values.TransactionDetailsValue
 import com.gemwallet.android.ext.networkName
 import com.gemwallet.android.model.ValueFormatter
+import com.gemwallet.android.model.masked
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.ListItemDefaults
 import com.gemwallet.android.ui.components.list_item.listItem
@@ -49,10 +50,11 @@ import com.gemwallet.android.ui.theme.space24
 import com.wallet.core.primitives.TransactionState
 
 @Composable
-internal fun SwapProgressItem(progress: TransactionDetailsValue.SwapProgress) {
+internal fun SwapProgressItem(progress: TransactionDetailsValue.SwapProgress, hideBalance: Boolean) {
     val chainName = progress.fromAsset.chain.networkName()
     val transferValue = ValueFormatter(style = ValueFormatter.Style.Auto)
         .string(progress.fromValue.toBigInteger(), progress.fromAsset)
+        .masked(hideBalance)
 
     val statuses = progress.state.swapProgressStatuses()
 

--- a/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionDetailsViewModel.kt
+++ b/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionDetailsViewModel.kt
@@ -3,17 +3,22 @@ package com.gemwallet.android.features.activities.viewmodels
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
 import com.gemwallet.android.application.transactions.coordinators.GetTransactionDetails
 import com.gemwallet.android.ui.models.navigation.RouteArgument
 import com.wallet.core.primitives.TransactionId
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class TransactionDetailsViewModel @Inject constructor(
     private val getTransactionDetails: GetTransactionDetails,
+    getHideBalancesState: GetHideBalancesState,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -21,7 +26,11 @@ class TransactionDetailsViewModel @Inject constructor(
         TransactionId.from(savedStateHandle.requireString(RouteArgument.TransactionId))
     ) { "Invalid TransactionId route argument" }
 
-    val data = getTransactionDetails.getTransactionDetails(transactionId)
+    val hideBalance = getHideBalancesState()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    val data = hideBalance
+        .flatMapLatest { hide -> getTransactionDetails.getTransactionDetails(transactionId, hide) }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 }
 

--- a/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModel.kt
+++ b/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModel.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.features.activities.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
 import com.gemwallet.android.application.transactions.coordinators.GetTransactions
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
 import com.gemwallet.android.application.transactions.coordinators.TransactionsRequestFilter
@@ -32,6 +33,7 @@ import javax.inject.Inject
 class TransactionsViewModel @Inject constructor(
     sessionRepository: SessionRepository,
     getTransactions: GetTransactions,
+    getHideBalancesState: GetHideBalancesState,
     private val syncTransactions: SyncTransactions,
 ) : ViewModel() {
 
@@ -54,14 +56,16 @@ class TransactionsViewModel @Inject constructor(
     val transactions = combine(
         chainsFilter,
         typeFilter,
-    ) { chains, types ->
-        buildList<TransactionsRequestFilter> {
+        getHideBalancesState(),
+    ) { chains, types, hideBalance ->
+        val filters = buildList<TransactionsRequestFilter> {
             if (chains.isNotEmpty()) add(TransactionsRequestFilter.Chains(chains))
             val allowedTypes = types.flatMap { it.types }
             if (allowedTypes.isNotEmpty()) add(TransactionsRequestFilter.Types(allowedTypes))
         }
+        filters to hideBalance
     }
-    .flatMapLatest { filters -> getTransactions.getTransactions(filters) }
+    .flatMapLatest { (filters, hideBalance) -> getTransactions.getTransactions(filters, hideBalance) }
     .stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/chart/AssetChartScene.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/chart/AssetChartScene.kt
@@ -27,6 +27,7 @@ import com.gemwallet.android.domains.percentage.formatAsPercentage
 import com.gemwallet.android.domains.price.toValueDirection
 import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.ValueFormatter
+import com.gemwallet.android.model.masked
 import java.math.BigDecimal
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.InfoSheetEntity
@@ -317,7 +318,7 @@ private fun LazyListScope.marketProperties(asset: Asset, items: List<MarketInfoU
     }
 }
 
-internal fun LazyListScope.allTimeProperties(currency: Currency, items: List<AllTimeUIModel>) {
+internal fun LazyListScope.allTimeProperties(currency: Currency, items: List<AllTimeUIModel>, hideBalance: Boolean = false) {
     val dateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM)
 
     itemsPositioned(items) { position, item ->
@@ -332,7 +333,8 @@ internal fun LazyListScope.allTimeProperties(currency: Currency, items: List<All
             trailing = {
                 val rowScope = this
                 Column(horizontalAlignment = Alignment.End) {
-                    with(rowScope) { PropertyDataText(CurrencyFormatter(currency = currency).string(item.value)) }
+                    val value = CurrencyFormatter(currency = currency).string(item.value).masked(hideBalance)
+                    with(rowScope) { PropertyDataText(value) }
                     ListItemSupportText(item.percentage.formatAsPercentage(), color = item.percentage.toValueDirection().color())
                 }
             },

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/chart/PortfolioChartScene.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/chart/PortfolioChartScene.kt
@@ -41,6 +41,7 @@ fun PortfolioChartScene(
 ) {
     val statistics by viewModel.statistics.collectAsStateWithLifecycle()
     val currency by viewModel.currency.collectAsStateWithLifecycle()
+    val hideBalance by viewModel.hideBalance.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val selectedType by viewModel.selectedType.collectAsStateWithLifecycle()
     val showSegmentedControl by viewModel.showSegmentedControl.collectAsStateWithLifecycle()
@@ -79,7 +80,7 @@ fun PortfolioChartScene(
             LazyColumn {
                 item { PortfolioChart(viewModel) }
                 if (state.chart is StateViewType.Data || state.chart == StateViewType.NoData) {
-                    portfolioStatistics(currency, statistics)
+                    portfolioStatistics(currency, statistics, hideBalance)
                 }
             }
         }

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/chart/PortfolioStatistics.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/chart/PortfolioStatistics.kt
@@ -16,11 +16,11 @@ import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.PortfolioMarginUsage
 import com.wallet.core.primitives.PortfolioStatistic
 
-internal fun LazyListScope.portfolioStatistics(currency: Currency, statistics: List<PortfolioStatistic>) {
+internal fun LazyListScope.portfolioStatistics(currency: Currency, statistics: List<PortfolioStatistic>, hideBalance: Boolean = false) {
     if (statistics.isEmpty()) return
     item { SubheaderItem(R.string.common_info) }
     val (allTime, perpetual) = statistics.partition { it.asAllTimeUIModel() != null }
-    allTimeProperties(currency, allTime.mapNotNull(PortfolioStatistic::asAllTimeUIModel))
+    allTimeProperties(currency, allTime.mapNotNull(PortfolioStatistic::asAllTimeUIModel), hideBalance)
     perpetualStatistics(currency, perpetual)
 }
 

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/models/ChartUIModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/models/ChartUIModel.kt
@@ -6,6 +6,7 @@ import com.gemwallet.android.math.getRelativeDate
 import com.gemwallet.android.model.AssetPriceInfo
 import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.PriceChangeFormatter
+import com.gemwallet.android.model.maskedOrNull
 import com.gemwallet.android.ui.components.chart.ChartPoint
 import com.gemwallet.android.ui.models.StateViewType
 import com.gemwallet.android.ui.models.chart.ChartHeaderUIModel
@@ -25,13 +26,18 @@ data class ChartUIModel(
     internal val priceFormatter: (Double) -> String = { "" },
     internal val priceChangeFormatter: (Double) -> String = { "" },
     internal val showHeaderValue: Boolean = true,
+    internal val hideBalance: Boolean = false,
 ) {
     val renderPoints: List<ChartPoint> by lazy {
         chartPoints.mapIndexed { index, point -> ChartPoint(x = index.toFloat(), y = point.y) }
     }
 
-    val minLabel: String? by lazy { chartPoints.minByOrNull { it.y }?.price?.let(priceFormatter) }
-    val maxLabel: String? by lazy { chartPoints.maxByOrNull { it.y }?.price?.let(priceFormatter) }
+    val minLabel: String? by lazy {
+        chartPoints.minByOrNull { it.y }?.price?.let(priceFormatter).maskedOrNull(hideBalance)
+    }
+    val maxLabel: String? by lazy {
+        chartPoints.maxByOrNull { it.y }?.price?.let(priceFormatter).maskedOrNull(hideBalance)
+    }
 
     companion object {}
 
@@ -88,6 +94,7 @@ internal fun ChartUIModel.Companion.from(
     period: ChartPeriod,
     currency: Currency,
     showHeaderValue: Boolean,
+    hideBalance: Boolean = false,
 ): ChartUIModel {
     val basePrice = values.firstOrNull()?.value ?: 0.0
     val currencyFormatter = CurrencyFormatter(currency = currency)
@@ -105,6 +112,7 @@ internal fun ChartUIModel.Companion.from(
         priceFormatter = currencyFormatter::string,
         priceChangeFormatter = PriceChangeFormatter(currencyFormatter)::string,
         showHeaderValue = showHeaderValue,
+        hideBalance = hideBalance,
     )
 }
 
@@ -131,5 +139,6 @@ fun portfolioChartHeader(uiModel: ChartUIModel, selectedPoint: PricePoint?): Cha
         priceFormatter = uiModel.priceFormatter,
         priceChangeFormatter = uiModel.priceChangeFormatter,
         dateFormatter = ::getRelativeDate,
+        hideBalance = uiModel.hideBalance,
     )
 }

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/PortfolioChartViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/PortfolioChartViewModel.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.features.asset.viewmodels.chart.viewmodels
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
 import com.gemwallet.android.application.assets.coordinators.GetPortfolioData
 import com.gemwallet.android.application.assets.coordinators.walletChartPeriods
 import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
@@ -42,8 +43,11 @@ class PortfolioChartViewModel internal constructor(
     getCurrentCurrency: GetCurrentCurrency,
     observePerpetualWallet: ObservePerpetualWallet,
     private val getPortfolioData: GetPortfolioData,
+    getHideBalancesState: GetHideBalancesState,
     initialType: PortfolioType,
 ) : ViewModel() {
+    val hideBalance = getHideBalancesState()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(StopTimeoutMillis), false)
     private val _selectedType = MutableStateFlow(initialType)
     val selectedType = _selectedType.asStateFlow()
 
@@ -89,7 +93,7 @@ class PortfolioChartViewModel internal constructor(
             PortfolioState(initialType, selectedPeriod.value, Currency.USD),
         )
 
-    val chartUIState = combine(portfolio, selectedChartType) { state, chartType ->
+    val chartUIState = combine(portfolio, selectedChartType, hideBalance) { state, chartType, hide ->
         ChartUIModel.State(
             period = state.period,
             chart = state.data.flatMap { data ->
@@ -101,6 +105,7 @@ class PortfolioChartViewModel internal constructor(
                             period = state.period,
                             currency = state.displayCurrency(),
                             showHeaderValue = state.type == PortfolioType.Wallet || chartType == PortfolioChartType.Value,
+                            hideBalance = hide,
                         ),
                     )
                 } else {
@@ -143,11 +148,13 @@ class PortfolioChartViewModel internal constructor(
         getCurrentCurrency: GetCurrentCurrency,
         observePerpetualWallet: ObservePerpetualWallet,
         getPortfolioData: GetPortfolioData,
+        getHideBalancesState: GetHideBalancesState,
         savedStateHandle: SavedStateHandle,
     ) : this(
         getCurrentCurrency = getCurrentCurrency,
         observePerpetualWallet = observePerpetualWallet,
         getPortfolioData = getPortfolioData,
+        getHideBalancesState = getHideBalancesState,
         initialType = savedStateHandle.portfolioType(),
     )
 }

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/models/AssetInfoUIModelFactory.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/models/AssetInfoUIModelFactory.kt
@@ -14,6 +14,7 @@ import com.gemwallet.android.model.CurrencyFormatter
 import com.gemwallet.android.model.ValueFormatter
 import com.gemwallet.android.model.getStackedAmount
 import com.gemwallet.android.model.getTotalAmount
+import com.gemwallet.android.model.masked
 import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.AssetSubtype
 import com.wallet.core.primitives.AssetType
@@ -23,7 +24,7 @@ import uniffi.gemstone.Explorer
 
 object AssetInfoUIModelFactory {
 
-    fun create(chainAssetInfo: ChainAssetInfo, explorerName: String): AssetInfoUIModel {
+    fun create(chainAssetInfo: ChainAssetInfo, explorerName: String, hideBalance: Boolean = false): AssetInfoUIModel {
         val assetInfo = chainAssetInfo.assetInfo
         val feeAssetInfo = chainAssetInfo.feeAssetInfo
         val asset = assetInfo.asset
@@ -32,7 +33,11 @@ object AssetInfoUIModelFactory {
         val currency = assetInfo.price?.currency ?: Currency.USD
         val currencyFormatter = CurrencyFormatter(currency = currency)
         val valueFormatter = ValueFormatter(style = ValueFormatter.Style.Auto)
-        val fiatTotal = if (balances.fiatTotalAmount == 0.0) "" else currencyFormatter.string(balances.fiatTotalAmount)
+        val fiatTotal = if (balances.fiatTotalAmount == 0.0) {
+            ""
+        } else {
+            currencyFormatter.string(balances.fiatTotalAmount).masked(hideBalance)
+        }
 
         return AssetInfoUIModel(
             assetInfo = assetInfo,
@@ -53,14 +58,14 @@ object AssetInfoUIModelFactory {
             },
             accountInfoUIModel = AssetInfoUIModel.AccountInfoUIModel(
                 walletType = assetInfo.walletType,
-                totalBalance = valueFormatter.string(balances.balance.getTotalAmount(), balances.asset),
+                totalBalance = valueFormatter.string(balances.balance.getTotalAmount(), balances.asset).masked(hideBalance),
                 totalFiat = fiatTotal,
                 owner = assetInfo.owner?.address ?: "",
                 balanceMetadata = feeAssetInfo.balance.metadata,
                 hasBalanceDetails = StakeChain.isStaked(asset.id.chain) || balances.balanceAmount.reserved != 0.0,
-                available = formatAvailable(assetInfo, valueFormatter),
-                stake = formatStake(assetInfo, valueFormatter),
-                reserved = formatReserved(assetInfo, valueFormatter),
+                available = formatAvailable(assetInfo, valueFormatter, hideBalance),
+                stake = formatStake(assetInfo, valueFormatter, hideBalance),
+                reserved = formatReserved(assetInfo, valueFormatter, hideBalance),
             ),
         )
     }
@@ -68,16 +73,16 @@ object AssetInfoUIModelFactory {
     private fun assetName(asset: Asset): String =
         if (asset.type == AssetType.NATIVE) asset.id.chain.asset().name else asset.name
 
-    private fun formatAvailable(assetInfo: AssetInfo, formatter: ValueFormatter): String {
+    private fun formatAvailable(assetInfo: AssetInfo, formatter: ValueFormatter, hideBalance: Boolean): String {
         val balances = assetInfo.balance
         return if (balances.balanceAmount.available != balances.totalAmount) {
-            formatter.string(balances.balance.available.toBigInteger(), balances.asset)
+            formatter.string(balances.balance.available.toBigInteger(), balances.asset).masked(hideBalance)
         } else {
             ""
         }
     }
 
-    private fun formatStake(assetInfo: AssetInfo, formatter: ValueFormatter): String {
+    private fun formatStake(assetInfo: AssetInfo, formatter: ValueFormatter, hideBalance: Boolean): String {
         val asset = assetInfo.asset
         if (asset.id.type() != AssetSubtype.NATIVE || !StakeChain.isStaked(asset.id.chain)) {
             return ""
@@ -86,14 +91,14 @@ object AssetInfoUIModelFactory {
         return if (balances.balanceAmount.getStackedAmount() == 0.0) {
             "APR ${(assetInfo.stakeApr ?: 0.0).formatAsPercentage(style = PercentageFormatterStyle.PercentSignLess)}"
         } else {
-            formatter.string(balances.balance.getStackedAmount(), balances.asset)
+            formatter.string(balances.balance.getStackedAmount(), balances.asset).masked(hideBalance)
         }
     }
 
-    private fun formatReserved(assetInfo: AssetInfo, formatter: ValueFormatter): String {
+    private fun formatReserved(assetInfo: AssetInfo, formatter: ValueFormatter, hideBalance: Boolean): String {
         val balances = assetInfo.balance
         return if (balances.balanceAmount.reserved != 0.0) {
-            formatter.string(balances.balance.reserved.toBigInteger(), balances.asset)
+            formatter.string(balances.balance.reserved.toBigInteger(), balances.asset).masked(hideBalance)
         } else {
             ""
         }

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.assets.coordinators.EnableAsset
 import com.gemwallet.android.application.assets.coordinators.GetChainAssetInfo
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
 import com.gemwallet.android.application.assets.coordinators.SyncAssetInfo
 import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
 import com.gemwallet.android.application.pricealerts.coordinators.GetAssetPriceAlertState
@@ -34,6 +35,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -52,6 +54,7 @@ class AssetDetailsViewModel @Inject constructor(
     getSession: GetSession,
     savedStateHandle: SavedStateHandle,
     private val getChainAssetInfo: GetChainAssetInfo,
+    private val getHideBalancesState: GetHideBalancesState,
     private val toggleAssetPin: ToggleAssetPin,
     private val enableAsset: EnableAsset,
     private val syncAssetInfo: SyncAssetInfo,
@@ -112,13 +115,17 @@ class AssetDetailsViewModel @Inject constructor(
         .map { it.size }
         .stateIn(viewModelScope, SharingStarted.Eagerly, 0)
 
-    val transactions = getTransactions.getTransactions(listOf(TransactionsRequestFilter.Asset(assetId)))
+    private val hideBalance = getHideBalancesState()
+
+    val transactions = hideBalance.flatMapLatest { hide ->
+        getTransactions.getTransactions(listOf(TransactionsRequestFilter.Asset(assetId)), hide)
+    }
         .map { it.toImmutableList() }
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    val uiModel = model.map { current ->
-        current?.let { AssetInfoUIModelFactory.create(it.chainAssetInfo, it.explorerName) }
+    val uiModel = combine(model, hideBalance) { current, hide ->
+        current?.let { AssetInfoUIModelFactory.create(it.chainAssetInfo, it.explorerName, hide) }
     }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 

--- a/android/features/asset/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/PortfolioChartViewModelTest.kt
+++ b/android/features/asset/viewmodels/src/test/kotlin/com/gemwallet/android/features/asset/viewmodels/chart/viewmodels/PortfolioChartViewModelTest.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.features.asset.viewmodels.chart.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
 import com.gemwallet.android.application.assets.coordinators.GetPortfolioData
 import com.gemwallet.android.application.session.coordinators.GetCurrentCurrency
 import com.gemwallet.android.data.repositories.perpetual.ObservePerpetualWallet
@@ -49,6 +50,9 @@ class PortfolioChartViewModelTest {
     }
     private val observePerpetualWallet = mockk<ObservePerpetualWallet>(relaxed = true)
     private val getPortfolioData = mockk<GetPortfolioData>(relaxed = true)
+    private val getHideBalancesState = mockk<GetHideBalancesState>(relaxed = true) {
+        every { invoke() } returns flowOf(false)
+    }
 
     @Before
     fun setUp() {
@@ -196,6 +200,7 @@ class PortfolioChartViewModelTest {
         getCurrentCurrency = getCurrentCurrency,
         observePerpetualWallet = observePerpetualWallet,
         getPortfolioData = getPortfolioData,
+        getHideBalancesState = getHideBalancesState,
         initialType = initialType,
     ).also(viewModels::add)
 }

--- a/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/BaseAssetSelectViewModel.kt
+++ b/android/features/asset_select/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset_select/viewmodels/BaseAssetSelectViewModel.kt
@@ -44,8 +44,10 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -62,6 +64,7 @@ open class BaseAssetSelectViewModel(
     private val searchTokensCase: SearchTokensCase,
     val search: SelectSearch,
     private val remoteSearch: Boolean = true,
+    protected val hideBalance: Flow<Boolean> = flowOf(false),
 ) : ViewModel(), AssetToastEmitter by AssetToastEmitterImpl() {
 
     val queryState = TextFieldState()
@@ -99,7 +102,8 @@ open class BaseAssetSelectViewModel(
     private val assetsContent = combine(
         filters,
         search.items(filters),
-    ) { filters, items ->
+        hideBalance,
+    ) { filters, items, hide ->
         val chainFilter = filters?.chainFilter.orEmpty()
         val balanceFilter = filters?.hasBalance == true
         val wallet = session.value?.wallet
@@ -107,7 +111,7 @@ open class BaseAssetSelectViewModel(
             .filter { (chainFilter.isEmpty() || it.id().chain in chainFilter) && (!balanceFilter || it.balance.totalAmount > 0.0) }
             .map { item ->
                 val owner = item.owner ?: wallet?.getAccount(item.asset.id.chain)
-                AssetInfoUIModel(if (item.owner == owner) item else item.copy(owner = owner))
+                AssetInfoUIModel(if (item.owner == owner) item else item.copy(owner = owner), hideBalances = hide)
             }
     }
     .flowOn(Dispatchers.IO)

--- a/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsResultsViewModel.kt
+++ b/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsResultsViewModel.kt
@@ -8,6 +8,7 @@ import com.gemwallet.android.application.asset_select.coordinators.GetRecentAsse
 import com.gemwallet.android.application.asset_select.coordinators.SearchListAssets
 import com.gemwallet.android.application.asset_select.coordinators.SearchSelectAssets
 import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
 import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
 import com.gemwallet.android.application.asset_select.coordinators.UpdateRecentAsset
 import com.gemwallet.android.application.perpetual.coordinators.GetPerpetuals
@@ -65,6 +66,7 @@ class AssetsResultsViewModel @Inject constructor(
     private val searchScopeCase: WalletSearchScopeCase,
     getPerpetuals: GetPerpetuals,
     userConfig: UserConfig,
+    getHideBalancesState: GetHideBalancesState,
     private val togglePerpetualPin: TogglePerpetualPin,
     @ApplicationContext context: Context,
     savedStateHandle: SavedStateHandle,
@@ -77,6 +79,7 @@ class AssetsResultsViewModel @Inject constructor(
     searchTokensCase,
     resolveSearch(savedStateHandle, searchSelectAssets, searchListAssets),
     remoteSearch = false,
+    hideBalance = getHideBalancesState(),
 ) {
 
     private val scope: WalletSearchTag = walletSearchTagOf(savedStateHandle.get<String?>(RouteArgument.Scope.key))

--- a/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/NetworkAssetsViewModel.kt
+++ b/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/NetworkAssetsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.asset_select.coordinators.GetChainAssets
 import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
 import com.gemwallet.android.application.assets.coordinators.HideAsset
 import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
 import com.gemwallet.android.application.session.coordinators.GetSession
@@ -35,6 +36,7 @@ class NetworkAssetsViewModel @Inject constructor(
     private val hideAsset: HideAsset,
     private val toggleAssetPin: ToggleAssetPin,
     private val switchAssetVisibility: SwitchAssetVisibility,
+    getHideBalancesState: GetHideBalancesState,
     @ApplicationContext context: Context,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -43,20 +45,25 @@ class NetworkAssetsViewModel @Inject constructor(
 
     val title: String = context.getString(R.string.assets_title)
 
+    private val hideBalance = getHideBalancesState()
+
     private val activeAssets = getChainAssets(chain)
         .map { assets -> assets.filter { it.asset.type != AssetType.NATIVE } }
         .flowOn(Dispatchers.IO)
 
-    val pinned: StateFlow<List<AssetItemUIModel>> = activeAssets
-        .map { assets -> assets.filter { it.metadata?.isPinned == true }.map { AssetInfoUIModel(it) } }
+    val pinned: StateFlow<List<AssetItemUIModel>> = combine(activeAssets, hideBalance) { assets, hide ->
+        assets.filter { it.metadata?.isPinned == true }.map { AssetInfoUIModel(it, hideBalances = hide) }
+    }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    val unpinned: StateFlow<List<AssetItemUIModel>> = activeAssets
-        .map { assets -> assets.filter { it.metadata?.isPinned != true }.map { AssetInfoUIModel(it) } }
+    val unpinned: StateFlow<List<AssetItemUIModel>> = combine(activeAssets, hideBalance) { assets, hide ->
+        assets.filter { it.metadata?.isPinned != true }.map { AssetInfoUIModel(it, hideBalances = hide) }
+    }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    val hidden: StateFlow<List<AssetItemUIModel>> = getChainAssets.hidden(chain)
-        .map { assets -> assets.filter { it.asset.type != AssetType.NATIVE }.map { AssetInfoUIModel(it) } }
+    val hidden: StateFlow<List<AssetItemUIModel>> = combine(getChainAssets.hidden(chain), hideBalance) { assets, hide ->
+        assets.filter { it.asset.type != AssetType.NATIVE }.map { AssetInfoUIModel(it, hideBalances = hide) }
+    }
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 

--- a/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/WalletSearchViewModel.kt
+++ b/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/WalletSearchViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.asset_select.coordinators.GetRecentAssets
 import com.gemwallet.android.application.asset_select.coordinators.SearchSelectAssets
 import com.gemwallet.android.application.asset_select.coordinators.SwitchAssetVisibility
+import com.gemwallet.android.application.assets.coordinators.GetHideBalancesState
 import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
 import com.gemwallet.android.application.asset_select.coordinators.UpdateRecentAsset
 import com.gemwallet.android.application.assets.coordinators.GetSearchLists
@@ -58,6 +59,7 @@ class WalletSearchViewModel @Inject constructor(
     getNftCollections: GetNftCollections,
     getSearchLists: GetSearchLists,
     userConfig: UserConfig,
+    getHideBalancesState: GetHideBalancesState,
     private val togglePerpetualPin: TogglePerpetualPin,
 ) : BaseAssetSelectViewModel(
     getSession,
@@ -67,6 +69,7 @@ class WalletSearchViewModel @Inject constructor(
     toggleAssetPin,
     searchTokensCase,
     BaseSelectSearch(searchSelectAssets),
+    hideBalance = getHideBalancesState(),
 ) {
 
     private val showPerpetuals = userConfig.showPerpetuals(getSession())

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/transactions/coordinators/GetTransactionDetails.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/transactions/coordinators/GetTransactionDetails.kt
@@ -5,5 +5,5 @@ import com.wallet.core.primitives.TransactionId
 import kotlinx.coroutines.flow.Flow
 
 interface GetTransactionDetails {
-    fun getTransactionDetails(id: TransactionId): Flow<TransactionDetailsAggregate?>
+    fun getTransactionDetails(id: TransactionId, hideBalance: Boolean = false): Flow<TransactionDetailsAggregate?>
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/transactions/coordinators/GetTransactions.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/transactions/coordinators/GetTransactions.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 interface GetTransactions {
     fun getTransactions(
         filters: List<TransactionsRequestFilter> = emptyList(),
+        hideBalance: Boolean = false,
     ): Flow<List<TransactionDataAggregate>>
 
     fun transactions(): StateFlow<List<TransactionDataAggregate>>

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/BalancePrivacy.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/BalancePrivacy.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.model
+
+const val HIDDEN_BALANCE_MASK = "✱✱✱✱✱"
+
+fun String.masked(hideBalance: Boolean): String = if (hideBalance) HIDDEN_BALANCE_MASK else this
+
+fun String?.maskedOrNull(hideBalance: Boolean): String? = this?.masked(hideBalance)

--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/chart/ChartHeaderUIModel.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/chart/ChartHeaderUIModel.kt
@@ -4,6 +4,8 @@ import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
 import com.gemwallet.android.domains.percentage.formatAsPercentage
 import com.gemwallet.android.domains.price.ValueDirection
 import com.gemwallet.android.domains.price.toValueDirection
+import com.gemwallet.android.model.masked
+import com.gemwallet.android.model.maskedOrNull
 
 enum class ChartValueType { Price, PriceChange }
 
@@ -25,11 +27,12 @@ data class ChartHeaderUIModel(
             priceFormatter: (Double) -> String,
             priceChangeFormatter: (Double) -> String = priceFormatter,
             dateFormatter: (Long) -> String = { "" },
+            hideBalance: Boolean = false,
         ): ChartHeaderUIModel = ChartHeaderUIModel(
             priceText = when (type) {
                 ChartValueType.Price -> priceFormatter(price)
                 ChartValueType.PriceChange -> priceChangeFormatter(price)
-            },
+            }.masked(hideBalance),
             changeText = when (type) {
                 ChartValueType.Price -> priceChangePercentage.formatAsPercentage()
                 ChartValueType.PriceChange ->
@@ -41,7 +44,7 @@ data class ChartHeaderUIModel(
             },
             direction = (if (type == ChartValueType.PriceChange) price else priceChangePercentage).toValueDirection(),
             dateText = timestamp?.let(dateFormatter),
-            headerValueText = headerValue?.let(priceFormatter),
+            headerValueText = headerValue?.let(priceFormatter).maskedOrNull(hideBalance),
             type = type,
         )
     }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/DisplayText.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/DisplayText.kt
@@ -20,20 +20,20 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.gemwallet.android.model.masked
 import com.gemwallet.android.ui.theme.paddingDefault
 
-private const val BALANCE_MASK = "✱✱✱✱✱"
 private val balanceTextLineHeight = 44.sp
 private val balanceTextHeight = 52.dp
 
 data class HideToggle(
     val hidden: Boolean,
-    val onToggle: () -> Unit,
+    val onToggle: (() -> Unit)? = null,
 )
 
 internal val HideToggle?.isHidden: Boolean get() = this?.hidden == true
 
-internal fun HideToggle?.mask(text: String): String = if (isHidden) BALANCE_MASK else text
+internal fun HideToggle?.mask(text: String): String = text.masked(isHidden)
 
 @Composable
 fun DisplayText(
@@ -78,12 +78,12 @@ fun DisplayText(
                 autoSize = balanceAutoSize,
             )
         }
-        hideToggle?.let { toggle ->
+        hideToggle?.onToggle?.let { onToggle ->
             val haptic = LocalHapticFeedback.current
             Surface(
                 onClick = {
                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    toggle.onToggle()
+                    onToggle()
                 },
                 shape = CircleShape,
                 color = if (hidden) MaterialTheme.colorScheme.background else Color.Transparent,

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_head/SwapListHead.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_head/SwapListHead.kt
@@ -19,6 +19,7 @@ import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.CryptoFiatConverter
 import com.gemwallet.android.model.ValueFormatter
+import com.gemwallet.android.model.masked
 import com.gemwallet.android.ui.components.list_item.ListItemDefaults
 import com.gemwallet.android.ui.components.list_item.listItem
 import com.gemwallet.android.ui.icons.AppIcons
@@ -37,6 +38,7 @@ fun SwapListHead(
     toAsset: AssetInfo?,
     toValue: String,
     currency: Currency? = null,
+    hideBalance: Boolean = false,
     onSwapClick: (() -> Unit)? = null,
     onAssetClick: ((AssetId) -> Unit)? = null,
 ) {
@@ -55,6 +57,7 @@ fun SwapListHead(
                 assetInfo = fromAsset,
                 value = fromValue,
                 currency = currency,
+                hideBalance = hideBalance,
                 onSwapClick = onSwapClick,
                 onAssetClick = onAssetClick,
             )
@@ -72,6 +75,7 @@ fun SwapListHead(
                 assetInfo = toAsset,
                 value = toValue,
                 currency = currency,
+                hideBalance = hideBalance,
                 onSwapClick = onSwapClick,
                 onAssetClick = onAssetClick,
             )
@@ -84,6 +88,7 @@ private fun SwapItem(
     assetInfo: AssetInfo,
     value: String,
     currency: Currency?,
+    hideBalance: Boolean,
     onSwapClick: (() -> Unit)?,
     onAssetClick: ((AssetId) -> Unit)?,
 ) {
@@ -105,7 +110,7 @@ private fun SwapItem(
                 ),
         ) {
             Text(
-                text = ValueFormatter(style = ValueFormatter.Style.Auto).string(value.toBigInteger(), asset),
+                text = ValueFormatter(style = ValueFormatter.Style.Auto).string(value.toBigInteger(), asset).masked(hideBalance),
                 style = MaterialTheme.typography.headlineMedium.copy(
                     fontSize = 24.sp,
                     lineHeight = 32.sp,
@@ -117,7 +122,7 @@ private fun SwapItem(
                 Text(
                     text = CryptoFiatConverter.toFiatString(
                         Crypto(value), decimals, assetInfo.price?.price?.price ?: 0.0, currency
-                    ),
+                    ).masked(hideBalance),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.secondary,
                     textAlign = TextAlign.Start

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/AssetItemUIModel.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/AssetItemUIModel.kt
@@ -5,6 +5,7 @@ import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.asset.subtype
 import com.gemwallet.android.ext.asset
 import com.gemwallet.android.model.AssetInfo
+import com.gemwallet.android.model.masked
 import com.gemwallet.android.ui.models.CryptoFormattedUIModel
 import com.gemwallet.android.ui.models.FiatFormattedUIModel
 import com.gemwallet.android.ui.models.PriceUIModel
@@ -47,7 +48,7 @@ open class AssetInfoUIModel(
         get() = assetInfo.balance.totalAmount
 
     override val cryptoFormatted: String
-        get() = if (hideBalances) "*****" else super.cryptoFormatted
+        get() = super.cryptoFormatted.masked(hideBalances)
 
     override val fiat: Double? by lazy {
         val price = assetInfo.price?.price?.price ?: 0.0
@@ -55,7 +56,7 @@ open class AssetInfoUIModel(
     }
 
     override val fiatFormatted: String
-        get() = if (hideBalances) "*****" else super.fiatFormatted
+        get() = super.fiatFormatted.masked(hideBalances)
 
     override val price: PriceUIModel by lazy {
         AssetPriceUIModel(currency, assetInfo.price?.price)

--- a/ios/Features/Assets/Sources/Scenes/AssetScene.swift
+++ b/ios/Features/Assets/Sources/Scenes/AssetScene.swift
@@ -185,6 +185,7 @@ public struct AssetScene: View {
                     explorerService: model.explorerService,
                     model.transactions,
                     currency: model.assetDataModel.currencyCode,
+                    hideBalance: model.hideBalance,
                 )
                 .listRowInsets(.assetListRowInsets)
             } else {

--- a/ios/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/ios/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -218,11 +218,16 @@ public final class AssetSceneViewModel: Sendable {
         )
     }
 
+    var hideBalance: Bool {
+        preferences.isHideBalanceEnabled
+    }
+
     var assetDataModel: AssetDataViewModel {
         AssetDataViewModel(
             assetData: assetData,
             formatter: .auto,
             currencyCode: preferences.preferences.currency,
+            hideBalance: hideBalance,
         )
     }
 

--- a/ios/Features/Transactions/Sources/Scenes/TransactionScene.swift
+++ b/ios/Features/Transactions/Sources/Scenes/TransactionScene.swift
@@ -38,6 +38,7 @@ public struct TransactionScene: View {
             TransactionHeaderListItemView(
                 model: model,
                 action: self.model.onTransactionHeaderTap,
+                hideBalance: self.model.hideBalance,
             )
         case let .swapProgress(model):
             TransactionSwapProgressView(model: model)

--- a/ios/Features/Transactions/Sources/Scenes/TransactionsScene.swift
+++ b/ios/Features/Transactions/Sources/Scenes/TransactionsScene.swift
@@ -22,6 +22,7 @@ public struct TransactionsScene: View {
                     explorerService: model.explorerService,
                     model.transactions,
                     currency: model.currency,
+                    hideBalance: model.hideBalance,
                 )
                 .listRowInsets(.assetListRowInsets)
             }

--- a/ios/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
@@ -15,7 +15,7 @@ import SwiftUI
 @Observable
 @MainActor
 public final class TransactionSceneViewModel {
-    private let preferences: Preferences
+    private let preferences: ObservablePreferences
     private let explorerService: ExplorerService
     private let onHeaderAction: ((TransactionHeaderAction) -> Void)?
     private let onAddContact: ((AddContactType) -> Void)?
@@ -31,7 +31,7 @@ public final class TransactionSceneViewModel {
     public init(
         transaction: TransactionExtended,
         walletId: WalletId,
-        preferences: Preferences = Preferences.standard,
+        preferences: ObservablePreferences = .default,
         explorerService: ExplorerService = ExplorerService.standard,
         onHeaderAction: ((TransactionHeaderAction) -> Void)? = nil,
         onAddContact: ((AddContactType) -> Void)? = nil,
@@ -55,6 +55,10 @@ public final class TransactionSceneViewModel {
         guard onHeaderAction != nil, headerAction != nil else { return nil }
         return { [weak self] tap in self?.handleHeaderTap(tap) }
     }
+
+    var hideBalance: Bool {
+        preferences.isHideBalanceEnabled
+    }
 }
 
 // MARK: - ListSectionProvideable
@@ -74,7 +78,7 @@ extension TransactionSceneViewModel: ListSectionProvideable {
     public func itemModel(for item: TransactionItem) -> any ItemModelProvidable<TransactionItemModel> {
         switch item {
         case .header: headerViewModel
-        case .swapProgress: TransactionSwapProgressViewModel(transaction: transactionExtended)
+        case .swapProgress: TransactionSwapProgressViewModel(transaction: transactionExtended, hideBalance: hideBalance)
         case .swapButton: TransactionSwapButtonViewModel(metadata: model.transaction.transaction.metadata?.decode(TransactionSwapMetadata.self), state: model.transaction.transaction.state)
         case .date: TransactionDateViewModel(date: model.transaction.transaction.createdAt)
         case .status: TransactionStatusViewModel(state: model.transaction.transaction.state, onInfoAction: onSelectStatusInfo)
@@ -148,7 +152,7 @@ extension TransactionSceneViewModel {
         TransactionViewModel(
             explorerService: explorerService,
             transaction: transactionExtended,
-            currency: preferences.currency,
+            currency: preferences.preferences.currency,
         )
     }
 
@@ -203,7 +207,7 @@ extension TransactionSceneViewModel {
             chain: model.transaction.transaction.assetId.chain,
             feeAsset: model.transaction.feeAsset,
             priority: .normal,
-            currency: Currency(rawValue: preferences.currency) ?? .usd,
+            currency: Currency(rawValue: preferences.preferences.currency) ?? .usd,
             feeAmount: BigInt(model.transaction.transaction.fee),
         )
         viewModel.update(rates: [], feeAssetPrice: model.transaction.feePrice)

--- a/ios/Features/Transactions/Sources/ViewModels/TransactionSwapProgressViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionSwapProgressViewModel.swift
@@ -10,9 +10,11 @@ import Primitives
 
 struct TransactionSwapProgressViewModel {
     private let transaction: TransactionExtended
+    private let hideBalance: Bool
 
-    init(transaction: TransactionExtended) {
+    init(transaction: TransactionExtended, hideBalance: Bool = false) {
         self.transaction = transaction
+        self.hideBalance = hideBalance
     }
 }
 
@@ -49,7 +51,7 @@ extension TransactionSwapProgressViewModel {
         let transferTitle = Localized.Transfer.title
         let chainName = fromAsset.id.chain.networkName
         let amount = ValueFormatter.auto.string(BigInt.fromString(metadata.fromValue), asset: fromAsset)
-        let transferSubtitle = "\(amount) (\(chainName))"
+        let transferSubtitle = "\(amount.masked(if: hideBalance)) (\(chainName))"
         let swapTitle = Localized.Wallet.swap
         let swapSubtitle = provider.name
 

--- a/ios/Features/Transactions/Sources/ViewModels/TransactionsViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionsViewModel.swift
@@ -16,7 +16,7 @@ import WalletService
 public final class TransactionsViewModel {
     public let explorerService: any ExplorerLinkFetchable = ExplorerService.standard
     public let transactionsService: TransactionsService
-    public let preferences: Preferences
+    public let preferences: ObservablePreferences
 
     private let walletService: WalletService
     private let type: TransactionsRequestType
@@ -37,7 +37,7 @@ public final class TransactionsViewModel {
         walletService: WalletService,
         wallet: Wallet,
         type: TransactionsRequestType,
-        preferences: Preferences = .standard,
+        preferences: ObservablePreferences = .default,
     ) {
         self.walletService = walletService
         self.transactionsService = transactionsService
@@ -61,7 +61,11 @@ public final class TransactionsViewModel {
     }
 
     public var currency: String {
-        preferences.currency
+        preferences.preferences.currency
+    }
+
+    public var hideBalance: Bool {
+        preferences.isHideBalanceEnabled
     }
 
     public var emptyContentModel: EmptyContentTypeViewModel {

--- a/ios/Features/Transactions/Tests/TransactionsTests/ViewModels/TransactionSceneViewModelTests.swift
+++ b/ios/Features/Transactions/Tests/TransactionsTests/ViewModels/TransactionSceneViewModelTests.swift
@@ -48,7 +48,7 @@ struct TransactionSceneViewModelTests {
                 ),
             ),
             walletId: .mock(),
-            preferences: Preferences.standard,
+            preferences: .mock(),
             onHeaderAction: { selectedAction = $0 },
         )
 
@@ -69,7 +69,7 @@ struct TransactionSceneViewModelTests {
                 ),
             ),
             walletId: .mock(),
-            preferences: Preferences.standard,
+            preferences: .mock(),
         )
 
         #expect(model.onTransactionHeaderTap == nil)
@@ -274,7 +274,7 @@ struct TransactionSceneViewModelTests {
         let modelWithAddresses = TransactionSceneViewModel(
             transaction: transaction,
             walletId: .mock(),
-            preferences: Preferences.standard,
+            preferences: .mock(),
         )
 
         if case let .participant(item) = modelWithAddresses.item(for: TransactionItem.participant) {
@@ -425,7 +425,7 @@ extension TransactionSceneViewModel {
                 assets: assets,
             ),
             walletId: .mock(),
-            preferences: Preferences.standard,
+            preferences: .mock(),
         )
     }
 

--- a/ios/Features/WalletTab/Sources/Scenes/AssetsResultsScene.swift
+++ b/ios/Features/WalletTab/Sources/Scenes/AssetsResultsScene.swift
@@ -64,6 +64,7 @@ public struct AssetsResultsScene: View {
             currencyCode: model.currencyCode,
             contextMenuItems: model.contextMenuItems,
             onSelect: { model.onSelectAsset($0) },
+            hideBalance: model.hideBalance,
         )
     }
 }

--- a/ios/Features/WalletTab/Sources/Scenes/NetworkAssetsScene.swift
+++ b/ios/Features/WalletTab/Sources/Scenes/NetworkAssetsScene.swift
@@ -73,7 +73,7 @@ public struct NetworkAssetsScene: View {
             onPinAsset: model.onPinAsset,
             onAddToWallet: onAddToWallet,
             onCopyAddress: model.onCopyAddress,
-            showBalancePrivacy: .constant(false),
+            showBalancePrivacy: .constant(model.hideBalance),
         )
     }
 }

--- a/ios/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
+++ b/ios/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
@@ -153,6 +153,7 @@ public struct WalletSearchScene: View {
             currencyCode: model.currencyCode,
             contextMenuItems: model.contextMenuItems,
             onSelect: model.onSelectAsset,
+            hideBalance: model.hideBalance,
         )
     }
 

--- a/ios/Features/WalletTab/Sources/ViewModels/AssetsResultsSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/AssetsResultsSceneViewModel.swift
@@ -66,6 +66,10 @@ public final class AssetsResultsSceneViewModel {
         preferences.currency
     }
 
+    var hideBalance: Bool {
+        preferences.isHideBalanceEnabled
+    }
+
     var sections: WalletSearchSections {
         .from(searchResult)
     }

--- a/ios/Features/WalletTab/Sources/ViewModels/NetworkAssetsSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/NetworkAssetsSceneViewModel.swift
@@ -16,7 +16,7 @@ import SwiftUI
 public final class NetworkAssetsSceneViewModel {
     private let balanceService: BalanceService
     private let assetsEnabler: any AssetsEnabler
-    private let preferences: Preferences
+    private let preferences: ObservablePreferences
     private let wallet: Wallet
     private let onManageAssetsAction: () -> Void
 
@@ -30,7 +30,7 @@ public final class NetworkAssetsSceneViewModel {
         chain: Chain,
         balanceService: BalanceService,
         assetsEnabler: any AssetsEnabler,
-        preferences: Preferences = .standard,
+        preferences: ObservablePreferences = .default,
         onManageAssets: @escaping () -> Void,
     ) {
         self.wallet = wallet
@@ -61,7 +61,11 @@ public final class NetworkAssetsSceneViewModel {
     }
 
     var currencyCode: String {
-        preferences.currency
+        preferences.preferences.currency
+    }
+
+    var hideBalance: Bool {
+        preferences.isHideBalanceEnabled
     }
 
     var active: [AssetData] {

--- a/ios/Features/WalletTab/Sources/ViewModels/PortfolioSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/PortfolioSceneViewModel.swift
@@ -164,11 +164,12 @@ extension PortfolioSceneViewModel {
             period: selectedPeriod,
             formatter: chartFormatter,
             showHeaderValue: state.selectedType == .wallet || state.selectedChartType == .value,
+            hideBalance: preferences.isHideBalanceEnabled,
         )
     }
 
     private func allTimeModel(title: String, chartValue: ChartValuePercentage) -> ListItemModel {
-        AllTimeValueViewModel(priceFormatter: priceFormatter, percentFormatter: percentFormatter)
+        AllTimeValueViewModel(priceFormatter: priceFormatter, percentFormatter: percentFormatter, hideBalance: preferences.isHideBalanceEnabled)
             .model(title: title, chartValue: chartValue)
     }
 

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
@@ -132,6 +132,10 @@ public final class WalletSearchSceneViewModel: Sendable {
         preferences.preferences.currency
     }
 
+    var hideBalance: Bool {
+        preferences.isHideBalanceEnabled
+    }
+
     var showTags: Bool {
         searchModel.searchableQuery.isEmpty
     }

--- a/ios/Features/WalletTab/Sources/Views/AssetItemsView.swift
+++ b/ios/Features/WalletTab/Sources/Views/AssetItemsView.swift
@@ -10,13 +10,14 @@ struct AssetItemsView: View {
     let currencyCode: String
     let contextMenuItems: (AssetData) -> [ContextMenuItemType]
     let onSelect: (Asset) -> Void
+    var hideBalance: Bool = false
 
     var body: some View {
         ForEach(items) { assetData in
             NavigationCustomLink(
                 with: ListAssetItemView(
                     model: ListAssetItemViewModel(
-                        showBalancePrivacy: .constant(false),
+                        showBalancePrivacy: .constant(hideBalance),
                         assetData: assetData,
                         formatter: .short,
                         currencyCode: currencyCode,

--- a/ios/Gem/Navigation/Wallet/WalletNavigationStack.swift
+++ b/ios/Gem/Navigation/Wallet/WalletNavigationStack.swift
@@ -119,7 +119,7 @@ struct WalletNavigationStack: View {
                         chain: destination.chain,
                         balanceService: balanceService,
                         assetsEnabler: assetsEnabler,
-                        preferences: preferences.preferences,
+                        preferences: preferences,
                         onManageAssets: { model.onSelectManage(chains: [destination.chain]) },
                     ),
                 )

--- a/ios/Packages/Components/Sources/Privacy/PrivacyMasking.swift
+++ b/ios/Packages/Components/Sources/Privacy/PrivacyMasking.swift
@@ -1,0 +1,24 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Style
+import SwiftUI
+
+public extension String {
+    func masked(if hideBalance: Bool) -> String {
+        hideBalance ? PrivacyText.placeholder : self
+    }
+}
+
+public extension TextValue {
+    func masked(if hideBalance: Bool) -> TextValue {
+        guard hideBalance else { return self }
+        return TextValue(text: PrivacyText.placeholder, style: style, lineLimit: lineLimit, truncationMode: truncationMode)
+    }
+}
+
+public extension Optional where Wrapped == TextValue {
+    func masked(if hideBalance: Bool) -> TextValue? {
+        self?.masked(if: hideBalance)
+    }
+}

--- a/ios/Packages/Components/Sources/Privacy/PrivacyText.swift
+++ b/ios/Packages/Components/Sources/Privacy/PrivacyText.swift
@@ -4,6 +4,8 @@ import Style
 import SwiftUI
 
 public struct PrivacyText: View {
+    public static let placeholder = "∗∗∗∗∗"
+
     @Binding private var isEnabled: Bool
 
     private let text: String
@@ -12,7 +14,7 @@ public struct PrivacyText: View {
     public init(
         _ text: String,
         isEnabled: Binding<Bool>,
-        placeholder: String = "∗∗∗∗∗",
+        placeholder: String = PrivacyText.placeholder,
     ) {
         self.text = text
         self.placeholder = placeholder

--- a/ios/Packages/Components/Sources/Types/HeaderTitleActionType.swift
+++ b/ios/Packages/Components/Sources/Types/HeaderTitleActionType.swift
@@ -4,6 +4,7 @@ import Foundation
 
 public enum HeaderTitleActionType: Sendable {
     case privacyToggle
+    case privacyMasked
     case action(@MainActor @Sendable () -> Void)
     case none
 }

--- a/ios/Packages/PrimitivesComponents/Sources/Components/SwapAmountView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/SwapAmountView.swift
@@ -28,10 +28,11 @@ struct SwapAmountView: View {
     let from: SwapAmountField
     let to: SwapAmountField
     let action: TransactionHeaderActionHandler?
+    let hideBalance: Bool
 
     var body: some View {
         VStack(spacing: 0) {
-            SwapAmountSingleView(field: from, action: action)
+            SwapAmountSingleView(field: from, action: action, hideBalance: hideBalance)
             Images.Actions.receive
                 .resizable()
                 .colorMultiply(Colors.black)
@@ -39,7 +40,7 @@ struct SwapAmountView: View {
                 .scaledToFit()
                 .padding(.bottom, .small)
                 .offset(y: -.small)
-            SwapAmountSingleView(field: to, action: action)
+            SwapAmountSingleView(field: to, action: action, hideBalance: hideBalance)
         }
     }
 }
@@ -47,6 +48,7 @@ struct SwapAmountView: View {
 struct SwapAmountSingleView: View {
     let field: SwapAmountField
     let action: TransactionHeaderActionHandler?
+    let hideBalance: Bool
 
     var body: some View {
         HStack(spacing: 0) {
@@ -68,13 +70,13 @@ struct SwapAmountSingleView: View {
 
     private var textContent: some View {
         VStack(alignment: .leading) {
-            Text(field.amount)
+            Text(field.amount.masked(if: hideBalance))
                 .foregroundStyle(Colors.black)
                 .font(.app.title2)
                 .truncationMode(.middle)
                 .lineLimit(1)
             if let fiatAmount = field.fiatAmount {
-                Text(fiatAmount)
+                Text(fiatAmount.masked(if: hideBalance))
                     .font(.app.footnote)
                     .foregroundStyle(Colors.gray)
             }

--- a/ios/Packages/PrimitivesComponents/Sources/Components/TransactionHeaderListItemView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/TransactionHeaderListItemView.swift
@@ -9,24 +9,29 @@ public struct TransactionHeaderListItemView: View {
     private let headerType: TransactionHeaderType
     private let showClearHeader: Bool
     private let action: TransactionHeaderActionHandler?
+    private let hideBalance: Bool
 
     public init(
         headerType: TransactionHeaderType,
         showClearHeader: Bool,
         action: TransactionHeaderActionHandler? = nil,
+        hideBalance: Bool = false,
     ) {
         self.headerType = headerType
         self.showClearHeader = showClearHeader
         self.action = action
+        self.hideBalance = hideBalance
     }
 
     public init(
         model: TransactionHeaderItemModel,
         action: TransactionHeaderActionHandler? = nil,
+        hideBalance: Bool = false,
     ) {
         headerType = model.headerType
         showClearHeader = model.showClearHeader
         self.action = action
+        self.hideBalance = hideBalance
     }
 
     public var body: some View {
@@ -46,14 +51,14 @@ public struct TransactionHeaderListItemView: View {
         switch headerType {
         case .swap:
             // Swap row has two distinct tap regions; SwapAmountView wires Buttons internally.
-            TransactionHeaderView(type: headerType, action: action)
+            TransactionHeaderView(type: headerType, action: action, hideBalance: hideBalance)
         case .amount, .nft, .asset, .assetValue:
             if let action {
                 Button { action(.header) } label: {
-                    TransactionHeaderView(type: headerType)
+                    TransactionHeaderView(type: headerType, hideBalance: hideBalance)
                 }
             } else {
-                TransactionHeaderView(type: headerType)
+                TransactionHeaderView(type: headerType, hideBalance: hideBalance)
             }
         }
     }

--- a/ios/Packages/PrimitivesComponents/Sources/Components/TransactionHeaderView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/TransactionHeaderView.swift
@@ -16,13 +16,16 @@ public enum TransactionHeaderType {
 public struct TransactionHeaderView: View {
     public let type: TransactionHeaderType
     private let action: TransactionHeaderActionHandler?
+    private let hideBalance: Bool
 
     public init(
         type: TransactionHeaderType,
         action: TransactionHeaderActionHandler? = nil,
+        hideBalance: Bool = false,
     ) {
         self.type = type
         self.action = action
+        self.hideBalance = hideBalance
     }
 
     public var body: some View {
@@ -31,14 +34,14 @@ public struct TransactionHeaderView: View {
             case let .amount(display):
                 ValueHeaderView(
                     model: TransactionAmountHeaderViewModel(display: display),
-                    isPrivacyEnabled: .constant(false),
-                    titleActionType: .none,
+                    isPrivacyEnabled: .constant(hideBalance),
+                    titleActionType: .privacyMasked,
                     spacing: .transactionAmount,
                     onHeaderAction: nil,
                     onInfoAction: nil,
                 )
             case let .swap(from, to):
-                SwapAmountView(from: from, to: to, action: action)
+                SwapAmountView(from: from, to: to, action: action, hideBalance: hideBalance)
             case let .nft(name, image):
                 NftPreviewView(assetImage: image, name: name, size: .image.large)
             case let .asset(image):
@@ -47,8 +50,8 @@ public struct TransactionHeaderView: View {
             case let .assetValue(data):
                 ValueHeaderView(
                     model: AssetValueHeaderViewModel(data: data),
-                    isPrivacyEnabled: .constant(false),
-                    titleActionType: .none,
+                    isPrivacyEnabled: .constant(hideBalance),
+                    titleActionType: .privacyMasked,
                     onHeaderAction: nil,
                     onInfoAction: nil,
                 )

--- a/ios/Packages/PrimitivesComponents/Sources/Components/TransactionsList.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/TransactionsList.swift
@@ -9,6 +9,7 @@ public struct TransactionsList: View {
     let showSections: Bool
     let explorerService: any ExplorerLinkFetchable
     let currency: String
+    let hideBalance: Bool
 
     private var sections: [ListSection<Primitives.TransactionExtended>] {
         DateSectionBuilder(items: transactions, dateKeyPath: \.transaction.createdAt).build()
@@ -19,11 +20,13 @@ public struct TransactionsList: View {
         _ transactions: [Primitives.TransactionExtended],
         currency: String,
         showSections: Bool = true,
+        hideBalance: Bool = false,
     ) {
         self.explorerService = explorerService
         self.transactions = transactions
         self.currency = currency
         self.showSections = showSections
+        self.hideBalance = hideBalance
     }
 
     public var body: some View {
@@ -34,6 +37,7 @@ public struct TransactionsList: View {
                         explorerService: explorerService,
                         transactions: section.values,
                         currency: currency,
+                        hideBalance: hideBalance,
                     )
                 } header: {
                     section.title.map { Text($0) }
@@ -44,6 +48,7 @@ public struct TransactionsList: View {
                 explorerService: explorerService,
                 transactions: transactions,
                 currency: currency,
+                hideBalance: hideBalance,
             )
         }
     }
@@ -53,14 +58,17 @@ private struct TransactionsListView: View {
     let transactions: [Primitives.TransactionExtended]
     let explorerService: any ExplorerLinkFetchable
     let currency: String
+    let hideBalance: Bool
 
     init(explorerService: any ExplorerLinkFetchable,
          transactions: [Primitives.TransactionExtended],
-         currency: String)
+         currency: String,
+         hideBalance: Bool)
     {
         self.explorerService = explorerService
         self.transactions = transactions
         self.currency = currency
+        self.hideBalance = hideBalance
     }
 
     var body: some View {
@@ -71,6 +79,7 @@ private struct TransactionsListView: View {
                         explorerService: explorerService,
                         transaction: transaction,
                         currency: currency,
+                        hideBalance: hideBalance,
                     ),
                 )
             }

--- a/ios/Packages/PrimitivesComponents/Sources/Components/ValueHeaderView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/ValueHeaderView.swift
@@ -163,6 +163,8 @@ public struct ValueHeaderView: View {
         switch titleActionType {
         case .privacyToggle:
             PrivacyToggleView(model.title, isEnabled: $isPrivacyEnabled)
+        case .privacyMasked:
+            PrivacyText(model.title, isEnabled: $isPrivacyEnabled)
         case let .action(action):
             Button(action: action) {
                 PrivacyText(model.title, isEnabled: $isPrivacyEnabled)

--- a/ios/Packages/PrimitivesComponents/Sources/Types/ChartHeaderViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Types/ChartHeaderViewModel.swift
@@ -17,6 +17,7 @@ public struct ChartHeaderViewModel {
 
     private let formatter: CurrencyFormatter
     private let dateFormatter: ChartDateFormatter
+    private let hideBalance: Bool
 
     public init(
         period: ChartPeriod,
@@ -27,6 +28,7 @@ public struct ChartHeaderViewModel {
         formatter: CurrencyFormatter,
         dateFormatter: ChartDateFormatter = ChartDateFormatter(),
         type: ChartValueType = .price,
+        hideBalance: Bool = false,
     ) {
         self.period = period
         self.date = date
@@ -36,6 +38,7 @@ public struct ChartHeaderViewModel {
         self.type = type
         self.formatter = formatter
         self.dateFormatter = dateFormatter
+        self.hideBalance = hideBalance
     }
 
     private var valueChange: PriceChangeViewModel? {
@@ -47,11 +50,12 @@ public struct ChartHeaderViewModel {
     }
 
     public var headerValueText: String? {
-        headerValue.map { formatter.string($0) }
+        guard let headerValue else { return nil }
+        return formatter.string(headerValue).masked(if: hideBalance)
     }
 
     public var priceText: String {
-        valueChange?.text ?? formatter.string(price)
+        (valueChange?.text ?? formatter.string(price)).masked(if: hideBalance)
     }
 
     public var priceColor: Color {

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/AllTimeValueViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/AllTimeValueViewModel.swift
@@ -10,10 +10,12 @@ import Style
 public struct AllTimeValueViewModel: Sendable {
     private let priceFormatter: CurrencyFormatter
     private let percentFormatter: PercentFormatter
+    private let hideBalance: Bool
 
-    public init(priceFormatter: CurrencyFormatter, percentFormatter: PercentFormatter) {
+    public init(priceFormatter: CurrencyFormatter, percentFormatter: PercentFormatter, hideBalance: Bool = false) {
         self.priceFormatter = priceFormatter
         self.percentFormatter = percentFormatter
+        self.hideBalance = hideBalance
     }
 
     public func allTimeHigh(chartValue: ChartValuePercentage) -> ListItemModel {
@@ -29,7 +31,7 @@ public struct AllTimeValueViewModel: Sendable {
         return ListItemModel(
             title: title,
             titleExtra: TransactionDateFormatter(date: chartValue.date).section,
-            subtitle: priceFormatter.string(Double(chartValue.value)),
+            subtitle: priceFormatter.string(Double(chartValue.value)).masked(if: hideBalance),
             subtitleExtra: percentFormatter.string(percentage),
             subtitleStyleExtra: TextStyle(font: .callout, color: PriceViewModel.priceChangeTextColor(value: percentage)),
         )

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/AssetDataViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/AssetDataViewModel.swift
@@ -11,6 +11,7 @@ import SwiftUI
 public struct AssetDataViewModel: Sendable {
     private let assetData: AssetData
     private let balanceViewModel: BalanceViewModel
+    private let hideBalance: Bool
 
     public let priceViewModel: PriceViewModel
     public let currencyCode: String
@@ -20,6 +21,7 @@ public struct AssetDataViewModel: Sendable {
         formatter: ValueFormatter,
         currencyCode: String,
         currencyFormatterType: CurrencyFormatterType = .currency,
+        hideBalance: Bool = false,
     ) {
         self.assetData = assetData
         priceViewModel = PriceViewModel(
@@ -33,6 +35,7 @@ public struct AssetDataViewModel: Sendable {
             formatter: formatter,
         )
         self.currencyCode = currencyCode
+        self.hideBalance = hideBalance
     }
 
     public var availableBalanceTitle: String {
@@ -94,15 +97,15 @@ public struct AssetDataViewModel: Sendable {
     }
 
     public var totalBalanceTextWithSymbol: String {
-        balanceViewModel.totalBalanceTextWithSymbol
+        balanceViewModel.totalBalanceTextWithSymbol.masked(if: hideBalance)
     }
 
     public var availableBalanceTextWithSymbol: String {
-        balanceViewModel.availableBalanceTextWithSymbol
+        balanceViewModel.availableBalanceTextWithSymbol.masked(if: hideBalance)
     }
 
     public func balanceTextWithSymbol(for type: StakeProviderType) -> String {
-        balanceViewModel.balanceTextWithSymbol(for: type)
+        balanceViewModel.balanceTextWithSymbol(for: type).masked(if: hideBalance)
     }
 
     public var hasReservedBalance: Bool {
@@ -118,11 +121,11 @@ public struct AssetDataViewModel: Sendable {
     }
 
     public var reservedBalanceTextWithSymbol: String {
-        balanceViewModel.reservedBalanceTextWithSymbol
+        balanceViewModel.reservedBalanceTextWithSymbol.masked(if: hideBalance)
     }
 
     public var pendingUnconfirmedBalanceTextWithSymbol: String {
-        balanceViewModel.pendingUnconfirmedBalanceTextWithSymbol
+        balanceViewModel.pendingUnconfirmedBalanceTextWithSymbol.masked(if: hideBalance)
     }
 
     public var balanceTextColor: Color {
@@ -148,7 +151,7 @@ public struct AssetDataViewModel: Sendable {
         return CurrencyFormatter(
             type: .currency,
             currencyCode: currencyCode,
-        ).string(value)
+        ).string(value).masked(if: hideBalance)
     }
 
     public var isEnabled: Bool {

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/ChartValuesViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/ChartValuesViewModel.swift
@@ -1,5 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
+import Components
 import Formatters
 import Foundation
 import GemstonePrimitives
@@ -18,6 +19,7 @@ public struct ChartValuesViewModel: Sendable {
     public let formatter: CurrencyFormatter
     public let type: ChartValueType
     public let headerValue: Double?
+    public let hideBalance: Bool
 
     public static let defaultPeriod = ChartPeriod.day
 
@@ -29,6 +31,7 @@ public struct ChartValuesViewModel: Sendable {
         formatter: CurrencyFormatter,
         type: ChartValueType = .price,
         headerValue: Double? = nil,
+        hideBalance: Bool = false,
     ) {
         self.period = period
         self.price = price
@@ -37,6 +40,7 @@ public struct ChartValuesViewModel: Sendable {
         self.formatter = formatter
         self.type = type
         self.headerValue = headerValue
+        self.hideBalance = hideBalance
     }
 
     var charts: [ChartDateValue] {
@@ -44,11 +48,11 @@ public struct ChartValuesViewModel: Sendable {
     }
 
     var lowerBoundValueText: String {
-        formatter.string(values.lowerBoundValue)
+        formatter.string(values.lowerBoundValue).masked(if: hideBalance)
     }
 
     var upperBoundValueText: String {
-        formatter.string(values.upperBoundValue)
+        formatter.string(values.upperBoundValue).masked(if: hideBalance)
     }
 
     var chartHeaderViewModel: ChartHeaderViewModel? {
@@ -61,7 +65,7 @@ public struct ChartValuesViewModel: Sendable {
                 ? price.priceChangePercentage24h
                 : Self.priceChangeCalculator.percentage(from: values.baseValue, to: price.price)
         }
-        return ChartHeaderViewModel(period: period, date: nil, price: price.price, priceChangePercentage: priceChangePercentage, headerValue: headerValue, formatter: formatter, type: type)
+        return ChartHeaderViewModel(period: period, date: nil, price: price.price, priceChangePercentage: priceChangePercentage, headerValue: headerValue, formatter: formatter, type: type, hideBalance: hideBalance)
     }
 
     public static func priceChange(
@@ -69,6 +73,7 @@ public struct ChartValuesViewModel: Sendable {
         period: ChartPeriod,
         formatter: CurrencyFormatter,
         showHeaderValue: Bool = false,
+        hideBalance: Bool = false,
     ) -> ChartValuesViewModel? {
         guard let values = try? ChartValues.from(charts: charts), values.hasVariation else {
             return nil
@@ -85,6 +90,7 @@ public struct ChartValuesViewModel: Sendable {
             formatter: formatter,
             type: .priceChange,
             headerValue: showHeaderValue ? values.lastValue : nil,
+            hideBalance: hideBalance,
         )
     }
 
@@ -93,6 +99,6 @@ public struct ChartValuesViewModel: Sendable {
         let priceChangePercentage = Self.priceChangeCalculator.percentage(from: base, to: element.value)
         let displayPrice = type == .priceChange ? element.value - base : element.value
         let elementHeaderValue = headerValue != nil ? element.value : nil
-        return ChartHeaderViewModel(period: period, date: element.date, price: displayPrice, priceChangePercentage: priceChangePercentage, headerValue: elementHeaderValue, formatter: formatter, type: type)
+        return ChartHeaderViewModel(period: period, date: element.date, price: displayPrice, priceChangePercentage: priceChangePercentage, headerValue: elementHeaderValue, formatter: formatter, type: type, hideBalance: hideBalance)
     }
 }

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
@@ -16,16 +16,19 @@ public struct TransactionViewModel: Sendable {
     private let explorerService: any ExplorerLinkFetchable
     private let assetImageFormatter = AssetImageFormatter()
     private let currency: String
+    private let hideBalance: Bool
     private let formatter: ValueFormatter = .short
 
     public init(
         explorerService: any ExplorerLinkFetchable,
         transaction: TransactionExtended,
         currency: String,
+        hideBalance: Bool = false,
     ) {
         self.transaction = transaction
         self.explorerService = explorerService
         self.currency = currency
+        self.hideBalance = hideBalance
     }
 
     public var assetImage: AssetImage {
@@ -226,6 +229,11 @@ public struct TransactionViewModel: Sendable {
     }
 
     public var subtitleTextValue: TextValue? {
+        let isAmount = transaction.transaction.type != .tokenApproval
+        return rawSubtitleTextValue.masked(if: hideBalance && isAmount)
+    }
+
+    private var rawSubtitleTextValue: TextValue? {
         switch transaction.transaction.type {
         case .transfer,
              .smartContractCall,
@@ -272,6 +280,10 @@ public struct TransactionViewModel: Sendable {
     }
 
     public var subtitleExtraTextValue: TextValue? {
+        rawSubtitleExtraTextValue.masked(if: hideBalance)
+    }
+
+    private var rawSubtitleExtraTextValue: TextValue? {
         switch transaction.transaction.type {
         case .transfer,
              .transferNFT,


### PR DESCRIPTION
Extends the global Hide Balance switch beyond the Wallet screen to Asset details, Transactions list/detail, Swap transaction progress, and Portfolio chart (current value, ATH/ATL), on both iOS and Android.

Closes #639