### PR TITLE
Validate stake/transfer amounts from Sui, Aptos, and TON events

### DIFF
--- a/core/crates/gem_aptos/src/models/transaction.rs
+++ b/core/crates/gem_aptos/src/models/transaction.rs
@@ -1,6 +1,7 @@
 use crate::{FUNGIBLE_ASSET_DEPOSIT_EVENT, FUNGIBLE_ASSET_WITHDRAW_EVENT, NO_ACCOUNT_SIGNATURE_TYPE, STAKE_DEPOSIT_EVENT, STAKE_WITHDRAW_EVENT};
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
-use serde_serializers::{deserialize_option_u64_from_str, deserialize_u64_from_str};
+use serde_serializers::{deserialize_biguint_from_str, deserialize_option_biguint_from_str, deserialize_option_u64_from_str, deserialize_u64_from_str};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Transaction {
@@ -30,19 +31,22 @@ pub struct Event {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AmountData {
-    pub amount: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_biguint_from_str")]
+    pub amount: Option<BigUint>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DelegationPoolAddStakeData {
     pub pool_address: String,
-    pub amount_added: String,
+    #[serde(deserialize_with = "deserialize_biguint_from_str")]
+    pub amount_added: BigUint,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DelegationPoolUnlockStakeData {
     pub pool_address: String,
-    pub amount_unlocked: String,
+    #[serde(deserialize_with = "deserialize_biguint_from_str")]
+    pub amount_unlocked: BigUint,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -54,7 +58,9 @@ impl Event {
     pub fn get_amount(&self) -> Option<String> {
         let data = self.data.clone()?;
         match self.event_type.as_str() {
-            STAKE_WITHDRAW_EVENT | STAKE_DEPOSIT_EVENT | FUNGIBLE_ASSET_WITHDRAW_EVENT | FUNGIBLE_ASSET_DEPOSIT_EVENT => serde_json::from_value::<AmountData>(data).ok()?.amount,
+            STAKE_WITHDRAW_EVENT | STAKE_DEPOSIT_EVENT | FUNGIBLE_ASSET_WITHDRAW_EVENT | FUNGIBLE_ASSET_DEPOSIT_EVENT => {
+                serde_json::from_value::<AmountData>(data).ok()?.amount.map(|amount| amount.to_string())
+            }
             _ => None,
         }
     }

--- a/core/crates/gem_aptos/src/provider/transactions_mapper.rs
+++ b/core/crates/gem_aptos/src/provider/transactions_mapper.rs
@@ -194,7 +194,7 @@ pub fn map_transaction(transaction: Transaction) -> Option<PrimitivesTransaction
                     asset_id.clone(),
                     asset_id,
                     data.pool_address,
-                    data.amount_added,
+                    data.amount_added.to_string(),
                     TransactionType::StakeDelegate,
                     None,
                 ));
@@ -206,7 +206,7 @@ pub fn map_transaction(transaction: Transaction) -> Option<PrimitivesTransaction
                     asset_id.clone(),
                     asset_id,
                     data.pool_address,
-                    data.amount_unlocked,
+                    data.amount_unlocked.to_string(),
                     TransactionType::StakeUndelegate,
                     None,
                 ));
@@ -357,5 +357,14 @@ mod tests {
         assert_eq!(tx.state, TransactionState::Confirmed);
         assert_eq!(tx.transaction_type, TransactionType::StakeUndelegate);
         assert_eq!(tx.fee, "88400");
+    }
+
+    #[test]
+    fn test_map_transaction_rejects_non_integer_stake_amount() {
+        let transaction: Transaction = serde_json::from_str(include_str!("../../testdata/transaction_stake_delegate_malformed_amount.json")).unwrap();
+
+        let result = map_transaction(transaction);
+
+        assert!(result.is_none());
     }
 }

--- a/core/crates/gem_aptos/testdata/transaction_stake_delegate_malformed_amount.json
+++ b/core/crates/gem_aptos/testdata/transaction_stake_delegate_malformed_amount.json
@@ -1,0 +1,21 @@
+{
+    "hash": "0x130cc74c1a768780ca062a97bc833a01dec85b2d315484869559b7cdee4d0e75",
+    "sender": "0xc95615aa095c100b18eb6eaa0f0a0f30b9cd96685118a7cbc1a2328a91ca2eda",
+    "success": true,
+    "gas_used": "1424",
+    "gas_unit_price": "100",
+    "timestamp": "1759780099581734",
+    "type": "user_transaction",
+    "events": [
+        {
+            "guid": {
+                "account_address": "0x0"
+            },
+            "type": "0x1::delegation_pool::AddStake",
+            "data": {
+                "amount_added": "54.108086",
+                "pool_address": "0xe5452230b8d5f4a664e33b8ad95354e50da64caaf003f11c0158391e96a4db2c"
+            }
+        }
+    ]
+}

--- a/core/crates/gem_sui/src/models/staking.rs
+++ b/core/crates/gem_sui/src/models/staking.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "rpc")]
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
+use serde_serializers::deserialize_biguint_from_str;
 #[cfg(feature = "rpc")]
-use serde_serializers::{deserialize_biguint_from_str, deserialize_option_biguint_from_str};
+use serde_serializers::deserialize_option_biguint_from_str;
 
 #[cfg(feature = "rpc")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,15 +59,18 @@ pub struct SuiValidator {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventStake {
-    pub amount: String,
+    #[serde(deserialize_with = "deserialize_biguint_from_str")]
+    pub amount: BigUint,
     pub staker_address: String,
     pub validator_address: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventUnstake {
-    pub principal_amount: String,
-    pub reward_amount: String,
+    #[serde(deserialize_with = "deserialize_biguint_from_str")]
+    pub principal_amount: BigUint,
+    #[serde(deserialize_with = "deserialize_biguint_from_str")]
+    pub reward_amount: BigUint,
     pub staker_address: String,
     pub validator_address: String,
 }

--- a/core/crates/gem_sui/src/provider/transactions_mapper.rs
+++ b/core/crates/gem_sui/src/provider/transactions_mapper.rs
@@ -89,7 +89,7 @@ fn map_transaction_type(
             stake.staker_address,
             stake.validator_address,
             TransactionType::StakeDelegate,
-            stake.amount,
+            stake.amount.to_string(),
             None,
         ));
     }
@@ -126,7 +126,7 @@ fn map_transaction_type(
             stake.staker_address,
             stake.validator_address,
             TransactionType::StakeUndelegate,
-            stake.principal_amount,
+            stake.principal_amount.to_string(),
             None,
         ));
     }
@@ -247,7 +247,7 @@ mod tests {
     use super::*;
     use crate::models::{Effect, GasObject, Owner, OwnerObject, Status};
     use crate::provider::testkit::TEST_TRANSACTION_ID;
-    use crate::{SUI_COIN_TYPE_FULL, SUI_UNSTAKE_EVENT};
+    use crate::{SUI_COIN_TYPE_FULL, SUI_STAKE_EVENT, SUI_UNSTAKE_EVENT};
     use num_bigint::{BigInt, BigUint};
     use serde_json::json;
 
@@ -428,5 +428,35 @@ mod tests {
         assert_eq!(unstake.value, "3000000000");
         assert_eq!(unstake.from, OWNER_ADDRESS);
         assert_eq!(unstake.to, VALIDATOR_ADDRESS);
+    }
+
+    #[test]
+    fn test_map_transaction_rejects_non_integer_stake_amount() {
+        let malformed_stake = map_transaction(make_digest(
+            vec![event(
+                full_coin_type(SUI_STAKE_EVENT),
+                json!({
+                    "amount": "54.108086",
+                    "staker_address": OWNER_ADDRESS,
+                    "validator_address": VALIDATOR_ADDRESS,
+                }),
+            )],
+            vec![balance_change(OWNER_ADDRESS, SUI_COIN_TYPE_FULL, -3000000000)],
+        ));
+        assert!(malformed_stake.is_none());
+
+        let malformed_unstake = map_transaction(make_digest(
+            vec![event(
+                full_coin_type(SUI_UNSTAKE_EVENT),
+                json!({
+                    "principal_amount": "",
+                    "reward_amount": "42",
+                    "staker_address": OWNER_ADDRESS,
+                    "validator_address": VALIDATOR_ADDRESS,
+                }),
+            )],
+            vec![balance_change(OWNER_ADDRESS, SUI_COIN_TYPE_FULL, 3000000000)],
+        ));
+        assert!(malformed_unstake.is_none());
     }
 }

--- a/core/crates/gem_ton/src/provider/transactions_mapper.rs
+++ b/core/crates/gem_ton/src/provider/transactions_mapper.rs
@@ -194,7 +194,7 @@ fn simple_transfer_details(message: &TransactionMessage) -> Option<TransferDetai
             asset_id,
             from: parse_address(&out_message.source)?,
             to,
-            value: parse_ton_value(&out_message.value),
+            value: parse_ton_value(&out_message.value)?,
             transaction_type: TransactionType::Transfer,
             memo: extract_memo(out_message),
             metadata: None,
@@ -221,8 +221,11 @@ fn simple_transfer_details(message: &TransactionMessage) -> Option<TransferDetai
     None
 }
 
-fn parse_ton_value(value: &Option<String>) -> String {
-    value.as_deref().and_then(|value| value.parse::<BigUint>().ok()).unwrap_or_default().to_string()
+fn parse_ton_value(value: &Option<String>) -> Option<String> {
+    match value.as_deref() {
+        None => Some("0".to_string()),
+        Some(raw) => raw.parse::<BigUint>().ok().map(|value| value.to_string()),
+    }
 }
 
 fn parse_address(address: &str) -> Option<String> {
@@ -367,10 +370,10 @@ mod tests {
 
     #[test]
     fn test_parse_ton_value() {
-        assert_eq!(parse_ton_value(&Some("137245095".to_string())), "137245095");
-        assert_eq!(parse_ton_value(&None), "0");
-        assert_eq!(parse_ton_value(&Some("".to_string())), "0");
-        assert_eq!(parse_ton_value(&Some("54.108086".to_string())), "0");
+        assert_eq!(parse_ton_value(&Some("137245095".to_string())), Some("137245095".to_string()));
+        assert_eq!(parse_ton_value(&None), Some("0".to_string()));
+        assert_eq!(parse_ton_value(&Some("".to_string())), None);
+        assert_eq!(parse_ton_value(&Some("54.108086".to_string())), None);
     }
 
     #[test]

--- a/core/crates/gem_ton/src/provider/transactions_mapper.rs
+++ b/core/crates/gem_ton/src/provider/transactions_mapper.rs
@@ -6,6 +6,7 @@ use crate::models::{
 };
 use chrono::DateTime;
 use gem_encoding::decode_base64;
+use num_bigint::BigUint;
 use primitives::{AssetId, NFTAssetId, Transaction, TransactionNFTTransferMetadata, TransactionState, TransactionSwapMetadata, TransactionType, chain::Chain};
 use std::error::Error;
 
@@ -221,11 +222,7 @@ fn simple_transfer_details(message: &TransactionMessage) -> Option<TransferDetai
 }
 
 fn parse_ton_value(value: &Option<String>) -> String {
-    value
-        .as_deref()
-        .filter(|value| !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
-        .unwrap_or("0")
-        .to_string()
+    value.as_deref().and_then(|value| value.parse::<BigUint>().ok()).unwrap_or_default().to_string()
 }
 
 fn parse_address(address: &str) -> Option<String> {

--- a/core/crates/gem_ton/src/provider/transactions_mapper.rs
+++ b/core/crates/gem_ton/src/provider/transactions_mapper.rs
@@ -193,7 +193,7 @@ fn simple_transfer_details(message: &TransactionMessage) -> Option<TransferDetai
             asset_id,
             from: parse_address(&out_message.source)?,
             to,
-            value: out_message.value.clone().unwrap_or_else(|| "0".to_string()),
+            value: parse_ton_value(&out_message.value),
             transaction_type: TransactionType::Transfer,
             memo: extract_memo(out_message),
             metadata: None,
@@ -218,6 +218,14 @@ fn simple_transfer_details(message: &TransactionMessage) -> Option<TransferDetai
     }
 
     None
+}
+
+fn parse_ton_value(value: &Option<String>) -> String {
+    value
+        .as_deref()
+        .filter(|value| !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
+        .unwrap_or("0")
+        .to_string()
 }
 
 fn parse_address(address: &str) -> Option<String> {
@@ -358,6 +366,14 @@ mod tests {
         assert_eq!(transaction.out_msgs[0].destination, None);
 
         assert_eq!(transaction.out_msgs[1].value, Some("137245095".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ton_value() {
+        assert_eq!(parse_ton_value(&Some("137245095".to_string())), "137245095");
+        assert_eq!(parse_ton_value(&None), "0");
+        assert_eq!(parse_ton_value(&Some("".to_string())), "0");
+        assert_eq!(parse_ton_value(&Some("54.108086".to_string())), "0");
     }
 
     #[test]


### PR DESCRIPTION
Root-cause fix for a client crash on malformed transaction amounts (follow-up to #818). Sui, Aptos, and TON built the amount for stake/transfer transactions from raw event strings with no digit validation, unlike other numeric fields in the same files. A non-integer or empty value from the upstream event data now makes that transaction get dropped instead of reaching the client broken.