### PR TITLE
Remove unused case interfaces

### DIFF
--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/operators/FindPhraseWord.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/operators/FindPhraseWord.kt
@@ -1,5 +1,0 @@
-package com.gemwallet.android.blockchain.operators
-
-interface FindPhraseWord {
-    operator fun invoke(query: String): List<String>
-}

--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/operators/GetAsset.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/operators/GetAsset.kt
@@ -1,8 +1,0 @@
-package com.gemwallet.android.blockchain.operators
-
-import com.wallet.core.primitives.Asset
-import com.wallet.core.primitives.AssetId
-
-fun interface GetAsset {
-    suspend fun getAsset(assetId: AssetId): Asset?
-}

--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/operators/gemstone/GemFindPhraseWord.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/operators/gemstone/GemFindPhraseWord.kt
@@ -1,10 +1,9 @@
 package com.gemwallet.android.blockchain.operators.gemstone
 
-import com.gemwallet.android.blockchain.operators.FindPhraseWord
 import uniffi.gemstone.GemMnemonic
 
-class GemFindPhraseWord : FindPhraseWord {
-    override fun invoke(query: String): List<String> {
+class GemFindPhraseWord {
+    operator fun invoke(query: String): List<String> {
         return GemMnemonic().use { mnemonic ->
             mnemonic.suggestWords(query, null)
         }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
@@ -1,7 +1,6 @@
 package com.gemwallet.android.data.repositories.assets
 
 import android.util.Log
-import com.gemwallet.android.blockchain.operators.GetAsset
 import com.gemwallet.android.blockchain.services.BalancesService
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.data.repositories.session.SessionRepository
@@ -78,8 +77,7 @@ class AssetsRepository @Inject constructor(
     private val currencyRatesService: CurrencyRatesService,
     private val updateBalances: UpdateBalances = UpdateBalances(balancesDao, balancesService),
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
-) : GetAsset {
-
+) {
 
     init {
         scope.launch(Dispatchers.IO) {
@@ -163,10 +161,6 @@ class AssetsRepository @Inject constructor(
             .firstOrNull()
             ?.toDTO()
             ?: emptyList()
-    }
-
-    override suspend fun getAsset(assetId: AssetId): Asset? = withContext(Dispatchers.IO) {
-        getAssetInfo(assetId).firstOrNull()?.asset
     }
 
     suspend fun hasAssets(assetIds: List<AssetId>): Set<AssetId> = withContext(Dispatchers.IO) {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/config/UserConfig.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/config/UserConfig.kt
@@ -10,10 +10,6 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import com.gemwallet.android.cases.config.GetLockInterval
-import com.gemwallet.android.cases.config.HideWelcomeBanner
-import com.gemwallet.android.cases.config.IsWelcomeBannerHidden
-import com.gemwallet.android.cases.config.SetLockInterval
 import com.gemwallet.android.domains.perpetual.PerpetualConfig
 import com.gemwallet.android.model.AppUpdateInfo
 import com.wallet.core.primitives.ChartPeriod
@@ -22,11 +18,7 @@ import kotlinx.coroutines.flow.map
 
 class UserConfig(
     private val context: Context,
-) : GetLockInterval,
-        SetLockInterval,
-        IsWelcomeBannerHidden,
-        HideWelcomeBanner
-{
+) {
 
     private lateinit var store: SharedPreferences
     private val Context.dataStore by preferencesDataStore(name = "user_config")
@@ -154,19 +146,19 @@ class UserConfig(
         }
     }
 
-    override fun getLockInterval(): Flow<Int> = context.dataStore.data
+    fun getLockInterval(): Flow<Int> = context.dataStore.data
     .map { preferences -> preferences[Key.LockInterval] ?: 1 }
 
-    override suspend fun setLockInterval(minutes: Int) {
+    suspend fun setLockInterval(minutes: Int) {
         context.dataStore.edit { preferences ->
             preferences[Key.LockInterval] = minutes
         }
     }
 
-    override fun isWelcomeBannerHidden(walletId: String): Flow<Boolean> = context.dataStore.data
+    fun isWelcomeBannerHidden(walletId: String): Flow<Boolean> = context.dataStore.data
         .map { preferences -> preferences[Key.IsWelcomeBannerHidden]?.contains(walletId) ?: false }
 
-    override suspend fun hideWelcomeBanner(walletId: String) {
+    suspend fun hideWelcomeBanner(walletId: String) {
         context.dataStore.edit { preferences ->
             val value = preferences[Key.IsWelcomeBannerHidden]?.let {
                 it.toMutableSet().apply { add(walletId) }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/TransactionsModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/TransactionsModule.kt
@@ -5,7 +5,6 @@ import com.gemwallet.android.application.transactions.coordinators.GetPendingTra
 import com.gemwallet.android.blockchain.services.TransactionStatusService
 import com.gemwallet.android.cases.transactions.ClearPendingTransactions
 import com.gemwallet.android.cases.transactions.CreateTransaction
-import com.gemwallet.android.cases.transactions.GetTransaction
 import com.gemwallet.android.cases.transactions.SaveTransactions
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.transactions.TransactionRepository
@@ -51,12 +50,6 @@ object TransactionsModule {
     @Singleton
     @Provides
     fun provideGetPendingTransactionsCount(transactionsRepository: TransactionsRepositoryImpl): GetPendingTransactionsCount {
-        return transactionsRepository
-    }
-
-    @Singleton
-    @Provides
-    fun provideGetTransactionCase(transactionsRepository: TransactionsRepositoryImpl): GetTransaction {
         return transactionsRepository
     }
 

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
@@ -9,7 +9,6 @@ import com.gemwallet.android.blockchain.model.ServiceUnavailable
 import com.gemwallet.android.blockchain.services.TransactionStatusService
 import com.gemwallet.android.cases.transactions.ClearPendingTransactions
 import com.gemwallet.android.cases.transactions.CreateTransaction
-import com.gemwallet.android.cases.transactions.GetTransaction
 import com.gemwallet.android.cases.transactions.SaveTransactions
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.service.store.database.TransactionsDao
@@ -68,7 +67,6 @@ class TransactionsRepositoryImpl(
 ) : TransactionRepository,
     GetChangedTransactions,
     GetPendingTransactionsCount,
-    GetTransaction,
     CreateTransaction,
     SaveTransactions,
     ClearPendingTransactions {

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/config/GetLockInterval.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/config/GetLockInterval.kt
@@ -1,7 +1,0 @@
-package com.gemwallet.android.cases.config
-
-import kotlinx.coroutines.flow.Flow
-
-interface GetLockInterval {
-    fun getLockInterval(): Flow<Int>
-}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/config/HideWelcomeBanner.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/config/HideWelcomeBanner.kt
@@ -1,5 +1,0 @@
-package com.gemwallet.android.cases.config
-
-interface HideWelcomeBanner {
-    suspend fun hideWelcomeBanner(walletId: String)
-}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/config/IsWelcomeBannerHidden.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/config/IsWelcomeBannerHidden.kt
@@ -1,7 +1,0 @@
-package com.gemwallet.android.cases.config
-
-import kotlinx.coroutines.flow.Flow
-
-interface IsWelcomeBannerHidden {
-    fun isWelcomeBannerHidden(walletId: String): Flow<Boolean>
-}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/config/SetLockInterval.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/config/SetLockInterval.kt
@@ -1,5 +1,0 @@
-package com.gemwallet.android.cases.config
-
-interface SetLockInterval {
-    suspend fun setLockInterval(minutes: Int)
-}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/transactions/GetTransaction.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/transactions/GetTransaction.kt
@@ -1,9 +1,0 @@
-package com.gemwallet.android.cases.transactions
-
-import com.gemwallet.android.model.TransactionExtended
-import com.wallet.core.primitives.TransactionId
-import kotlinx.coroutines.flow.Flow
-
-interface GetTransaction {
-    fun getTransaction(transactionId: TransactionId): Flow<TransactionExtended?>
-}


### PR DESCRIPTION
Removes seven interfaces that nothing used.

The whole `cases/config` package, `GetTransaction`, `GetAsset` and `FindPhraseWord` were never injected anywhere - every caller already talks to the concrete class. One of them also shadowed a live `HideWelcomeBanner` with the same name, which was confusing to read.

No behaviour change.