### PR TITLE
Keep Room-generated classes from R8 shrinking

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -15,3 +15,10 @@
 -keepclassmembers class androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback {
     *;
 }
+
+# Room resolves its generated Database/Dao implementations by class name at runtime;
+# keep them and the annotated declarations they're generated from intact.
+-keep class * extends androidx.room.RoomDatabase { *; }
+-keep @androidx.room.Dao class * { *; }
+-keep @androidx.room.Entity class * { *; }
+-keep class com.gemwallet.android.data.service.store.database.** { *; }


### PR DESCRIPTION
Fixes a production crash on app update where Room's database migration fails on some devices.

A recent ProGuard rules change removed protection for Room's generated database classes, letting R8 rename them in release builds. This restores that protection specifically for the database layer.