### PR TITLE
Share asset actions across wallet tab view models

### DIFF
--- a/ios/Features/WalletTab/Sources/Types/AssetActions.swift
+++ b/ios/Features/WalletTab/Sources/Types/AssetActions.swift
@@ -1,0 +1,72 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import BalanceService
+import Components
+import Foundation
+import PerpetualService
+import Primitives
+import PrimitivesComponents
+
+@MainActor
+protocol AssetBalanceActions: AnyObject {
+    var balanceService: BalanceService { get }
+    var wallet: Wallet { get }
+    var isPresentingToastMessage: ToastMessage? { get set }
+}
+
+extension AssetBalanceActions {
+    func onPinAsset(_ asset: Asset, value: Bool) {
+        do {
+            try balanceService.setPinned(value, walletId: wallet.id, assetId: asset.id)
+            isPresentingToastMessage = .pin(asset.name, pinned: value)
+        } catch {
+            debugLog("\(Self.self) pin asset error: \(error)")
+        }
+    }
+
+    func onHideAsset(_ assetId: AssetId) {
+        do {
+            try balanceService.hideAsset(walletId: wallet.id, assetId: assetId)
+        } catch {
+            debugLog("\(Self.self) hide asset error: \(error)")
+        }
+    }
+}
+
+@MainActor
+protocol AssetEnableActions: AnyObject {
+    var assetsEnabler: any AssetsEnabler { get }
+    var wallet: Wallet { get }
+    var isPresentingToastMessage: ToastMessage? { get set }
+}
+
+extension AssetEnableActions {
+    func onAddToWallet(_ assetId: AssetId) {
+        Task {
+            do {
+                try await assetsEnabler.enableAssets(wallet: wallet, assetIds: [assetId], enabled: true)
+                isPresentingToastMessage = .addedToWallet()
+            } catch {
+                debugLog("\(Self.self) enable asset error: \(error)")
+            }
+        }
+    }
+}
+
+@MainActor
+protocol PerpetualPinActions: AnyObject {
+    var perpetualService: PerpetualService { get }
+    var isPresentingToastMessage: ToastMessage? { get set }
+}
+
+extension PerpetualPinActions {
+    func onSelectPinPerpetual(_ perpetualData: PerpetualData) {
+        let pinned = !perpetualData.metadata.isPinned
+        do {
+            try perpetualService.setPinned(pinned, perpetualId: perpetualData.perpetual.id)
+            isPresentingToastMessage = .pin(perpetualData.perpetual.name, pinned: pinned)
+        } catch {
+            debugLog("\(Self.self) pin perpetual error: \(error)")
+        }
+    }
+}

--- a/ios/Features/WalletTab/Sources/ViewModels/AssetsResultsSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/AssetsResultsSceneViewModel.swift
@@ -16,16 +16,16 @@ import SwiftUI
 
 @Observable
 @MainActor
-public final class AssetsResultsSceneViewModel {
+public final class AssetsResultsSceneViewModel: AssetBalanceActions, AssetEnableActions, PerpetualPinActions {
     public static let defaultLimit = 100
 
-    private let assetsEnabler: any AssetsEnabler
-    private let balanceService: BalanceService
+    let assetsEnabler: any AssetsEnabler
+    let balanceService: BalanceService
     private let preferences: Preferences
     private let searchService: WalletSearchService
-    private let perpetualService: PerpetualService
+    let perpetualService: PerpetualService
     private let activityService: ActivityService
-    private let wallet: Wallet
+    let wallet: Wallet
 
     let title: String
     let onSelectAssetAction: AssetAction
@@ -108,10 +108,10 @@ public final class AssetsResultsSceneViewModel {
                 )
             },
             onPin: { [weak self] in
-                self?.onPinAsset(assetData, value: !assetData.metadata.isPinned)
+                self?.onPinAsset(assetData.asset, value: !assetData.metadata.isPinned)
             },
             onAddToWallet: { [weak self] in
-                self?.onAddToWallet(assetData.asset)
+                self?.onAddToWallet(assetData.asset.id)
             },
         )
     }
@@ -144,36 +144,6 @@ extension AssetsResultsSceneViewModel {
             try activityService.updateRecent(data: .search(asset), walletId: wallet.id)
         } catch {
             debugLog("AssetsResultsSceneViewModel update recent error: \(error)")
-        }
-    }
-
-    func onSelectPinPerpetual(_ perpetualData: PerpetualData) {
-        let pinned = !perpetualData.metadata.isPinned
-        do {
-            try perpetualService.setPinned(pinned, perpetualId: perpetualData.perpetual.id)
-            isPresentingToastMessage = .pin(perpetualData.perpetual.name, pinned: pinned)
-        } catch {
-            debugLog("AssetsResultsSceneViewModel pin perpetual error: \(error)")
-        }
-    }
-
-    private func onAddToWallet(_ asset: Asset) {
-        Task {
-            do {
-                try await assetsEnabler.enableAssets(wallet: wallet, assetIds: [asset.id], enabled: true)
-                isPresentingToastMessage = .addedToWallet()
-            } catch {
-                debugLog("AssetsResultsSceneViewModel add to wallet error: \(error)")
-            }
-        }
-    }
-
-    private func onPinAsset(_ assetData: AssetData, value: Bool) {
-        do {
-            try balanceService.setPinned(value, walletId: wallet.id, assetId: assetData.asset.id)
-            isPresentingToastMessage = .pin(assetData.asset.name, pinned: value)
-        } catch {
-            debugLog("AssetsResultsSceneViewModel pin asset error: \(error)")
         }
     }
 }

--- a/ios/Features/WalletTab/Sources/ViewModels/NetworkAssetsSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/NetworkAssetsSceneViewModel.swift
@@ -13,11 +13,11 @@ import SwiftUI
 
 @Observable
 @MainActor
-public final class NetworkAssetsSceneViewModel {
-    private let balanceService: BalanceService
-    private let assetsEnabler: any AssetsEnabler
+public final class NetworkAssetsSceneViewModel: AssetBalanceActions, AssetEnableActions {
+    let balanceService: BalanceService
+    let assetsEnabler: any AssetsEnabler
     private let preferences: Preferences
-    private let wallet: Wallet
+    let wallet: Wallet
     private let onManageAssetsAction: () -> Void
 
     public var isPresentingToastMessage: ToastMessage?
@@ -110,34 +110,6 @@ public final class NetworkAssetsSceneViewModel {
 
     func updateBalances() async {
         await balanceService.updateBalance(for: wallet, assetIds: assetIds)
-    }
-
-    func onHideAsset(_ assetId: AssetId) {
-        do {
-            try balanceService.hideAsset(walletId: wallet.id, assetId: assetId)
-        } catch {
-            debugLog("NetworkAssetsSceneViewModel hide asset error: \(error)")
-        }
-    }
-
-    func onPinAsset(_ asset: Asset, value: Bool) {
-        do {
-            try balanceService.setPinned(value, walletId: wallet.id, assetId: asset.id)
-            isPresentingToastMessage = .pin(asset.name, pinned: value)
-        } catch {
-            debugLog("NetworkAssetsSceneViewModel pin asset error: \(error)")
-        }
-    }
-
-    func onAddToWallet(_ assetId: AssetId) {
-        Task {
-            do {
-                try await assetsEnabler.enableAssets(wallet: wallet, assetIds: [assetId], enabled: true)
-                isPresentingToastMessage = .addedToWallet()
-            } catch {
-                debugLog("NetworkAssetsSceneViewModel add asset error: \(error)")
-            }
-        }
     }
 
     func onCopyAddress(_ message: String) {

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -21,9 +21,9 @@ import WalletService
 
 @Observable
 @MainActor
-public final class WalletSceneViewModel: Sendable {
+public final class WalletSceneViewModel: Sendable, AssetBalanceActions {
     private let assetDiscoveryService: any AssetDiscoverable
-    private let balanceService: BalanceService
+    let balanceService: BalanceService
     private let bannerService: BannerService
     private let walletService: WalletService
     private let balanceCalculator = BalanceCalculator()
@@ -225,23 +225,6 @@ public extension WalletSceneViewModel {
             }
         }
         isPresentingUrl = action.url
-    }
-
-    internal func onHideAsset(_ assetId: AssetId) {
-        do {
-            try balanceService.hideAsset(walletId: wallet.id, assetId: assetId)
-        } catch {
-            debugLog("WalletSceneViewModel hide Asset error: \(error)")
-        }
-    }
-
-    internal func onPinAsset(_ asset: Asset, value: Bool) {
-        do {
-            try balanceService.setPinned(value, walletId: wallet.id, assetId: asset.id)
-            isPresentingToastMessage = .pin(asset.name, pinned: value)
-        } catch {
-            debugLog("WalletSceneViewModel pin asset error: \(error)")
-        }
     }
 
     internal func onCopyAddress(_ message: String) {

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
@@ -18,15 +18,15 @@ import SwiftUI
 
 @Observable
 @MainActor
-public final class WalletSearchSceneViewModel: Sendable {
+public final class WalletSearchSceneViewModel: Sendable, AssetBalanceActions, AssetEnableActions, PerpetualPinActions {
     private let searchService: WalletSearchService
     private let activityService: ActivityService
-    private let assetsEnabler: any AssetsEnabler
-    private let balanceService: BalanceService
-    private let perpetualService: PerpetualService
+    let assetsEnabler: any AssetsEnabler
+    let balanceService: BalanceService
+    let perpetualService: PerpetualService
     private let preferences: ObservablePreferences
 
-    private let wallet: Wallet
+    let wallet: Wallet
     private let onDismissSearch: VoidAction
     private let onAddToken: VoidAction
 
@@ -240,7 +240,7 @@ public final class WalletSearchSceneViewModel: Sendable {
                 self?.onSelectPinAsset(assetData, value: !assetData.metadata.isPinned)
             },
             onAddToWallet: { [weak self] in
-                self?.onSelectAddToWallet(assetData.asset)
+                self?.onAddToWallet(assetData.asset.id)
             },
         )
     }
@@ -290,30 +290,11 @@ extension WalletSearchSceneViewModel {
         onAddToken?()
     }
 
-    func onSelectAddToWallet(_ asset: Asset) {
-        enableAsset(asset.id)
-        isPresentingToastMessage = .addedToWallet()
-    }
-
     func onSelectPinAsset(_ assetData: AssetData, value: Bool) {
-        do {
-            try balanceService.setPinned(value, walletId: wallet.id, assetId: assetData.asset.id)
-            isPresentingToastMessage = .pin(assetData.asset.name, pinned: value)
-            if value, !assetData.metadata.isBalanceEnabled {
-                enableAsset(assetData.asset.id)
-            }
-        } catch {
-            debugLog("WalletSearchSceneViewModel pin asset error: \(error)")
-        }
-    }
+        onPinAsset(assetData.asset, value: value)
 
-    func onSelectPinPerpetual(_ perpetualData: PerpetualData) {
-        let pinned = !perpetualData.metadata.isPinned
-        do {
-            try perpetualService.setPinned(pinned, perpetualId: perpetualData.perpetual.id)
-            isPresentingToastMessage = .pin(perpetualData.perpetual.name, pinned: pinned)
-        } catch {
-            debugLog("WalletSearchSceneViewModel pin perpetual error: \(error)")
+        if value, !assetData.metadata.isBalanceEnabled {
+            onAddToWallet(assetData.asset.id)
         }
     }
 
@@ -346,16 +327,6 @@ extension WalletSearchSceneViewModel {
 extension WalletSearchSceneViewModel {
     private var assetsPreviewLimit: Int {
         searchModel.assetsLimit(scope: searchQuery.request.scope)
-    }
-
-    private func enableAsset(_ assetId: AssetId) {
-        Task {
-            do {
-                try await assetsEnabler.enableAssets(wallet: wallet, assetIds: [assetId], enabled: true)
-            } catch {
-                debugLog("WalletSearchSceneViewModel enable asset error: \(error)")
-            }
-        }
     }
 
     private func updateRecent(_ asset: Asset) {


### PR DESCRIPTION
Pin, hide, add to wallet and pin perpetual were implemented separately in four wallet tab view models. They now share one implementation.

Add to wallet always shows a confirmation toast now, including when it happens right after pinning an asset that is not in the wallet yet.