### PR TITLE
Show indicator dot on Android swap settings when slippage is custom

### DIFF
--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,6 +24,7 @@ import androidx.compose.ui.unit.Dp
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.PercentSuggestionsBar
+import com.gemwallet.android.ui.components.buttons.IndicatorButton
 import com.gemwallet.android.ui.components.list_item.sectionHeaderItem
 import com.gemwallet.android.ui.components.screen.MainActionWidth
 import com.gemwallet.android.ui.components.screen.Scene
@@ -54,6 +54,7 @@ internal fun SwapScene(
     swapDetails: SwapDetailsUIModel?,
     payValue: TextFieldState,
     receiveValue: TextFieldState,
+    showsSlippageIndicator: Boolean,
     onAction: (SwapSceneAction) -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
@@ -66,13 +67,11 @@ internal fun SwapScene(
     Scene(
         title = stringResource(id = R.string.wallet_swap),
         actions = {
-            IconButton(onClick = { onAction(SwapSceneAction.Slippage) }) {
-                Icon(
-                    imageVector = AppIcons.Tune,
-                    tint = MaterialTheme.colorScheme.onSurface,
-                    contentDescription = null,
-                )
-            }
+            IndicatorButton(
+                imageVector = AppIcons.Tune,
+                showsIndicator = showsSlippageIndicator,
+                onClick = { onAction(SwapSceneAction.Slippage) },
+            )
         },
         mainActionWidth = if (isPercentBarVisible) MainActionWidth.FillWidth else MainActionWidth.Constrained,
         mainActionPadding = PaddingValues(

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScreen.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScreen.kt
@@ -66,6 +66,7 @@ fun SwapScreen(
         receiveEquivalent = toEquivalent,
         payValue = viewModel.payValue,
         receiveValue = viewModel.receiveValue,
+        showsSlippageIndicator = selectedSlippage != null,
         onAction = { action ->
             when (action) {
                 is SwapSceneAction.SelectAsset -> onSelect(action.type, pay?.id(), receive?.id())

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/buttons/IndicatorButton.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/buttons/IndicatorButton.kt
@@ -1,0 +1,44 @@
+package com.gemwallet.android.ui.components.buttons
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.gemwallet.android.ui.theme.space2
+import com.gemwallet.android.ui.theme.space8
+
+@Composable
+fun IndicatorButton(
+    imageVector: ImageVector,
+    showsIndicator: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(onClick = onClick, modifier = modifier) {
+        Box {
+            Icon(
+                imageVector = imageVector,
+                tint = MaterialTheme.colorScheme.onSurface,
+                contentDescription = null,
+            )
+            if (showsIndicator) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .background(MaterialTheme.colorScheme.surface, CircleShape)
+                        .padding(space2)
+                        .size(space8)
+                        .background(MaterialTheme.colorScheme.primary, CircleShape)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Android now shows the blue dot on the Swap settings icon when slippage is set to a custom value, the same as iOS. The dot disappears when slippage goes back to Auto.

<img width="320" alt="Screenshot_1785824998" src="https://github.com/user-attachments/assets/588ba158-53a4-43f9-bc18-0e8a369bf976" />
