### PR TITLE
Collapse duplicate UI state classes in Android view models

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/AppViewModel.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/AppViewModel.kt
@@ -47,8 +47,7 @@ class AppViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val state = MutableStateFlow(AppState())
-    val uiState = state.map { it.toUIState() }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, AppUIState())
+    val uiState = state.asStateFlow()
     private val startDestination = MutableStateFlow<NavKey?>(null)
     val startDestinationState = startDestination.asStateFlow()
     private val walletReadyState = getWalletSummary.getWalletSummary()
@@ -206,18 +205,6 @@ class AppViewModel @Inject constructor(
 }
 
 data class AppState(
-    val session: Session? = null,
-    val intent: AppIntent = AppIntent.None,
-    val update: AppUpdateInfo? = null,
-) {
-    fun toUIState() = AppUIState(
-        session = session,
-        intent = intent,
-        update = update,
-    )
-}
-
-data class AppUIState(
     val session: Session? = null,
     val intent: AppIntent = AppIntent.None,
     val update: AppUpdateInfo? = null,

--- a/android/features/create_wallet/viewmodels/src/main/kotlin/com/gemwallet/android/features/create_wallet/viewmodels/CreateWalletViewModel.kt
+++ b/android/features/create_wallet/viewmodels/src/main/kotlin/com/gemwallet/android/features/create_wallet/viewmodels/CreateWalletViewModel.kt
@@ -9,9 +9,7 @@ import com.wallet.core.primitives.WalletId
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -25,8 +23,7 @@ class CreateWalletViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val state = MutableStateFlow(CreateWalletViewModelState())
-    val uiState = state.map { it.toUIState() }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, CreateWalletUIState())
+    val uiState = state.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -80,34 +77,11 @@ class CreateWalletViewModel @Inject constructor(
 
 data class CreateWalletViewModelState(
     val loading: Boolean = false,
-    val error: String = "",
     val generatedNameIndex: Int = 0,
     val name: String = "",
-    val nameError: String = "",
     val data: List<String> = emptyList(),
     val dataError: String = "",
     val isShowSafeMessage: Boolean = false,
 ) {
     fun isExistingWallets() = generatedNameIndex > 1
-
-    fun toUIState() = CreateWalletUIState(
-        loading = loading,
-        name = name,
-        generatedNameIndex = generatedNameIndex,
-        nameError = nameError,
-        data = data,
-        dataError = dataError,
-        isShowSafeMessage = isShowSafeMessage,
-    )
 }
-
-data class CreateWalletUIState(
-    val loading: Boolean = false,
-    val error: String = "",
-    val generatedNameIndex: Int = 0,
-    val name: String = "",
-    val nameError: String = "",
-    val data: List<String> = emptyList(),
-    val dataError: String = "",
-    val isShowSafeMessage: Boolean = false,
-)

--- a/android/features/settings/settings/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/settings/viewmodels/SettingsViewModel.kt
+++ b/android/features/settings/settings/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/settings/viewmodels/SettingsViewModel.kt
@@ -15,6 +15,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
@@ -36,8 +37,7 @@ class SettingsViewModel @Inject constructor(
     private val session = sessionRepository.session()
     private val wallets = walletsRepository.getAll()
     private val state = MutableStateFlow(SettingsViewModelState())
-    val uiState = state.map { it.toUIState() }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUIState.General())
+    val uiState = state.asStateFlow()
 
     val isRewardsAvailable = wallets
         .map { items ->
@@ -131,19 +131,4 @@ class SettingsViewModel @Inject constructor(
 data class SettingsViewModelState(
     val currency: Currency = Currency.USD,
     val developEnabled: Boolean = false,
-) {
-    fun toUIState(): SettingsUIState.General {
-        return SettingsUIState.General(
-            currency = currency,
-            developEnabled = developEnabled,
-        )
-    }
-}
-
-sealed interface SettingsUIState {
-
-    data class General(
-        val currency: Currency = Currency.USD,
-        val developEnabled: Boolean = false,
-    ) : SettingsUIState
-}
+)


### PR DESCRIPTION
Three Android view models kept two copies of the same state class and copied one into the other on every update. The second copy is gone now, along with a few fields nothing ever read.

No behavior change.