### PR TITLE
Fix Aptos LocalKeystore test

### DIFF
--- a/ios/Packages/Keystore/Tests/LocalKeystoreTests.swift
+++ b/ios/Packages/Keystore/Tests/LocalKeystoreTests.swift
@@ -184,7 +184,7 @@ struct LocalKeystoreTests {
                 case .doge:
                     "DJRFZNg8jkUtjcpo2zJd92FUAzwRjitw6f"
                 case .aptos:
-                    "0x7968dab936c1bad187c60ce4082f307d030d780e91e694ae03aef16aba73f30"
+                    "0x07968dab936c1bad187c60ce4082f307d030d780e91e694ae03aef16aba73f30"
                 case .sui:
                     "0xada112cfb90b44ba889cc5d39ac2bf46281e4a91f7919c693bcd9b8323e81ed2"
                 case .xrp:


### PR DESCRIPTION
## Summary

- update the iOS `LocalKeystoreTests` Aptos derivation expectation to the fixed-length address format

## Root cause

Commit `43e7bd5` normalized Aptos address encoding but left the iOS test expecting the previous shortened address.

## Validation

- `just ios test KeystoreTests`
- `just ios build`