### PR TITLE
Take perpetual balance from spot state for unified accounts

### DIFF
--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/gemstone/GemPerpetualMapper.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/gemstone/GemPerpetualMapper.kt
@@ -9,6 +9,7 @@ import com.wallet.core.primitives.ChartCandleUpdate
 import com.wallet.core.primitives.ChartDateValue
 import com.wallet.core.primitives.Perpetual
 import com.wallet.core.primitives.PerpetualAccountSummary
+import com.wallet.core.primitives.PerpetualAccountMode
 import com.wallet.core.primitives.PerpetualBalance
 import com.wallet.core.primitives.PerpetualData
 import com.wallet.core.primitives.PerpetualDirection
@@ -26,6 +27,7 @@ import uniffi.gemstone.GemChartCandleStick
 import uniffi.gemstone.GemChartCandleUpdate
 import uniffi.gemstone.GemChartDateValue
 import uniffi.gemstone.GemPerpetualAccountSummary
+import uniffi.gemstone.GemPerpetualAccountMode
 import uniffi.gemstone.GemPerpetualBalance
 import uniffi.gemstone.GemPerpetualData
 import uniffi.gemstone.GemPerpetualMarginType
@@ -65,6 +67,11 @@ internal fun GemPerpetualPositionsSummary.toDTO(): PerpetualPositionsSummary {
         positions = positions.mapNotNull { it.toDTO() },
         balance = balance.toDTO(),
     )
+}
+
+fun GemPerpetualAccountMode.toDTO(): PerpetualAccountMode = when (this) {
+    GemPerpetualAccountMode.STANDARD -> PerpetualAccountMode.Standard
+    GemPerpetualAccountMode.UNIFIED -> PerpetualAccountMode.Unified
 }
 
 fun GemPerpetualBalance.toDTO(): PerpetualBalance {

--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/services/PerpetualService.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/services/PerpetualService.kt
@@ -4,6 +4,7 @@ import com.gemwallet.android.blockchain.gemstone.toDTO
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.ChartCandleStick
 import com.wallet.core.primitives.ChartPeriod
+import com.wallet.core.primitives.PerpetualAccountMode
 import com.wallet.core.primitives.PerpetualData
 import com.wallet.core.primitives.PerpetualPortfolio
 import com.wallet.core.primitives.PerpetualPositionsSummary
@@ -28,6 +29,10 @@ class PerpetualService(
             return null
         }
         return response.toDTO()
+    }
+
+    suspend fun getAccountMode(chain: Chain = Chain.HyperCore, address: String): PerpetualAccountMode {
+        return gateway.getPerpetualAccountMode(chain.string, address).toDTO()
     }
 
     suspend fun getCandleSticks(chain: Chain = Chain.HyperCore, symbol: String, period: ChartPeriod): List<ChartCandleStick> {

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetWalletSummaryImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetWalletSummaryImpl.kt
@@ -19,6 +19,7 @@ import com.gemwallet.android.ext.isSwapSupport
 import com.gemwallet.android.model.CurrencyFormatter
 import com.wallet.core.primitives.Wallet
 import com.wallet.core.primitives.Currency
+import com.wallet.core.primitives.PerpetualAccountMode
 import com.wallet.core.primitives.PerpetualBalance
 import com.wallet.core.primitives.WalletType
 import kotlinx.coroutines.CoroutineScope
@@ -49,7 +50,16 @@ class GetWalletSummaryImpl(
 
     private val perpetualCollateral: Flow<PerpetualBalance?> =
         observePerpetualWallet().flatMapLatest { wallet ->
-            wallet?.let { perpetualRepository.getBalance(it.id, HypercoreUSDC.id) } ?: flowOf(null)
+            wallet ?: return@flatMapLatest flowOf(null)
+            combine(
+                perpetualRepository.getBalance(wallet.id, HypercoreUSDC.id),
+                userConfig.perpetualAccountMode(wallet.id),
+            ) { balance, mode ->
+                when (mode) {
+                    PerpetualAccountMode.Unified -> null
+                    PerpetualAccountMode.Standard -> balance
+                }
+            }
         }
 
     private val walletSummary = sessionRepository.session().flatMapLatest { session ->

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PerpetualModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PerpetualModule.kt
@@ -64,9 +64,11 @@ object PerpetualModule {
     @Singleton
     fun provideGetPerpetualAccountMode(
         perpetualService: PerpetualService,
+        userConfig: UserConfig,
     ): GetPerpetualAccountMode {
         return GetPerpetualAccountModeImpl(
             perpetualService = perpetualService,
+            userConfig = userConfig,
         )
     }
 

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PerpetualModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PerpetualModule.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.data.coordinators.di
 
 import com.gemwallet.android.application.perpetual.coordinators.BuildPerpetualParams
 import com.gemwallet.android.application.perpetual.coordinators.GetPerpetual
+import com.gemwallet.android.application.perpetual.coordinators.GetPerpetualAccountMode
 import com.gemwallet.android.application.perpetual.coordinators.GetPerpetualBalance
 import com.gemwallet.android.application.perpetual.coordinators.GetPerpetualBalances
 import com.gemwallet.android.application.perpetual.coordinators.GetPerpetualChartData
@@ -15,6 +16,7 @@ import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetuals
 import com.gemwallet.android.application.perpetual.coordinators.TogglePerpetualPin
 import com.gemwallet.android.blockchain.services.PerpetualService
 import com.gemwallet.android.data.coordinators.perpetuals.BuildPerpetualParamsImpl
+import com.gemwallet.android.data.coordinators.perpetuals.GetPerpetualAccountModeImpl
 import com.gemwallet.android.data.coordinators.perpetuals.GetPerpetualBalanceImpl
 import com.gemwallet.android.data.coordinators.perpetuals.GetPerpetualBalancesImpl
 import com.gemwallet.android.data.coordinators.perpetuals.GetPerpetualChartDataImpl
@@ -55,6 +57,16 @@ object PerpetualModule {
             pricesDao = pricesDao,
             sessionRepository = sessionRepository,
             chains = listOf(Chain.HyperCore)
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideGetPerpetualAccountMode(
+        perpetualService: PerpetualService,
+    ): GetPerpetualAccountMode {
+        return GetPerpetualAccountModeImpl(
+            perpetualService = perpetualService,
         )
     }
 

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualAccountModeImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualAccountModeImpl.kt
@@ -2,17 +2,22 @@ package com.gemwallet.android.data.coordinators.perpetuals
 
 import com.gemwallet.android.application.perpetual.coordinators.GetPerpetualAccountMode
 import com.gemwallet.android.blockchain.services.PerpetualService
+import com.gemwallet.android.data.repositories.config.UserConfig
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.PerpetualAccountMode
+import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class GetPerpetualAccountModeImpl @Inject constructor(
     private val perpetualService: PerpetualService,
+    private val userConfig: UserConfig,
 ) : GetPerpetualAccountMode {
 
-    override suspend fun getPerpetualAccountMode(address: String): PerpetualAccountMode = withContext(Dispatchers.IO) {
-        perpetualService.getAccountMode(Chain.HyperCore, address)
+    override suspend fun getPerpetualAccountMode(walletId: WalletId, address: String): PerpetualAccountMode = withContext(Dispatchers.IO) {
+        val mode = perpetualService.getAccountMode(Chain.HyperCore, address)
+        userConfig.setPerpetualAccountMode(walletId, mode)
+        mode
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualAccountModeImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualAccountModeImpl.kt
@@ -7,6 +7,7 @@ import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.PerpetualAccountMode
 import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -16,8 +17,8 @@ class GetPerpetualAccountModeImpl @Inject constructor(
 ) : GetPerpetualAccountMode {
 
     override suspend fun getPerpetualAccountMode(walletId: WalletId, address: String): PerpetualAccountMode = withContext(Dispatchers.IO) {
-        val mode = perpetualService.getAccountMode(Chain.HyperCore, address)
-        userConfig.setPerpetualAccountMode(walletId, mode)
-        mode
+        runCatching { perpetualService.getAccountMode(Chain.HyperCore, address) }
+            .onSuccess { mode -> userConfig.setPerpetualAccountMode(walletId, mode) }
+            .getOrElse { userConfig.perpetualAccountMode(walletId).first() }
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualAccountModeImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualAccountModeImpl.kt
@@ -1,0 +1,18 @@
+package com.gemwallet.android.data.coordinators.perpetuals
+
+import com.gemwallet.android.application.perpetual.coordinators.GetPerpetualAccountMode
+import com.gemwallet.android.blockchain.services.PerpetualService
+import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.PerpetualAccountMode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class GetPerpetualAccountModeImpl @Inject constructor(
+    private val perpetualService: PerpetualService,
+) : GetPerpetualAccountMode {
+
+    override suspend fun getPerpetualAccountMode(address: String): PerpetualAccountMode = withContext(Dispatchers.IO) {
+        perpetualService.getAccountMode(Chain.HyperCore, address)
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/config/UserConfig.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/config/UserConfig.kt
@@ -13,6 +13,8 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.gemwallet.android.domains.perpetual.PerpetualConfig
 import com.gemwallet.android.model.AppUpdateInfo
 import com.wallet.core.primitives.ChartPeriod
+import com.wallet.core.primitives.PerpetualAccountMode
+import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -78,6 +80,19 @@ class UserConfig(
     suspend fun setPerpetualEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[Key.IsPerpetualEnabled] = enabled
+        }
+    }
+
+    fun perpetualAccountMode(walletId: WalletId): Flow<PerpetualAccountMode> = context.dataStore.data
+        .map { preferences ->
+            preferences[Key.perpetualAccountMode(walletId)]
+                ?.let { value -> PerpetualAccountMode.entries.firstOrNull { it.string == value } }
+                ?: PerpetualAccountMode.Standard
+        }
+
+    suspend fun setPerpetualAccountMode(walletId: WalletId, mode: PerpetualAccountMode) {
+        context.dataStore.edit { preferences ->
+            preferences[Key.perpetualAccountMode(walletId)] = mode.string
         }
     }
 
@@ -246,6 +261,7 @@ class UserConfig(
         val IsRequestNotifications = booleanPreferencesKey("is_request_notifications")
         val AskNotifications = longPreferencesKey("ask_notifications")
         val IsPerpetualEnabled = booleanPreferencesKey("is_perpetual_enabled")
+        fun perpetualAccountMode(walletId: WalletId) = stringPreferencesKey("perpetual_account_mode_${walletId.id}")
         val PerpetualLeverage = intPreferencesKey("perpetual_leverage")
         val PerpetualTakeProfit = intPreferencesKey("perpetual_take_profit")
         val PerpetualStopLoss = intPreferencesKey("perpetual_stop_loss")

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/PerpetualModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/PerpetualModule.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.data.repositories.di
 
 import com.gemwallet.android.application.perpetual.coordinators.PerpetualObserver
+import com.gemwallet.android.application.perpetual.coordinators.GetPerpetualAccountMode
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetualPositions
 import com.gemwallet.android.cases.nodes.GetNodeUrlCase
 import com.gemwallet.android.data.repositories.perpetual.HyperliquidEventHandler
@@ -75,6 +76,8 @@ object PerpetualModule {
     fun provideHyperliquidObserverService(
         observePerpetualWallet: ObservePerpetualWallet,
         syncPerpetualPositions: SyncPerpetualPositions,
+        getPerpetualAccountMode: GetPerpetualAccountMode,
+        hyperliquid: Hyperliquid,
         eventHandler: HyperliquidEventHandler,
         subscriptionService: HyperliquidSubscriptionService,
         getNodeUrlCase: GetNodeUrlCase,
@@ -82,6 +85,8 @@ object PerpetualModule {
     ): HyperliquidObserverService = HyperliquidObserverService(
         observePerpetualWallet = observePerpetualWallet,
         syncPerpetualPositions = syncPerpetualPositions,
+        getPerpetualAccountMode = getPerpetualAccountMode,
+        hyperliquid = hyperliquid,
         eventHandler = eventHandler,
         subscriptionService = subscriptionService,
         connection = WebSocketConnection(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidEventHandler.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidEventHandler.kt
@@ -7,6 +7,7 @@ import com.gemwallet.android.domains.perpetual.toGem
 import com.gemwallet.android.ext.HypercoreUSDC
 import com.gemwallet.android.ext.runCatchingCancellable
 import com.wallet.core.primitives.ChartCandleUpdate
+import com.wallet.core.primitives.PerpetualAccountMode
 import com.wallet.core.primitives.PerpetualProvider
 import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.channels.BufferOverflow
@@ -33,10 +34,11 @@ class HyperliquidEventHandler(
     private val pricesUpdateIntervalMs = PerpetualConfig.pricesUpdateIntervalSeconds * 1000L
     private var pricesUpdatedAt = 0L
 
-    suspend fun handle(walletId: WalletId, text: String) {
+    suspend fun handle(walletId: WalletId, mode: PerpetualAccountMode, text: String) {
         runCatchingCancellable {
-            when (val message = hyperliquid.parseWebsocketData(text.encodeToByteArray())) {
+            when (val message = hyperliquid.parseWebsocketData(text.encodeToByteArray(), mode.toGem())) {
                 is GemHyperliquidSocketMessage.AccountState -> handleAccountState(walletId, message.balance, message.positions)
+                is GemHyperliquidSocketMessage.SpotState -> putBalance(walletId, message.balance)
                 is GemHyperliquidSocketMessage.OpenOrders -> handleOpenOrders(walletId, message.orders)
                 is GemHyperliquidSocketMessage.Candle -> chartFlow.emit(message.candle.toDTO())
                 is GemHyperliquidSocketMessage.MarketData -> perpetualRepository.updateMarket(message.market.toDTO())
@@ -49,13 +51,17 @@ class HyperliquidEventHandler(
 
     private suspend fun handleAccountState(
         walletId: WalletId,
-        balance: GemPerpetualBalance,
+        balance: GemPerpetualBalance?,
         positions: List<GemPerpetualPosition>,
     ) {
         val diff = hyperliquid.diffClearinghousePositions(positions, getProviderPositions(walletId))
+        perpetualRepository.applyPositionsDiff(walletId, diff.deletePositionIds, diff.positions.mapNotNull { it.toDTO() })
+        balance?.let { putBalance(walletId, it) }
+    }
+
+    private suspend fun putBalance(walletId: WalletId, balance: GemPerpetualBalance) {
         perpetualRepository.putAsset(HypercoreUSDC)
         perpetualRepository.putBalance(walletId, HypercoreUSDC, balance.toDTO())
-        perpetualRepository.applyPositionsDiff(walletId, diff.deletePositionIds, diff.positions.mapNotNull { it.toDTO() })
     }
 
     private suspend fun handleOpenOrders(walletId: WalletId, orders: List<GemHyperliquidOpenOrder>) {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverService.kt
@@ -1,13 +1,16 @@
 package com.gemwallet.android.data.repositories.perpetual
 
 import android.util.Log
+import com.gemwallet.android.application.perpetual.coordinators.GetPerpetualAccountMode
 import com.gemwallet.android.application.perpetual.coordinators.PerpetualObserver
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetualPositions
 import com.gemwallet.android.data.repositories.stream.WebSocketConnectable
 import com.gemwallet.android.data.repositories.stream.WebSocketEvent
+import com.gemwallet.android.domains.perpetual.toGem
 import com.gemwallet.android.ext.hyperliquidAccount
 import com.gemwallet.android.ext.runCatchingCancellable
 import com.wallet.core.primitives.ChartCandleUpdate
+import com.wallet.core.primitives.PerpetualAccountMode
 import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -19,10 +22,13 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 import uniffi.gemstone.GemPerpetualSubscription
+import uniffi.gemstone.Hyperliquid
 
 class HyperliquidObserverService(
     private val observePerpetualWallet: ObservePerpetualWallet,
     private val syncPerpetualPositions: SyncPerpetualPositions,
+    private val getPerpetualAccountMode: GetPerpetualAccountMode,
+    private val hyperliquid: Hyperliquid,
     private val eventHandler: HyperliquidEventHandler,
     private val subscriptionService: HyperliquidSubscriptionService,
     private val connection: WebSocketConnectable,
@@ -41,8 +47,9 @@ class HyperliquidObserverService(
                 .distinctUntilChangedBy { it?.id?.id }
                 .collectLatest { wallet ->
                     val address = wallet?.hyperliquidAccount?.address ?: return@collectLatest
+                    val mode = getPerpetualAccountMode.getPerpetualAccountMode(address)
                     runCatching { syncPerpetualPositions.syncPerpetualPositions() }
-                    observeConnection(wallet.id, address)
+                    observeConnection(wallet.id, address, mode)
                 }
         }
     }
@@ -63,12 +70,12 @@ class HyperliquidObserverService(
         subscriptionService.unsubscribe(subscription)
     }
 
-    private suspend fun observeConnection(walletId: WalletId, address: String) = coroutineScope {
+    private suspend fun observeConnection(walletId: WalletId, address: String, mode: PerpetualAccountMode) = coroutineScope {
         launch { sendSubscriptionRequests() }
         connection.connect().collect { event ->
             when (event) {
-                WebSocketEvent.Connected -> subscriptionService.resubscribe(address)
-                is WebSocketEvent.Message -> eventHandler.handle(walletId, event.text)
+                WebSocketEvent.Connected -> subscriptionService.resubscribe(hyperliquid.accountSubscriptions(address, mode.toGem()))
+                is WebSocketEvent.Message -> eventHandler.handle(walletId, mode, event.text)
                 WebSocketEvent.Disconnected -> Unit
             }
         }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverService.kt
@@ -47,7 +47,7 @@ class HyperliquidObserverService(
                 .distinctUntilChangedBy { it?.id?.id }
                 .collectLatest { wallet ->
                     val address = wallet?.hyperliquidAccount?.address ?: return@collectLatest
-                    val mode = getPerpetualAccountMode.getPerpetualAccountMode(address)
+                    val mode = getPerpetualAccountMode.getPerpetualAccountMode(wallet.id, address)
                     runCatching { syncPerpetualPositions.syncPerpetualPositions() }
                     observeConnection(wallet.id, address, mode)
                 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidSubscriptionService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidSubscriptionService.kt
@@ -24,14 +24,9 @@ class HyperliquidSubscriptionService(
         outgoing.trySend(encodeRequest(GemSubscriptionMethod.UNSUBSCRIBE, subscription))
     }
 
-    suspend fun resubscribe(address: String) {
-        (defaultSubscriptions(address) + activeSubscriptions).distinct().forEach {
+    suspend fun resubscribe(defaultSubscriptions: List<GemPerpetualSubscription>) {
+        (defaultSubscriptions + activeSubscriptions).distinct().forEach {
             outgoing.send(encodeRequest(GemSubscriptionMethod.SUBSCRIBE, it))
         }
     }
-
-    private fun defaultSubscriptions(address: String): List<GemPerpetualSubscription> = listOf(
-        GemPerpetualSubscription.AccountState(address),
-        GemPerpetualSubscription.OpenOrders(address),
-    )
 }

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverServiceTest.kt
@@ -47,7 +47,7 @@ class HyperliquidObserverServiceTest {
         val observer = HyperliquidObserverService(
             observePerpetualWallet = observePerpetualWallet,
             syncPerpetualPositions = mockk(relaxed = true),
-            getPerpetualAccountMode = mockk { coEvery { getPerpetualAccountMode(any()) } returns PerpetualAccountMode.Standard },
+            getPerpetualAccountMode = mockk { coEvery { getPerpetualAccountMode(any(), any()) } returns PerpetualAccountMode.Standard },
             hyperliquid = mockk {
                 every { accountSubscriptions(any(), any()) } returns listOf(
                     GemPerpetualSubscription.AccountState(ADDRESS),

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverServiceTest.kt
@@ -5,6 +5,8 @@ import com.gemwallet.android.data.repositories.stream.WebSocketEvent
 import com.gemwallet.android.testkit.mockAccount
 import com.gemwallet.android.testkit.mockWallet
 import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.PerpetualAccountMode
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -19,6 +21,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import uniffi.gemstone.GemPerpetualSubscription
 
 class HyperliquidObserverServiceTest {
 
@@ -44,6 +47,13 @@ class HyperliquidObserverServiceTest {
         val observer = HyperliquidObserverService(
             observePerpetualWallet = observePerpetualWallet,
             syncPerpetualPositions = mockk(relaxed = true),
+            getPerpetualAccountMode = mockk { coEvery { getPerpetualAccountMode(any()) } returns PerpetualAccountMode.Standard },
+            hyperliquid = mockk {
+                every { accountSubscriptions(any(), any()) } returns listOf(
+                    GemPerpetualSubscription.AccountState(ADDRESS),
+                    GemPerpetualSubscription.OpenOrders(ADDRESS),
+                )
+            },
             eventHandler = eventHandler,
             subscriptionService = HyperliquidSubscriptionService { _, _ -> SUBSCRIBE_REQUEST },
             connection = connection,
@@ -54,7 +64,7 @@ class HyperliquidObserverServiceTest {
         advanceUntilIdle()
 
         assertEquals(listOf(SUBSCRIBE_REQUEST, SUBSCRIBE_REQUEST), connection.sent)
-        coVerify { eventHandler.handle(wallet.id, MESSAGE) }
+        coVerify { eventHandler.handle(wallet.id, PerpetualAccountMode.Standard, MESSAGE) }
         scope.cancel()
     }
 

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidSubscriptionServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidSubscriptionServiceTest.kt
@@ -11,10 +11,7 @@ class HyperliquidSubscriptionServiceTest {
     @Test
     fun `subscribe and unsubscribe encode matching commands`() = runTest {
         val encoded = mutableListOf<Pair<GemSubscriptionMethod, GemPerpetualSubscription>>()
-        val service = HyperliquidSubscriptionService { method, subscription ->
-            encoded += method to subscription
-            REQUEST
-        }
+        val service = subscriptionService(encoded)
 
         service.subscribe(GemPerpetualSubscription.MarketPrices)
         assertEquals(REQUEST, service.messages.receive())
@@ -34,26 +31,34 @@ class HyperliquidSubscriptionServiceTest {
     @Test
     fun `resubscribe replays default subscriptions and the active set`() = runTest {
         val encoded = mutableListOf<Pair<GemSubscriptionMethod, GemPerpetualSubscription>>()
-        val service = HyperliquidSubscriptionService { method, subscription ->
-            encoded += method to subscription
-            REQUEST
-        }
+        val service = subscriptionService(encoded)
         service.subscribe(GemPerpetualSubscription.MarketPrices)
         service.messages.receive() // drain the subscribe command
         encoded.clear()
 
-        service.resubscribe(ADDRESS)
+        service.resubscribe(
+            listOf(
+                GemPerpetualSubscription.AccountState(ADDRESS),
+                GemPerpetualSubscription.SpotState(ADDRESS),
+            ),
+        )
         repeat(3) { service.messages.receive() }
 
         assertEquals(
             setOf(
                 GemSubscriptionMethod.SUBSCRIBE to GemPerpetualSubscription.AccountState(ADDRESS),
-                GemSubscriptionMethod.SUBSCRIBE to GemPerpetualSubscription.OpenOrders(ADDRESS),
+                GemSubscriptionMethod.SUBSCRIBE to GemPerpetualSubscription.SpotState(ADDRESS),
                 GemSubscriptionMethod.SUBSCRIBE to GemPerpetualSubscription.MarketPrices,
             ),
             encoded.toSet(),
         )
     }
+
+    private fun subscriptionService(encoded: MutableList<Pair<GemSubscriptionMethod, GemPerpetualSubscription>>) =
+        HyperliquidSubscriptionService { method, subscription ->
+            encoded += method to subscription
+            REQUEST
+        }
 
     private companion object {
         const val ADDRESS = "0xabc"

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/perpetual/coordinators/GetPerpetualAccountMode.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/perpetual/coordinators/GetPerpetualAccountMode.kt
@@ -1,7 +1,8 @@
 package com.gemwallet.android.application.perpetual.coordinators
 
 import com.wallet.core.primitives.PerpetualAccountMode
+import com.wallet.core.primitives.WalletId
 
 interface GetPerpetualAccountMode {
-    suspend fun getPerpetualAccountMode(address: String): PerpetualAccountMode
+    suspend fun getPerpetualAccountMode(walletId: WalletId, address: String): PerpetualAccountMode
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/perpetual/coordinators/GetPerpetualAccountMode.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/perpetual/coordinators/GetPerpetualAccountMode.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.perpetual.coordinators
+
+import com.wallet.core.primitives.PerpetualAccountMode
+
+interface GetPerpetualAccountMode {
+    suspend fun getPerpetualAccountMode(address: String): PerpetualAccountMode
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/perpetual/PerpetualMappers.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/perpetual/PerpetualMappers.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.domains.perpetual
 import com.gemwallet.android.domains.asset.toGem
 import com.gemwallet.android.ext.toIdentifier
 import com.wallet.core.primitives.CancelOrderData
+import com.wallet.core.primitives.PerpetualAccountMode
 import com.wallet.core.primitives.PerpetualConfirmData
 import com.wallet.core.primitives.PerpetualDirection
 import com.wallet.core.primitives.PerpetualMarginType
@@ -15,6 +16,7 @@ import com.wallet.core.primitives.PerpetualTriggerOrder
 import com.wallet.core.primitives.PerpetualType
 import com.wallet.core.primitives.TPSLOrderData
 import com.wallet.core.primitives.TpslType
+import uniffi.gemstone.GemPerpetualAccountMode
 import uniffi.gemstone.GemPerpetualMarginType
 import uniffi.gemstone.GemPerpetualOrderType
 import uniffi.gemstone.GemPerpetualPosition
@@ -94,6 +96,11 @@ fun PerpetualPosition.toGem(): GemPerpetualPosition = GemPerpetualPosition(
     pnl = pnl,
     funding = funding,
 )
+
+fun PerpetualAccountMode.toGem(): GemPerpetualAccountMode = when (this) {
+    PerpetualAccountMode.Standard -> GemPerpetualAccountMode.STANDARD
+    PerpetualAccountMode.Unified -> GemPerpetualAccountMode.UNIFIED
+}
 
 fun PerpetualTriggerOrder.toGem(): GemPerpetualTriggerOrder = GemPerpetualTriggerOrder(
     price = price,

--- a/android/gemcore/src/main/kotlin/com/wallet/core/primitives/generated/Perpetual.kt
+++ b/android/gemcore/src/main/kotlin/com/wallet/core/primitives/generated/Perpetual.kt
@@ -164,6 +164,14 @@ enum class AccountDataType(val string: String) {
 }
 
 @Serializable
+enum class PerpetualAccountMode(val string: String) {
+	@SerialName("standard")
+	Standard("standard"),
+	@SerialName("unified")
+	Unified("unified"),
+}
+
+@Serializable
 sealed class PerpetualType {
 	@Serializable
 	@SerialName("Open")

--- a/core/crates/chain_traits/src/lib.rs
+++ b/core/crates/chain_traits/src/lib.rs
@@ -3,7 +3,7 @@ use std::{error::Error, str, time::Duration};
 use async_trait::async_trait;
 pub use primitives::TransactionIdRequest;
 use primitives::chart::ChartCandleStick;
-use primitives::perpetual::{PerpetualData, PerpetualPositionsSummary};
+use primitives::perpetual::{PerpetualAccountMode, PerpetualData, PerpetualPositionsSummary};
 use primitives::portfolio::PerpetualPortfolio;
 use primitives::{
     AddressStatus, Asset, AssetBalance, AssetId, BroadcastOptions, Chain, ChainRequest, ChainRequestType, ChartPeriod, DelegationBase, DelegationValidator, FeeRate,
@@ -190,6 +190,10 @@ pub trait ChainAccount: Send + Sync {}
 #[async_trait]
 pub trait ChainPerpetual: Send + Sync {
     async fn get_positions(&self, _address: String) -> Result<PerpetualPositionsSummary, Box<dyn Error + Sync + Send>> {
+        Err("Chain does not support perpetual trading".into())
+    }
+
+    async fn get_perpetual_account_mode(&self, _address: String) -> Result<PerpetualAccountMode, Box<dyn Error + Sync + Send>> {
         Err("Chain does not support perpetual trading".into())
     }
 

--- a/core/crates/gem_hypercore/src/models/balance.rs
+++ b/core/crates/gem_hypercore/src/models/balance.rs
@@ -20,11 +20,11 @@ pub struct Balances {
 }
 
 impl Balances {
-    pub fn available_after_maintenance(&self, token: u32) -> Option<f64> {
+    pub fn available_after_maintenance(&self, token: u32) -> Option<&str> {
         self.token_to_available_after_maintenance
             .iter()
             .find(|(index, _)| *index == token)
-            .and_then(|(_, amount)| amount.parse().ok())
+            .map(|(_, amount)| amount.as_str())
     }
 }
 

--- a/core/crates/gem_hypercore/src/models/balance.rs
+++ b/core/crates/gem_hypercore/src/models/balance.rs
@@ -15,6 +15,17 @@ pub struct Balance {
 #[serde(rename_all = "camelCase")]
 pub struct Balances {
     pub balances: Vec<Balance>,
+    #[serde(default)]
+    pub token_to_available_after_maintenance: Vec<(u32, String)>,
+}
+
+impl Balances {
+    pub fn available_after_maintenance(&self, token: u32) -> Option<f64> {
+        self.token_to_available_after_maintenance
+            .iter()
+            .find(|(index, _)| *index == token)
+            .and_then(|(_, amount)| amount.parse().ok())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/core/crates/gem_hypercore/src/models/user.rs
+++ b/core/crates/gem_hypercore/src/models/user.rs
@@ -1,3 +1,4 @@
+use primitives::PerpetualAccountMode;
 use serde::{Deserialize, Serialize};
 use serde_serializers::f64::deserialize_f64_from_str;
 
@@ -11,6 +12,15 @@ pub enum UserAbstractionMode {
     DexAbstraction,
     UnifiedAccount,
     PortfolioMargin,
+}
+
+impl From<UserAbstractionMode> for PerpetualAccountMode {
+    fn from(value: UserAbstractionMode) -> Self {
+        match value {
+            UserAbstractionMode::Default | UserAbstractionMode::Disabled | UserAbstractionMode::DexAbstraction => Self::Standard,
+            UserAbstractionMode::UnifiedAccount | UserAbstractionMode::PortfolioMargin => Self::Unified,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/core/crates/gem_hypercore/src/models/websocket.rs
+++ b/core/crates/gem_hypercore/src/models/websocket.rs
@@ -6,6 +6,7 @@ use primitives::{PerpetualMarketData, PerpetualPosition};
 use serde::{Deserialize, Serialize};
 use serde_serializers::{deserialize_f64_from_str, deserialize_option_f64_from_str};
 
+use super::balance::Balances;
 use super::candlestick::Candlestick;
 use super::order::OpenOrder;
 use super::position::AssetPositions;
@@ -15,6 +16,9 @@ use super::position::AssetPositions;
 pub enum RawSocketMessage {
     #[serde(rename = "clearinghouseState")]
     AccountState(AccountStateData),
+
+    #[serde(rename = "spotState")]
+    SpotState(SpotStateData),
 
     #[serde(rename = "openOrders")]
     OpenOrders(OpenOrdersData),
@@ -47,6 +51,12 @@ pub enum HyperliquidMethod {
 pub enum HyperliquidSubscription {
     #[serde(rename = "clearinghouseState")]
     AccountState {
+        #[serde(rename = "user")]
+        address: String,
+    },
+
+    #[serde(rename = "spotState")]
+    SpotState {
         #[serde(rename = "user")]
         address: String,
     },
@@ -118,6 +128,12 @@ pub struct AccountStateData {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpotStateData {
+    pub spot_state: Balances,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct OpenOrdersData {
     #[serde(rename = "user")]
     pub address: String,
@@ -143,12 +159,28 @@ pub struct PositionsDiff {
 
 #[derive(Debug)]
 pub enum HyperliquidSocketMessage {
-    AccountState { balance: PerpetualBalance, positions: Vec<PerpetualPosition> },
-    OpenOrders { orders: Vec<OpenOrder> },
-    Candle { candle: ChartCandleUpdate },
-    MarketData { market: PerpetualMarketData },
-    MarketPrices { prices: HashMap<String, f64> },
-    SubscriptionResponse { subscription_type: String },
+    AccountState {
+        balance: Option<PerpetualBalance>,
+        positions: Vec<PerpetualPosition>,
+    },
+    SpotState {
+        balance: PerpetualBalance,
+    },
+    OpenOrders {
+        orders: Vec<OpenOrder>,
+    },
+    Candle {
+        candle: ChartCandleUpdate,
+    },
+    MarketData {
+        market: PerpetualMarketData,
+    },
+    MarketPrices {
+        prices: HashMap<String, f64>,
+    },
+    SubscriptionResponse {
+        subscription_type: String,
+    },
     Unknown,
 }
 

--- a/core/crates/gem_hypercore/src/provider/balances.rs
+++ b/core/crates/gem_hypercore/src/provider/balances.rs
@@ -4,10 +4,9 @@ use futures::try_join;
 use std::error::Error;
 
 use gem_client::Client;
-use number_formatter::BigNumberFormatter;
 use primitives::{Asset, AssetBalance};
 
-use super::balances_mapper::{map_balance_assets, map_balance_coin, map_balance_staking, map_balance_tokens};
+use super::balances_mapper::{map_balance_assets, map_balance_staking, map_balance_token, map_balance_tokens};
 use crate::rpc::client::HyperCoreClient;
 
 const NATIVE_TOKEN_INDEX: u32 = 150;
@@ -15,17 +14,13 @@ const NATIVE_TOKEN_INDEX: u32 = 150;
 #[async_trait]
 impl<C: Client> ChainBalances for HyperCoreClient<C> {
     async fn get_balance_coin(&self, address: String) -> Result<AssetBalance, Box<dyn Error + Sync + Send>> {
-        let total = self
-            .get_spot_balances(&address)
-            .await?
-            .balances
-            .into_iter()
-            .find(|balance| balance.token == NATIVE_TOKEN_INDEX)
-            .map(|balance| balance.total)
-            .unwrap_or_else(|| "0".to_string());
-        let native_decimals = Asset::from_chain(self.chain).decimals as u32;
-        let available: String = BigNumberFormatter::value_from_amount(&total, native_decimals)?;
-        Ok(map_balance_coin(available, self.chain))
+        let balances = self.get_spot_balances(&address).await?;
+        let native_decimals = Asset::from_chain(self.chain).decimals;
+        let Some(balance) = balances.balances.iter().find(|balance| balance.token == NATIVE_TOKEN_INDEX) else {
+            return Ok(AssetBalance::new_zero_balance(self.chain.as_asset_id()));
+        };
+
+        map_balance_token(self.chain.as_asset_id(), balance, balances.available_after_maintenance(balance.token), native_decimals)
     }
 
     async fn get_balance_tokens(&self, address: String, token_ids: Vec<String>) -> Result<Vec<AssetBalance>, Box<dyn Error + Sync + Send>> {

--- a/core/crates/gem_hypercore/src/provider/balances_mapper.rs
+++ b/core/crates/gem_hypercore/src/provider/balances_mapper.rs
@@ -1,20 +1,25 @@
 use crate::models::{
-    balance::{Balances, StakeBalance},
+    balance::{Balance as SpotBalance, Balances, StakeBalance},
     token::SpotToken,
 };
-use num_bigint::BigUint;
 use number_formatter::BigNumberFormatter;
 use primitives::{Asset, AssetBalance, AssetId, Balance, Chain};
 use std::error::Error;
 
-pub fn map_balance_coin(balance: String, chain: Chain) -> AssetBalance {
-    AssetBalance::new(chain.as_asset_id(), balance.parse::<BigUint>().unwrap_or_default())
-}
+pub fn map_balance_token(asset_id: AssetId, balance: &SpotBalance, available_after_maintenance: Option<&str>, decimals: i32) -> Result<AssetBalance, Box<dyn Error + Sync + Send>> {
+    let decimals = decimals as u32;
+    let total = BigNumberFormatter::value_from_amount_biguint(&balance.total, decimals)?;
+    let available = match available_after_maintenance {
+        Some(amount) => BigNumberFormatter::value_from_amount_biguint(amount, decimals)?,
+        None => {
+            let hold = BigNumberFormatter::value_from_amount_biguint(&balance.hold, decimals)?;
+            total.clone() - hold.min(total.clone())
+        }
+    };
+    let available = available.min(total.clone());
+    let reserved = total - available.clone();
 
-pub fn map_balance_token(asset_id: AssetId, balance: String, decimals: i32) -> Result<AssetBalance, Box<dyn Error + Sync + Send>> {
-    let available = BigNumberFormatter::value_from_amount_biguint(&balance, decimals as u32)?;
-
-    Ok(AssetBalance::new(asset_id, available))
+    Ok(AssetBalance::new_balance(asset_id, Balance::with_reserved(available, reserved)))
 }
 
 pub fn map_balance_assets(spot_balances: &Balances, spot_tokens: &[SpotToken], chain: Chain) -> Vec<AssetBalance> {
@@ -23,7 +28,7 @@ pub fn map_balance_assets(spot_balances: &Balances, spot_tokens: &[SpotToken], c
         .iter()
         .filter_map(|x| {
             let token = spot_tokens.iter().find(|t| t.index as u32 == x.token)?;
-            map_balance_token(token.asset_id(chain), x.total.clone(), token.wei_decimals).ok()
+            map_balance_token(token.asset_id(chain), x, spot_balances.available_after_maintenance(x.token), token.wei_decimals).ok()
         })
         .collect()
 }
@@ -37,7 +42,7 @@ pub fn map_balance_tokens(spot_balances: &Balances, spot_tokens: &[SpotToken], t
             let token = spot_tokens.iter().find(|t| &t.name == symbol)?;
             let asset_id = AssetId::from(chain, Some(token_id.clone()));
             if let Some(balance) = spot_balances.balances.iter().find(|b| b.token == token.index as u32) {
-                map_balance_token(asset_id, balance.total.clone(), token.wei_decimals).ok()
+                map_balance_token(asset_id, balance, spot_balances.available_after_maintenance(balance.token), token.wei_decimals).ok()
             } else {
                 Some(AssetBalance::new_zero_balance(asset_id))
             }
@@ -60,25 +65,29 @@ pub fn map_balance_staking(balance: &StakeBalance, chain: Chain) -> Result<Asset
 mod tests {
     use super::*;
     use crate::models::balance::Balance;
+    use num_bigint::BigUint;
     use primitives::{Chain, asset_constants::HYPERCORE_SPOT_USDC_TOKEN_ID};
-
-    #[test]
-    fn test_map_balance_coin() {
-        let balance = "1000000000000000000".to_string();
-        let result = map_balance_coin(balance, Chain::SmartChain);
-
-        assert_eq!(result.balance.available, BigUint::from(1000000000000000000_u64));
-        assert_eq!(result.asset_id.chain, Chain::SmartChain);
-    }
 
     #[test]
     fn test_map_balance_token() {
         let asset_id = AssetId::from(Chain::HyperCore, Some("USDC::0".to_string()));
-        let result = map_balance_token(asset_id, "56003537".to_string(), 8).unwrap();
+        let balance = SpotBalance {
+            coin: "USDC".to_string(),
+            token: 0,
+            total: "12.89353003".to_string(),
+            hold: "2.020032".to_string(),
+        };
 
-        assert_eq!(result.balance.available, "5600353700000000".parse::<BigUint>().unwrap());
-        assert_eq!(result.asset_id.chain, Chain::HyperCore);
+        let result = map_balance_token(asset_id.clone(), &balance, None, 8).unwrap();
+
+        assert_eq!(result.balance.available, "1087349803".parse::<BigUint>().unwrap());
+        assert_eq!(result.balance.reserved, "202003200".parse::<BigUint>().unwrap());
         assert_eq!(result.asset_id.token_id, Some("USDC::0".to_string()));
+
+        let result = map_balance_token(asset_id, &balance, Some("12.69152703"), 8).unwrap();
+
+        assert_eq!(result.balance.available, "1269152703".parse::<BigUint>().unwrap());
+        assert_eq!(result.balance.reserved, "20200300".parse::<BigUint>().unwrap());
     }
 
     #[test]

--- a/core/crates/gem_hypercore/src/provider/balances_mapper.rs
+++ b/core/crates/gem_hypercore/src/provider/balances_mapper.rs
@@ -84,6 +84,7 @@ mod tests {
     #[test]
     fn test_map_balance_tokens() {
         let spot_balances = Balances {
+            token_to_available_after_maintenance: vec![],
             balances: vec![Balance {
                 coin: "USDC".to_string(),
                 token: 0,
@@ -117,7 +118,10 @@ mod tests {
 
     #[test]
     fn test_map_balance_tokens_missing_balance() {
-        let spot_balances = Balances { balances: vec![] };
+        let spot_balances = Balances {
+            balances: vec![],
+            token_to_available_after_maintenance: vec![],
+        };
 
         let spot_tokens = vec![SpotToken {
             name: "USDC".to_string(),

--- a/core/crates/gem_hypercore/src/provider/perpetual.rs
+++ b/core/crates/gem_hypercore/src/provider/perpetual.rs
@@ -7,13 +7,13 @@ use gem_client::Client;
 use primitives::{
     ChartPeriod,
     chart::ChartCandleStick,
-    perpetual::{PerpetualBalance, PerpetualData, PerpetualPositionsSummary},
+    perpetual::{PerpetualAccountMode, PerpetualBalance, PerpetualData, PerpetualPositionsSummary},
     portfolio::PerpetualPortfolio,
 };
 
 use crate::{
     config::HypercoreConfig,
-    models::{order::OpenOrder, perp_dex::PerpDex, position::AssetPositions, user::UserAbstractionMode},
+    models::{order::OpenOrder, perp_dex::PerpDex, position::AssetPositions},
     provider::perpetual_mapper::{
         map_account_summary_aggregate, map_candlesticks, map_perpetual_balance_from_spot, map_perpetual_portfolio, map_perpetuals_data, map_positions, merge_perpetual_portfolios,
     },
@@ -129,15 +129,16 @@ impl<C: Client> ChainPerpetual for HyperCoreClient<C> {
             },
         );
 
-        let balance = match mode {
-            UserAbstractionMode::Default | UserAbstractionMode::Disabled | UserAbstractionMode::DexAbstraction => balance,
-            UserAbstractionMode::UnifiedAccount | UserAbstractionMode::PortfolioMargin => {
-                let spot = self.get_spot_balances(&address).await?;
-                map_perpetual_balance_from_spot(&spot)
-            }
+        let balance = match PerpetualAccountMode::from(mode) {
+            PerpetualAccountMode::Unified => map_perpetual_balance_from_spot(&self.get_spot_balances(&address).await?),
+            PerpetualAccountMode::Standard => balance,
         };
 
         Ok(PerpetualPositionsSummary { positions, balance })
+    }
+
+    async fn get_perpetual_account_mode(&self, address: String) -> Result<PerpetualAccountMode, Box<dyn Error + Sync + Send>> {
+        Ok(self.get_user_abstraction(&address).await?.into())
     }
 
     async fn get_perpetuals_data(&self) -> Result<Vec<PerpetualData>, Box<dyn Error + Sync + Send>> {
@@ -357,6 +358,49 @@ mod tests {
         assert_eq!(summary.positions.len(), 2);
         assert_eq!(btc.take_profit.as_ref().map(|order| order.price), Some(110.0));
         assert_eq!(eth.stop_loss.as_ref().map(|order| order.price), Some(90.0));
+    }
+
+    #[tokio::test]
+    async fn test_get_perpetual_account_mode() {
+        let unified = HyperCoreClient::mock_with_responses_by_request_type(vec![(
+            "userAbstraction",
+            include_bytes!("../../testdata/perpetual_balance_response_user_abstraction_unified.json").to_vec(),
+        )]);
+        let default = HyperCoreClient::mock_with_responses_by_request_type(vec![(
+            "userAbstraction",
+            include_bytes!("../../testdata/perpetual_positions_response_user_abstraction_default.json").to_vec(),
+        )]);
+
+        assert_eq!(unified.get_perpetual_account_mode("0x123".to_string()).await.unwrap(), PerpetualAccountMode::Unified);
+        assert_eq!(default.get_perpetual_account_mode("0x123".to_string()).await.unwrap(), PerpetualAccountMode::Standard);
+    }
+
+    #[tokio::test]
+    async fn test_get_positions_takes_balance_from_spot_for_unified_account() {
+        let client = HyperCoreClient::mock_with_responses_by_request_type(vec![
+            (
+                "userAbstraction",
+                include_bytes!("../../testdata/perpetual_balance_response_user_abstraction_unified.json").to_vec(),
+            ),
+            (
+                "clearinghouseState",
+                include_bytes!("../../testdata/perpetual_positions_response_clearinghouse_state.json").to_vec(),
+            ),
+            (
+                "frontendOpenOrders",
+                include_bytes!("../../testdata/perpetual_positions_response_open_orders.json").to_vec(),
+            ),
+            (
+                "spotClearinghouseState",
+                include_bytes!("../../testdata/perpetual_balance_response_spot_clearinghouse_state.json").to_vec(),
+            ),
+        ]);
+
+        let summary = client.get_positions("0x123".to_string()).await.unwrap();
+
+        assert_eq!(summary.balance.available, 3.797316);
+        assert_eq!(summary.balance.reserved, 4.331289 - 3.797316);
+        assert_eq!(summary.positions.len(), 1);
     }
 
     #[tokio::test]

--- a/core/crates/gem_hypercore/src/provider/perpetual_mapper.rs
+++ b/core/crates/gem_hypercore/src/provider/perpetual_mapper.rs
@@ -56,7 +56,11 @@ pub fn map_perpetual_balance_from_spot(balances: &Balances) -> PerpetualBalance 
         };
     };
     let total = f64::max(collateral.total.parse().unwrap_or(0.0), 0.0);
-    let available = balances.available_after_maintenance(collateral.token).map(|value| value.clamp(0.0, total)).unwrap_or(total);
+    let available = balances
+        .available_after_maintenance(collateral.token)
+        .and_then(|value| value.parse::<f64>().ok())
+        .map(|value| value.clamp(0.0, total))
+        .unwrap_or(total);
 
     PerpetualBalance {
         available,

--- a/core/crates/gem_hypercore/src/provider/perpetual_mapper.rs
+++ b/core/crates/gem_hypercore/src/provider/perpetual_mapper.rs
@@ -48,15 +48,19 @@ pub fn map_perpetual_balance(positions: &AssetPositions) -> PerpetualBalance {
 }
 
 pub fn map_perpetual_balance_from_spot(balances: &Balances) -> PerpetualBalance {
-    let usdc = balances.balances.iter().find(|b| b.coin == USDC_SYMBOL);
-    let total = usdc.and_then(|b| b.total.parse::<f64>().ok()).unwrap_or(0.0);
-    let hold = usdc.and_then(|b| b.hold.parse::<f64>().ok()).unwrap_or(0.0);
-    let reserved = f64::min(f64::max(hold, 0.0), f64::max(total, 0.0));
-    let available = f64::max(total - reserved, 0.0);
+    let Some(collateral) = balances.balances.iter().find(|balance| balance.coin == USDC_SYMBOL) else {
+        return PerpetualBalance {
+            available: 0.0,
+            reserved: 0.0,
+            withdrawable: 0.0,
+        };
+    };
+    let total = f64::max(collateral.total.parse().unwrap_or(0.0), 0.0);
+    let available = balances.available_after_maintenance(collateral.token).map(|value| value.clamp(0.0, total)).unwrap_or(total);
 
     PerpetualBalance {
         available,
-        reserved,
+        reserved: total - available,
         withdrawable: available,
     }
 }
@@ -889,19 +893,30 @@ mod tests {
 
     #[test]
     fn test_map_perpetual_balance_from_spot() {
-        let balances = Balances {
-            balances: vec![Balance {
-                coin: "USDC".to_string(),
-                token: 0,
-                total: "100.0".to_string(),
-                hold: "30.0".to_string(),
-            }],
+        let collateral = Balance {
+            coin: "USDC".to_string(),
+            token: 0,
+            total: "4.331289".to_string(),
+            hold: "4.331289".to_string(),
         };
 
+        let balances = Balances {
+            balances: vec![collateral.clone()],
+            token_to_available_after_maintenance: vec![(0, "3.797316".to_string())],
+        };
         let balance = map_perpetual_balance_from_spot(&balances);
 
-        assert_eq!(balance.available, 70.0);
-        assert_eq!(balance.reserved, 30.0);
-        assert_eq!(balance.withdrawable, 70.0);
+        assert_eq!(balance.available, 3.797316);
+        assert_eq!(balance.reserved, 4.331289 - 3.797316);
+        assert_eq!(balance.withdrawable, 3.797316);
+
+        let balances = Balances {
+            balances: vec![collateral],
+            token_to_available_after_maintenance: vec![],
+        };
+        let balance = map_perpetual_balance_from_spot(&balances);
+
+        assert_eq!(balance.available, 4.331289);
+        assert_eq!(balance.reserved, 0.0);
     }
 }

--- a/core/crates/gem_hypercore/src/provider/websocket_mapper.rs
+++ b/core/crates/gem_hypercore/src/provider/websocket_mapper.rs
@@ -10,14 +10,13 @@ use crate::models::{
 use super::perpetual_mapper::{map_perpetual_balance_from_spot, map_positions, map_tp_sl_from_orders};
 
 pub fn account_subscriptions(address: String, mode: PerpetualAccountMode) -> Vec<HyperliquidSubscription> {
-    let mut subscriptions = vec![
-        HyperliquidSubscription::AccountState { address: address.clone() },
-        HyperliquidSubscription::OpenOrders { address: address.clone() },
-    ];
-    if mode == PerpetualAccountMode::Unified {
-        subscriptions.push(HyperliquidSubscription::SpotState { address });
+    let account_state = HyperliquidSubscription::AccountState { address: address.clone() };
+    let open_orders = HyperliquidSubscription::OpenOrders { address: address.clone() };
+
+    match mode {
+        PerpetualAccountMode::Standard => vec![account_state, open_orders],
+        PerpetualAccountMode::Unified => vec![account_state, open_orders, HyperliquidSubscription::SpotState { address }],
     }
-    subscriptions
 }
 
 pub fn parse_websocket_data(data: &[u8], mode: PerpetualAccountMode) -> Result<HyperliquidSocketMessage, serde_json::Error> {

--- a/core/crates/gem_hypercore/src/provider/websocket_mapper.rs
+++ b/core/crates/gem_hypercore/src/provider/websocket_mapper.rs
@@ -1,25 +1,43 @@
 use std::collections::{HashMap, HashSet};
 
-use primitives::{AssetId, PerpetualMarketData, PerpetualPosition};
+use primitives::{AssetId, PerpetualAccountMode, PerpetualMarketData, PerpetualPosition};
 
 use crate::models::{
     order::OpenOrder,
-    websocket::{ActiveAssetCtxData, HyperliquidSocketMessage, PositionsDiff, RawSocketMessage},
+    websocket::{ActiveAssetCtxData, HyperliquidSocketMessage, HyperliquidSubscription, PositionsDiff, RawSocketMessage},
 };
 
-use super::perpetual_mapper::{map_positions, map_tp_sl_from_orders};
+use super::perpetual_mapper::{map_perpetual_balance_from_spot, map_positions, map_tp_sl_from_orders};
 
-pub fn parse_websocket_data(data: &[u8]) -> Result<HyperliquidSocketMessage, serde_json::Error> {
+pub fn account_subscriptions(address: String, mode: PerpetualAccountMode) -> Vec<HyperliquidSubscription> {
+    let mut subscriptions = vec![
+        HyperliquidSubscription::AccountState { address: address.clone() },
+        HyperliquidSubscription::OpenOrders { address: address.clone() },
+    ];
+    if mode == PerpetualAccountMode::Unified {
+        subscriptions.push(HyperliquidSubscription::SpotState { address });
+    }
+    subscriptions
+}
+
+pub fn parse_websocket_data(data: &[u8], mode: PerpetualAccountMode) -> Result<HyperliquidSocketMessage, serde_json::Error> {
     let raw: RawSocketMessage = serde_json::from_slice(data)?;
 
     match raw {
         RawSocketMessage::AccountState(data) => {
             let summary = map_positions(data.clearinghouse_state, data.address, &[]);
+            let balance = match mode {
+                PerpetualAccountMode::Unified => None,
+                PerpetualAccountMode::Standard => Some(summary.balance),
+            };
             Ok(HyperliquidSocketMessage::AccountState {
-                balance: summary.balance,
+                balance,
                 positions: summary.positions,
             })
         }
+        RawSocketMessage::SpotState(data) => Ok(HyperliquidSocketMessage::SpotState {
+            balance: map_perpetual_balance_from_spot(&data.spot_state),
+        }),
         RawSocketMessage::OpenOrders(data) => Ok(HyperliquidSocketMessage::OpenOrders { orders: data.orders }),
         RawSocketMessage::Candle(candlestick) => Ok(HyperliquidSocketMessage::Candle { candle: candlestick.into() }),
         RawSocketMessage::MarketData(data) => Ok(HyperliquidSocketMessage::MarketData {
@@ -109,7 +127,7 @@ mod tests {
     #[test]
     fn test_parse_all_mids() {
         let json = include_bytes!("../../testdata/ws_all_mids.json");
-        let HyperliquidSocketMessage::MarketPrices { prices } = parse_websocket_data(json).unwrap() else {
+        let HyperliquidSocketMessage::MarketPrices { prices } = parse_websocket_data(json, PerpetualAccountMode::Standard).unwrap() else {
             panic!("expected MarketPrices");
         };
 
@@ -124,7 +142,7 @@ mod tests {
     #[test]
     fn test_parse_active_asset_ctx() {
         let json = include_bytes!("../../testdata/ws_active_asset_ctx.json");
-        let HyperliquidSocketMessage::MarketData { market } = parse_websocket_data(json).unwrap() else {
+        let HyperliquidSocketMessage::MarketData { market } = parse_websocket_data(json, PerpetualAccountMode::Standard).unwrap() else {
             panic!("expected MarketData");
         };
 
@@ -158,13 +176,13 @@ mod tests {
           }
         }"#;
 
-        assert!(parse_websocket_data(json).is_err());
+        assert!(parse_websocket_data(json, PerpetualAccountMode::Standard).is_err());
     }
 
     #[test]
     fn test_parse_candle() {
         let json = include_bytes!("../../testdata/ws_candle.json");
-        let HyperliquidSocketMessage::Candle { candle: update } = parse_websocket_data(json).unwrap() else {
+        let HyperliquidSocketMessage::Candle { candle: update } = parse_websocket_data(json, PerpetualAccountMode::Standard).unwrap() else {
             panic!("expected Candle");
         };
 
@@ -180,7 +198,7 @@ mod tests {
     #[test]
     fn test_parse_open_orders() {
         let json = include_bytes!("../../testdata/ws_open_orders.json");
-        let HyperliquidSocketMessage::OpenOrders { orders } = parse_websocket_data(json).unwrap() else {
+        let HyperliquidSocketMessage::OpenOrders { orders } = parse_websocket_data(json, PerpetualAccountMode::Standard).unwrap() else {
             panic!("expected OpenOrders");
         };
 
@@ -202,9 +220,10 @@ mod tests {
     #[test]
     fn test_parse_clearinghouse_state() {
         let json = include_bytes!("../../testdata/ws_clearinghouse_state.json");
-        let HyperliquidSocketMessage::AccountState { balance, positions } = parse_websocket_data(json).unwrap() else {
+        let HyperliquidSocketMessage::AccountState { balance, positions } = parse_websocket_data(json, PerpetualAccountMode::Standard).unwrap() else {
             panic!("expected AccountState");
         };
+        let balance = balance.expect("clearinghouse account owns its balance");
 
         assert_eq!(balance.available, 15230.5 - 830.5);
         assert_eq!(balance.reserved, 830.5);
@@ -226,5 +245,49 @@ mod tests {
         assert_eq!(pos.funding, Some(-1.82));
         assert_eq!(pos.take_profit, None);
         assert_eq!(pos.stop_loss, None);
+    }
+
+    #[test]
+    fn test_parse_clearinghouse_state_drops_balance_for_spot_collateral() {
+        let json = include_bytes!("../../testdata/ws_clearinghouse_state.json");
+        let HyperliquidSocketMessage::AccountState { balance, positions } = parse_websocket_data(json, PerpetualAccountMode::Unified).unwrap() else {
+            panic!("expected AccountState");
+        };
+
+        assert!(balance.is_none());
+        assert_eq!(positions.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_spot_state() {
+        let json = include_bytes!("../../testdata/ws_spot_state.json");
+        let HyperliquidSocketMessage::SpotState { balance } = parse_websocket_data(json, PerpetualAccountMode::Unified).unwrap() else {
+            panic!("expected SpotState");
+        };
+
+        assert_eq!(balance.available, 3.797316);
+        assert_eq!(balance.reserved, 4.331289 - 3.797316);
+        assert_eq!(balance.withdrawable, 3.797316);
+    }
+
+    #[test]
+    fn test_account_subscriptions() {
+        let address = "0x123".to_string();
+
+        assert_eq!(
+            account_subscriptions(address.clone(), PerpetualAccountMode::Standard),
+            vec![
+                HyperliquidSubscription::AccountState { address: address.clone() },
+                HyperliquidSubscription::OpenOrders { address: address.clone() },
+            ]
+        );
+        assert_eq!(
+            account_subscriptions(address.clone(), PerpetualAccountMode::Unified),
+            vec![
+                HyperliquidSubscription::AccountState { address: address.clone() },
+                HyperliquidSubscription::OpenOrders { address: address.clone() },
+                HyperliquidSubscription::SpotState { address },
+            ]
+        );
     }
 }

--- a/core/crates/gem_hypercore/src/testkit.rs
+++ b/core/crates/gem_hypercore/src/testkit.rs
@@ -5,9 +5,11 @@ pub use crate::models::position::{AssetPositions, MarginSummary};
 #[cfg(test)]
 use crate::rpc::client::HyperCoreClient;
 #[cfg(test)]
-use gem_client::testkit::MockClient;
+use gem_client::{ClientError, testkit::MockClient};
 #[cfg(test)]
 use primitives::InMemoryPreferences;
+#[cfg(test)]
+use serde_json::Value;
 #[cfg(test)]
 use std::sync::Arc;
 
@@ -93,8 +95,25 @@ impl AssetMetadata {
 #[cfg(test)]
 impl HyperCoreClient<MockClient> {
     pub fn mock() -> Self {
-        let preferences = Arc::new(InMemoryPreferences::new());
-        let secure_preferences = Arc::new(InMemoryPreferences::new());
-        Self::new_with_preferences(MockClient::new(), preferences, secure_preferences)
+        Self::mock_with_client(MockClient::new())
+    }
+
+    pub fn mock_with_responses_by_request_type(responses: Vec<(&'static str, Vec<u8>)>) -> Self {
+        let responses = Arc::new(responses);
+        Self::mock_with_client(MockClient::new().with_post(move |path, body| {
+            assert_eq!(path, "/info");
+
+            let request: Value = serde_json::from_slice(body).unwrap();
+            let request_type = request["type"].as_str().unwrap_or_default();
+            responses
+                .iter()
+                .find(|(expected_type, _)| *expected_type == request_type)
+                .map(|(_, response)| response.clone())
+                .ok_or_else(|| ClientError::Http { status: 404, body: body.to_vec() })
+        }))
+    }
+
+    fn mock_with_client(client: MockClient) -> Self {
+        Self::new_with_preferences(client, Arc::new(InMemoryPreferences::new()), Arc::new(InMemoryPreferences::new()))
     }
 }

--- a/core/crates/gem_hypercore/testdata/perpetual_balance_response_spot_clearinghouse_state.json
+++ b/core/crates/gem_hypercore/testdata/perpetual_balance_response_spot_clearinghouse_state.json
@@ -1,0 +1,17 @@
+{
+  "balances": [
+    {
+      "coin": "USDC",
+      "token": 0,
+      "total": "4.331289",
+      "hold": "4.331289",
+      "entryNtl": "0.0"
+    }
+  ],
+  "tokenToAvailableAfterMaintenance": [
+    [
+      0,
+      "3.797316"
+    ]
+  ]
+}

--- a/core/crates/gem_hypercore/testdata/perpetual_balance_response_user_abstraction_unified.json
+++ b/core/crates/gem_hypercore/testdata/perpetual_balance_response_user_abstraction_unified.json
@@ -1,0 +1,1 @@
+"unifiedAccount"

--- a/core/crates/gem_hypercore/testdata/ws_spot_state.json
+++ b/core/crates/gem_hypercore/testdata/ws_spot_state.json
@@ -1,0 +1,30 @@
+{
+  "channel": "spotState",
+  "data": {
+    "user": "0xece114137b2e9dbf29712bdc39639eb0b72b41b8",
+    "spotState": {
+      "balances": [
+        {
+          "coin": "USDC",
+          "token": 0,
+          "total": "4.331289",
+          "hold": "4.331289",
+          "entryNtl": "0.0"
+        },
+        {
+          "coin": "USDE",
+          "token": 235,
+          "total": "0.0",
+          "hold": "0.0",
+          "entryNtl": "0.0"
+        }
+      ],
+      "tokenToAvailableAfterMaintenance": [
+        [
+          0,
+          "3.797316"
+        ]
+      ]
+    }
+  }
+}

--- a/core/crates/primitives/src/lib.rs
+++ b/core/crates/primitives/src/lib.rs
@@ -275,8 +275,9 @@ pub use self::asset_address::AssetAddress;
 pub mod graphql;
 pub mod perpetual;
 pub use self::perpetual::{
-    AccountDataType, CancelOrderData, Perpetual, PerpetualBalance, PerpetualBasic, PerpetualConfirmData, PerpetualDirection, PerpetualMarketData, PerpetualModifyConfirmData,
-    PerpetualModifyPositionType, PerpetualPositionData, PerpetualPositionsSummary, PerpetualReduceData, PerpetualSearchData, PerpetualType, TPSLOrderData,
+    AccountDataType, CancelOrderData, Perpetual, PerpetualAccountMode, PerpetualBalance, PerpetualBasic, PerpetualConfirmData, PerpetualDirection, PerpetualMarketData,
+    PerpetualModifyConfirmData, PerpetualModifyPositionType, PerpetualPositionData, PerpetualPositionsSummary, PerpetualReduceData, PerpetualSearchData, PerpetualType,
+    TPSLOrderData,
 };
 pub mod search;
 pub use self::search::{AssetList, SearchResponse};

--- a/core/crates/primitives/src/perpetual.rs
+++ b/core/crates/primitives/src/perpetual.rs
@@ -99,6 +99,14 @@ pub struct PerpetualBalance {
     pub withdrawable: f64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[typeshare(swift = "Equatable, Sendable, Hashable")]
+#[serde(rename_all = "camelCase")]
+pub enum PerpetualAccountMode {
+    Standard,
+    Unified,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[typeshare(swift = "Equatable, Sendable, Hashable")]
 #[serde(rename_all = "camelCase")]

--- a/core/gemstone/src/gateway/mod.rs
+++ b/core/gemstone/src/gateway/mod.rs
@@ -170,10 +170,9 @@ impl GemGateway {
         self.with_provider(chain, |provider| async move { provider.get_positions(address).await }).await
     }
 
-    pub async fn get_perpetual_account_mode(&self, chain: Chain, address: String) -> GemPerpetualAccountMode {
+    pub async fn get_perpetual_account_mode(&self, chain: Chain, address: String) -> Result<GemPerpetualAccountMode, GatewayError> {
         self.with_provider(chain, |provider| async move { provider.get_perpetual_account_mode(address).await })
             .await
-            .unwrap_or(GemPerpetualAccountMode::Standard)
     }
 
     pub async fn get_perpetuals_data(&self, chain: Chain) -> Result<Vec<GemPerpetualData>, GatewayError> {

--- a/core/gemstone/src/gateway/mod.rs
+++ b/core/gemstone/src/gateway/mod.rs
@@ -170,6 +170,12 @@ impl GemGateway {
         self.with_provider(chain, |provider| async move { provider.get_positions(address).await }).await
     }
 
+    pub async fn get_perpetual_account_mode(&self, chain: Chain, address: String) -> GemPerpetualAccountMode {
+        self.with_provider(chain, |provider| async move { provider.get_perpetual_account_mode(address).await })
+            .await
+            .unwrap_or(GemPerpetualAccountMode::Standard)
+    }
+
     pub async fn get_perpetuals_data(&self, chain: Chain) -> Result<Vec<GemPerpetualData>, GatewayError> {
         self.with_provider(chain, |provider| async move { provider.get_perpetuals_data().await }).await
     }

--- a/core/gemstone/src/models/perpetual.rs
+++ b/core/gemstone/src/models/perpetual.rs
@@ -6,7 +6,7 @@ use gem_hypercore::models::websocket::{HyperliquidSocketMessage, PositionsDiff};
 use primitives::{
     Asset, AssetId, PerpetualDirection, PerpetualId, PerpetualMarginType, PerpetualMarketData, PerpetualOrderType, PerpetualPosition, PerpetualProvider, PerpetualTriggerOrder,
     chart::{ChartCandleStick, ChartCandleUpdate, ChartDateValue},
-    perpetual::{Perpetual, PerpetualBalance, PerpetualData, PerpetualMetadata, PerpetualPositionsSummary},
+    perpetual::{Perpetual, PerpetualAccountMode, PerpetualBalance, PerpetualData, PerpetualMetadata, PerpetualPositionsSummary},
 };
 
 pub type GemHyperliquidOpenOrder = OpenOrder;
@@ -15,6 +15,7 @@ pub type GemPerpetualMarginType = PerpetualMarginType;
 pub type GemPerpetualOrderType = PerpetualOrderType;
 pub type GemPerpetualPositionsSummary = PerpetualPositionsSummary;
 pub type GemPerpetualBalance = PerpetualBalance;
+pub type GemPerpetualAccountMode = PerpetualAccountMode;
 pub type GemPerpetualPosition = PerpetualPosition;
 pub type GemPerpetual = Perpetual;
 pub type GemPerpetualMetadata = PerpetualMetadata;
@@ -49,6 +50,12 @@ pub struct GemPerpetualTriggerOrder {
 pub struct GemPerpetualPositionsSummary {
     pub positions: Vec<PerpetualPosition>,
     pub balance: PerpetualBalance,
+}
+
+#[uniffi::remote(Enum)]
+pub enum GemPerpetualAccountMode {
+    Standard,
+    Unified,
 }
 
 #[uniffi::remote(Record)]
@@ -163,6 +170,7 @@ pub enum GemSubscriptionMethod {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Enum)]
 pub enum GemPerpetualSubscription {
     AccountState { address: String },
+    SpotState { address: String },
     OpenOrders { address: String },
     Candle { symbol: String, interval: String },
     MarketData { symbol: String },
@@ -173,11 +181,27 @@ pub type GemHyperliquidSocketMessage = HyperliquidSocketMessage;
 
 #[uniffi::remote(Enum)]
 pub enum GemHyperliquidSocketMessage {
-    AccountState { balance: PerpetualBalance, positions: Vec<PerpetualPosition> },
-    OpenOrders { orders: Vec<GemHyperliquidOpenOrder> },
-    Candle { candle: ChartCandleUpdate },
-    MarketData { market: GemPerpetualMarketData },
-    MarketPrices { prices: HashMap<String, f64> },
-    SubscriptionResponse { subscription_type: String },
+    AccountState {
+        balance: Option<PerpetualBalance>,
+        positions: Vec<PerpetualPosition>,
+    },
+    SpotState {
+        balance: PerpetualBalance,
+    },
+    OpenOrders {
+        orders: Vec<GemHyperliquidOpenOrder>,
+    },
+    Candle {
+        candle: ChartCandleUpdate,
+    },
+    MarketData {
+        market: GemPerpetualMarketData,
+    },
+    MarketPrices {
+        prices: HashMap<String, f64>,
+    },
+    SubscriptionResponse {
+        subscription_type: String,
+    },
     Unknown,
 }

--- a/core/gemstone/src/perpetual.rs
+++ b/core/gemstone/src/perpetual.rs
@@ -1,9 +1,9 @@
 use gem_hypercore::{
     models::websocket::{HyperliquidMethod, HyperliquidRequest, HyperliquidSubscription},
     perpetual_formatter::PerpetualFormatter,
-    provider::websocket_mapper::{diff_clearinghouse_positions, diff_open_orders_positions, parse_websocket_data},
+    provider::websocket_mapper::{account_subscriptions, diff_clearinghouse_positions, diff_open_orders_positions, parse_websocket_data},
 };
-use primitives::{AutocloseValidation, AutocloseValidator as Validator, PerpetualDirection, PerpetualPosition, PerpetualProvider, TpslType};
+use primitives::{AutocloseValidation, AutocloseValidator as Validator, PerpetualAccountMode, PerpetualDirection, PerpetualPosition, PerpetualProvider, TpslType};
 
 use crate::models::perpetual::{GemHyperliquidOpenOrder, GemHyperliquidSocketMessage, GemPerpetualSubscription, GemPositionsDiff, GemSubscriptionMethod};
 
@@ -54,8 +54,12 @@ impl Hyperliquid {
         Self {}
     }
 
-    pub fn parse_websocket_data(&self, data: Vec<u8>) -> Result<GemHyperliquidSocketMessage, crate::GemstoneError> {
-        Ok(parse_websocket_data(&data)?)
+    pub fn account_subscriptions(&self, address: String, mode: PerpetualAccountMode) -> Vec<GemPerpetualSubscription> {
+        account_subscriptions(address, mode).into_iter().map(GemPerpetualSubscription::from).collect()
+    }
+
+    pub fn parse_websocket_data(&self, data: Vec<u8>, mode: PerpetualAccountMode) -> Result<GemHyperliquidSocketMessage, crate::GemstoneError> {
+        Ok(parse_websocket_data(&data, mode)?)
     }
 
     pub fn websocket_request(&self, method: GemSubscriptionMethod, subscription: GemPerpetualSubscription) -> Result<String, crate::GemstoneError> {
@@ -116,10 +120,24 @@ impl GemSubscriptionMethod {
     }
 }
 
+impl From<HyperliquidSubscription> for GemPerpetualSubscription {
+    fn from(value: HyperliquidSubscription) -> Self {
+        match value {
+            HyperliquidSubscription::AccountState { address } => Self::AccountState { address },
+            HyperliquidSubscription::SpotState { address } => Self::SpotState { address },
+            HyperliquidSubscription::OpenOrders { address } => Self::OpenOrders { address },
+            HyperliquidSubscription::Candle { symbol, interval } => Self::Candle { symbol, interval },
+            HyperliquidSubscription::MarketData { symbol } => Self::MarketData { symbol },
+            HyperliquidSubscription::MarketPrices => Self::MarketPrices,
+        }
+    }
+}
+
 impl GemPerpetualSubscription {
     fn map(self) -> HyperliquidSubscription {
         match self {
             Self::AccountState { address } => HyperliquidSubscription::AccountState { address },
+            Self::SpotState { address } => HyperliquidSubscription::SpotState { address },
             Self::OpenOrders { address } => HyperliquidSubscription::OpenOrders { address },
             Self::Candle { symbol, interval } => HyperliquidSubscription::Candle { symbol, interval },
             Self::MarketData { symbol } => HyperliquidSubscription::MarketData { symbol },
@@ -135,13 +153,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_websocket_request_maps_generic_subscription() {
-        let request = Hyperliquid::new()
-            .websocket_request(GemSubscriptionMethod::Subscribe, GemPerpetualSubscription::AccountState { address: "0x123".to_string() })
-            .unwrap();
+    fn test_account_subscriptions() {
+        let hyperliquid = Hyperliquid::new();
 
         assert_eq!(
-            serde_json::from_str::<serde_json::Value>(&request).unwrap(),
+            hyperliquid.account_subscriptions("0x123".to_string(), PerpetualAccountMode::Standard),
+            vec![
+                GemPerpetualSubscription::AccountState { address: "0x123".to_string() },
+                GemPerpetualSubscription::OpenOrders { address: "0x123".to_string() },
+            ]
+        );
+        assert_eq!(
+            hyperliquid.account_subscriptions("0x123".to_string(), PerpetualAccountMode::Unified),
+            vec![
+                GemPerpetualSubscription::AccountState { address: "0x123".to_string() },
+                GemPerpetualSubscription::OpenOrders { address: "0x123".to_string() },
+                GemPerpetualSubscription::SpotState { address: "0x123".to_string() },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_websocket_request_maps_generic_subscription() {
+        let request = HyperliquidRequest {
+            method: GemSubscriptionMethod::Subscribe.map(),
+            subscription: GemPerpetualSubscription::AccountState { address: "0x123".to_string() }.map(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
             json!({
                 "method": "subscribe",
                 "subscription": {

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -69,7 +69,14 @@ public final class WalletSceneViewModel: Sendable, AssetBalanceActions {
             wallet: wallet,
         )
 
-        fiatValuesQuery = ObservableQuery(AssetFiatValuesRequest(walletId: wallet.id, type: .wallet), initialValue: [])
+        fiatValuesQuery = ObservableQuery(
+            AssetFiatValuesRequest(
+                walletId: wallet.id,
+                type: .wallet,
+                perpetualAccountMode: WalletPreferences(walletId: wallet.id).perpetualAccountMode,
+            ),
+            initialValue: [],
+        )
         assetsQuery = ObservableQuery(AssetsRequest(walletId: wallet.id, filters: [.enabledBalance]), initialValue: [])
         bannersQuery = ObservableQuery(BannersRequest(walletId: wallet.id, assetId: .none, chain: .none, events: [.accountBlockedMultiSignature, .onboarding]), initialValue: [])
         self.isPresentingSelectedAssetInput = isPresentingSelectedAssetInput

--- a/ios/Packages/Blockchain/Sources/Gateway/GatewayService.swift
+++ b/ios/Packages/Blockchain/Sources/Gateway/GatewayService.swift
@@ -170,8 +170,8 @@ public extension GatewayService {
         try await gateway.getPositions(chain: chain.rawValue, address: address).map()
     }
 
-    func getPerpetualAccountMode(chain: Primitives.Chain, address: String) async -> PerpetualAccountMode {
-        await gateway.getPerpetualAccountMode(chain: chain.rawValue, address: address).map()
+    func getPerpetualAccountMode(chain: Primitives.Chain, address: String) async throws -> PerpetualAccountMode {
+        try await gateway.getPerpetualAccountMode(chain: chain.rawValue, address: address).map()
     }
 
     func getPerpetualsData(chain: Primitives.Chain) async throws -> [PerpetualData] {

--- a/ios/Packages/Blockchain/Sources/Gateway/GatewayService.swift
+++ b/ios/Packages/Blockchain/Sources/Gateway/GatewayService.swift
@@ -170,6 +170,10 @@ public extension GatewayService {
         try await gateway.getPositions(chain: chain.rawValue, address: address).map()
     }
 
+    func getPerpetualAccountMode(chain: Primitives.Chain, address: String) async -> PerpetualAccountMode {
+        await gateway.getPerpetualAccountMode(chain: chain.rawValue, address: address).map()
+    }
+
     func getPerpetualsData(chain: Primitives.Chain) async throws -> [PerpetualData] {
         try await gateway.getPerpetualsData(chain: chain.rawValue).map {
             try $0.map()

--- a/ios/Packages/FeatureServices/PerpetualService/HyperliquidObserverService.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/HyperliquidObserverService.swift
@@ -76,46 +76,49 @@ public actor HyperliquidObserverService: PerpetualObservable {
 
         await disconnect()
         currentWallet = wallet
+        let mode = await accountMode(for: wallet)
         await update(for: wallet)
 
         guard observeTask == nil else { return }
 
         observeTask = Task { [weak self] in
             guard let self else { return }
-            await observeConnection()
+            await observeConnection(mode: mode)
         }
     }
 
-    private func observeConnection() async {
+    private func observeConnection(mode: PerpetualAccountMode) async {
         for await event in await webSocket.connect() {
             guard !Task.isCancelled else { break }
 
             switch event {
             case .connected:
-                await handleConnected()
+                await handleConnected(mode: mode)
             case let .message(data):
-                await handleMessage(data)
+                await handleMessage(data, mode: mode)
             case .disconnected:
                 break
             }
         }
     }
 
-    private func handleConnected() async {
+    private func handleConnected(mode: PerpetualAccountMode) async {
         guard let address = currentWallet?.hyperliquidAccount?.address else { return }
         do {
-            let subscriptions = Array(Set(defaultSubscriptions(for: address) + Array(activeSubscriptions)))
+            let subscriptions = (hyperliquid.accountSubscriptions(address: address, mode: mode.map()) + activeSubscriptions.asArray()).distinct()
             try await subscribe(subscriptions)
         } catch {
             debugLog("HyperliquidObserver: subscribe failed: \(error)")
         }
     }
 
-    private func handleMessage(_ data: Data) async {
+    private func handleMessage(_ data: Data, mode: PerpetualAccountMode) async {
         do {
-            switch try hyperliquid.parseWebsocketData(data: data) {
+            switch try hyperliquid.parseWebsocketData(data: data, mode: mode.map()) {
             case let .accountState(balance, newPositions):
                 try handleAccountState(balance: balance, newPositions: newPositions)
+            case let .spotState(balance):
+                try handleBalance(balance)
             case let .openOrders(orders):
                 try handleOpenOrders(orders: orders)
             case let .candle(candle):
@@ -134,8 +137,13 @@ public actor HyperliquidObserverService: PerpetualObservable {
         }
     }
 
+    private func accountMode(for wallet: Wallet) async -> PerpetualAccountMode {
+        guard let address = wallet.hyperliquidAccount?.address else { return .standard }
+        return await perpetualService.accountMode(address: address)
+    }
+
     private func handleAccountState(
-        balance: GemPerpetualBalance,
+        balance: GemPerpetualBalance?,
         newPositions: [GemPerpetualPosition],
     ) throws {
         guard let walletId = currentWallet?.id else { return }
@@ -145,15 +153,19 @@ public actor HyperliquidObserverService: PerpetualObservable {
             existingPositions: perpetualService.getHypercorePositions(walletId: walletId),
         )
 
-        try perpetualService.updateBalance(
-            walletId: walletId,
-            balance: balance,
-        )
         try perpetualService.diffPositions(
             deleteIds: diff.deletePositionIds,
             positions: diff.positions,
             walletId: walletId,
         )
+        if let balance {
+            try handleBalance(balance)
+        }
+    }
+
+    private func handleBalance(_ balance: GemPerpetualBalance) throws {
+        guard let walletId = currentWallet?.id else { return }
+        try perpetualService.updateBalance(walletId: walletId, balance: balance)
     }
 
     private func handleOpenOrders(orders: [GemHyperliquidOpenOrder]) throws {
@@ -172,10 +184,6 @@ public actor HyperliquidObserverService: PerpetualObservable {
 
     private func handleCandle(candle: GemChartCandleUpdate) async throws {
         await chartService.yield(candle.map())
-    }
-
-    private func defaultSubscriptions(for address: String) -> [GemPerpetualSubscription] {
-        [.accountState(address: address), .openOrders(address: address)]
     }
 
     private func subscribe(_ subscriptions: [GemPerpetualSubscription]) async throws {

--- a/ios/Packages/FeatureServices/PerpetualService/HyperliquidObserverService.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/HyperliquidObserverService.swift
@@ -139,7 +139,7 @@ public actor HyperliquidObserverService: PerpetualObservable {
 
     private func accountMode(for wallet: Wallet) async -> PerpetualAccountMode {
         guard let address = wallet.hyperliquidAccount?.address else { return .standard }
-        return await perpetualService.accountMode(address: address)
+        return await perpetualService.accountMode(walletId: wallet.id, address: address)
     }
 
     private func handleAccountState(

--- a/ios/Packages/FeatureServices/PerpetualService/PerpetualProvider.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/PerpetualProvider.swift
@@ -7,7 +7,7 @@ import Primitives
 public protocol PerpetualProvidable: Sendable {
     func provider() -> Primitives.PerpetualProvider
     func getPositions(address: String) async throws -> PerpetualPositionsSummary
-    func getAccountMode(address: String) async -> PerpetualAccountMode
+    func getAccountMode(address: String) async throws -> PerpetualAccountMode
     func getPerpetualsData() async throws -> [PerpetualData]
     func getCandlesticks(symbol: String, period: ChartPeriod) async throws -> [ChartCandleStick]
     func getPortfolio(address: String) async throws -> PerpetualPortfolio
@@ -33,8 +33,8 @@ struct GatewayPerpetualProvider: PerpetualProvidable {
         try await gateway.getPositions(chain: chain, address: address)
     }
 
-    func getAccountMode(address: String) async -> PerpetualAccountMode {
-        await gateway.getPerpetualAccountMode(chain: chain, address: address)
+    func getAccountMode(address: String) async throws -> PerpetualAccountMode {
+        try await gateway.getPerpetualAccountMode(chain: chain, address: address)
     }
 
     func getPerpetualsData() async throws -> [PerpetualData] {

--- a/ios/Packages/FeatureServices/PerpetualService/PerpetualProvider.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/PerpetualProvider.swift
@@ -7,6 +7,7 @@ import Primitives
 public protocol PerpetualProvidable: Sendable {
     func provider() -> Primitives.PerpetualProvider
     func getPositions(address: String) async throws -> PerpetualPositionsSummary
+    func getAccountMode(address: String) async -> PerpetualAccountMode
     func getPerpetualsData() async throws -> [PerpetualData]
     func getCandlesticks(symbol: String, period: ChartPeriod) async throws -> [ChartCandleStick]
     func getPortfolio(address: String) async throws -> PerpetualPortfolio
@@ -30,6 +31,10 @@ struct GatewayPerpetualProvider: PerpetualProvidable {
 
     func getPositions(address: String) async throws -> PerpetualPositionsSummary {
         try await gateway.getPositions(chain: chain, address: address)
+    }
+
+    func getAccountMode(address: String) async -> PerpetualAccountMode {
+        await gateway.getPerpetualAccountMode(chain: chain, address: address)
     }
 
     func getPerpetualsData() async throws -> [PerpetualData] {

--- a/ios/Packages/FeatureServices/PerpetualService/PerpetualService.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/PerpetualService.swift
@@ -140,9 +140,15 @@ public struct PerpetualService: PerpetualServiceable {
 
 extension PerpetualService: HyperliquidPerpetualServiceable {
     public func accountMode(walletId: WalletId, address: String) async -> PerpetualAccountMode {
-        let mode = await provider.getAccountMode(address: address)
-        WalletPreferences(walletId: walletId).perpetualAccountMode = mode
-        return mode
+        let walletPreferences = WalletPreferences(walletId: walletId)
+        do {
+            let mode = try await provider.getAccountMode(address: address)
+            walletPreferences.perpetualAccountMode = mode
+            return mode
+        } catch {
+            debugLog("PerpetualService: account mode failed: \(error)")
+            return walletPreferences.perpetualAccountMode
+        }
     }
 
     public func getHypercorePositions(walletId: WalletId) throws -> [GemPerpetualPosition] {

--- a/ios/Packages/FeatureServices/PerpetualService/PerpetualService.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/PerpetualService.swift
@@ -139,8 +139,10 @@ public struct PerpetualService: PerpetualServiceable {
 // MARK: - HyperliquidPerpetualServiceable
 
 extension PerpetualService: HyperliquidPerpetualServiceable {
-    public func accountMode(address: String) async -> PerpetualAccountMode {
-        await provider.getAccountMode(address: address)
+    public func accountMode(walletId: WalletId, address: String) async -> PerpetualAccountMode {
+        let mode = await provider.getAccountMode(address: address)
+        WalletPreferences(walletId: walletId).perpetualAccountMode = mode
+        return mode
     }
 
     public func getHypercorePositions(walletId: WalletId) throws -> [GemPerpetualPosition] {

--- a/ios/Packages/FeatureServices/PerpetualService/PerpetualService.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/PerpetualService.swift
@@ -139,6 +139,10 @@ public struct PerpetualService: PerpetualServiceable {
 // MARK: - HyperliquidPerpetualServiceable
 
 extension PerpetualService: HyperliquidPerpetualServiceable {
+    public func accountMode(address: String) async -> PerpetualAccountMode {
+        await provider.getAccountMode(address: address)
+    }
+
     public func getHypercorePositions(walletId: WalletId) throws -> [GemPerpetualPosition] {
         try store.getPositions(walletId: walletId, provider: .hypercore).map { $0.map() }
     }

--- a/ios/Packages/FeatureServices/PerpetualService/Protocols/HyperliquidPerpetualServiceable.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/Protocols/HyperliquidPerpetualServiceable.swift
@@ -6,7 +6,7 @@ import struct Gemstone.GemPerpetualPosition
 import Primitives
 
 public protocol HyperliquidPerpetualServiceable: PerpetualServiceable {
-    func accountMode(address: String) async -> PerpetualAccountMode
+    func accountMode(walletId: WalletId, address: String) async -> PerpetualAccountMode
     func getHypercorePositions(walletId: WalletId) throws -> [GemPerpetualPosition]
     func updateBalance(walletId: WalletId, balance: GemPerpetualBalance) throws
     func diffPositions(deleteIds: [String], positions: [GemPerpetualPosition], walletId: WalletId) throws

--- a/ios/Packages/FeatureServices/PerpetualService/Protocols/HyperliquidPerpetualServiceable.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/Protocols/HyperliquidPerpetualServiceable.swift
@@ -6,6 +6,7 @@ import struct Gemstone.GemPerpetualPosition
 import Primitives
 
 public protocol HyperliquidPerpetualServiceable: PerpetualServiceable {
+    func accountMode(address: String) async -> PerpetualAccountMode
     func getHypercorePositions(walletId: WalletId) throws -> [GemPerpetualPosition]
     func updateBalance(walletId: WalletId, balance: GemPerpetualBalance) throws
     func diffPositions(deleteIds: [String], positions: [GemPerpetualPosition], walletId: WalletId) throws

--- a/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualService+TestKit.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualService+TestKit.swift
@@ -41,7 +41,7 @@ public struct PerpetualProviderMock: PerpetualProvidable {
         )
     }
 
-    public func getAccountMode(address _: String) async -> PerpetualAccountMode {
+    public func getAccountMode(address _: String) async throws -> PerpetualAccountMode {
         .standard
     }
 

--- a/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualService+TestKit.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualService+TestKit.swift
@@ -41,6 +41,10 @@ public struct PerpetualProviderMock: PerpetualProvidable {
         )
     }
 
+    public func getAccountMode(address _: String) async -> PerpetualAccountMode {
+        .standard
+    }
+
     public func getPerpetualsData() async throws -> [PerpetualData] {
         []
     }

--- a/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualServiceMock.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualServiceMock.swift
@@ -27,7 +27,7 @@ public struct PerpetualServiceMock: PerpetualServiceable {
 // MARK: - HyperliquidPerpetualServiceable
 
 extension PerpetualServiceMock: HyperliquidPerpetualServiceable {
-    public func accountMode(address _: String) async -> PerpetualAccountMode {
+    public func accountMode(walletId _: WalletId, address _: String) async -> PerpetualAccountMode {
         .standard
     }
 

--- a/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualServiceMock.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualServiceMock.swift
@@ -27,6 +27,10 @@ public struct PerpetualServiceMock: PerpetualServiceable {
 // MARK: - HyperliquidPerpetualServiceable
 
 extension PerpetualServiceMock: HyperliquidPerpetualServiceable {
+    public func accountMode(address _: String) async -> PerpetualAccountMode {
+        .standard
+    }
+
     public func getHypercorePositions(walletId _: WalletId) throws -> [GemPerpetualPosition] {
         []
     }

--- a/ios/Packages/GemstonePrimitives/Sources/Extensions/GemPerpetualAccountMode+GemstonePrimitives.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/Extensions/GemPerpetualAccountMode+GemstonePrimitives.swift
@@ -1,0 +1,23 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Gemstone
+import Primitives
+
+public extension GemPerpetualAccountMode {
+    func map() -> PerpetualAccountMode {
+        switch self {
+        case .standard: .standard
+        case .unified: .unified
+        }
+    }
+}
+
+public extension PerpetualAccountMode {
+    func map() -> GemPerpetualAccountMode {
+        switch self {
+        case .standard: .standard
+        case .unified: .unified
+        }
+    }
+}

--- a/ios/Packages/Preferences/Sources/WalletPreferences.swift
+++ b/ios/Packages/Preferences/Sources/WalletPreferences.swift
@@ -13,6 +13,7 @@ public final class WalletPreferences: @unchecked Sendable {
         static let completeInitialLoadTransactions = "complete_initial_load_transactions"
         static let completeInitialLoadNFTs = "complete_initial_load_nfts"
         static let completeInitialWalletConfiguration = "complete_initial_wallet_configuration"
+        static let perpetualAccountMode = "perpetual_account_mode"
     }
 
     private let defaults: UserDefaults
@@ -21,6 +22,11 @@ public final class WalletPreferences: @unchecked Sendable {
     public init(walletId: WalletId) {
         suiteName = Self.suiteName(walletId: walletId.id)
         defaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    public var perpetualAccountMode: PerpetualAccountMode {
+        set { defaults.setValue(newValue.rawValue, forKey: Keys.perpetualAccountMode) }
+        get { defaults.string(forKey: Keys.perpetualAccountMode).flatMap(PerpetualAccountMode.init(rawValue:)) ?? .standard }
     }
 
     public var completeInitialLoadAssets: Bool {

--- a/ios/Packages/Primitives/Sources/Generated/Perpetual.swift
+++ b/ios/Packages/Primitives/Sources/Generated/Perpetual.swift
@@ -292,6 +292,11 @@ public enum AccountDataType: String, Codable, Equatable, Hashable, Sendable {
 	case activate
 }
 
+public enum PerpetualAccountMode: String, Codable, Equatable, Hashable, Sendable {
+	case standard
+	case unified
+}
+
 public enum PerpetualType: Codable, Equatable, Hashable, Sendable {
 	case open(PerpetualConfirmData)
 	case close(PerpetualConfirmData)

--- a/ios/Packages/Store/Sources/Requests/AssetFiatValuesRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/AssetFiatValuesRequest.swift
@@ -6,10 +6,12 @@ import Primitives
 public struct AssetFiatValuesRequest: DatabaseQueryable, Equatable {
     public var walletId: WalletId
     public var type: TotalValueType
+    public var perpetualAccountMode: PerpetualAccountMode
 
-    public init(walletId: WalletId, type: TotalValueType) {
+    public init(walletId: WalletId, type: TotalValueType, perpetualAccountMode: PerpetualAccountMode = .standard) {
         self.walletId = walletId
         self.type = type
+        self.perpetualAccountMode = perpetualAccountMode
     }
 
     public func fetch(_ db: Database) throws -> [AssetFiatValue] {
@@ -20,7 +22,10 @@ public struct AssetFiatValuesRequest: DatabaseQueryable, Equatable {
             let assets = try assetRecords(db).compactMap {
                 AssetFiatValue(record: $0, amount: $0.balance.totalAmount)
             }
-            return try assets + [perpetualFiatValue(db)]
+            switch perpetualAccountMode {
+            case .unified: return assets
+            case .standard: return try assets + [perpetualFiatValue(db)]
+            }
         case .earn:
             return try assetRecords(db).compactMap {
                 AssetFiatValue(record: $0, amount: $0.balance.stakedAmount + $0.balance.earnAmount)


### PR DESCRIPTION
Perpetual balance jumped between the real value and zero for wallets with unified account mode enabled. Their trading money lives in the spot balance, while the app read it from the perpetual account, which is empty for such wallets.

Now the balance for those wallets comes from the spot state and the available amount is the one Hyperliquid itself reports. The same money is no longer counted twice in the wallet total, and sending no longer offers the part that backs an open position. Wallets in the standard mode keep working as before.

Closes #675