### PR TITLE
Move stream event persistence into owning repositories

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
@@ -75,7 +75,7 @@ class AssetsRepository @Inject constructor(
     private val streamSubscriptionService: StreamSubscriptionService,
     private val availabilityService: AssetsAvailabilityService,
     private val currencyRatesService: CurrencyRatesService,
-    private val updateBalances: UpdateBalances = UpdateBalances(balancesDao, balancesService),
+    private val updateBalances: UpdateBalances,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
 ) {
 

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/UpdateBalances.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/UpdateBalances.kt
@@ -1,21 +1,38 @@
 package com.gemwallet.android.data.repositories.assets
 
 import com.gemwallet.android.blockchain.services.BalancesService
+import com.gemwallet.android.data.service.store.database.AssetsDao
 import com.gemwallet.android.data.service.store.database.BalancesDao
 import com.gemwallet.android.data.service.store.database.entities.DbBalance
+import com.gemwallet.android.data.service.store.database.entities.toAssetInfoModel
 import com.gemwallet.android.data.service.store.database.entities.toDTO
+import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.model.AssetBalance
 import com.wallet.core.primitives.Account
 import com.wallet.core.primitives.Asset
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
 
 class UpdateBalances(
     private val balancesDao: BalancesDao,
     private val balancesService: BalancesService,
+    private val assetsDao: AssetsDao,
 ) {
+
+    suspend fun updateBalances(walletId: String, assetIds: List<String>) {
+        assetsDao.getAssetsInfo(walletId, assetIds)
+            .toAssetInfoModel()
+            .firstOrNull()
+            ?.groupBy { it.asset.chain }
+            ?.mapKeys { it.value.firstOrNull()?.owner }
+            ?.forEach { (account, assetInfos) ->
+                val owner: Account = account ?: return@forEach
+                updateBalances(walletId, owner, assetInfos.map { it.asset })
+            }
+    }
 
     suspend fun updateBalances(
         walletId: String,

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
@@ -15,10 +15,13 @@ import com.gemwallet.android.data.repositories.assets.AssetsAvailabilityService
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.assets.CurrencyRatesService
 import com.gemwallet.android.data.repositories.assets.UpdateBalances
+import com.gemwallet.android.data.repositories.notifications.InAppNotificationsRepository
+import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
+import com.gemwallet.android.data.repositories.prices.PricesRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.stream.ExponentialReconnection
 import com.gemwallet.android.data.repositories.stream.StreamEventHandler
-import com.gemwallet.android.data.repositories.support.SupportTypingState
+import com.gemwallet.android.data.repositories.support.SupportChatRepository
 import com.gemwallet.android.data.repositories.stream.StreamObserverService
 import com.gemwallet.android.data.repositories.stream.StreamSubscriptionService
 import com.gemwallet.android.data.repositories.stream.WebSocketConnection
@@ -26,10 +29,7 @@ import com.gemwallet.android.data.repositories.stream.WebSocketRequest
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.data.service.store.database.AssetsDao
 import com.gemwallet.android.data.service.store.database.BalancesDao
-import com.gemwallet.android.data.service.store.database.InAppNotificationsDao
-import com.gemwallet.android.data.service.store.database.PriceAlertsDao
 import com.gemwallet.android.data.service.store.database.PricesDao
-import com.gemwallet.android.data.service.store.database.SupportMessagesDao
 import com.gemwallet.android.data.services.gemapi.http.DeviceRequestSigner
 import com.gemwallet.android.data.services.gemapi.http.GemDeviceRequestSigner
 import dagger.Module
@@ -55,6 +55,7 @@ object AssetsModule {
         streamSubscriptionService: StreamSubscriptionService,
         availabilityService: AssetsAvailabilityService,
         currencyRatesService: CurrencyRatesService,
+        updateBalances: UpdateBalances,
     ): AssetsRepository = AssetsRepository(
         assetsDao = assetsDao,
         balancesDao = balancesDao,
@@ -65,6 +66,7 @@ object AssetsModule {
         streamSubscriptionService = streamSubscriptionService,
         availabilityService = availabilityService,
         currencyRatesService = currencyRatesService,
+        updateBalances = updateBalances,
     )
 
     @Provides
@@ -80,49 +82,45 @@ object AssetsModule {
     fun provideUpdateBalances(
         balancesDao: BalancesDao,
         balancesService: BalancesService,
+        assetsDao: AssetsDao,
     ): UpdateBalances = UpdateBalances(
         balancesDao = balancesDao,
         balancesService = balancesService,
+        assetsDao = assetsDao,
     )
 
     @Provides
     @Singleton
     fun provideStreamEventHandler(
-        pricesDao: PricesDao,
-        sessionRepository: SessionRepository,
+        pricesRepository: PricesRepository,
         syncTransactions: dagger.Lazy<SyncTransactions>,
         syncNfts: SyncNfts,
         updatePriceAlerts: UpdatePriceAlerts,
         syncFiatTransactions: dagger.Lazy<SyncFiatTransactions>,
         walletsRepository: WalletsRepository,
-        assetsDao: AssetsDao,
         updateBalances: UpdateBalances,
-        inAppNotificationsDao: InAppNotificationsDao,
-        supportMessagesDao: SupportMessagesDao,
-        supportTypingState: SupportTypingState,
+        inAppNotificationsRepository: InAppNotificationsRepository,
+        supportChatRepository: SupportChatRepository,
     ): StreamEventHandler = StreamEventHandler(
-        pricesDao = pricesDao,
-        sessionRepository = sessionRepository,
+        pricesRepository = pricesRepository,
         syncTransactions = syncTransactions,
         syncNfts = syncNfts,
         updatePriceAlerts = updatePriceAlerts,
         syncFiatTransactions = syncFiatTransactions,
         walletsRepository = walletsRepository,
-        assetsDao = assetsDao,
         updateBalances = updateBalances,
-        inAppNotificationsDao = inAppNotificationsDao,
-        supportMessagesDao = supportMessagesDao,
-        supportTypingState = supportTypingState,
+        inAppNotificationsRepository = inAppNotificationsRepository,
+        supportChatRepository = supportChatRepository,
     )
 
     @Provides
     @Singleton
     fun provideStreamSubscriptionService(
         assetsDao: AssetsDao,
-        priceAlertsDao: PriceAlertsDao,
+        priceAlertRepository: PriceAlertRepository,
     ): StreamSubscriptionService = StreamSubscriptionService(
         assetsDao = assetsDao,
-        priceAlertsDao = priceAlertsDao,
+        priceAlertRepository = priceAlertRepository,
     )
 
     @Provides
@@ -137,9 +135,7 @@ object AssetsModule {
     @Singleton
     fun provideStreamObserverService(
         sessionRepository: SessionRepository,
-        userConfig: com.gemwallet.android.data.repositories.config.UserConfig,
         syncAssets: SyncAssets,
-        syncPerpetuals: com.gemwallet.android.application.perpetual.coordinators.SyncPerpetuals,
         deviceRequestSigner: DeviceRequestSigner,
         streamSubscriptionService: StreamSubscriptionService,
         eventHandler: StreamEventHandler,
@@ -147,9 +143,7 @@ object AssetsModule {
         okHttpClient: OkHttpClient,
     ): StreamObserverService = StreamObserverService(
         sessionRepository = sessionRepository,
-        userConfig = userConfig,
         syncAssets = syncAssets,
-        syncPerpetuals = syncPerpetuals,
         subscriptionService = streamSubscriptionService,
         eventHandler = eventHandler,
         connection = WebSocketConnection(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/PerpetualModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/PerpetualModule.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.data.repositories.di
 
 import com.gemwallet.android.application.perpetual.coordinators.PerpetualObserver
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetualPositions
+import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetuals
 import com.gemwallet.android.cases.nodes.GetNodeUrlCase
 import com.gemwallet.android.data.repositories.perpetual.HyperliquidEventHandler
 import com.gemwallet.android.data.repositories.perpetual.HyperliquidObserverService
@@ -74,6 +75,7 @@ object PerpetualModule {
     @Singleton
     fun provideHyperliquidObserverService(
         observePerpetualWallet: ObservePerpetualWallet,
+        syncPerpetuals: SyncPerpetuals,
         syncPerpetualPositions: SyncPerpetualPositions,
         eventHandler: HyperliquidEventHandler,
         subscriptionService: HyperliquidSubscriptionService,
@@ -81,6 +83,7 @@ object PerpetualModule {
         okHttpClient: OkHttpClient,
     ): HyperliquidObserverService = HyperliquidObserverService(
         observePerpetualWallet = observePerpetualWallet,
+        syncPerpetuals = syncPerpetuals,
         syncPerpetualPositions = syncPerpetualPositions,
         eventHandler = eventHandler,
         subscriptionService = subscriptionService,

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/notifications/InAppNotificationsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/notifications/InAppNotificationsRepository.kt
@@ -28,6 +28,10 @@ class InAppNotificationsRepository(
         preferences.notificationsTimestamp = newTimestamp
     }
 
+    suspend fun addNotification(notification: InAppNotification) {
+        notificationsDao.put(listOf(notification.toRecord()))
+    }
+
     suspend fun markNotificationsRead() {
         gemDeviceApiClient.markNotificationsRead()
     }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverService.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.data.repositories.perpetual
 import android.util.Log
 import com.gemwallet.android.application.perpetual.coordinators.PerpetualObserver
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetualPositions
+import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetuals
 import com.gemwallet.android.data.repositories.stream.WebSocketConnectable
 import com.gemwallet.android.data.repositories.stream.WebSocketEvent
 import com.gemwallet.android.ext.hyperliquidAccount
@@ -22,6 +23,7 @@ import uniffi.gemstone.GemPerpetualSubscription
 
 class HyperliquidObserverService(
     private val observePerpetualWallet: ObservePerpetualWallet,
+    private val syncPerpetuals: SyncPerpetuals,
     private val syncPerpetualPositions: SyncPerpetualPositions,
     private val eventHandler: HyperliquidEventHandler,
     private val subscriptionService: HyperliquidSubscriptionService,
@@ -43,6 +45,14 @@ class HyperliquidObserverService(
                     val address = wallet?.hyperliquidAccount?.address ?: return@collectLatest
                     runCatching { syncPerpetualPositions.syncPerpetualPositions() }
                     observeConnection(wallet.id, address)
+                }
+        }
+        scope.launch {
+            observePerpetualWallet()
+                .distinctUntilChangedBy { it?.id?.id }
+                .collectLatest { wallet ->
+                    if (wallet == null) return@collectLatest
+                    runCatching { syncPerpetuals.syncPerpetuals() }
                 }
         }
     }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/pricealerts/PriceAlertRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/pricealerts/PriceAlertRepository.kt
@@ -16,6 +16,8 @@ interface PriceAlertRepository {
 
     fun getPriceAlerts(assetId: AssetId? = null): Flow<List<PriceAlertInfo>>
 
+    fun getPriceAlertAssetIds(): Flow<List<AssetId>>
+
     fun getAssetPriceAlert(assetId: AssetId): Flow<PriceAlertInfo?>
 
     suspend fun addPriceAlert(priceAlert: PriceAlert)

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/pricealerts/PriceAlertRepositoryImpl.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/pricealerts/PriceAlertRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.gemwallet.android.data.service.store.database.entities.DbPriceAlert
 import com.gemwallet.android.data.service.store.database.entities.toDTO
 import com.gemwallet.android.data.service.store.database.entities.toRecord
 import com.gemwallet.android.ext.id
+import com.gemwallet.android.ext.toAssetId
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.model.PriceAlertInfo
 import com.wallet.core.primitives.AssetId
@@ -51,6 +52,10 @@ class PriceAlertRepositoryImpl(
     override fun getPriceAlerts(assetId: AssetId?): Flow<List<PriceAlertInfo>> {
         return (assetId?.let { priceAlertsDao.getAlerts(it.toIdentifier()) } ?: priceAlertsDao.getAlerts())
             .map { it.toDTO() }
+    }
+
+    override fun getPriceAlertAssetIds(): Flow<List<AssetId>> {
+        return priceAlertsDao.getAlerts().map { alerts -> alerts.mapNotNull { it.assetId.toAssetId() } }
     }
 
     override fun getAssetPriceAlert(assetId: AssetId): Flow<PriceAlertInfo?> {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/prices/PricesRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/prices/PricesRepository.kt
@@ -1,0 +1,33 @@
+package com.gemwallet.android.data.repositories.prices
+
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.data.service.store.database.PricesDao
+import com.gemwallet.android.data.service.store.database.entities.toDTO
+import com.gemwallet.android.data.service.store.database.entities.toRecord
+import com.wallet.core.primitives.Currency
+import com.wallet.core.primitives.FiatRate
+import com.wallet.core.primitives.WebSocketPricePayload
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PricesRepository @Inject constructor(
+    private val pricesDao: PricesDao,
+    private val sessionRepository: SessionRepository,
+) {
+
+    suspend fun updatePrices(payload: WebSocketPricePayload) {
+        val currency = sessionRepository.getCurrentCurrency()
+        updateRates(payload.rates, currency)
+        val rate = pricesDao.getRates(currency).firstOrNull()?.toDTO() ?: return
+        pricesDao.insert(payload.prices.toRecord(rate))
+    }
+
+    private suspend fun updateRates(newRates: List<FiatRate>, currency: Currency) {
+        pricesDao.setRates(newRates.toRecord())
+        newRates.firstOrNull { it.symbol == currency.string }?.let { rate ->
+            pricesDao.updateValues(currency.string, rate.rate)
+        }
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamEventHandler.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamEventHandler.kt
@@ -6,22 +6,11 @@ import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAle
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
 import com.gemwallet.android.cases.nft.SyncNfts
 import com.gemwallet.android.data.repositories.assets.UpdateBalances
-import com.gemwallet.android.data.repositories.session.SessionRepository
-import com.gemwallet.android.data.repositories.support.SupportTypingState
+import com.gemwallet.android.data.repositories.notifications.InAppNotificationsRepository
+import com.gemwallet.android.data.repositories.prices.PricesRepository
+import com.gemwallet.android.data.repositories.support.SupportChatRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
-import com.gemwallet.android.data.service.store.database.AssetsDao
-import com.gemwallet.android.data.service.store.database.InAppNotificationsDao
-import com.gemwallet.android.data.service.store.database.PricesDao
-import com.gemwallet.android.data.service.store.database.SupportMessagesDao
-import com.gemwallet.android.data.service.store.database.entities.toAssetInfoModel
-import com.gemwallet.android.data.service.store.database.entities.toDTO
-import com.gemwallet.android.data.service.store.database.entities.toRecord
-import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.ext.toIdentifier
-import com.wallet.core.primitives.Account
-import com.wallet.core.primitives.AssetPrice
-import com.wallet.core.primitives.Currency
-import com.wallet.core.primitives.FiatRate
 import com.wallet.core.primitives.StreamBalanceUpdate
 import com.wallet.core.primitives.StreamEvent
 import com.wallet.core.primitives.StreamNotificationUpdate
@@ -33,18 +22,15 @@ import com.wallet.core.primitives.WebSocketPricePayload
 import kotlinx.coroutines.flow.firstOrNull
 
 class StreamEventHandler(
-    private val pricesDao: PricesDao,
-    private val sessionRepository: SessionRepository,
+    private val pricesRepository: PricesRepository,
     private val syncTransactions: dagger.Lazy<SyncTransactions>,
     private val syncNfts: SyncNfts,
     private val updatePriceAlerts: UpdatePriceAlerts,
     private val syncFiatTransactions: dagger.Lazy<SyncFiatTransactions>,
     private val walletsRepository: WalletsRepository,
-    private val assetsDao: AssetsDao,
     private val updateBalances: UpdateBalances,
-    private val inAppNotificationsDao: InAppNotificationsDao,
-    private val supportMessagesDao: SupportMessagesDao,
-    private val supportTypingState: SupportTypingState,
+    private val inAppNotificationsRepository: InAppNotificationsRepository,
+    private val supportChatRepository: SupportChatRepository,
 ) {
 
     suspend fun handle(event: StreamEvent) {
@@ -70,39 +56,17 @@ class StreamEventHandler(
     }
 
     private suspend fun handlePrices(payload: WebSocketPricePayload) {
-        val currency = sessionRepository.getCurrentCurrency()
-        updateRates(payload.rates, currency)
-        val rate = pricesDao.getRates(currency).firstOrNull()?.toDTO() ?: return
-        pricesDao.insert(payload.prices.toRecord(rate))
-    }
-
-    private suspend fun updateRates(newRates: List<FiatRate>, currency: Currency) {
-        pricesDao.setRates(newRates.toRecord())
-        newRates.firstOrNull { it.symbol == currency.string }?.let { rate ->
-            pricesDao.updateValues(currency.string, rate.rate)
-        }
+        pricesRepository.updatePrices(payload)
     }
 
     private suspend fun handleBalances(update: StreamBalanceUpdate) {
-        updateBalances(update.walletId.id, update.assetIds.map { it.toIdentifier() })
+        updateBalances.updateBalances(update.walletId.id, update.assetIds.map { it.toIdentifier() })
     }
 
     private suspend fun handleTransactions(update: StreamTransactionsUpdate) {
         val wallet = walletsRepository.getWallet(update.walletId).firstOrNull() ?: return
         syncTransactions.get().syncTransactions(wallet)
-        updateBalances(update.walletId.id, update.assetIds.map { it.toIdentifier() })
-    }
-
-    private suspend fun updateBalances(walletId: String, assetIds: List<String>) {
-        assetsDao.getAssetsInfo(walletId, assetIds)
-            .toAssetInfoModel()
-            .firstOrNull()
-            ?.groupBy { it.asset.chain }
-            ?.mapKeys { it.value.firstOrNull()?.owner }
-            ?.forEach { (account, assetInfos) ->
-                val owner: Account = account ?: return@forEach
-                updateBalances.updateBalances(walletId, owner, assetInfos.map { it.asset })
-            }
+        updateBalances.updateBalances(update.walletId.id, update.assetIds.map { it.toIdentifier() })
     }
 
     private suspend fun handlePriceAlerts() {
@@ -118,19 +82,19 @@ class StreamEventHandler(
     }
 
     private suspend fun handleInAppNotification(update: StreamNotificationUpdate) {
-        inAppNotificationsDao.put(listOf(update.notification.toRecord()))
+        inAppNotificationsRepository.addNotification(update.notification)
     }
 
     private suspend fun handleSupport(event: SupportStreamEvent) {
         when (event) {
             is SupportStreamEvent.Message -> {
-                supportMessagesDao.addMessages(listOf(event.data.toRecord()))
+                supportChatRepository.addMessages(listOf(event.data))
                 when (event.data.sender) {
                     is SupportMessageSender.User -> { }
-                    is SupportMessageSender.Agent -> supportTypingState.clear()
+                    is SupportMessageSender.Agent -> supportChatRepository.clearTyping()
                 }
             }
-            is SupportStreamEvent.Typing -> supportTypingState.update(event.data)
+            is SupportStreamEvent.Typing -> supportChatRepository.updateTyping(event.data)
         }
     }
 

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamObserverService.kt
@@ -2,31 +2,20 @@ package com.gemwallet.android.data.repositories.stream
 
 import android.util.Log
 import com.gemwallet.android.application.assets.coordinators.SyncAssets
-import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetuals
 import com.gemwallet.android.cases.device.SyncDevice
-import com.gemwallet.android.data.repositories.config.UserConfig
 import com.gemwallet.android.data.repositories.session.SessionRepository
-import com.gemwallet.android.ext.hasPerpetualsSupport
-import com.gemwallet.android.model.Session
 import com.gemwallet.android.serializer.StreamEventSerializer
 import com.gemwallet.android.serializer.jsonEncoder
 import com.gemwallet.android.serializer.toJson
-import com.wallet.core.primitives.StreamMessage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import kotlinx.serialization.encodeToString
 
 class StreamObserverService(
     private val sessionRepository: SessionRepository,
-    private val userConfig: UserConfig,
     private val syncAssets: SyncAssets,
-    private val syncPerpetuals: SyncPerpetuals,
     private val subscriptionService: StreamSubscriptionService,
     private val eventHandler: StreamEventHandler,
     private val connection: WebSocketConnectable,
@@ -47,11 +36,6 @@ class StreamObserverService(
                 runCatching { syncAssets() }
             }
         }
-        scope.launchPerpetualSync(
-            session = sessionRepository.session(),
-            isPerpetualEnabled = userConfig.isPerpetualEnabled(),
-            syncPerpetuals = syncPerpetuals,
-        )
     }
 
     fun start() {
@@ -93,20 +77,4 @@ class StreamObserverService(
     companion object {
         private const val TAG = "StreamObserverService"
     }
-}
-
-internal fun CoroutineScope.launchPerpetualSync(
-    session: Flow<Session?>,
-    isPerpetualEnabled: Flow<Boolean>,
-    syncPerpetuals: SyncPerpetuals,
-): Job = launch {
-    combine(session, isPerpetualEnabled) { current, enabled ->
-        val wallet = current?.wallet
-        if (wallet != null && wallet.hasPerpetualsSupport && enabled) wallet.id.id else null
-    }
-        .distinctUntilChanged()
-        .collectLatest { walletId ->
-            if (walletId == null) return@collectLatest
-            runCatching { syncPerpetuals.syncPerpetuals() }
-        }
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamSubscriptionService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stream/StreamSubscriptionService.kt
@@ -2,8 +2,8 @@ package com.gemwallet.android.data.repositories.stream
 
 import android.util.Log
 import com.gemwallet.android.data.repositories.assets.visibleByDefault
+import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.data.service.store.database.AssetsDao
-import com.gemwallet.android.data.service.store.database.PriceAlertsDao
 import com.gemwallet.android.ext.toAssetId
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.StreamMessage
@@ -17,7 +17,7 @@ import kotlinx.coroutines.sync.withLock
 
 class StreamSubscriptionService(
     private val assetsDao: AssetsDao,
-    private val priceAlertsDao: PriceAlertsDao,
+    private val priceAlertRepository: PriceAlertRepository,
 ) {
     private val outgoing = Channel<StreamMessage>(Channel.UNLIMITED)
     val messages: ReceiveChannel<StreamMessage> = outgoing
@@ -56,8 +56,7 @@ class StreamSubscriptionService(
 
     private suspend fun observableAssets(walletId: String): List<AssetId> {
         val ids = assetsDao.getAssetsPriceUpdate(walletId).mapNotNull { it.toAssetId() }
-        val priceAlerts = priceAlertsDao.getAlerts().firstOrNull()
-            ?.mapNotNull { it.assetId.toAssetId() } ?: emptyList()
+        val priceAlerts = priceAlertRepository.getPriceAlertAssetIds().firstOrNull() ?: emptyList()
         return (ids + priceAlerts).takeIf { it.isNotEmpty() }
             ?: visibleByDefault
     }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/support/SupportChatRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/support/SupportChatRepository.kt
@@ -10,6 +10,7 @@ import com.wallet.core.primitives.SupportMessageImage
 import com.wallet.core.primitives.SupportMessageInput
 import com.wallet.core.primitives.SupportMessageSender
 import com.wallet.core.primitives.SupportMessageStatus
+import com.wallet.core.primitives.SupportTyping
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -26,6 +27,8 @@ class SupportChatRepository(
     val typing: StateFlow<SupportAgent?> = supportTypingState.agent
 
     fun clearTyping() = supportTypingState.clear()
+
+    fun updateTyping(typing: SupportTyping) = supportTypingState.update(typing)
 
     fun getMessages(): Flow<List<SupportMessage>> =
         supportMessagesDao.getMessages().map { records -> records.map { it.toModel() } }

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/UpdateBalancesTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/UpdateBalancesTest.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.data.repositories.assets
 
 import com.gemwallet.android.blockchain.services.BalancesService
+import com.gemwallet.android.data.service.store.database.AssetsDao
 import com.gemwallet.android.data.service.store.database.BalancesDao
 import com.gemwallet.android.data.service.store.database.entities.DbBalance
 import com.gemwallet.android.ext.asset
@@ -29,10 +30,12 @@ class UpdateBalancesTest {
 
     private val balancesDao = mockk<BalancesDao>(relaxed = true)
     private val balancesService = mockk<BalancesService>(relaxed = true)
+    private val assetsDao = mockk<AssetsDao>(relaxed = true)
 
     private val subject = UpdateBalances(
         balancesDao = balancesDao,
         balancesService = balancesService,
+        assetsDao = assetsDao,
     )
 
     @After

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverServiceTest.kt
@@ -43,6 +43,7 @@ class HyperliquidObserverServiceTest {
         every { observePerpetualWallet() } returns flowOf(wallet)
         val observer = HyperliquidObserverService(
             observePerpetualWallet = observePerpetualWallet,
+            syncPerpetuals = mockk(relaxed = true),
             syncPerpetualPositions = mockk(relaxed = true),
             eventHandler = eventHandler,
             subscriptionService = HyperliquidSubscriptionService { _, _ -> SUBSCRIBE_REQUEST },

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/stream/StreamEventHandlerTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/stream/StreamEventHandlerTest.kt
@@ -5,14 +5,10 @@ import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAle
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
 import com.gemwallet.android.cases.nft.SyncNfts
 import com.gemwallet.android.data.repositories.assets.UpdateBalances
-import com.gemwallet.android.data.repositories.session.SessionRepository
-import com.gemwallet.android.data.repositories.support.SupportTypingState
+import com.gemwallet.android.data.repositories.notifications.InAppNotificationsRepository
+import com.gemwallet.android.data.repositories.prices.PricesRepository
+import com.gemwallet.android.data.repositories.support.SupportChatRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
-import com.gemwallet.android.data.service.store.database.AssetsDao
-import com.gemwallet.android.data.service.store.database.InAppNotificationsDao
-import com.gemwallet.android.data.service.store.database.PricesDao
-import com.gemwallet.android.data.service.store.database.SupportMessagesDao
-import com.gemwallet.android.data.service.store.database.entities.toRecord
 import com.gemwallet.android.ext.toIdentifier
 import com.gemwallet.android.testkit.mockAssetId
 import com.gemwallet.android.testkit.mockTransactionId
@@ -30,39 +26,32 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class StreamEventHandlerTest {
 
-    private val pricesDao = mockk<PricesDao>(relaxed = true)
-    private val sessionRepository = mockk<SessionRepository>(relaxed = true)
+    private val pricesRepository = mockk<PricesRepository>(relaxed = true)
     private val syncTransactions = mockk<dagger.Lazy<SyncTransactions>>()
     private val syncNfts = mockk<SyncNfts>(relaxed = true)
     private val updatePriceAlerts = mockk<UpdatePriceAlerts>(relaxed = true)
     private val syncFiatTransactions = mockk<dagger.Lazy<SyncFiatTransactions>>()
     private val walletsRepository = mockk<WalletsRepository>()
-    private val assetsDao = mockk<AssetsDao>(relaxed = true)
     private val updateBalances = mockk<UpdateBalances>(relaxed = true)
-    private val inAppNotificationsDao = mockk<InAppNotificationsDao>(relaxed = true)
-    private val supportMessagesDao = mockk<SupportMessagesDao>(relaxed = true)
-    private val supportTypingState = SupportTypingState()
+    private val inAppNotificationsRepository = mockk<InAppNotificationsRepository>(relaxed = true)
+    private val supportChatRepository = mockk<SupportChatRepository>(relaxed = true)
 
     private val handler = StreamEventHandler(
-        pricesDao = pricesDao,
-        sessionRepository = sessionRepository,
+        pricesRepository = pricesRepository,
         syncTransactions = syncTransactions,
         syncNfts = syncNfts,
         updatePriceAlerts = updatePriceAlerts,
         syncFiatTransactions = syncFiatTransactions,
         walletsRepository = walletsRepository,
-        assetsDao = assetsDao,
         updateBalances = updateBalances,
-        inAppNotificationsDao = inAppNotificationsDao,
-        supportMessagesDao = supportMessagesDao,
-        supportTypingState = supportTypingState,
+        inAppNotificationsRepository = inAppNotificationsRepository,
+        supportChatRepository = supportChatRepository,
     )
 
     private val walletId = mockWalletId("w1")
@@ -86,7 +75,7 @@ class StreamEventHandlerTest {
         )
 
         coVerify { sync.syncTransactions(wallet) }
-        verify { assetsDao.getAssetsInfo(walletId.id, listOf(assetId.toIdentifier())) }
+        coVerify { updateBalances.updateBalances(walletId.id, listOf(assetId.toIdentifier())) }
     }
 
     @Test
@@ -130,7 +119,7 @@ class StreamEventHandlerTest {
             )
         )
 
-        coVerify { inAppNotificationsDao.put(listOf(notification.toRecord())) }
+        coVerify { inAppNotificationsRepository.addNotification(notification) }
     }
 
     @Test

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/stream/StreamSubscriptionServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/stream/StreamSubscriptionServiceTest.kt
@@ -1,8 +1,8 @@
 package com.gemwallet.android.data.repositories.stream
 
 import com.gemwallet.android.data.repositories.assets.visibleByDefault
+import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
 import com.gemwallet.android.data.service.store.database.AssetsDao
-import com.gemwallet.android.data.service.store.database.PriceAlertsDao
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.StreamMessage
@@ -18,17 +18,17 @@ import org.junit.Test
 class StreamSubscriptionServiceTest {
 
     private val assetsDao = mockk<AssetsDao>()
-    private val priceAlertsDao = mockk<PriceAlertsDao>()
+    private val priceAlertRepository = mockk<PriceAlertRepository>()
 
     private fun service() = StreamSubscriptionService(
         assetsDao = assetsDao,
-        priceAlertsDao = priceAlertsDao,
+        priceAlertRepository = priceAlertRepository,
     )
 
     @Test
     fun `setupAssets enqueues subscribe message`() = runTest {
         coEvery { assetsDao.getAssetsPriceUpdate("wallet-1") } returns listOf("bitcoin")
-        every { priceAlertsDao.getAlerts() } returns flowOf(emptyList())
+        every { priceAlertRepository.getPriceAlertAssetIds() } returns flowOf(emptyList())
         val service = service()
 
         service.setupAssets(WalletId("wallet-1"))
@@ -40,7 +40,7 @@ class StreamSubscriptionServiceTest {
     @Test
     fun `setupAssets falls back to default assets`() = runTest {
         coEvery { assetsDao.getAssetsPriceUpdate("wallet-1") } returns emptyList()
-        every { priceAlertsDao.getAlerts() } returns flowOf(emptyList())
+        every { priceAlertRepository.getPriceAlertAssetIds() } returns flowOf(emptyList())
         val service = service()
 
         service.setupAssets(WalletId("wallet-1"))
@@ -52,7 +52,7 @@ class StreamSubscriptionServiceTest {
     @Test
     fun `messages sent before consumer attaches are buffered`() = runTest {
         coEvery { assetsDao.getAssetsPriceUpdate("wallet-1") } returns listOf("bitcoin")
-        every { priceAlertsDao.getAlerts() } returns flowOf(emptyList())
+        every { priceAlertRepository.getPriceAlertAssetIds() } returns flowOf(emptyList())
         val service = service()
 
         service.setupAssets(WalletId("wallet-1"))
@@ -66,7 +66,7 @@ class StreamSubscriptionServiceTest {
 
     @Test
     fun `addAssetIds skips already subscribed ids`() = runTest {
-        every { priceAlertsDao.getAlerts() } returns flowOf(emptyList())
+        every { priceAlertRepository.getPriceAlertAssetIds() } returns flowOf(emptyList())
         val service = service()
 
         val id = AssetId(Chain.Ethereum)


### PR DESCRIPTION
The websocket stream layer wrote directly into four Room tables that already had owners, so support messages, in-app notifications, prices and balances each had two writers. Every stream event now goes through the repository that owns its data, and perpetual sync moves from the stream service to the perpetual observer where the rest of the perpetual lifecycle lives.

Behaviour is unchanged: the same calls happen in the same order, with the same error handling.