### PR TITLE
Own price writes in a single repository

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PerpetualModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PerpetualModule.kt
@@ -29,8 +29,8 @@ import com.gemwallet.android.data.coordinators.perpetuals.SyncPerpetualsImpl
 import com.gemwallet.android.data.coordinators.perpetuals.TogglePerpetualPinImpl
 import com.gemwallet.android.data.repositories.config.UserConfig
 import com.gemwallet.android.data.repositories.perpetual.PerpetualRepository
+import com.gemwallet.android.data.repositories.prices.PricesRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
-import com.gemwallet.android.data.service.store.database.PricesDao
 import com.wallet.core.primitives.Chain
 import dagger.Module
 import dagger.Provides
@@ -46,14 +46,12 @@ object PerpetualModule {
     fun provideSyncPerpetuals(
         perpetualService: PerpetualService,
         perpetualRepository: PerpetualRepository,
-        pricesDao: PricesDao,
-        sessionRepository: SessionRepository,
+        pricesRepository: PricesRepository,
     ): SyncPerpetuals {
         return SyncPerpetualsImpl(
             perpetualService = perpetualService,
             perpetualRepository = perpetualRepository,
-            pricesDao = pricesDao,
-            sessionRepository = sessionRepository,
+            pricesRepository = pricesRepository,
             chains = listOf(Chain.HyperCore)
         )
     }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/SyncPerpetualsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/SyncPerpetualsImpl.kt
@@ -3,21 +3,23 @@ package com.gemwallet.android.data.coordinators.perpetuals
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetuals
 import com.gemwallet.android.blockchain.services.PerpetualService
 import com.gemwallet.android.data.repositories.perpetual.PerpetualRepository
-import com.gemwallet.android.data.repositories.session.SessionRepository
-import com.gemwallet.android.data.service.store.database.PricesDao
-import com.gemwallet.android.data.service.store.database.entities.toDTO
-import com.gemwallet.android.data.service.store.database.entities.toRecord
+import com.gemwallet.android.data.repositories.prices.PricesRepository
 import com.gemwallet.android.ext.HypercoreUSDC
 import com.wallet.core.primitives.AssetPrice
 import com.wallet.core.primitives.Chain
-import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
+
+private val hypercoreUsdcPrice = AssetPrice(
+    assetId = HypercoreUSDC.id,
+    price = 1.0,
+    priceChangePercentage24h = 0.0,
+    updatedAt = 0L,
+)
 
 class SyncPerpetualsImpl @Inject constructor(
     private val perpetualService: PerpetualService,
     private val perpetualRepository: PerpetualRepository,
-    private val pricesDao: PricesDao,
-    private val sessionRepository: SessionRepository,
+    private val pricesRepository: PricesRepository,
     private val chains: List<Chain>,
 ) : SyncPerpetuals {
 
@@ -26,18 +28,6 @@ class SyncPerpetualsImpl @Inject constructor(
             val data = runCatching { perpetualService.getPerpetualsData(chain = chain) }.getOrNull() ?: return@forEach
             perpetualRepository.putPerpetuals(data)
         }
-        setupPrices()
-    }
-
-    private suspend fun setupPrices() {
-        val currency = sessionRepository.getCurrentCurrency()
-        val rate = pricesDao.getRates(currency).firstOrNull()?.toDTO() ?: return
-        val usdcPrice = AssetPrice(
-            assetId = HypercoreUSDC.id,
-            price = 1.0,
-            priceChangePercentage24h = 0.0,
-            updatedAt = 0L,
-        )
-        pricesDao.insert(usdcPrice.toRecord(rate))
+        pricesRepository.updatePrice(hypercoreUsdcPrice)
     }
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepository.kt
@@ -3,21 +3,19 @@ package com.gemwallet.android.data.repositories.assets
 import android.util.Log
 import com.gemwallet.android.blockchain.services.BalancesService
 import com.gemwallet.android.cases.tokens.SearchTokensCase
+import com.gemwallet.android.data.repositories.prices.PricesRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.stream.StreamSubscriptionService
 import com.gemwallet.android.data.service.store.database.AssetsDao
 import com.gemwallet.android.data.service.store.database.BalancesDao
-import com.gemwallet.android.data.service.store.database.PricesDao
 import com.gemwallet.android.data.service.store.database.entities.DbAsset
 import com.gemwallet.android.data.service.store.database.entities.DbAssetBasicUpdate
 import com.gemwallet.android.data.service.store.database.entities.DbBalance
-import com.gemwallet.android.data.service.store.database.entities.DbPrice
 import com.gemwallet.android.data.service.store.database.entities.toAssetInfoModel
 import com.gemwallet.android.data.service.store.database.entities.toAssetLinkRecord
 import com.gemwallet.android.data.service.store.database.entities.toAssetLinksModel
 import com.gemwallet.android.data.service.store.database.entities.toMarketRecord
 import com.gemwallet.android.data.service.store.database.entities.toDTO
-import com.gemwallet.android.data.service.store.database.entities.toPriceRecord
 import com.gemwallet.android.data.service.store.database.entities.toRecord
 import com.gemwallet.android.data.service.store.database.entities.toUpdateRecord
 import com.gemwallet.android.domains.asset.chain
@@ -68,7 +66,7 @@ private const val TAG = "AssetsRepository"
 class AssetsRepository @Inject constructor(
     private val assetsDao: AssetsDao,
     private val balancesDao: BalancesDao,
-    private val pricesDao: PricesDao,
+    private val pricesRepository: PricesRepository,
     private val sessionRepository: SessionRepository,
     private val balancesService: BalancesService,
     private val searchTokensCase: SearchTokensCase,
@@ -82,7 +80,7 @@ class AssetsRepository @Inject constructor(
     init {
         scope.launch(Dispatchers.IO) {
             sessionRepository.session().collectLatest {
-                currencyRatesService.changeCurrency(it?.currency ?: return@collectLatest)
+                pricesRepository.convertPricesToCurrency(it?.currency ?: return@collectLatest)
             }
         }
         scope.launch(Dispatchers.IO) {
@@ -98,7 +96,6 @@ class AssetsRepository @Inject constructor(
 
     suspend fun saveAssetMetadata(assetFull: AssetFull) = withContext(Dispatchers.IO) {
         val assetId = assetFull.asset.id
-        val assetIdIdentifier = assetId.toIdentifier()
         val currency = sessionRepository.getCurrentCurrency()
         val rate = currencyRatesService.getCurrencyRate(currency).firstOrNull() ?: when (currency) {
             Currency.USD -> FiatRate(Currency.USD.string, 1.0)
@@ -110,11 +107,7 @@ class AssetsRepository @Inject constructor(
         val linkRecords = assetFull.links.toAssetLinkRecord(assetId)
         val marketRecord = rate?.let { assetFull.toMarketRecord(it.rate) }
         assetsDao.upsertAssetMetadata(record, linkRecords, marketRecord)
-        rate?.let {
-            pricesDao.insert(
-                assetFull.toPriceRecord(it) ?: DbPrice(assetId = assetIdIdentifier, currency = currency.string)
-            )
-        }
+        rate?.let { pricesRepository.updatePrice(assetFull, it, currency) }
     }
 
     suspend fun updateAssetMarket(assetId: AssetId, market: AssetMarket, currency: Currency) = withContext(Dispatchers.IO) {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/CurrencyRatesService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/assets/CurrencyRatesService.kt
@@ -5,7 +5,6 @@ import com.gemwallet.android.data.service.store.database.entities.toDTO
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.FiatRate
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -14,13 +13,6 @@ import javax.inject.Singleton
 class CurrencyRatesService @Inject constructor(
     private val pricesDao: PricesDao,
 ) {
-
-    suspend fun changeCurrency(currency: Currency) {
-        val rate = pricesDao.getRates(currency).map { it?.toDTO() }.firstOrNull() ?: return
-        pricesDao.getAll().firstOrNull()?.map {
-            it.copy(value = (it.usdValue ?: 0.0) * rate.rate, currency = currency.string)
-        }?.let { pricesDao.insert(it) }
-    }
 
     fun getCurrencyRate(currency: Currency): Flow<FiatRate?> {
         return pricesDao.getRates(currency).map { it?.toDTO() }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/AssetsModule.kt
@@ -29,7 +29,6 @@ import com.gemwallet.android.data.repositories.stream.WebSocketRequest
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.data.service.store.database.AssetsDao
 import com.gemwallet.android.data.service.store.database.BalancesDao
-import com.gemwallet.android.data.service.store.database.PricesDao
 import com.gemwallet.android.data.services.gemapi.http.DeviceRequestSigner
 import com.gemwallet.android.data.services.gemapi.http.GemDeviceRequestSigner
 import dagger.Module
@@ -48,7 +47,7 @@ object AssetsModule {
     fun provideAssetsRepository(
         assetsDao: AssetsDao,
         balancesDao: BalancesDao,
-        pricesDao: PricesDao,
+        pricesRepository: PricesRepository,
         sessionRepository: SessionRepository,
         balancesService: BalancesService,
         searchTokensCase: SearchTokensCase,
@@ -59,7 +58,7 @@ object AssetsModule {
     ): AssetsRepository = AssetsRepository(
         assetsDao = assetsDao,
         balancesDao = balancesDao,
-        pricesDao = pricesDao,
+        pricesRepository = pricesRepository,
         sessionRepository = sessionRepository,
         balancesService = balancesService,
         searchTokensCase = searchTokensCase,

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/TokensModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/TokensModule.kt
@@ -7,6 +7,7 @@ import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.cases.tokens.SyncAssetPrices
 import com.gemwallet.android.cases.tokens.WalletSearchScopeCase
 import com.gemwallet.android.data.repositories.perpetual.PerpetualRepository
+import com.gemwallet.android.data.repositories.prices.PricesRepository
 import com.gemwallet.android.data.repositories.tokens.TokensRepository
 import com.gemwallet.android.data.repositories.tokens.WalletSearch
 import com.gemwallet.android.data.repositories.tokens.WalletSearchTokens
@@ -29,12 +30,14 @@ object TokensModule {
     fun provideTokensRepository(
         assetsDao: AssetsDao,
         pricesDao: PricesDao,
+        pricesRepository: PricesRepository,
         searchDao: SearchDao,
         gateway: GemGateway,
         searchAssets: SearchAssets,
     ): TokensRepository = TokensRepository(
         assetsDao = assetsDao,
         pricesDao = pricesDao,
+        pricesRepository = pricesRepository,
         searchDao = searchDao,
         searchAssets = searchAssets,
         tokenService = TokenService(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/prices/PricesRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/prices/PricesRepository.kt
@@ -2,8 +2,14 @@ package com.gemwallet.android.data.repositories.prices
 
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.service.store.database.PricesDao
+import com.gemwallet.android.data.service.store.database.entities.DbPrice
 import com.gemwallet.android.data.service.store.database.entities.toDTO
+import com.gemwallet.android.data.service.store.database.entities.toPriceRecord
 import com.gemwallet.android.data.service.store.database.entities.toRecord
+import com.gemwallet.android.ext.toIdentifier
+import com.wallet.core.primitives.AssetBasic
+import com.wallet.core.primitives.AssetFull
+import com.wallet.core.primitives.AssetPrice
 import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.FiatRate
 import com.wallet.core.primitives.WebSocketPricePayload
@@ -20,8 +26,40 @@ class PricesRepository @Inject constructor(
     suspend fun updatePrices(payload: WebSocketPricePayload) {
         val currency = sessionRepository.getCurrentCurrency()
         updateRates(payload.rates, currency)
-        val rate = pricesDao.getRates(currency).firstOrNull()?.toDTO() ?: return
+        val rate = currentRate(currency) ?: return
         pricesDao.insert(payload.prices.toRecord(rate))
+    }
+
+    suspend fun updatePrice(price: AssetPrice) {
+        val currency = sessionRepository.getCurrentCurrency()
+        val rate = currentRate(currency) ?: return
+        pricesDao.insert(price.toRecord(rate))
+    }
+
+    suspend fun updatePrices(assets: List<AssetBasic>, currency: Currency) {
+        val rate = currentRate(currency) ?: return
+        val prices = assets.toPriceRecord(rate)
+        if (prices.isNotEmpty()) {
+            pricesDao.insert(prices)
+        }
+    }
+
+    suspend fun updatePrice(assetFull: AssetFull, rate: FiatRate, currency: Currency) {
+        pricesDao.insert(
+            assetFull.toPriceRecord(rate)
+                ?: DbPrice(assetId = assetFull.asset.id.toIdentifier(), currency = currency.string)
+        )
+    }
+
+    suspend fun convertPricesToCurrency(currency: Currency) {
+        val rate = currentRate(currency) ?: return
+        pricesDao.getAll().firstOrNull()?.map {
+            it.copy(value = (it.usdValue ?: 0.0) * rate.rate, currency = currency.string)
+        }?.let { pricesDao.insert(it) }
+    }
+
+    private suspend fun currentRate(currency: Currency): FiatRate? {
+        return pricesDao.getRates(currency).firstOrNull()?.toDTO()
     }
 
     private suspend fun updateRates(newRates: List<FiatRate>, currency: Currency) {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/tokens/TokensRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/tokens/TokensRepository.kt
@@ -4,12 +4,11 @@ import com.gemwallet.android.application.assets.coordinators.SearchAssets
 import com.gemwallet.android.blockchain.services.TokenService
 import com.gemwallet.android.cases.tokens.SearchTokensCase
 import com.gemwallet.android.cases.tokens.SyncAssetPrices
+import com.gemwallet.android.data.repositories.prices.PricesRepository
 import com.gemwallet.android.data.service.store.database.AssetsDao
 import com.gemwallet.android.data.service.store.database.PricesDao
 import com.gemwallet.android.data.service.store.database.SearchDao
-import com.gemwallet.android.data.service.store.database.entities.toDTO
 import com.gemwallet.android.data.service.store.database.entities.toRecord
-import com.gemwallet.android.data.service.store.database.entities.toPriceRecord
 import com.gemwallet.android.data.service.store.database.entities.toSearchRecord
 import com.gemwallet.android.data.service.store.database.entities.toUpdateRecord
 import com.gemwallet.android.domains.asset.defaultBasic
@@ -22,12 +21,12 @@ import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.Currency
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
 
 class TokensRepository (
     private val assetsDao: AssetsDao,
     private val pricesDao: PricesDao,
+    private val pricesRepository: PricesRepository,
     private val searchDao: SearchDao,
     private val searchAssets: SearchAssets,
     private val tokenService: TokenService,
@@ -96,12 +95,7 @@ class TokensRepository (
             assetsDao.updateBasicAssets(assets.map { it.toUpdateRecord() })
         }
         runCatching {
-            val rate = pricesDao.getRates(currency).firstOrNull() ?: return@runCatching
-            val prices = assets.toPriceRecord(rate.toDTO())
-
-            if (prices.isNotEmpty()) {
-                pricesDao.insert(prices)
-            }
+            pricesRepository.updatePrices(assets, currency)
         }
     }
 }

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/assets/AssetsRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.gemwallet.android.data.repositories.assets
 
 import com.gemwallet.android.blockchain.services.BalancesService
+import com.gemwallet.android.data.repositories.prices.PricesRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.stream.StreamSubscriptionService
 import com.gemwallet.android.cases.tokens.SearchTokensCase
@@ -80,7 +81,7 @@ class AssetsRepositoryTest {
     private fun createSubject() = AssetsRepository(
         assetsDao = assetsDao,
         balancesDao = balancesDao,
-        pricesDao = pricesDao,
+        pricesRepository = PricesRepository(pricesDao, sessionRepository),
         sessionRepository = sessionRepository,
         balancesService = balancesService,
         searchTokensCase = searchTokensCase,

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/prices/PricesRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/prices/PricesRepositoryTest.kt
@@ -1,0 +1,64 @@
+package com.gemwallet.android.data.repositories.prices
+
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.data.service.store.database.PricesDao
+import com.gemwallet.android.data.service.store.database.entities.DbFiatRate
+import com.gemwallet.android.data.service.store.database.entities.DbPrice
+import com.gemwallet.android.testkit.mockAssetBasic
+import com.gemwallet.android.testkit.mockAssetFull
+import com.gemwallet.android.testkit.mockAssetSolana
+import com.gemwallet.android.testkit.mockPrice
+import com.wallet.core.primitives.Currency
+import com.wallet.core.primitives.FiatRate
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PricesRepositoryTest {
+
+    private val pricesDao = mockk<PricesDao>(relaxed = true)
+    private val sessionRepository = mockk<SessionRepository>(relaxed = true)
+
+    private val subject = PricesRepository(
+        pricesDao = pricesDao,
+        sessionRepository = sessionRepository,
+    )
+
+    @Test
+    fun updatePrice_assetWithoutPrice_storesZeroedRow() = runTest {
+        val assetFull = mockAssetFull(asset = mockAssetSolana(), price = null)
+        val stored = slot<DbPrice>()
+
+        subject.updatePrice(assetFull, FiatRate(Currency.EUR.string, 0.5), Currency.EUR)
+
+        coVerify(exactly = 1) { pricesDao.insert(capture(stored)) }
+        assertEquals("solana", stored.captured.assetId)
+        assertEquals("EUR", stored.captured.currency)
+        assertEquals(0.0, stored.captured.value ?: -1.0, 0.0)
+        assertEquals(0.0, stored.captured.usdValue ?: -1.0, 0.0)
+    }
+
+    @Test
+    fun updatePrices_noAssetCarriesPrice_storesNothing() = runTest {
+        every { pricesDao.getRates(Currency.USD) } returns flowOf(DbFiatRate(Currency.USD, 1.0))
+
+        subject.updatePrices(listOf(mockAssetBasic(asset = mockAssetSolana())), Currency.USD)
+
+        coVerify(exactly = 0) { pricesDao.insert(any<List<DbPrice>>()) }
+    }
+
+    @Test
+    fun updatePrices_withoutStoredRate_storesNothing() = runTest {
+        val asset = mockAssetBasic(asset = mockAssetSolana()).copy(price = mockPrice(price = 100.0))
+        every { pricesDao.getRates(Currency.EUR) } returns flowOf(null)
+
+        subject.updatePrices(listOf(asset), Currency.EUR)
+
+        coVerify(exactly = 0) { pricesDao.insert(any<List<DbPrice>>()) }
+    }
+}

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/tokens/TokensRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/tokens/TokensRepositoryTest.kt
@@ -2,11 +2,11 @@ package com.gemwallet.android.data.repositories.tokens
 
 import com.gemwallet.android.application.assets.coordinators.SearchAssets
 import com.gemwallet.android.blockchain.services.TokenService
+import com.gemwallet.android.data.repositories.prices.PricesRepository
 import com.gemwallet.android.data.service.store.database.AssetsDao
 import com.gemwallet.android.data.service.store.database.PricesDao
 import com.gemwallet.android.data.service.store.database.SearchDao
 import com.gemwallet.android.data.service.store.database.entities.DbAssetBasicUpdate
-import com.gemwallet.android.data.service.store.database.entities.DbFiatRate
 import com.gemwallet.android.data.service.store.database.entities.DbSearch
 import com.gemwallet.android.data.service.store.database.entities.DbPrice
 import com.gemwallet.android.ext.toIdentifier
@@ -18,10 +18,8 @@ import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.Currency
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.slot
 import io.mockk.mockk
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -31,6 +29,7 @@ class TokensRepositoryTest {
 
     private val assetsDao = mockk<AssetsDao>(relaxed = true)
     private val pricesDao = mockk<PricesDao>(relaxed = true)
+    private val pricesRepository = mockk<PricesRepository>(relaxed = true)
     private val searchDao = mockk<SearchDao>(relaxed = true)
     private val searchAssets = mockk<SearchAssets>()
     private val tokenService = mockk<TokenService>(relaxed = true)
@@ -38,6 +37,7 @@ class TokensRepositoryTest {
     private val subject = TokensRepository(
         assetsDao = assetsDao,
         pricesDao = pricesDao,
+        pricesRepository = pricesRepository,
         searchDao = searchDao,
         searchAssets = searchAssets,
         tokenService = tokenService,
@@ -53,7 +53,6 @@ class TokensRepositoryTest {
                 tags = listOf(AssetTag.Trending),
             )
         } returns listOf(asset)
-        every { pricesDao.getRates(Currency.USD) } returns flowOf(DbFiatRate(Currency.USD, 1.0))
 
         val result = subject.search(
             query = "btc",
@@ -86,7 +85,6 @@ class TokensRepositoryTest {
                 tags = emptyList(),
             )
         } returns listOf(firstResult, secondResult)
-        every { pricesDao.getRates(Currency.USD) } returns flowOf(DbFiatRate(Currency.USD, 1.0))
 
         subject.search(
             query = "usdt arbitrum",
@@ -109,7 +107,6 @@ class TokensRepositoryTest {
         val assetBasic = mockAssetBasic(asset = asset, rank = 100)
         val updates = slot<List<DbAssetBasicUpdate>>()
         coEvery { searchAssets.getAssets(listOf(asset.id)) } returns listOf(assetBasic)
-        every { pricesDao.getRates(Currency.USD) } returns flowOf(DbFiatRate(Currency.USD, 1.0))
 
         val result = subject.search(
             assetIds = listOf(asset.id),
@@ -131,7 +128,6 @@ class TokensRepositoryTest {
             pricesDao.getByAssets(listOf(cached.id.toIdentifier(), missing.id.toIdentifier()))
         } returns listOf(DbPrice(assetId = cached.id.toIdentifier(), currency = Currency.USD.string))
         coEvery { searchAssets.getAssets(listOf(missing.id)) } returns listOf(missingBasic)
-        every { pricesDao.getRates(Currency.USD) } returns flowOf(DbFiatRate(Currency.USD, 1.0))
 
         subject(listOf(cached.id, missing.id), Currency.USD)
 


### PR DESCRIPTION
Writing a price meant reading the current fiat rate, converting, then inserting — and that sequence was copied into four different classes.

`PricesRepository` now owns every price write. The price stream, perpetuals sync, token search, and asset metadata all go through it. Recalculating prices after a currency change moved there too, so `CurrencyRatesService` is left with just the rate read.

No behaviour change. Follow-up to #841.