### PR TITLE
Keep local transaction data when syncing from backend

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.gemwallet.android.data.repositories.transactions
 
-import android.text.format.DateUtils
 import android.util.Log
 import com.gemwallet.android.application.transactions.coordinators.GetChangedTransactions
 import com.gemwallet.android.application.transactions.coordinators.GetPendingTransactionsCount
@@ -12,7 +11,6 @@ import com.gemwallet.android.cases.transactions.CreateTransaction
 import com.gemwallet.android.cases.transactions.SaveTransactions
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.service.store.database.TransactionsDao
-import com.gemwallet.android.data.service.store.database.entities.DbTransaction
 import com.gemwallet.android.data.service.store.database.entities.DbTransactionExtended
 import com.gemwallet.android.data.service.store.database.entities.DbTxSwapMetadata
 import com.gemwallet.android.data.service.store.database.entities.toDTO
@@ -50,7 +48,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import uniffi.gemstone.Config
 import uniffi.gemstone.transactionStateConfig
 import java.math.BigInteger
 import java.util.concurrent.ConcurrentHashMap
@@ -105,7 +102,7 @@ class TransactionsRepositoryImpl(
     override fun getChangedTransactions(): Flow<List<TransactionExtended>> = changedTransactions
 
     override suspend fun saveTransactions(walletId: WalletId, transactions: List<Transaction>) = withContext(Dispatchers.IO) {
-        transactionsDao.insert(transactions.toRecord(walletId))
+        transactionsDao.syncTransactions(transactions.toRecord(walletId))
         addSwapMetadata(transactions)
     }
 
@@ -219,13 +216,6 @@ class TransactionsRepositoryImpl(
                     )
                 }
 
-                val hasTimedOut = !currentTransaction.transaction.state.isCompleted() &&
-                    currentTransaction.transaction.createdAt < System.currentTimeMillis() - transactionTimeout(currentTransaction.transaction)
-                if (hasTimedOut) {
-                    currentTransaction = currentTransaction.copy(transaction = currentTransaction.transaction.copy(state = TransactionState.Failed))
-                    updateTransactions(listOf(currentTransaction))
-                    break
-                }
                 if (currentTransaction.transaction.state.isCompleted()) {
                     Log.d(
                         TAG,
@@ -242,20 +232,6 @@ class TransactionsRepositoryImpl(
         } finally {
             jobKeys.forEach { pollingTransactionJobs.remove(it) }
         }
-    }
-
-    private fun transactionTimeout(transaction: DbTransaction): Long {
-        val chain = transaction.assetId.chain
-        val sourceTimeout = Config().getChainConfig(chain.string).transactionTimeout.toLong()
-        if (transaction.state != TransactionState.InTransit) {
-            return sourceTimeout
-        }
-        val destinationChain = getTransactionSwapMetadata(transaction.type, transaction.metadata)?.toAsset?.chain ?: chain
-        if (destinationChain == chain) {
-            return sourceTimeout
-        }
-        val destinationTimeout = Config().getChainConfig(destinationChain.string).transactionTimeout.toLong()
-        return ((sourceTimeout + destinationTimeout) * 3).coerceAtLeast(DateUtils.DAY_IN_MILLIS)
     }
 
     private suspend fun checkTransaction(transaction: DbTransactionExtended): DbTransactionExtended? {
@@ -318,63 +294,21 @@ class TransactionsRepositoryImpl(
             return updatedTransaction
         }
 
-        val existingState = transactionsDao.getTransactionState(
-            updatedTransaction.transaction.id,
-            currentTransaction.transaction.walletId,
+        val walletId = currentTransaction.transaction.walletId
+        transactionsDao.deleteSwapMetadata(updatedTransaction.transaction.id.identifier)
+        transactionsDao.delete(updatedTransaction.transaction.id, walletId)
+        transactionsDao.updateSwapMetadataTransactionId(
+            oldTransactionId = currentTransaction.transaction.id.identifier,
+            newTransactionId = updatedTransaction.transaction.id.identifier,
         )
-        if (existingState == null) {
-            transactionsDao.updateSwapMetadataTransactionId(
-                oldTransactionId = currentTransaction.transaction.id.identifier,
-                newTransactionId = updatedTransaction.transaction.id.identifier,
-            )
-            transactionsDao.updateTransactionId(
-                oldId = currentTransaction.transaction.id,
-                newId = updatedTransaction.transaction.id,
-                walletId = currentTransaction.transaction.walletId,
-                hash = updatedTransaction.transaction.hash,
-            )
-            updateTransactions(listOf(updatedTransaction))
-            return updatedTransaction
-        }
-
-        transactionsDao.deleteSwapMetadata(currentTransaction.transaction.id.identifier)
-        transactionsDao.delete(
-            currentTransaction.transaction.id,
-            currentTransaction.transaction.walletId,
+        transactionsDao.updateTransactionId(
+            oldId = currentTransaction.transaction.id,
+            newId = updatedTransaction.transaction.id,
+            walletId = walletId,
+            hash = updatedTransaction.transaction.hash,
         )
-        val nextState = updateExistingTransaction(
-            placeholder = currentTransaction.transaction,
-            updatedTransaction = updatedTransaction.transaction,
-            existingState = existingState,
-        )
-        return updatedTransaction.copy(
-            transaction = updatedTransaction.transaction.copy(
-                state = nextState,
-            )
-        )
-    }
-
-    private fun updateExistingTransaction(
-        placeholder: DbTransaction,
-        updatedTransaction: DbTransaction,
-        existingState: TransactionState,
-    ): TransactionState {
-        val nextState = nextTransactionState(
-            oldState = existingState,
-            newState = updatedTransaction.state,
-        )
-        if (nextState != existingState) {
-            transactionsDao.updateState(updatedTransaction.id, updatedTransaction.walletId, nextState)
-        }
-        if (placeholder.fee != updatedTransaction.fee) {
-            transactionsDao.updateFee(updatedTransaction.id, updatedTransaction.walletId, updatedTransaction.fee)
-        }
-        val metadata = updatedTransaction.metadata
-        if (placeholder.metadata != metadata && metadata != null) {
-            transactionsDao.updateMetadata(updatedTransaction.id, updatedTransaction.walletId, metadata)
-            addSwapMetadata(listOf(updatedTransaction.toDTO()))
-        }
-        return nextState
+        updateTransactions(listOf(updatedTransaction))
+        return updatedTransaction
     }
 }
 

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -203,6 +204,8 @@ class TransactionsRepositoryImpl(
                 delay(pollingDelay.toLong())
                 pollingDelay = jobConfig.nextIntervalMs(pollingDelay)
 
+                currentTransaction = storedTransaction(currentTransaction) ?: break
+
                 checkTransaction(currentTransaction)?.let { updatedTransaction ->
                     if (updatedTransaction.transaction.id != currentTransaction.transaction.id) {
                         coroutineContext[Job]?.let { runningJob ->
@@ -233,6 +236,12 @@ class TransactionsRepositoryImpl(
             jobKeys.forEach { pollingTransactionJobs.remove(it) }
         }
     }
+
+    private suspend fun storedTransaction(transaction: DbTransactionExtended): DbTransactionExtended? =
+        transactionsDao.getExtendedTransaction(
+            transaction.transaction.walletId,
+            transaction.transaction.id,
+        ).first()
 
     private suspend fun checkTransaction(transaction: DbTransactionExtended): DbTransactionExtended? {
         val transactionRecord = transaction.transaction

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsDao.kt
@@ -5,6 +5,8 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.RawQuery
+import androidx.room.Transaction
+import androidx.room.Update
 import androidx.sqlite.db.SupportSQLiteQuery
 import com.gemwallet.android.application.transactions.coordinators.TransactionsRequestFilter
 import com.gemwallet.android.data.service.store.database.entities.DbAddress
@@ -12,11 +14,17 @@ import com.gemwallet.android.data.service.store.database.entities.DbAsset
 import com.gemwallet.android.data.service.store.database.entities.DbPrice
 import com.gemwallet.android.data.service.store.database.entities.DbTransaction
 import com.gemwallet.android.data.service.store.database.entities.DbTransactionExtended
+import com.gemwallet.android.data.service.store.database.entities.DbTransactionObservation
 import com.gemwallet.android.data.service.store.database.entities.DbTxSwapMetadata
+import com.gemwallet.android.data.service.store.database.entities.toObservation
+import com.gemwallet.android.ext.isCompleted
 import com.wallet.core.primitives.TransactionId
 import com.wallet.core.primitives.TransactionState
+import com.wallet.core.primitives.TransactionType
 import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.flow.Flow
+
+private val settledTransactionStates = TransactionState.entries.filter { it.isCompleted() }
 
 const val EXTENDED_COLUMNS = """
     tx.*,
@@ -74,6 +82,32 @@ interface TransactionsDao {
     @Insert(entity = DbTransaction::class, onConflict = OnConflictStrategy.REPLACE)
     fun insert(transactions: List<DbTransaction>)
 
+    @Transaction
+    fun syncTransactions(transactions: List<DbTransaction>) {
+        insertMissingTransactions(transactions)
+        updateObservedValues(transactions.map { it.toObservation() })
+        transactions.forEach { updateDescription(it.id, it.walletId, it.type, it.metadata) }
+    }
+
+    @Insert(entity = DbTransaction::class, onConflict = OnConflictStrategy.IGNORE)
+    fun insertMissingTransactions(transactions: List<DbTransaction>)
+
+    @Update(entity = DbTransaction::class)
+    fun updateObservedValues(observations: List<DbTransactionObservation>)
+
+    @Query(
+        "UPDATE transactions SET type = :type, metadata = :metadata, updatedAt = :updatedAt " +
+            "WHERE id = :id AND walletId = :walletId AND :metadata IS NOT NULL AND state IN (:settledStates)"
+    )
+    fun updateDescription(
+        id: TransactionId,
+        walletId: WalletId,
+        type: TransactionType,
+        metadata: String?,
+        settledStates: List<TransactionState> = settledTransactionStates,
+        updatedAt: Long = System.currentTimeMillis(),
+    )
+
     @Query("DELETE FROM transactions WHERE id = :id AND walletId = :walletId")
     fun delete(id: TransactionId, walletId: WalletId)
 
@@ -99,9 +133,6 @@ interface TransactionsDao {
     @Query("SELECT $EXTENDED_COLUMNS $EXTENDED_SOURCE AND tx.id = :id")
     fun getExtendedTransaction(walletId: WalletId, id: TransactionId): Flow<DbTransactionExtended?>
 
-    @Query("SELECT state FROM transactions WHERE id = :id AND walletId = :walletId")
-    fun getTransactionState(id: TransactionId, walletId: WalletId): TransactionState?
-
     @Query("UPDATE transactions SET id = :newId, hash = :hash, updatedAt = :updatedAt WHERE id = :oldId AND walletId = :walletId")
     fun updateTransactionId(
         oldId: TransactionId,
@@ -110,15 +141,6 @@ interface TransactionsDao {
         hash: String,
         updatedAt: Long = System.currentTimeMillis(),
     )
-
-    @Query("UPDATE transactions SET state = :state, updatedAt = :updatedAt WHERE id = :id AND walletId = :walletId")
-    fun updateState(id: TransactionId, walletId: WalletId, state: TransactionState, updatedAt: Long = System.currentTimeMillis())
-
-    @Query("UPDATE transactions SET fee = :fee, updatedAt = :updatedAt WHERE id = :id AND walletId = :walletId")
-    fun updateFee(id: TransactionId, walletId: WalletId, fee: String, updatedAt: Long = System.currentTimeMillis())
-
-    @Query("UPDATE transactions SET metadata = :metadata, updatedAt = :updatedAt WHERE id = :id AND walletId = :walletId")
-    fun updateMetadata(id: TransactionId, walletId: WalletId, metadata: String, updatedAt: Long = System.currentTimeMillis())
 
     @Insert(entity = DbTxSwapMetadata::class, onConflict = OnConflictStrategy.REPLACE)
     fun addSwapMetadata(metadata: List<DbTxSwapMetadata>)

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbTransaction.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbTransaction.kt
@@ -92,3 +92,33 @@ fun DbTransaction.toDTO(): Transaction {
 fun List<DbTransaction>.toDTO() = map { it.toDTO() }
 
 fun List<Transaction>.toRecord(walletId: WalletId) = map { it.toRecord(walletId) }
+
+data class DbTransactionObservation(
+    val id: TransactionId,
+    val walletId: WalletId,
+    val owner: String,
+    val recipient: String,
+    val contract: String? = null,
+    val state: TransactionState,
+    val blockNumber: String,
+    val sequence: String,
+    val fee: String,
+    val value: String,
+    val payload: String? = null,
+    val updatedAt: Long,
+)
+
+fun DbTransaction.toObservation(): DbTransactionObservation = DbTransactionObservation(
+    id = id,
+    walletId = walletId,
+    owner = owner,
+    recipient = recipient,
+    contract = contract,
+    state = state,
+    blockNumber = blockNumber,
+    sequence = sequence,
+    fee = fee,
+    value = value,
+    payload = payload,
+    updatedAt = updatedAt,
+)

--- a/ios/Gem/Navigation/NavigationHandler.swift
+++ b/ios/Gem/Navigation/NavigationHandler.swift
@@ -154,7 +154,7 @@ extension NavigationHandler {
             return
         }
 
-        try transactionsService.addTransaction(walletId: walletId, transaction: transaction)
+        try transactionsService.syncTransaction(walletId: walletId, transaction: transaction)
         let transaction = try transactionsService.getTransaction(walletId: walletId, transactionId: transaction.id)
 
         await selectWalletIfNeeded(walletId)

--- a/ios/Packages/FeatureServices/TransactionStateService/Tests/TransactionStateServiceTests.swift
+++ b/ios/Packages/FeatureServices/TransactionStateService/Tests/TransactionStateServiceTests.swift
@@ -110,26 +110,26 @@ struct TransactionStateServiceTests {
     }
 
     @Test
-    func hashChangeDoesNotDowngradeCompletedTransaction() async throws {
+    func hashChangeKeepsTrackedTransactionOverIndexedDuplicate() async throws {
         let fixture = try makeFixture(stateChanges: TransactionChanges(
             state: .inTransit,
             changes: [
                 .hashChange(old: "hash", new: "new-hash"),
             ],
         ))
-        let existingTransaction = try makeSwapTransaction(
+        let indexedTransaction = try makeSwapTransaction(
             hash: "new-hash",
             fromAsset: .mock(.bitcoin),
             toAsset: .mock(.ethereum),
             state: .confirmed,
         )
-        try fixture.store.addTransactions(walletId: fixture.walletId, transactions: [existingTransaction])
+        try fixture.store.syncTransactions(walletId: fixture.walletId, transactions: [indexedTransaction])
 
         let status = await fixture.service.update(for: fixture.transaction).status
 
-        expectComplete(status)
-        #expect(try fixture.store.getTransactions(states: [.pending]).isEmpty)
-        let saved = try #require(fixture.store.getTransactions(states: [.confirmed]).first)
+        expectRetry(status)
+        #expect(try fixture.store.getTransactions(states: TransactionState.allCases).count == 1)
+        let saved = try #require(fixture.store.getTransactions(states: [.inTransit]).first)
         #expect(saved.id.hash == "new-hash")
     }
 

--- a/ios/Packages/FeatureServices/TransactionStateService/TransactionStateService.swift
+++ b/ios/Packages/FeatureServices/TransactionStateService/TransactionStateService.swift
@@ -17,11 +17,6 @@ struct TransactionStateUpdateResult {
     let status: JobStatus
 }
 
-private struct LocalTransactionRecord {
-    let transactionId: TransactionId
-    let state: TransactionState
-}
-
 public struct TransactionStateService: Sendable {
     private let transactionStore: TransactionStore
     private let postProcessingService: TransactionPostProcessingService
@@ -128,40 +123,32 @@ extension TransactionStateService {
             )
         }
 
-        let localTransaction = try localTransactionRecord(for: transaction, changes: stateChanges.changes)
+        let transactionId = try updatedTransactionId(for: transaction, changes: stateChanges.changes)
         let nextState = try updateStateIfNeeded(
-            transactionId: localTransaction.transactionId,
-            oldState: localTransaction.state,
+            transactionId: transactionId,
+            oldState: transaction.state,
             newState: stateChanges.state,
         )
-        try updateTransactionFields(stateChanges.changes, transactionId: localTransaction.transactionId)
+        try updateTransactionFields(stateChanges.changes, transactionId: transactionId)
 
         return TransactionStateUpdateResult(
-            transactionId: localTransaction.transactionId,
+            transactionId: transactionId,
             status: nextState.isCompleted ? .complete : .retry(),
         )
     }
 
-    private func localTransactionRecord(for transaction: Transaction, changes: [TransactionChange]) throws -> LocalTransactionRecord {
-        try changes.reduce(
-            LocalTransactionRecord(
-                transactionId: transaction.id,
-                state: transaction.state,
-            ),
-        ) { localTransaction, change in
+    private func updatedTransactionId(for transaction: Transaction, changes: [TransactionChange]) throws -> TransactionId {
+        try changes.reduce(transaction.id) { transactionId, change in
             guard case let .hashChange(_, newHash) = change else {
-                return localTransaction
+                return transactionId
             }
             let newTransactionId = TransactionId(chain: transaction.assetId.chain, hash: newHash)
-            let state = try transactionStore.updateTransactionId(
-                oldTransactionId: localTransaction.transactionId,
+            try transactionStore.updateTransactionId(
+                oldTransactionId: transactionId,
                 transactionId: newTransactionId,
                 hash: newHash,
-            ) ?? localTransaction.state
-            return LocalTransactionRecord(
-                transactionId: newTransactionId,
-                state: state,
             )
+            return newTransactionId
         }
     }
 
@@ -171,6 +158,10 @@ extension TransactionStateService {
             _ = try transactionStore.updateState(id: transactionId, state: nextState)
         }
         return nextState
+    }
+
+    private func nextTransactionState(oldState: TransactionState, newState: TransactionState) -> TransactionState {
+        oldState == .pending || newState.isCompleted ? newState : oldState
     }
 
     private func updateTransactionFields(_ changes: [TransactionChange], transactionId: TransactionId) throws {
@@ -188,9 +179,5 @@ extension TransactionStateService {
                 _ = try transactionStore.updateMetadata(transactionId: transactionId, metadata: metadata)
             }
         }
-    }
-
-    private func nextTransactionState(oldState: TransactionState, newState: TransactionState) -> TransactionState {
-        oldState == .pending || newState.isCompleted ? newState : oldState
     }
 }

--- a/ios/Packages/FeatureServices/TransactionsService/TransactionsService.swift
+++ b/ios/Packages/FeatureServices/TransactionsService/TransactionsService.swift
@@ -35,7 +35,7 @@ public final class TransactionsService: Sendable {
         )
 
         try await prefetchAssets(walletId: walletId, transactions: response.transactions)
-        try transactionStore.addTransactions(walletId: walletId, transactions: response.transactions)
+        try transactionStore.syncTransactions(walletId: walletId, transactions: response.transactions)
         try addressStore.addAddressNames(response.addressNames)
 
         store.transactionsTimestamp = newTimestamp
@@ -51,14 +51,14 @@ public final class TransactionsService: Sendable {
         )
 
         try await prefetchAssets(walletId: walletId, transactions: response.transactions)
-        try transactionStore.addTransactions(walletId: walletId, transactions: response.transactions)
+        try transactionStore.syncTransactions(walletId: walletId, transactions: response.transactions)
         try addressStore.addAddressNames(response.addressNames)
 
         store.setTransactionsForAssetTimestamp(assetId: assetId.identifier, value: newTimestamp)
     }
 
-    public func addTransaction(walletId: WalletId, transaction: Transaction) throws {
-        try transactionStore.addTransactions(walletId: walletId, transactions: [transaction])
+    public func syncTransaction(walletId: WalletId, transaction: Transaction) throws {
+        try transactionStore.syncTransactions(walletId: walletId, transactions: [transaction])
     }
 
     public func getTransaction(walletId: WalletId, transactionId: TransactionId) throws -> TransactionExtended {

--- a/ios/Packages/Store/Sources/Models/TransactionRecord.swift
+++ b/ios/Packages/Store/Sources/Models/TransactionRecord.swift
@@ -138,6 +138,10 @@ extension TransactionRecord: CreateTable {
 }
 
 extension TransactionRecord {
+    var transactionState: TransactionState {
+        TransactionState(rawValue: state) ?? .pending
+    }
+
     func mapToTransaction() -> Transaction {
         Transaction(
             id: TransactionId(chain: assetId.chain, hash: hash),
@@ -146,7 +150,7 @@ extension TransactionRecord {
             to: to,
             contract: contract,
             type: type,
-            state: TransactionState(rawValue: state) ?? .pending,
+            state: transactionState,
             blockNumber: blockNumber.asString,
             sequence: sequence.asString,
             fee: fee,

--- a/ios/Packages/Store/Sources/Stores/TransactionStore.swift
+++ b/ios/Packages/Store/Sources/Stores/TransactionStore.swift
@@ -63,20 +63,29 @@ public struct TransactionStore: Sendable {
     }
 
     public func addTransactions(walletId: WalletId, transactions: [Transaction]) throws {
-        if transactions.isEmpty {
-            return
-        }
+        guard transactions.isNotEmpty else { return }
         try db.write { db in
             for transaction in transactions {
                 let record = try transaction.record(walletId: walletId.id).upsertAndFetch(db, as: TransactionRecord.self)
-                if let id = record.id {
-                    try TransactionAssetAssociationRecord
-                        .filter(TransactionAssetAssociationRecord.Columns.transactionId == id)
-                        .deleteAll(db)
+                try replaceAssetAssociations(of: record, with: transaction.assetIds, db: db)
+            }
+        }
+    }
 
-                    try transaction.assetIds.forEach {
-                        try TransactionAssetAssociationRecord(transactionId: id, assetId: $0).upsert(db)
-                    }
+    public func syncTransactions(walletId: WalletId, transactions: [Transaction]) throws {
+        guard transactions.isNotEmpty else { return }
+        try db.write { db in
+            for transaction in transactions {
+                let incomingRecord = try transaction.record(walletId: walletId.id)
+                guard let storedRecord = try storedRecord(of: incomingRecord, db: db) else {
+                    let insertedRecord = try incomingRecord.insertAndFetch(db, as: TransactionRecord.self)
+                    try replaceAssetAssociations(of: insertedRecord, with: transaction.assetIds, db: db)
+                    continue
+                }
+                try updateObservedValues(of: incomingRecord, db: db)
+                if incomingRecord.transactionState.isCompleted, incomingRecord.metadata != nil {
+                    try updateDescription(of: incomingRecord, db: db)
+                    try replaceAssetAssociations(of: storedRecord, with: transaction.assetIds, db: db)
                 }
             }
         }
@@ -106,32 +115,23 @@ public struct TransactionStore: Sendable {
         )
     }
 
-    public func updateTransactionId(oldTransactionId: TransactionId, transactionId: TransactionId, hash: String) throws -> TransactionState? {
+    public func updateTransactionId(oldTransactionId: TransactionId, transactionId: TransactionId, hash: String) throws {
         try db.write { db in
-            let oldRecord = try TransactionRecord
+            guard let trackedRecord = try TransactionRecord
                 .filter(TransactionRecord.Columns.transactionId == oldTransactionId.identifier)
                 .fetchOne(db)
-
-            if let oldRecord {
-                let existingRecord = try TransactionRecord
-                    .filter(TransactionRecord.Columns.walletId == oldRecord.walletId)
-                    .filter(TransactionRecord.Columns.transactionId == transactionId.identifier)
-                    .fetchOne(db)
-                if let existingRecord {
-                    _ = try TransactionRecord
-                        .filter(TransactionRecord.Columns.id == oldRecord.id)
-                        .deleteAll(db)
-                    return TransactionState(rawValue: existingRecord.state)
-                }
+            else {
+                return
             }
 
+            try deleteIndexedDuplicate(walletId: trackedRecord.walletId, transactionId: transactionId, db: db)
+
             try TransactionRecord
-                .filter(TransactionRecord.Columns.transactionId == oldTransactionId.identifier)
+                .filter(TransactionRecord.Columns.id == trackedRecord.id)
                 .updateAll(db, [
                     TransactionRecord.Columns.transactionId.set(to: transactionId.identifier),
                     TransactionRecord.Columns.hash.set(to: hash),
                 ])
-            return nil
         }
     }
 
@@ -141,6 +141,59 @@ public struct TransactionStore: Sendable {
                 .filter(ids.contains(TransactionRecord.Columns.transactionId))
                 .deleteAll(db)
         }
+    }
+
+    private func deleteIndexedDuplicate(walletId: String, transactionId: TransactionId, db: Database) throws {
+        _ = try TransactionRecord
+            .filter(TransactionRecord.Columns.walletId == walletId)
+            .filter(TransactionRecord.Columns.transactionId == transactionId.identifier)
+            .deleteAll(db)
+    }
+
+    private func replaceAssetAssociations(of record: TransactionRecord, with assetIds: [AssetId], db: Database) throws {
+        guard let recordId = record.id else { return }
+        try TransactionAssetAssociationRecord
+            .filter(TransactionAssetAssociationRecord.Columns.transactionId == recordId)
+            .deleteAll(db)
+
+        try assetIds.forEach {
+            try TransactionAssetAssociationRecord(transactionId: recordId, assetId: $0).upsert(db)
+        }
+    }
+
+    private func storedRecord(of record: TransactionRecord, db: Database) throws -> TransactionRecord? {
+        try TransactionRecord
+            .filter(TransactionRecord.Columns.walletId == record.walletId)
+            .filter(TransactionRecord.Columns.transactionId == record.transactionId)
+            .fetchOne(db)
+    }
+
+    private func updateDescription(of record: TransactionRecord, db: Database) throws {
+        _ = try TransactionRecord
+            .filter(TransactionRecord.Columns.walletId == record.walletId)
+            .filter(TransactionRecord.Columns.transactionId == record.transactionId)
+            .updateAll(db, [
+                TransactionRecord.Columns.type.set(to: record.type.rawValue),
+                TransactionRecord.Columns.metadata.set(to: try JSONEncoder().encode(record.metadata).encodeString()),
+            ])
+    }
+
+    private func updateObservedValues(of record: TransactionRecord, db: Database) throws {
+        _ = try TransactionRecord
+            .filter(TransactionRecord.Columns.walletId == record.walletId)
+            .filter(TransactionRecord.Columns.transactionId == record.transactionId)
+            .updateAll(db, [
+                TransactionRecord.Columns.from.set(to: record.from),
+                TransactionRecord.Columns.to.set(to: record.to),
+                TransactionRecord.Columns.contract.set(to: record.contract),
+                TransactionRecord.Columns.state.set(to: record.state),
+                TransactionRecord.Columns.blockNumber.set(to: record.blockNumber),
+                TransactionRecord.Columns.sequence.set(to: record.sequence),
+                TransactionRecord.Columns.value.set(to: record.value),
+                TransactionRecord.Columns.fee.set(to: record.fee),
+                TransactionRecord.Columns.memo.set(to: record.memo),
+                TransactionRecord.Columns.updatedAt.set(to: record.updatedAt),
+            ])
     }
 
     private func updateValues(id: TransactionId, values: [ColumnAssignment]) throws -> Int {

--- a/ios/Packages/Store/TestKit/Transaction+StoreTestKit.swift
+++ b/ios/Packages/Store/TestKit/Transaction+StoreTestKit.swift
@@ -11,6 +11,8 @@ public extension Transaction {
         state: TransactionState = .confirmed,
         assetId: AssetId = .mock(),
         metadata: AnyCodableValue? = nil,
+        fee: String = "1",
+        blockNumber: String = "1",
     ) -> Transaction {
         Transaction(
             id: transactionId,
@@ -20,9 +22,9 @@ public extension Transaction {
             contract: nil,
             type: type,
             state: state,
-            blockNumber: "1",
+            blockNumber: blockNumber,
             sequence: "1",
-            fee: "1",
+            fee: fee,
             feeAssetId: assetId,
             value: "100",
             memo: nil,

--- a/ios/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
@@ -73,4 +73,141 @@ struct TransactionStoreTests {
         #expect(assetIds.count == 2)
         #expect(Set(assetIds) == Set([btc, sol]))
     }
+
+    @Test func syncKeepsIntentAndUpdatesObservedValues() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .swap, state: .inTransit, metadata: Self.swapMetadata),
+        ])
+
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .transfer, state: .confirmed, metadata: nil, fee: "500", blockNumber: "77"),
+        ])
+
+        let transaction = try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction
+
+        #expect(transaction.type == .swap)
+        #expect(transaction.state == .confirmed)
+        #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
+        #expect(transaction.fee == "500")
+        #expect(transaction.blockNumber == "77")
+    }
+
+    @Test func syncEnrichesStoredTransactionWithIndexedDescription() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .smartContractCall, state: .confirmed, metadata: nil),
+        ])
+
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .swap, state: .confirmed, metadata: Self.swapMetadata),
+        ])
+
+        let transaction = try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction
+        let assetIds = try store.getTransactionAssetAssociations(for: transactionId).map(\.assetId)
+
+        #expect(transaction.type == .swap)
+        #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
+        #expect(Set(assetIds) == Set([Chain.bitcoin.assetId, Chain.ethereum.assetId]))
+    }
+
+    @Test func syncSettlesPendingTransaction() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .transfer, state: .pending, metadata: nil),
+        ])
+
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .transfer, state: .confirmed, metadata: nil),
+        ])
+
+        #expect(try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction.state == .confirmed)
+    }
+
+    @Test func syncKeepsDescriptionOfTrackedTransaction() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .swap, state: .inTransit, metadata: Self.swapMetadata),
+        ])
+
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .swap, state: .inTransit, metadata: Self.indexedSwapMetadata),
+        ])
+
+        let transaction = try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction
+
+        #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
+    }
+
+    @Test func syncStoresUnknownTransactionOnce() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        let indexed = Transaction.mock(transactionId: transactionId, type: .swap, state: .confirmed, metadata: Self.swapMetadata)
+
+        try store.syncTransactions(walletId: walletId, transactions: [indexed])
+        try store.syncTransactions(walletId: walletId, transactions: [indexed])
+
+        let transaction = try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction
+
+        #expect(try store.getTransactions(states: TransactionState.allCases).count == 1)
+        #expect(transaction.type == .swap)
+        #expect(transaction.state == .confirmed)
+        #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
+    }
+
+    @Test func syncStoresRepeatedBatchOnce() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        let indexed = Transaction.mock(transactionId: transactionId, type: .transfer, state: .confirmed, metadata: nil)
+
+        try store.syncTransactions(walletId: walletId, transactions: [indexed, indexed])
+
+        #expect(try store.getTransactions(states: TransactionState.allCases).count == 1)
+    }
+
+    @Test func hashChangeKeepsTrackedTransactionOverIndexedDuplicate() throws {
+        let (store, walletId) = transactionStore()
+        let localId = TransactionId(chain: .ethereum, hash: "message")
+        let indexedId = TransactionId(chain: .ethereum, hash: "onchain")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: localId, type: .swap, state: .inTransit, metadata: Self.swapMetadata),
+        ])
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: indexedId, type: .transfer, state: .confirmed, metadata: nil),
+        ])
+
+        try store.updateTransactionId(oldTransactionId: localId, transactionId: indexedId, hash: indexedId.hash)
+        let transaction = try store.getTransaction(walletId: walletId, transactionId: indexedId).transaction
+
+        #expect(try store.getTransactions(states: TransactionState.allCases).count == 1)
+        #expect(transaction.type == .swap)
+        #expect(transaction.state == .inTransit)
+        #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
+    }
+}
+
+extension TransactionStoreTests {
+    private static let swapMetadata = AnyCodableValue.encode(TransactionSwapMetadata.mock(
+        fromAsset: Chain.bitcoin.assetId,
+        toAsset: Chain.ethereum.assetId,
+        provider: "nearintents",
+    ))
+
+    private static let indexedSwapMetadata = AnyCodableValue.encode(TransactionSwapMetadata.mock(
+        fromAsset: Chain.bitcoin.assetId,
+        toAsset: Chain.ethereum.assetId,
+        provider: nil,
+    ))
+
+    private func transactionStore() -> (TransactionStore, WalletId) {
+        let db = DB.mockAssets(assets: [
+            .mock(asset: .mock(id: Chain.bitcoin.assetId)),
+            .mock(asset: .mockEthereum()),
+        ])
+        return (.mock(db: db), .mock())
+    }
 }


### PR DESCRIPTION
Sync from the backend overwrote the whole transaction row. A swap could lose its provider and assets, stop being tracked, and get marked as failed while it was still going.

Now sync updates only what the indexer observed on chain. Type and metadata are taken from it only when it has them and the transaction has already finished.

- [x] Test