### PR TITLE
Derive node rows from network settings state

### DIFF
--- a/android/features/settings/networks/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/networks/viewmodels/NetworksViewModel.kt
+++ b/android/features/settings/networks/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/networks/viewmodels/NetworksViewModel.kt
@@ -89,7 +89,6 @@ class NetworksViewModel @Inject constructor(
                 availableAddNode = true,
                 defaultNodeUrls = defaultNodeUrls,
                 nodes = emptyList(),
-                nodeRows = emptyList(),
                 nodeStates = emptyMap(),
                 refreshNonce = System.nanoTime(),
             )
@@ -105,18 +104,7 @@ class NetworksViewModel @Inject constructor(
     fun onSelectNode(node: Node) {
         val chain = state.value.chain ?: return
         setCurrentNodeCase.setCurrentNode(chain, node)
-        updateState {
-            it.copy(
-                currentNode = node,
-                nodeRows = buildNodeRows(
-                    chain = chain,
-                    nodes = it.nodes,
-                    currentNode = node,
-                    nodeStates = it.nodeStates,
-                    defaultNodeUrls = it.defaultNodeUrls,
-                ),
-            )
-        }
+        updateState { it.copy(currentNode = node) }
     }
 
     fun onSelectBlockExplorer(name: String) {
@@ -141,13 +129,6 @@ class NetworksViewModel @Inject constructor(
                     nodes = nodes,
                     currentNode = currentNode,
                     nodeStates = nodeStates,
-                    nodeRows = buildNodeRows(
-                        chain = chain,
-                        nodes = nodes,
-                        currentNode = currentNode,
-                        nodeStates = nodeStates,
-                        defaultNodeUrls = it.defaultNodeUrls,
-                    ),
                 )
             }
         }
@@ -165,13 +146,6 @@ class NetworksViewModel @Inject constructor(
                         nodes = nodes,
                         currentNode = currentNode,
                         nodeStates = currentStates,
-                        nodeRows = buildNodeRows(
-                            chain = chain,
-                            nodes = nodes,
-                            currentNode = currentNode,
-                            nodeStates = currentStates,
-                            defaultNodeUrls = it.defaultNodeUrls,
-                        ),
                     )
                 }
 
@@ -207,13 +181,6 @@ class NetworksViewModel @Inject constructor(
                         currentNode = currentNode,
                         refreshNonce = refreshNonce,
                         nodeStates = loadingStates,
-                        nodeRows = buildNodeRows(
-                            chain = chain,
-                            nodes = nodes,
-                            currentNode = currentNode,
-                            nodeStates = loadingStates,
-                            defaultNodeUrls = current.defaultNodeUrls,
-                        ),
                     )
                 }
             }
@@ -232,7 +199,7 @@ class NetworksViewModel @Inject constructor(
                                     current.nodes,
                                     current.nodeStates + (node.url to nodeState),
                                 )
-                                current.copy(nodeStates = nodeStates).refreshedNodeRows(chain, nodeStates)
+                                current.copy(nodeStates = nodeStates).withCurrentNodeFor(chain)
                             }
                         }
                     }
@@ -240,7 +207,7 @@ class NetworksViewModel @Inject constructor(
             }
 
             updateNodesIfCurrent(chain, refreshNonce) { current ->
-                current.refreshedNodeRows(chain, visibleNodeStates(current.nodes, current.nodeStates))
+                current.withCurrentNodeFor(chain)
             }
         }
     }
@@ -252,19 +219,8 @@ class NetworksViewModel @Inject constructor(
         }
     }
 
-    private fun State.refreshedNodeRows(chain: Chain, nodeStates: Map<String, NodeStatusState>): State {
-        val refreshedCurrentNode = currentNodeFor(chain, nodes, currentNode)
-        return copy(
-            currentNode = refreshedCurrentNode,
-            nodeRows = buildNodeRows(
-                chain = chain,
-                nodes = nodes,
-                currentNode = refreshedCurrentNode,
-                nodeStates = nodeStates,
-                defaultNodeUrls = defaultNodeUrls,
-            ),
-        )
-    }
+    private fun State.withCurrentNodeFor(chain: Chain): State =
+        copy(currentNode = currentNodeFor(chain, nodes, currentNode))
 
     private fun updateState(transform: (State) -> State) {
         state.update(transform)
@@ -282,7 +238,6 @@ class NetworksViewModel @Inject constructor(
         val currentExplorer: String? = null,
         val nodeStates: Map<String, NodeStatusState> = emptyMap(),
         val nodes: List<Node> = emptyList(),
-        val nodeRows: List<NodeRowUiModel> = emptyList(),
         val availableChains: List<Chain> = emptyList(),
         val selectChain: Boolean = true,
         val availableAddNode: Boolean = true,
@@ -297,7 +252,17 @@ class NetworksViewModel @Inject constructor(
                 blockExplorers = explorers,
                 currentExplorer = currentExplorer,
                 availableAddNode = availableAddNode,
-                nodeRows = nodeRows,
+                nodeRows = if (chain == null || currentNode == null) {
+                    emptyList()
+                } else {
+                    buildNodeRows(
+                        chain = chain,
+                        nodes = nodes,
+                        currentNode = currentNode,
+                        nodeStates = nodeStates,
+                        defaultNodeUrls = defaultNodeUrls,
+                    )
+                },
             )
         }
     }


### PR DESCRIPTION
Node rows on the networks settings screen were kept in state and rebuilt by hand in six different places. Any change to the node list, the selected node or their statuses had to remember to rebuild them, otherwise the screen showed stale rows.

Now the rows are computed where the screen reads them, so they can't fall out of sync. No change to what the screen shows.