### PR TITLE
Follow transaction details across a hash change

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.gemwallet.android.data.repositories.transactions
 
-import android.text.format.DateUtils
 import android.util.Log
 import com.gemwallet.android.application.transactions.coordinators.GetChangedTransactions
 import com.gemwallet.android.application.transactions.coordinators.GetPendingTransactionsCount
@@ -12,7 +11,6 @@ import com.gemwallet.android.cases.transactions.CreateTransaction
 import com.gemwallet.android.cases.transactions.SaveTransactions
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.service.store.database.TransactionsDao
-import com.gemwallet.android.data.service.store.database.entities.DbTransaction
 import com.gemwallet.android.data.service.store.database.entities.DbTransactionExtended
 import com.gemwallet.android.data.service.store.database.entities.DbTxSwapMetadata
 import com.gemwallet.android.data.service.store.database.entities.toDTO
@@ -50,7 +48,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import uniffi.gemstone.Config
 import uniffi.gemstone.transactionStateConfig
 import java.math.BigInteger
 import java.util.concurrent.ConcurrentHashMap
@@ -105,7 +102,7 @@ class TransactionsRepositoryImpl(
     override fun getChangedTransactions(): Flow<List<TransactionExtended>> = changedTransactions
 
     override suspend fun saveTransactions(walletId: WalletId, transactions: List<Transaction>) = withContext(Dispatchers.IO) {
-        transactionsDao.insert(transactions.toRecord(walletId))
+        transactionsDao.syncTransactions(transactions.toRecord(walletId))
         addSwapMetadata(transactions)
     }
 
@@ -219,13 +216,6 @@ class TransactionsRepositoryImpl(
                     )
                 }
 
-                val hasTimedOut = !currentTransaction.transaction.state.isCompleted() &&
-                    currentTransaction.transaction.createdAt < System.currentTimeMillis() - transactionTimeout(currentTransaction.transaction)
-                if (hasTimedOut) {
-                    currentTransaction = currentTransaction.copy(transaction = currentTransaction.transaction.copy(state = TransactionState.Failed))
-                    updateTransactions(listOf(currentTransaction))
-                    break
-                }
                 if (currentTransaction.transaction.state.isCompleted()) {
                     Log.d(
                         TAG,
@@ -242,20 +232,6 @@ class TransactionsRepositoryImpl(
         } finally {
             jobKeys.forEach { pollingTransactionJobs.remove(it) }
         }
-    }
-
-    private fun transactionTimeout(transaction: DbTransaction): Long {
-        val chain = transaction.assetId.chain
-        val sourceTimeout = Config().getChainConfig(chain.string).transactionTimeout.toLong()
-        if (transaction.state != TransactionState.InTransit) {
-            return sourceTimeout
-        }
-        val destinationChain = getTransactionSwapMetadata(transaction.type, transaction.metadata)?.toAsset?.chain ?: chain
-        if (destinationChain == chain) {
-            return sourceTimeout
-        }
-        val destinationTimeout = Config().getChainConfig(destinationChain.string).transactionTimeout.toLong()
-        return ((sourceTimeout + destinationTimeout) * 3).coerceAtLeast(DateUtils.DAY_IN_MILLIS)
     }
 
     private suspend fun checkTransaction(transaction: DbTransactionExtended): DbTransactionExtended? {
@@ -318,63 +294,21 @@ class TransactionsRepositoryImpl(
             return updatedTransaction
         }
 
-        val existingState = transactionsDao.getTransactionState(
-            updatedTransaction.transaction.id,
-            currentTransaction.transaction.walletId,
+        val walletId = currentTransaction.transaction.walletId
+        transactionsDao.deleteSwapMetadata(updatedTransaction.transaction.id.identifier)
+        transactionsDao.delete(updatedTransaction.transaction.id, walletId)
+        transactionsDao.updateSwapMetadataTransactionId(
+            oldTransactionId = currentTransaction.transaction.id.identifier,
+            newTransactionId = updatedTransaction.transaction.id.identifier,
         )
-        if (existingState == null) {
-            transactionsDao.updateSwapMetadataTransactionId(
-                oldTransactionId = currentTransaction.transaction.id.identifier,
-                newTransactionId = updatedTransaction.transaction.id.identifier,
-            )
-            transactionsDao.updateTransactionId(
-                oldId = currentTransaction.transaction.id,
-                newId = updatedTransaction.transaction.id,
-                walletId = currentTransaction.transaction.walletId,
-                hash = updatedTransaction.transaction.hash,
-            )
-            updateTransactions(listOf(updatedTransaction))
-            return updatedTransaction
-        }
-
-        transactionsDao.deleteSwapMetadata(currentTransaction.transaction.id.identifier)
-        transactionsDao.delete(
-            currentTransaction.transaction.id,
-            currentTransaction.transaction.walletId,
+        transactionsDao.updateTransactionId(
+            oldId = currentTransaction.transaction.id,
+            newId = updatedTransaction.transaction.id,
+            walletId = walletId,
+            hash = updatedTransaction.transaction.hash,
         )
-        val nextState = updateExistingTransaction(
-            placeholder = currentTransaction.transaction,
-            updatedTransaction = updatedTransaction.transaction,
-            existingState = existingState,
-        )
-        return updatedTransaction.copy(
-            transaction = updatedTransaction.transaction.copy(
-                state = nextState,
-            )
-        )
-    }
-
-    private fun updateExistingTransaction(
-        placeholder: DbTransaction,
-        updatedTransaction: DbTransaction,
-        existingState: TransactionState,
-    ): TransactionState {
-        val nextState = nextTransactionState(
-            oldState = existingState,
-            newState = updatedTransaction.state,
-        )
-        if (nextState != existingState) {
-            transactionsDao.updateState(updatedTransaction.id, updatedTransaction.walletId, nextState)
-        }
-        if (placeholder.fee != updatedTransaction.fee) {
-            transactionsDao.updateFee(updatedTransaction.id, updatedTransaction.walletId, updatedTransaction.fee)
-        }
-        val metadata = updatedTransaction.metadata
-        if (placeholder.metadata != metadata && metadata != null) {
-            transactionsDao.updateMetadata(updatedTransaction.id, updatedTransaction.walletId, metadata)
-            addSwapMetadata(listOf(updatedTransaction.toDTO()))
-        }
-        return nextState
+        updateTransactions(listOf(updatedTransaction))
+        return updatedTransaction
     }
 }
 

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
@@ -269,6 +269,11 @@ class TransactionsRepositoryImpl(
         val updatedTransaction = transaction.copy(
             transaction = transactionRecord.copy(
                 id = newHash?.let { TransactionId(chain, it) } ?: transactionRecord.id,
+                broadcastTransactionId = if (newHash == null) {
+                    transactionRecord.broadcastTransactionId
+                } else {
+                    transactionRecord.broadcastTransactionId ?: transactionRecord.id.identifier
+                },
                 state = nextTransactionState(
                     oldState = transactionRecord.state,
                     newState = stateChanges.state,

--- a/android/data/services/store/schemas/com.gemwallet.android.data.service.store.database.GemDatabase/85.json
+++ b/android/data/services/store/schemas/com.gemwallet.android.data.service.store.database.GemDatabase/85.json
@@ -1,0 +1,2702 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 85,
+    "identityHash": "39d0fe284ac711ab23acba11c63f3be6",
+    "entities": [
+      {
+        "tableName": "wallets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `domain_name` TEXT, `type` TEXT NOT NULL, `position` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `index` INTEGER NOT NULL, `source` TEXT NOT NULL DEFAULT 'Import', `imageUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainName",
+            "columnName": "domain_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Import'"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "accounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`wallet_id` TEXT NOT NULL, `derivation_path` TEXT NOT NULL, `address` TEXT NOT NULL, `chain` TEXT NOT NULL, `extendedPublicKey` TEXT, PRIMARY KEY(`wallet_id`, `chain`), FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "derivationPath",
+            "columnName": "derivation_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extendedPublicKey",
+            "columnName": "extendedPublicKey",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "wallet_id",
+            "chain"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_accounts_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_accounts_chain` ON `${TABLE_NAME}` (`chain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "addresses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chain` TEXT NOT NULL, `address` TEXT NOT NULL, `walletId` TEXT, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `status` TEXT NOT NULL, PRIMARY KEY(`chain`, `address`), FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`walletId`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "walletId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chain",
+            "address"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_addresses_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_addresses_chain` ON `${TABLE_NAME}` (`chain`)"
+          },
+          {
+            "name": "index_addresses_walletId",
+            "unique": false,
+            "columnNames": [
+              "walletId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_addresses_walletId` ON `${TABLE_NAME}` (`walletId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "walletId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contacts_addresses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `contactId` TEXT NOT NULL, `address` TEXT NOT NULL, `chain` TEXT NOT NULL, `memo` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`contactId`) REFERENCES `contacts`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memo",
+            "columnName": "memo",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_contacts_addresses_contactId",
+            "unique": false,
+            "columnNames": [
+              "contactId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contacts_addresses_contactId` ON `${TABLE_NAME}` (`contactId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "contacts",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "contactId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "asset",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `symbol` TEXT NOT NULL, `decimals` INTEGER NOT NULL, `type` TEXT NOT NULL, `chain` TEXT NOT NULL, `is_enabled` INTEGER NOT NULL, `is_buy_enabled` INTEGER NOT NULL, `is_sell_enabled` INTEGER NOT NULL, `is_swap_enabled` INTEGER NOT NULL, `is_stake_enabled` INTEGER NOT NULL, `staking_apr` REAL, `rank` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, `associations` TEXT NOT NULL DEFAULT '[]', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decimals",
+            "columnName": "decimals",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "is_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBuyEnabled",
+            "columnName": "is_buy_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSellEnabled",
+            "columnName": "is_sell_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSwapEnabled",
+            "columnName": "is_swap_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStakeEnabled",
+            "columnName": "is_stake_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stakingApr",
+            "columnName": "staking_apr",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associations",
+            "columnName": "associations",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `wallet_id` TEXT NOT NULL, `available` TEXT NOT NULL, `available_amount` REAL NOT NULL, `frozen` TEXT NOT NULL, `frozen_amount` REAL NOT NULL, `locked` TEXT NOT NULL, `locked_amount` REAL NOT NULL, `staked` TEXT NOT NULL, `staked_amount` REAL NOT NULL, `pending` TEXT NOT NULL, `pending_amount` REAL NOT NULL, `rewards` TEXT NOT NULL, `rewards_amount` REAL NOT NULL, `reserved` TEXT NOT NULL, `reserved_amount` REAL NOT NULL, `withdrawable` TEXT NOT NULL, `withdrawableAmount` REAL NOT NULL, `total_amount` REAL NOT NULL, `is_active` INTEGER NOT NULL, `is_pinned` INTEGER NOT NULL, `is_visible` INTEGER NOT NULL, `list_position` INTEGER NOT NULL, `votes` INTEGER NOT NULL DEFAULT 0, `energy_available` INTEGER NOT NULL DEFAULT 0, `energy_total` INTEGER NOT NULL DEFAULT 0, `bandwidth_available` INTEGER NOT NULL DEFAULT 0, `bandwidth_total` INTEGER NOT NULL DEFAULT 0, `updated_at` INTEGER, PRIMARY KEY(`asset_id`, `wallet_id`), FOREIGN KEY(`asset_id`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "available",
+            "columnName": "available",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "availableAmount",
+            "columnName": "available_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frozen",
+            "columnName": "frozen",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frozenAmount",
+            "columnName": "frozen_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lockedAmount",
+            "columnName": "locked_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staked",
+            "columnName": "staked",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stakedAmount",
+            "columnName": "staked_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pending",
+            "columnName": "pending",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingAmount",
+            "columnName": "pending_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rewards",
+            "columnName": "rewards",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rewardsAmount",
+            "columnName": "rewards_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reserved",
+            "columnName": "reserved",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reservedAmount",
+            "columnName": "reserved_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "withdrawable",
+            "columnName": "withdrawable",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "withdrawableAmount",
+            "columnName": "withdrawableAmount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalAmount",
+            "columnName": "total_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "is_pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isVisible",
+            "columnName": "is_visible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listPosition",
+            "columnName": "list_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "votes",
+            "columnName": "votes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "energyAvailable",
+            "columnName": "energy_available",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "energyTotal",
+            "columnName": "energy_total",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bandwidthAvailable",
+            "columnName": "bandwidth_available",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bandwidthTotal",
+            "columnName": "bandwidth_total",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id",
+            "wallet_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_balances_wallet_id",
+            "unique": false,
+            "columnNames": [
+              "wallet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_balances_wallet_id` ON `${TABLE_NAME}` (`wallet_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "prices",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `value` REAL, `usd_value` REAL, `day_changed` REAL, `currency` TEXT NOT NULL, PRIMARY KEY(`asset_id`))",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "usdValue",
+            "columnName": "usd_value",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "dayChanged",
+            "columnName": "day_changed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id"
+          ]
+        }
+      },
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `walletId` TEXT NOT NULL, `broadcastTransactionId` TEXT, `hash` TEXT NOT NULL, `assetId` TEXT NOT NULL, `feeAssetId` TEXT NOT NULL, `owner` TEXT NOT NULL, `recipient` TEXT NOT NULL, `contract` TEXT, `metadata` TEXT, `state` TEXT NOT NULL, `type` TEXT NOT NULL, `blockNumber` TEXT NOT NULL, `sequence` TEXT NOT NULL, `fee` TEXT NOT NULL, `value` TEXT NOT NULL, `payload` TEXT, `direction` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`, `walletId`), FOREIGN KEY(`walletId`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "walletId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "broadcastTransactionId",
+            "columnName": "broadcastTransactionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feeAssetId",
+            "columnName": "feeAssetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipient",
+            "columnName": "recipient",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contract",
+            "columnName": "contract",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockNumber",
+            "columnName": "blockNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fee",
+            "columnName": "fee",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "walletId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_walletId",
+            "unique": false,
+            "columnNames": [
+              "walletId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transactions_walletId` ON `${TABLE_NAME}` (`walletId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "walletId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tx_swap_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tx_id` TEXT NOT NULL, `from_asset_id` TEXT NOT NULL, `to_asset_id` TEXT NOT NULL, `from_amount` TEXT NOT NULL, `to_amount` TEXT NOT NULL, PRIMARY KEY(`tx_id`))",
+        "fields": [
+          {
+            "fieldPath": "txId",
+            "columnName": "tx_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromAssetId",
+            "columnName": "from_asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toAssetId",
+            "columnName": "to_asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromAmount",
+            "columnName": "from_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toAmount",
+            "columnName": "to_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tx_id"
+          ]
+        }
+      },
+      {
+        "tableName": "wallets_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `wallet_id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `state` TEXT NOT NULL, `chains` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `expire_at` INTEGER NOT NULL, `app_name` TEXT NOT NULL, `app_description` TEXT NOT NULL, `app_url` TEXT NOT NULL, `app_icon` TEXT NOT NULL, `redirect_native` TEXT, `redirect_universal` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chains",
+            "columnName": "chains",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expireAt",
+            "columnName": "expire_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "app_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appDescription",
+            "columnName": "app_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appUrl",
+            "columnName": "app_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appIcon",
+            "columnName": "app_icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "redirectNative",
+            "columnName": "redirect_native",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "redirectUniversal",
+            "columnName": "redirect_universal",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_wallets_connections_wallet_id",
+            "unique": false,
+            "columnNames": [
+              "wallet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_wallets_connections_wallet_id` ON `${TABLE_NAME}` (`wallet_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stake_validators",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `assetId` TEXT NOT NULL, `validatorId` TEXT NOT NULL, `name` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `commission` REAL NOT NULL, `apr` REAL NOT NULL, `providerType` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "validatorId",
+            "columnName": "validatorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commission",
+            "columnName": "commission",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apr",
+            "columnName": "apr",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stake_validators_assetId",
+            "unique": false,
+            "columnNames": [
+              "assetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stake_validators_assetId` ON `${TABLE_NAME}` (`assetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stake_delegations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `walletId` TEXT NOT NULL, `assetId` TEXT NOT NULL, `validatorId` TEXT NOT NULL, `state` TEXT NOT NULL, `delegationId` TEXT NOT NULL, `balance` TEXT NOT NULL, `shares` TEXT NOT NULL, `rewards` TEXT NOT NULL, `completionDate` INTEGER, PRIMARY KEY(`walletId`, `id`), FOREIGN KEY(`walletId`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`validatorId`) REFERENCES `stake_validators`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "walletId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "validatorId",
+            "columnName": "validatorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "delegationId",
+            "columnName": "delegationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shares",
+            "columnName": "shares",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rewards",
+            "columnName": "rewards",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completionDate",
+            "columnName": "completionDate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "walletId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stake_delegations_assetId",
+            "unique": false,
+            "columnNames": [
+              "assetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stake_delegations_assetId` ON `${TABLE_NAME}` (`assetId`)"
+          },
+          {
+            "name": "index_stake_delegations_validatorId",
+            "unique": false,
+            "columnNames": [
+              "validatorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stake_delegations_validatorId` ON `${TABLE_NAME}` (`validatorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "walletId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "stake_validators",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "validatorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `status` TEXT NOT NULL, `priority` INTEGER NOT NULL, `chain` TEXT NOT NULL, PRIMARY KEY(`url`), FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nodes_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_chain` ON `${TABLE_NAME}` (`chain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `wallet_id` TEXT NOT NULL, `currency` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "banners",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`wallet_id` TEXT NOT NULL, `asset_id` TEXT NOT NULL, `chain` TEXT, `state` TEXT NOT NULL, `event` TEXT NOT NULL, PRIMARY KEY(`wallet_id`, `asset_id`), FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "event",
+            "columnName": "event",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "wallet_id",
+            "asset_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_banners_event",
+            "unique": false,
+            "columnNames": [
+              "event"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_banners_event` ON `${TABLE_NAME}` (`event`)"
+          },
+          {
+            "name": "index_banners_wallet_id",
+            "unique": false,
+            "columnNames": [
+              "wallet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_banners_wallet_id` ON `${TABLE_NAME}` (`wallet_id`)"
+          },
+          {
+            "name": "index_banners_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_banners_chain` ON `${TABLE_NAME}` (`chain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "price_alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `assetId` TEXT NOT NULL, `currency` TEXT NOT NULL, `price` REAL, `pricePercentChange` REAL, `priceDirection` TEXT, `lastNotifiedAt` INTEGER, `enabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pricePercentChange",
+            "columnName": "pricePercentChange",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "priceDirection",
+            "columnName": "priceDirection",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastNotifiedAt",
+            "columnName": "lastNotifiedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "nft_collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `chain` TEXT NOT NULL, `contractAddress` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `previewImageUrl` TEXT NOT NULL, `originalSourceUrl` TEXT NOT NULL, `status` TEXT, `links` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contractAddress",
+            "columnName": "contractAddress",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "previewImageUrl",
+            "columnName": "previewImageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalSourceUrl",
+            "columnName": "originalSourceUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "links",
+            "columnName": "links",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nft_collections_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nft_collections_chain` ON `${TABLE_NAME}` (`chain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nft_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `collection_id` TEXT NOT NULL, `token_id` TEXT NOT NULL, `token_type` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `chain` TEXT NOT NULL, `contract_address` TEXT, `image_url` TEXT NOT NULL, `preview_image_url` TEXT NOT NULL, `original_image_url` TEXT NOT NULL, `attributes` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`collection_id`) REFERENCES `nft_collections`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collection_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenId",
+            "columnName": "token_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenType",
+            "columnName": "token_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contractAddress",
+            "columnName": "contract_address",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "previewImageUrl",
+            "columnName": "preview_image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalSourceUrl",
+            "columnName": "original_image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributes",
+            "columnName": "attributes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nft_assets_collection_id",
+            "unique": false,
+            "columnNames": [
+              "collection_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nft_assets_collection_id` ON `${TABLE_NAME}` (`collection_id`)"
+          },
+          {
+            "name": "index_nft_assets_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nft_assets_chain` ON `${TABLE_NAME}` (`chain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "nft_collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "collection_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nft_assets_associations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`wallet_id` TEXT NOT NULL, `asset_id` TEXT NOT NULL, PRIMARY KEY(`wallet_id`, `asset_id`), FOREIGN KEY(`asset_id`) REFERENCES `nft_assets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "wallet_id",
+            "asset_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nft_assets_associations_asset_id",
+            "unique": false,
+            "columnNames": [
+              "asset_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nft_assets_associations_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "nft_assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "asset_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL, PRIMARY KEY(`asset_id`, `name`), FOREIGN KEY(`asset_id`) REFERENCES `asset`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id",
+            "name"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "asset_market",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `marketCap` REAL, `marketCapFdv` REAL, `marketCapRank` INTEGER, `totalVolume` REAL, `circulatingSupply` REAL, `totalSupply` REAL, `maxSupply` REAL, `allTimeHigh` REAL, `allTimeHighDate` INTEGER, `allTimeHighChangePercentage` REAL, `allTimeLow` REAL, `allTimeLowDate` INTEGER, `allTimeLowChangePercentage` REAL, PRIMARY KEY(`asset_id`), FOREIGN KEY(`asset_id`) REFERENCES `asset`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "marketCap",
+            "columnName": "marketCap",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "marketCapFdv",
+            "columnName": "marketCapFdv",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "marketCapRank",
+            "columnName": "marketCapRank",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalVolume",
+            "columnName": "totalVolume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "circulatingSupply",
+            "columnName": "circulatingSupply",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "totalSupply",
+            "columnName": "totalSupply",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "maxSupply",
+            "columnName": "maxSupply",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "allTimeHigh",
+            "columnName": "allTimeHigh",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "allTimeHighDate",
+            "columnName": "allTimeHighDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "allTimeHighChangePercentage",
+            "columnName": "allTimeHighChangePercentage",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "allTimeLow",
+            "columnName": "allTimeLow",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "allTimeLowDate",
+            "columnName": "allTimeLowDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "allTimeLowChangePercentage",
+            "columnName": "allTimeLowChangePercentage",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "asset_lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `assetId` TEXT, `perpetualId` TEXT, `listId` TEXT, `priority` INTEGER NOT NULL, FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`perpetualId`) REFERENCES `perpetuals`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`listId`) REFERENCES `asset_lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "perpetualId",
+            "columnName": "perpetualId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_query",
+            "unique": false,
+            "columnNames": [
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_query` ON `${TABLE_NAME}` (`query`)"
+          },
+          {
+            "name": "index_search_assetId_query",
+            "unique": true,
+            "columnNames": [
+              "assetId",
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_assetId_query` ON `${TABLE_NAME}` (`assetId`, `query`)"
+          },
+          {
+            "name": "index_search_perpetualId_query",
+            "unique": true,
+            "columnNames": [
+              "perpetualId",
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_perpetualId_query` ON `${TABLE_NAME}` (`perpetualId`, `query`)"
+          },
+          {
+            "name": "index_search_listId_query",
+            "unique": true,
+            "columnNames": [
+              "listId",
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_listId_query` ON `${TABLE_NAME}` (`listId`, `query`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "perpetuals",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "perpetualId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "asset_lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "currency_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`currency` TEXT NOT NULL, `rate` REAL NOT NULL, PRIMARY KEY(`currency`))",
+        "fields": [
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "currency"
+          ]
+        }
+      },
+      {
+        "tableName": "fiat_transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `walletId` TEXT NOT NULL, `assetId` TEXT NOT NULL, `transactionType` TEXT NOT NULL, `provider` TEXT NOT NULL, `status` TEXT NOT NULL, `fiatAmount` REAL NOT NULL, `fiatCurrency` TEXT NOT NULL, `value` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `detailsUrl` TEXT, PRIMARY KEY(`id`, `walletId`), FOREIGN KEY(`walletId`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "walletId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transactionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fiatAmount",
+            "columnName": "fiatAmount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fiatCurrency",
+            "columnName": "fiatCurrency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detailsUrl",
+            "columnName": "detailsUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "walletId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiat_transactions_walletId",
+            "unique": false,
+            "columnNames": [
+              "walletId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiat_transactions_walletId` ON `${TABLE_NAME}` (`walletId`)"
+          },
+          {
+            "name": "index_fiat_transactions_assetId",
+            "unique": false,
+            "columnNames": [
+              "assetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiat_transactions_assetId` ON `${TABLE_NAME}` (`assetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "walletId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recent_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `wallet_id` TEXT NOT NULL, `to_asset_id` TEXT, `type` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`asset_id`, `wallet_id`, `type`), FOREIGN KEY(`asset_id`) REFERENCES `asset`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toAssetId",
+            "columnName": "to_asset_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id",
+            "wallet_id",
+            "type"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recent_assets_wallet_id",
+            "unique": false,
+            "columnNames": [
+              "wallet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recent_assets_wallet_id` ON `${TABLE_NAME}` (`wallet_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "perpetuals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `provider` TEXT NOT NULL, `assetId` TEXT NOT NULL, `identifier` TEXT NOT NULL, `price` REAL NOT NULL, `pricePercentChange24h` REAL NOT NULL, `openInterest` REAL NOT NULL, `volume24h` REAL NOT NULL, `funding` REAL NOT NULL, `maxLeverage` INTEGER NOT NULL, `isIsolatedOnly` INTEGER NOT NULL, `isPinned` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identifier",
+            "columnName": "identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pricePercentChange24h",
+            "columnName": "pricePercentChange24h",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openInterest",
+            "columnName": "openInterest",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volume24h",
+            "columnName": "volume24h",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "funding",
+            "columnName": "funding",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxLeverage",
+            "columnName": "maxLeverage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIsolatedOnly",
+            "columnName": "isIsolatedOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "perpetuals_asset_id_idx",
+            "unique": false,
+            "columnNames": [
+              "assetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `perpetuals_asset_id_idx` ON `${TABLE_NAME}` (`assetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "perpetuals_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `walletId` TEXT NOT NULL, `perpetualId` TEXT NOT NULL, `assetId` TEXT NOT NULL, `size` REAL NOT NULL, `sizeValue` REAL NOT NULL, `leverage` INTEGER NOT NULL, `entryPrice` REAL, `liquidationPrice` REAL, `marginType` TEXT NOT NULL, `direction` TEXT NOT NULL, `marginAmount` REAL NOT NULL, `takeProfitPrice` REAL, `takeProfitType` TEXT, `takeProfitOrderId` TEXT, `stopLossPrice` REAL, `stopLossType` TEXT, `stopLossOrderId` TEXT, `pnl` REAL NOT NULL, `funding` REAL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`, `walletId`), FOREIGN KEY(`walletId`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`perpetualId`) REFERENCES `perpetuals`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "walletId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perpetualId",
+            "columnName": "perpetualId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeValue",
+            "columnName": "sizeValue",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "leverage",
+            "columnName": "leverage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryPrice",
+            "columnName": "entryPrice",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "liquidationPrice",
+            "columnName": "liquidationPrice",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "marginType",
+            "columnName": "marginType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "marginAmount",
+            "columnName": "marginAmount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "takeProfitPrice",
+            "columnName": "takeProfitPrice",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "takeProfitType",
+            "columnName": "takeProfitType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "takeProfitOrderId",
+            "columnName": "takeProfitOrderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stopLossPrice",
+            "columnName": "stopLossPrice",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "stopLossType",
+            "columnName": "stopLossType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stopLossOrderId",
+            "columnName": "stopLossOrderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pnl",
+            "columnName": "pnl",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "funding",
+            "columnName": "funding",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "walletId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "perpetuals_positions_wallet_id_idx",
+            "unique": false,
+            "columnNames": [
+              "walletId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `perpetuals_positions_wallet_id_idx` ON `${TABLE_NAME}` (`walletId`)"
+          },
+          {
+            "name": "perpetuals_positions_perpetual_id_idx",
+            "unique": false,
+            "columnNames": [
+              "perpetualId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `perpetuals_positions_perpetual_id_idx` ON `${TABLE_NAME}` (`perpetualId`)"
+          },
+          {
+            "name": "perpetuals_positions_asset_id_idx",
+            "unique": false,
+            "columnNames": [
+              "assetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `perpetuals_positions_asset_id_idx` ON `${TABLE_NAME}` (`assetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "walletId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "perpetuals",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "perpetualId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "in_app_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `wallet_id` TEXT NOT NULL, `read_at` INTEGER, `created_at` INTEGER NOT NULL, `item` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readAt",
+            "columnName": "read_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_in_app_notifications_wallet_id",
+            "unique": false,
+            "columnNames": [
+              "wallet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_in_app_notifications_wallet_id` ON `${TABLE_NAME}` (`wallet_id`)"
+          },
+          {
+            "name": "index_in_app_notifications_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_in_app_notifications_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "support_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `content` TEXT NOT NULL, `sender` TEXT NOT NULL, `status` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `images` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "images",
+            "columnName": "images",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_support_messages_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_support_messages_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '39d0fe284ac711ab23acba11c63f3be6')"
+    ]
+  }
+}

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/GemDatabase.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/GemDatabase.kt
@@ -36,7 +36,7 @@ import com.gemwallet.android.data.service.store.database.entities.DbTxSwapMetada
 import com.gemwallet.android.data.service.store.database.entities.DbWallet
 
 @Database(
-    version = 84,
+    version = 85,
     entities = [
         DbWallet::class,
         DbAccount::class,

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsDao.kt
@@ -5,6 +5,8 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.RawQuery
+import androidx.room.Transaction
+import androidx.room.Update
 import androidx.sqlite.db.SupportSQLiteQuery
 import com.gemwallet.android.application.transactions.coordinators.TransactionsRequestFilter
 import com.gemwallet.android.data.service.store.database.entities.DbAddress
@@ -12,11 +14,17 @@ import com.gemwallet.android.data.service.store.database.entities.DbAsset
 import com.gemwallet.android.data.service.store.database.entities.DbPrice
 import com.gemwallet.android.data.service.store.database.entities.DbTransaction
 import com.gemwallet.android.data.service.store.database.entities.DbTransactionExtended
+import com.gemwallet.android.data.service.store.database.entities.DbTransactionObservation
 import com.gemwallet.android.data.service.store.database.entities.DbTxSwapMetadata
+import com.gemwallet.android.data.service.store.database.entities.toObservation
+import com.gemwallet.android.ext.isCompleted
 import com.wallet.core.primitives.TransactionId
 import com.wallet.core.primitives.TransactionState
+import com.wallet.core.primitives.TransactionType
 import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.flow.Flow
+
+private val settledTransactionStates = TransactionState.entries.filter { it.isCompleted() }
 
 const val EXTENDED_COLUMNS = """
     tx.*,
@@ -74,6 +82,49 @@ interface TransactionsDao {
     @Insert(entity = DbTransaction::class, onConflict = OnConflictStrategy.REPLACE)
     fun insert(transactions: List<DbTransaction>)
 
+    @Transaction
+    fun syncTransactions(transactions: List<DbTransaction>) {
+        insertMissingTransactions(transactions)
+        refreshObservedValues(transactions.map { it.toObservation() })
+        transactions.forEach { refreshState(it.id, it.walletId, it.state) }
+        transactions.forEach { refreshDescription(it.id, it.walletId, it.type, it.metadata, settledTransactionStates) }
+    }
+
+    @Insert(entity = DbTransaction::class, onConflict = OnConflictStrategy.IGNORE)
+    fun insertMissingTransactions(transactions: List<DbTransaction>)
+
+    @Update(entity = DbTransaction::class)
+    fun refreshObservedValues(observations: List<DbTransactionObservation>)
+
+    @Query(
+        "UPDATE transactions SET state = :state, updatedAt = :updatedAt " +
+            "WHERE id = :id AND walletId = :walletId " +
+            "AND state != :inTransitState " +
+            "AND (state = :pendingState OR :state IN (:settledStates))"
+    )
+    fun refreshState(
+        id: TransactionId,
+        walletId: WalletId,
+        state: TransactionState,
+        inTransitState: TransactionState = TransactionState.InTransit,
+        pendingState: TransactionState = TransactionState.Pending,
+        settledStates: List<TransactionState> = settledTransactionStates,
+        updatedAt: Long = System.currentTimeMillis(),
+    )
+
+    @Query(
+        "UPDATE transactions SET type = :type, metadata = :metadata, updatedAt = :updatedAt " +
+            "WHERE id = :id AND walletId = :walletId AND :metadata IS NOT NULL AND state IN (:settledStates)"
+    )
+    fun refreshDescription(
+        id: TransactionId,
+        walletId: WalletId,
+        type: TransactionType,
+        metadata: String?,
+        settledStates: List<TransactionState>,
+        updatedAt: Long = System.currentTimeMillis(),
+    )
+
     @Query("DELETE FROM transactions WHERE id = :id AND walletId = :walletId")
     fun delete(id: TransactionId, walletId: WalletId)
 
@@ -99,9 +150,6 @@ interface TransactionsDao {
     @Query("SELECT $EXTENDED_COLUMNS $EXTENDED_SOURCE AND tx.id = :id")
     fun getExtendedTransaction(walletId: WalletId, id: TransactionId): Flow<DbTransactionExtended?>
 
-    @Query("SELECT state FROM transactions WHERE id = :id AND walletId = :walletId")
-    fun getTransactionState(id: TransactionId, walletId: WalletId): TransactionState?
-
     @Query("UPDATE transactions SET id = :newId, hash = :hash, updatedAt = :updatedAt WHERE id = :oldId AND walletId = :walletId")
     fun updateTransactionId(
         oldId: TransactionId,
@@ -110,15 +158,6 @@ interface TransactionsDao {
         hash: String,
         updatedAt: Long = System.currentTimeMillis(),
     )
-
-    @Query("UPDATE transactions SET state = :state, updatedAt = :updatedAt WHERE id = :id AND walletId = :walletId")
-    fun updateState(id: TransactionId, walletId: WalletId, state: TransactionState, updatedAt: Long = System.currentTimeMillis())
-
-    @Query("UPDATE transactions SET fee = :fee, updatedAt = :updatedAt WHERE id = :id AND walletId = :walletId")
-    fun updateFee(id: TransactionId, walletId: WalletId, fee: String, updatedAt: Long = System.currentTimeMillis())
-
-    @Query("UPDATE transactions SET metadata = :metadata, updatedAt = :updatedAt WHERE id = :id AND walletId = :walletId")
-    fun updateMetadata(id: TransactionId, walletId: WalletId, metadata: String, updatedAt: Long = System.currentTimeMillis())
 
     @Insert(entity = DbTxSwapMetadata::class, onConflict = OnConflictStrategy.REPLACE)
     fun addSwapMetadata(metadata: List<DbTxSwapMetadata>)

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsDao.kt
@@ -147,10 +147,13 @@ interface TransactionsDao {
     @Query("SELECT COUNT(*) $EXTENDED_SOURCE AND tx.state IN (:states)")
     fun getTransactionsCount(walletId: WalletId, states: List<TransactionState>): Flow<Int?>
 
-    @Query("SELECT $EXTENDED_COLUMNS $EXTENDED_SOURCE AND tx.id = :id")
+    @Query("SELECT $EXTENDED_COLUMNS $EXTENDED_SOURCE AND (tx.id = :id OR tx.broadcastTransactionId = :id)")
     fun getExtendedTransaction(walletId: WalletId, id: TransactionId): Flow<DbTransactionExtended?>
 
-    @Query("UPDATE transactions SET id = :newId, hash = :hash, updatedAt = :updatedAt WHERE id = :oldId AND walletId = :walletId")
+    @Query(
+        "UPDATE transactions SET id = :newId, broadcastTransactionId = COALESCE(broadcastTransactionId, :oldId), hash = :hash, updatedAt = :updatedAt " +
+            "WHERE id = :oldId AND walletId = :walletId"
+    )
     fun updateTransactionId(
         oldId: TransactionId,
         newId: TransactionId,

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/di/DatabaseModule.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/di/DatabaseModule.kt
@@ -88,6 +88,7 @@ object DatabaseModule {
         .addMigrations(Migration_81_82)
         .addMigrations(Migration_82_83)
         .addMigrations(Migration_83_84)
+        .addMigrations(Migration_84_85)
         .build()
 
     @Singleton

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/di/Migration_84_85.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/di/Migration_84_85.kt
@@ -1,0 +1,10 @@
+package com.gemwallet.android.data.service.store.database.di
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+object Migration_84_85 : Migration(84, 85) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `transactions` ADD COLUMN `broadcastTransactionId` TEXT")
+    }
+}

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbTransaction.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbTransaction.kt
@@ -23,6 +23,7 @@ import com.wallet.core.primitives.WalletId
 data class DbTransaction(
     val id: TransactionId,
     val walletId: WalletId,
+    val broadcastTransactionId: String? = null,
     val hash: String,
     val assetId: AssetId,
     val feeAssetId: AssetId,

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbTransaction.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbTransaction.kt
@@ -92,3 +92,31 @@ fun DbTransaction.toDTO(): Transaction {
 fun List<DbTransaction>.toDTO() = map { it.toDTO() }
 
 fun List<Transaction>.toRecord(walletId: WalletId) = map { it.toRecord(walletId) }
+
+data class DbTransactionObservation(
+    val id: TransactionId,
+    val walletId: WalletId,
+    val owner: String,
+    val recipient: String,
+    val contract: String? = null,
+    val blockNumber: String,
+    val sequence: String,
+    val fee: String,
+    val value: String,
+    val payload: String? = null,
+    val updatedAt: Long,
+)
+
+fun DbTransaction.toObservation(): DbTransactionObservation = DbTransactionObservation(
+    id = id,
+    walletId = walletId,
+    owner = owner,
+    recipient = recipient,
+    contract = contract,
+    blockNumber = blockNumber,
+    sequence = sequence,
+    fee = fee,
+    value = value,
+    payload = payload,
+    updatedAt = updatedAt,
+)

--- a/ios/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
@@ -19,10 +19,11 @@ public final class TransactionSceneViewModel {
     private let explorerService: ExplorerService
     private let onHeaderAction: ((TransactionHeaderAction) -> Void)?
     private let onAddContact: ((AddContactType) -> Void)?
+    private let transaction: TransactionExtended
 
     public let query: ObservableQuery<TransactionRequest>
     var transactionExtended: TransactionExtended {
-        query.value
+        query.value ?? transaction
     }
 
     var isPresentingTransactionSheet: TransactionSheetType?
@@ -40,6 +41,7 @@ public final class TransactionSceneViewModel {
         self.explorerService = explorerService
         self.onHeaderAction = onHeaderAction
         self.onAddContact = onAddContact
+        self.transaction = transaction
         query = ObservableQuery(TransactionRequest(walletId: walletId, transactionId: transaction.transaction.id), initialValue: transaction)
     }
 

--- a/ios/Gem/Navigation/NavigationHandler.swift
+++ b/ios/Gem/Navigation/NavigationHandler.swift
@@ -154,7 +154,7 @@ extension NavigationHandler {
             return
         }
 
-        try transactionsService.addTransaction(walletId: walletId, transaction: transaction)
+        try transactionsService.syncTransaction(walletId: walletId, transaction: transaction)
         let transaction = try transactionsService.getTransaction(walletId: walletId, transactionId: transaction.id)
 
         await selectWalletIfNeeded(walletId)

--- a/ios/Packages/FeatureServices/TransactionStateService/Tests/TransactionStateServiceTests.swift
+++ b/ios/Packages/FeatureServices/TransactionStateService/Tests/TransactionStateServiceTests.swift
@@ -110,26 +110,26 @@ struct TransactionStateServiceTests {
     }
 
     @Test
-    func hashChangeDoesNotDowngradeCompletedTransaction() async throws {
+    func hashChangeKeepsTrackedTransactionOverIndexedDuplicate() async throws {
         let fixture = try makeFixture(stateChanges: TransactionChanges(
             state: .inTransit,
             changes: [
                 .hashChange(old: "hash", new: "new-hash"),
             ],
         ))
-        let existingTransaction = try makeSwapTransaction(
+        let indexedTransaction = try makeSwapTransaction(
             hash: "new-hash",
             fromAsset: .mock(.bitcoin),
             toAsset: .mock(.ethereum),
             state: .confirmed,
         )
-        try fixture.store.addTransactions(walletId: fixture.walletId, transactions: [existingTransaction])
+        try fixture.store.syncTransactions(walletId: fixture.walletId, transactions: [indexedTransaction])
 
         let status = await fixture.service.update(for: fixture.transaction).status
 
-        expectComplete(status)
-        #expect(try fixture.store.getTransactions(states: [.pending]).isEmpty)
-        let saved = try #require(fixture.store.getTransactions(states: [.confirmed]).first)
+        expectRetry(status)
+        #expect(try fixture.store.getTransactions(states: TransactionState.allCases).count == 1)
+        let saved = try #require(fixture.store.getTransactions(states: [.inTransit]).first)
         #expect(saved.id.hash == "new-hash")
     }
 

--- a/ios/Packages/FeatureServices/TransactionStateService/TransactionStateService.swift
+++ b/ios/Packages/FeatureServices/TransactionStateService/TransactionStateService.swift
@@ -17,11 +17,6 @@ struct TransactionStateUpdateResult {
     let status: JobStatus
 }
 
-private struct LocalTransactionRecord {
-    let transactionId: TransactionId
-    let state: TransactionState
-}
-
 public struct TransactionStateService: Sendable {
     private let transactionStore: TransactionStore
     private let postProcessingService: TransactionPostProcessingService
@@ -128,45 +123,37 @@ extension TransactionStateService {
             )
         }
 
-        let localTransaction = try localTransactionRecord(for: transaction, changes: stateChanges.changes)
+        let transactionId = try updatedTransactionId(for: transaction, changes: stateChanges.changes)
         let nextState = try updateStateIfNeeded(
-            transactionId: localTransaction.transactionId,
-            oldState: localTransaction.state,
+            transactionId: transactionId,
+            oldState: transaction.state,
             newState: stateChanges.state,
         )
-        try updateTransactionFields(stateChanges.changes, transactionId: localTransaction.transactionId)
+        try updateTransactionFields(stateChanges.changes, transactionId: transactionId)
 
         return TransactionStateUpdateResult(
-            transactionId: localTransaction.transactionId,
+            transactionId: transactionId,
             status: nextState.isCompleted ? .complete : .retry(),
         )
     }
 
-    private func localTransactionRecord(for transaction: Transaction, changes: [TransactionChange]) throws -> LocalTransactionRecord {
-        try changes.reduce(
-            LocalTransactionRecord(
-                transactionId: transaction.id,
-                state: transaction.state,
-            ),
-        ) { localTransaction, change in
+    private func updatedTransactionId(for transaction: Transaction, changes: [TransactionChange]) throws -> TransactionId {
+        try changes.reduce(transaction.id) { transactionId, change in
             guard case let .hashChange(_, newHash) = change else {
-                return localTransaction
+                return transactionId
             }
             let newTransactionId = TransactionId(chain: transaction.assetId.chain, hash: newHash)
-            let state = try transactionStore.updateTransactionId(
-                oldTransactionId: localTransaction.transactionId,
+            try transactionStore.updateTransactionId(
+                oldTransactionId: transactionId,
                 transactionId: newTransactionId,
                 hash: newHash,
-            ) ?? localTransaction.state
-            return LocalTransactionRecord(
-                transactionId: newTransactionId,
-                state: state,
             )
+            return newTransactionId
         }
     }
 
     private func updateStateIfNeeded(transactionId: TransactionId, oldState: TransactionState, newState: TransactionState) throws -> TransactionState {
-        let nextState = nextTransactionState(oldState: oldState, newState: newState)
+        let nextState = oldState.next(newState)
         if nextState != oldState {
             _ = try transactionStore.updateState(id: transactionId, state: nextState)
         }
@@ -188,9 +175,5 @@ extension TransactionStateService {
                 _ = try transactionStore.updateMetadata(transactionId: transactionId, metadata: metadata)
             }
         }
-    }
-
-    private func nextTransactionState(oldState: TransactionState, newState: TransactionState) -> TransactionState {
-        oldState == .pending || newState.isCompleted ? newState : oldState
     }
 }

--- a/ios/Packages/FeatureServices/TransactionsService/TransactionsService.swift
+++ b/ios/Packages/FeatureServices/TransactionsService/TransactionsService.swift
@@ -35,7 +35,7 @@ public final class TransactionsService: Sendable {
         )
 
         try await prefetchAssets(walletId: walletId, transactions: response.transactions)
-        try transactionStore.addTransactions(walletId: walletId, transactions: response.transactions)
+        try transactionStore.syncTransactions(walletId: walletId, transactions: response.transactions)
         try addressStore.addAddressNames(response.addressNames)
 
         store.transactionsTimestamp = newTimestamp
@@ -51,14 +51,14 @@ public final class TransactionsService: Sendable {
         )
 
         try await prefetchAssets(walletId: walletId, transactions: response.transactions)
-        try transactionStore.addTransactions(walletId: walletId, transactions: response.transactions)
+        try transactionStore.syncTransactions(walletId: walletId, transactions: response.transactions)
         try addressStore.addAddressNames(response.addressNames)
 
         store.setTransactionsForAssetTimestamp(assetId: assetId.identifier, value: newTimestamp)
     }
 
-    public func addTransaction(walletId: WalletId, transaction: Transaction) throws {
-        try transactionStore.addTransactions(walletId: walletId, transactions: [transaction])
+    public func syncTransaction(walletId: WalletId, transaction: Transaction) throws {
+        try transactionStore.syncTransactions(walletId: walletId, transactions: [transaction])
     }
 
     public func getTransaction(walletId: WalletId, transactionId: TransactionId) throws -> TransactionExtended {

--- a/ios/Packages/Primitives/Sources/Extensions/TransactionState+Primitives.swift
+++ b/ios/Packages/Primitives/Sources/Extensions/TransactionState+Primitives.swift
@@ -16,6 +16,14 @@ public extension TransactionState {
         }
     }
 
+    func next(_ newState: TransactionState) -> TransactionState {
+        self == .pending || newState.isCompleted ? newState : self
+    }
+
+    func next(onChain newState: TransactionState) -> TransactionState {
+        self == .inTransit ? self : next(newState)
+    }
+
     init(id: String) throws {
         if let state = TransactionState(rawValue: id) {
             self = state

--- a/ios/Packages/Store/Sources/Migrations.swift
+++ b/ios/Packages/Store/Sources/Migrations.swift
@@ -507,6 +507,13 @@ struct Migrations {
             }
         }
 
+        migrator.registerMigration("Add broadcastTransactionId to \(TransactionRecord.databaseTableName)") { db in
+            try? db.alter(table: TransactionRecord.databaseTableName) {
+                $0.add(column: TransactionRecord.Columns.broadcastTransactionId.name, .text)
+                    .indexed()
+            }
+        }
+
         try migrator.migrate(dbQueue)
     }
 }

--- a/ios/Packages/Store/Sources/Models/TransactionRecord.swift
+++ b/ios/Packages/Store/Sources/Models/TransactionRecord.swift
@@ -138,6 +138,10 @@ extension TransactionRecord: CreateTable {
 }
 
 extension TransactionRecord {
+    var transactionState: TransactionState {
+        TransactionState(rawValue: state) ?? .pending
+    }
+
     func mapToTransaction() -> Transaction {
         Transaction(
             id: TransactionId(chain: assetId.chain, hash: hash),
@@ -146,7 +150,7 @@ extension TransactionRecord {
             to: to,
             contract: contract,
             type: type,
-            state: TransactionState(rawValue: state) ?? .pending,
+            state: transactionState,
             blockNumber: blockNumber.asString,
             sequence: sequence.asString,
             fee: fee,

--- a/ios/Packages/Store/Sources/Models/TransactionRecord.swift
+++ b/ios/Packages/Store/Sources/Models/TransactionRecord.swift
@@ -11,6 +11,7 @@ struct TransactionRecord: Codable, TableRecord, FetchableRecord, PersistableReco
         static let id = Column("id")
         static let walletId = Column("walletId")
         static let transactionId = Column("transactionId")
+        static let broadcastTransactionId = Column("broadcastTransactionId")
         static let hash = Column("hash")
         static let from = Column("from")
         static let to = Column("to")
@@ -35,6 +36,7 @@ struct TransactionRecord: Codable, TableRecord, FetchableRecord, PersistableReco
     var id: Int? = .none
     var walletId: String
     var transactionId: String
+    var broadcastTransactionId: String? = .none
     var hash: String
     var type: TransactionType
     var from: String
@@ -88,6 +90,8 @@ extension TransactionRecord: CreateTable {
                 .references(WalletRecord.databaseTableName, onDelete: .cascade, onUpdate: .cascade)
             $0.column(Columns.transactionId.name, .text)
                 .notNull()
+                .indexed()
+            $0.column(Columns.broadcastTransactionId.name, .text)
                 .indexed()
             $0.column(Columns.hash.name, .text)
                 .indexed()

--- a/ios/Packages/Store/Sources/Requests/TransactionRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/TransactionRequest.swift
@@ -18,57 +18,14 @@ public struct TransactionRequest: DatabaseQueryable {
         self.transactionId = transactionId
     }
 
-    public func fetch(_ db: Database) throws -> TransactionExtended {
+    public func fetch(_ db: Database) throws -> TransactionExtended? {
         try TransactionsRequest.fetch(
             db,
             type: .transaction(id: transactionId.identifier),
             filters: filters,
             walletId: walletId,
-        ).first ?? .empty
+        ).first
     }
 }
 
 extension TransactionRequest: Equatable {}
-
-public extension TransactionExtended {
-    static let empty: TransactionExtended = {
-        let asset = Asset(
-            id: AssetId(chain: .bitcoin, tokenId: nil),
-            name: "",
-            symbol: "",
-            decimals: 0,
-            type: .native,
-        )
-
-        return TransactionExtended(
-            transaction: Transaction(
-                id: TransactionId(chain: .ethereum, hash: ""),
-                assetId: AssetId(chain: .bitcoin, tokenId: nil),
-                from: "",
-                to: "",
-                contract: nil,
-                type: .transfer,
-                state: .pending,
-                blockNumber: "",
-                sequence: "",
-                fee: "",
-                feeAssetId: AssetId(chain: .bitcoin, tokenId: nil),
-                value: "",
-                memo: nil,
-                direction: .selfTransfer,
-                utxoInputs: [],
-                utxoOutputs: [],
-                metadata: nil,
-                createdAt: .now,
-            ),
-            asset: asset,
-            feeAsset: asset,
-            price: nil,
-            feePrice: nil,
-            assets: [],
-            prices: [],
-            fromAddress: nil,
-            toAddress: nil,
-        )
-    }()
-}

--- a/ios/Packages/Store/Sources/Requests/TransactionsRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/TransactionsRequest.swift
@@ -55,7 +55,7 @@ public struct TransactionsRequest: DatabaseQueryable {
                 request = request.joining(required: TransactionRecord.assetsAssociation.filter(assetIds.map(\.identifier).contains(TransactionAssetAssociationRecord.Columns.assetId)))
             }
         case let .transaction(id):
-            request = request.filter(TransactionRecord.Columns.transactionId == id)
+            request = request.filter(TransactionRecord.Columns.transactionId == id || TransactionRecord.Columns.broadcastTransactionId == id)
         case .all, .pending:
             break
         }

--- a/ios/Packages/Store/Sources/Stores/TransactionStore.swift
+++ b/ios/Packages/Store/Sources/Stores/TransactionStore.swift
@@ -63,20 +63,35 @@ public struct TransactionStore: Sendable {
     }
 
     public func addTransactions(walletId: WalletId, transactions: [Transaction]) throws {
-        if transactions.isEmpty {
-            return
-        }
+        guard transactions.isNotEmpty else { return }
         try db.write { db in
             for transaction in transactions {
                 let record = try transaction.record(walletId: walletId.id).upsertAndFetch(db, as: TransactionRecord.self)
-                if let id = record.id {
-                    try TransactionAssetAssociationRecord
-                        .filter(TransactionAssetAssociationRecord.Columns.transactionId == id)
-                        .deleteAll(db)
+                try replaceAssetAssociations(of: record, with: transaction.assetIds, db: db)
+            }
+        }
+    }
 
-                    try transaction.assetIds.forEach {
-                        try TransactionAssetAssociationRecord(transactionId: id, assetId: $0).upsert(db)
-                    }
+    public func syncTransactions(walletId: WalletId, transactions: [Transaction]) throws {
+        guard transactions.isNotEmpty else { return }
+        try db.write { db in
+            for transaction in transactions {
+                let incomingRecord = try transaction.record(walletId: walletId.id)
+                guard let storedRecord = try storedRecord(of: incomingRecord, db: db) else {
+                    let insertedRecord = try incomingRecord.insertAndFetch(db, as: TransactionRecord.self)
+                    try replaceAssetAssociations(of: insertedRecord, with: transaction.assetIds, db: db)
+                    continue
+                }
+                let storedState = storedRecord.transactionState
+                let syncedState = storedState.next(onChain: incomingRecord.transactionState)
+
+                try refreshObservedValues(of: incomingRecord, db: db)
+                if syncedState != storedState {
+                    try refreshState(of: storedRecord, to: syncedState, db: db)
+                }
+                if syncedState.isCompleted, incomingRecord.metadata != nil {
+                    try refreshDescription(of: incomingRecord, db: db)
+                    try replaceAssetAssociations(of: storedRecord, with: transaction.assetIds, db: db)
                 }
             }
         }
@@ -106,32 +121,23 @@ public struct TransactionStore: Sendable {
         )
     }
 
-    public func updateTransactionId(oldTransactionId: TransactionId, transactionId: TransactionId, hash: String) throws -> TransactionState? {
+    public func updateTransactionId(oldTransactionId: TransactionId, transactionId: TransactionId, hash: String) throws {
         try db.write { db in
-            let oldRecord = try TransactionRecord
+            guard let trackedRecord = try TransactionRecord
                 .filter(TransactionRecord.Columns.transactionId == oldTransactionId.identifier)
                 .fetchOne(db)
-
-            if let oldRecord {
-                let existingRecord = try TransactionRecord
-                    .filter(TransactionRecord.Columns.walletId == oldRecord.walletId)
-                    .filter(TransactionRecord.Columns.transactionId == transactionId.identifier)
-                    .fetchOne(db)
-                if let existingRecord {
-                    _ = try TransactionRecord
-                        .filter(TransactionRecord.Columns.id == oldRecord.id)
-                        .deleteAll(db)
-                    return TransactionState(rawValue: existingRecord.state)
-                }
+            else {
+                return
             }
 
+            try deleteIndexedDuplicate(walletId: trackedRecord.walletId, transactionId: transactionId, db: db)
+
             try TransactionRecord
-                .filter(TransactionRecord.Columns.transactionId == oldTransactionId.identifier)
+                .filter(TransactionRecord.Columns.id == trackedRecord.id)
                 .updateAll(db, [
                     TransactionRecord.Columns.transactionId.set(to: transactionId.identifier),
                     TransactionRecord.Columns.hash.set(to: hash),
                 ])
-            return nil
         }
     }
 
@@ -141,6 +147,65 @@ public struct TransactionStore: Sendable {
                 .filter(ids.contains(TransactionRecord.Columns.transactionId))
                 .deleteAll(db)
         }
+    }
+
+    private func deleteIndexedDuplicate(walletId: String, transactionId: TransactionId, db: Database) throws {
+        _ = try TransactionRecord
+            .filter(TransactionRecord.Columns.walletId == walletId)
+            .filter(TransactionRecord.Columns.transactionId == transactionId.identifier)
+            .deleteAll(db)
+    }
+
+    private func replaceAssetAssociations(of record: TransactionRecord, with assetIds: [AssetId], db: Database) throws {
+        guard let recordId = record.id else { return }
+        try TransactionAssetAssociationRecord
+            .filter(TransactionAssetAssociationRecord.Columns.transactionId == recordId)
+            .deleteAll(db)
+
+        try assetIds.forEach {
+            try TransactionAssetAssociationRecord(transactionId: recordId, assetId: $0).upsert(db)
+        }
+    }
+
+    private func storedRecord(of record: TransactionRecord, db: Database) throws -> TransactionRecord? {
+        try TransactionRecord
+            .filter(TransactionRecord.Columns.walletId == record.walletId)
+            .filter(TransactionRecord.Columns.transactionId == record.transactionId)
+            .fetchOne(db)
+    }
+
+    private func refreshState(of record: TransactionRecord, to state: TransactionState, db: Database) throws {
+        _ = try TransactionRecord
+            .filter(TransactionRecord.Columns.walletId == record.walletId)
+            .filter(TransactionRecord.Columns.transactionId == record.transactionId)
+            .updateAll(db, [TransactionRecord.Columns.state.set(to: state.rawValue)])
+    }
+
+    private func refreshDescription(of record: TransactionRecord, db: Database) throws {
+        _ = try TransactionRecord
+            .filter(TransactionRecord.Columns.walletId == record.walletId)
+            .filter(TransactionRecord.Columns.transactionId == record.transactionId)
+            .updateAll(db, [
+                TransactionRecord.Columns.type.set(to: record.type.rawValue),
+                TransactionRecord.Columns.metadata.set(to: try JSONEncoder().encode(record.metadata).encodeString()),
+            ])
+    }
+
+    private func refreshObservedValues(of record: TransactionRecord, db: Database) throws {
+        _ = try TransactionRecord
+            .filter(TransactionRecord.Columns.walletId == record.walletId)
+            .filter(TransactionRecord.Columns.transactionId == record.transactionId)
+            .updateAll(db, [
+                TransactionRecord.Columns.from.set(to: record.from),
+                TransactionRecord.Columns.to.set(to: record.to),
+                TransactionRecord.Columns.contract.set(to: record.contract),
+                TransactionRecord.Columns.blockNumber.set(to: record.blockNumber),
+                TransactionRecord.Columns.sequence.set(to: record.sequence),
+                TransactionRecord.Columns.value.set(to: record.value),
+                TransactionRecord.Columns.fee.set(to: record.fee),
+                TransactionRecord.Columns.memo.set(to: record.memo),
+                TransactionRecord.Columns.updatedAt.set(to: record.updatedAt),
+            ])
     }
 
     private func updateValues(id: TransactionId, values: [ColumnAssignment]) throws -> Int {

--- a/ios/Packages/Store/Sources/Stores/TransactionStore.swift
+++ b/ios/Packages/Store/Sources/Stores/TransactionStore.swift
@@ -58,7 +58,10 @@ public struct TransactionStore: Sendable {
 
     public func getTransaction(walletId: WalletId, transactionId: TransactionId) throws -> TransactionExtended {
         try db.read { db in
-            try TransactionRequest(walletId: walletId, transactionId: transactionId).fetch(db)
+            guard let transaction = try TransactionRequest(walletId: walletId, transactionId: transactionId).fetch(db) else {
+                throw AnyError("Transaction not found")
+            }
+            return transaction
         }
     }
 
@@ -136,6 +139,7 @@ public struct TransactionStore: Sendable {
                 .filter(TransactionRecord.Columns.id == trackedRecord.id)
                 .updateAll(db, [
                     TransactionRecord.Columns.transactionId.set(to: transactionId.identifier),
+                    TransactionRecord.Columns.broadcastTransactionId.set(to: trackedRecord.broadcastTransactionId ?? oldTransactionId.identifier),
                     TransactionRecord.Columns.hash.set(to: hash),
                 ])
         }

--- a/ios/Packages/Store/TestKit/Transaction+StoreTestKit.swift
+++ b/ios/Packages/Store/TestKit/Transaction+StoreTestKit.swift
@@ -11,6 +11,8 @@ public extension Transaction {
         state: TransactionState = .confirmed,
         assetId: AssetId = .mock(),
         metadata: AnyCodableValue? = nil,
+        fee: String = "1",
+        blockNumber: String = "1",
     ) -> Transaction {
         Transaction(
             id: transactionId,
@@ -20,9 +22,9 @@ public extension Transaction {
             contract: nil,
             type: type,
             state: state,
-            blockNumber: "1",
+            blockNumber: blockNumber,
             sequence: "1",
-            fee: "1",
+            fee: fee,
             feeAssetId: assetId,
             value: "100",
             memo: nil,

--- a/ios/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
@@ -202,6 +202,23 @@ struct TransactionStoreTests {
         #expect(transaction.state == .inTransit)
         #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
     }
+
+    @Test func transactionFoundByBroadcastIdAfterHashChange() throws {
+        let (store, walletId) = transactionStore()
+        let originalId = TransactionId(chain: .ethereum, hash: "original")
+        let renamedId = TransactionId(chain: .ethereum, hash: "renamed")
+        let syncedId = TransactionId(chain: .ethereum, hash: "synced")
+        try store.addTransactions(walletId: walletId, transactions: [.mock(transactionId: originalId, type: .transfer, state: .pending, assetId: Chain.ethereum.assetId, metadata: nil)])
+
+        try store.updateTransactionId(oldTransactionId: originalId, transactionId: renamedId, hash: renamedId.hash)
+
+        #expect(try store.getTransaction(walletId: walletId, transactionId: originalId).transaction.id == renamedId)
+
+        try store.syncTransactions(walletId: walletId, transactions: [.mock(transactionId: syncedId, type: .transfer, state: .confirmed, assetId: Chain.ethereum.assetId, metadata: nil)])
+        try store.updateTransactionId(oldTransactionId: renamedId, transactionId: syncedId, hash: syncedId.hash)
+
+        #expect(try store.getTransaction(walletId: walletId, transactionId: originalId).transaction.id == syncedId)
+    }
 }
 
 extension TransactionStoreTests {

--- a/ios/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
@@ -73,4 +73,155 @@ struct TransactionStoreTests {
         #expect(assetIds.count == 2)
         #expect(Set(assetIds) == Set([btc, sol]))
     }
+
+    @Test func syncKeepsIntentAndRefreshesObservedValues() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .swap, state: .inTransit, metadata: Self.swapMetadata),
+        ])
+
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .transfer, state: .confirmed, metadata: nil, fee: "500", blockNumber: "77"),
+        ])
+
+        let transaction = try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction
+
+        #expect(transaction.type == .swap)
+        #expect(transaction.state == .inTransit)
+        #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
+        #expect(transaction.fee == "500")
+        #expect(transaction.blockNumber == "77")
+    }
+
+    @Test func syncEnrichesStoredTransactionWithIndexedDescription() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .smartContractCall, state: .confirmed, metadata: nil),
+        ])
+
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .swap, state: .confirmed, metadata: Self.swapMetadata),
+        ])
+
+        let transaction = try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction
+        let assetIds = try store.getTransactionAssetAssociations(for: transactionId).map(\.assetId)
+
+        #expect(transaction.type == .swap)
+        #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
+        #expect(Set(assetIds) == Set([Chain.bitcoin.assetId, Chain.ethereum.assetId]))
+    }
+
+    @Test func syncSettlesPendingTransaction() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .transfer, state: .pending, metadata: nil),
+        ])
+
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .transfer, state: .confirmed, metadata: nil),
+        ])
+
+        #expect(try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction.state == .confirmed)
+    }
+
+    @Test func syncKeepsStateOfTransactionWaitingOffChain() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .swap, state: .inTransit, metadata: Self.swapMetadata),
+        ])
+
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .transfer, state: .confirmed, metadata: nil),
+        ])
+
+        #expect(try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction.state == .inTransit)
+    }
+
+    @Test func syncKeepsDescriptionOfTrackedTransaction() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .swap, state: .inTransit, metadata: Self.swapMetadata),
+        ])
+
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: transactionId, type: .swap, state: .inTransit, metadata: Self.indexedSwapMetadata),
+        ])
+
+        let transaction = try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction
+
+        #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
+    }
+
+    @Test func syncStoresUnknownTransactionOnce() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        let indexed = Transaction.mock(transactionId: transactionId, type: .swap, state: .confirmed, metadata: Self.swapMetadata)
+
+        try store.syncTransactions(walletId: walletId, transactions: [indexed])
+        try store.syncTransactions(walletId: walletId, transactions: [indexed])
+
+        let transaction = try store.getTransaction(walletId: walletId, transactionId: transactionId).transaction
+
+        #expect(try store.getTransactions(states: TransactionState.allCases).count == 1)
+        #expect(transaction.type == .swap)
+        #expect(transaction.state == .confirmed)
+        #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
+    }
+
+    @Test func syncStoresRepeatedBatchOnce() throws {
+        let (store, walletId) = transactionStore()
+        let transactionId = TransactionId(chain: .ethereum, hash: "1")
+        let indexed = Transaction.mock(transactionId: transactionId, type: .transfer, state: .confirmed, metadata: nil)
+
+        try store.syncTransactions(walletId: walletId, transactions: [indexed, indexed])
+
+        #expect(try store.getTransactions(states: TransactionState.allCases).count == 1)
+    }
+
+    @Test func hashChangeKeepsTrackedTransactionOverIndexedDuplicate() throws {
+        let (store, walletId) = transactionStore()
+        let localId = TransactionId(chain: .ethereum, hash: "message")
+        let indexedId = TransactionId(chain: .ethereum, hash: "onchain")
+        try store.addTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: localId, type: .swap, state: .inTransit, metadata: Self.swapMetadata),
+        ])
+        try store.syncTransactions(walletId: walletId, transactions: [
+            .mock(transactionId: indexedId, type: .transfer, state: .confirmed, metadata: nil),
+        ])
+
+        try store.updateTransactionId(oldTransactionId: localId, transactionId: indexedId, hash: indexedId.hash)
+        let transaction = try store.getTransaction(walletId: walletId, transactionId: indexedId).transaction
+
+        #expect(try store.getTransactions(states: TransactionState.allCases).count == 1)
+        #expect(transaction.type == .swap)
+        #expect(transaction.state == .inTransit)
+        #expect(transaction.metadata?.decode(TransactionSwapMetadata.self)?.provider == "nearintents")
+    }
+}
+
+extension TransactionStoreTests {
+    private static let swapMetadata = AnyCodableValue.encode(TransactionSwapMetadata.mock(
+        fromAsset: Chain.bitcoin.assetId,
+        toAsset: Chain.ethereum.assetId,
+        provider: "nearintents",
+    ))
+
+    private static let indexedSwapMetadata = AnyCodableValue.encode(TransactionSwapMetadata.mock(
+        fromAsset: Chain.bitcoin.assetId,
+        toAsset: Chain.ethereum.assetId,
+        provider: nil,
+    ))
+
+    private func transactionStore() -> (TransactionStore, WalletId) {
+        let db = DB.mockAssets(assets: [
+            .mock(asset: .mock(id: Chain.bitcoin.assetId)),
+            .mock(asset: .mockEthereum()),
+        ])
+        return (.mock(db: db), .mock())
+    }
 }


### PR DESCRIPTION
TON and Hyperliquid transactions get a new hash once they land on chain. The details screen kept watching the old one, so it froze in Pending forever, and on iOS a missing transaction was drawn as an empty Bitcoin transfer.

Now the record remembers the id it was broadcast with, the details screen follows the transaction to its new hash on both platforms, and the placeholder is gone.

Closes #844

<img width="320" alt="Simulator Screenshot - wt3 - 2026-08-07 at 16 29 56" src="https://github.com/user-attachments/assets/e914ab12-41f4-4922-9634-b05fd43edfda" />
<img width="320" alt="Simulator Screenshot - wt3 - 2026-08-07 at 16 30 00" src="https://github.com/user-attachments/assets/faa33ad2-70dc-4852-bdc0-32b42219d62e" />

