### PR TITLE
Update device info on currency change

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -67,11 +67,13 @@ class DeviceRepository(
     private val syncCoordinator = DeviceSyncCoordinator(scope)
 
     override suspend fun syncDevice() {
-        repeat(SYNC_ATTEMPTS) {
-            if (!needsSynchronization()) {
-                return
+        if (!needsSynchronization()) {
+            return
+        }
+        syncCoordinator.synchronize {
+            if (needsSynchronization()) {
+                reconcileDevice()
             }
-            syncCoordinator.synchronize { reconcileDevice() }
         }
     }
 
@@ -264,8 +266,6 @@ class DeviceRepository(
     }
 
     companion object {
-        private const val SYNC_ATTEMPTS = 2
-
         fun getDeviceLocale(locale: Locale): DeviceLocale {
             val canonicalLocale = ULocale.addLikelySubtags(ULocale.forLocale(locale))
             val identifier = when (canonicalLocale.language) {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinator.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinator.kt
@@ -16,7 +16,9 @@ internal class DeviceSyncCoordinator(
 
     suspend fun synchronize(operation: suspend () -> Unit) {
         val task = mutex.withLock {
-            current.takeIf { it.isActive } ?: scope.async {
+            val previous = current
+            scope.async {
+                previous.join()
                 try {
                     operation()
                 } catch (error: CancellationException) {

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinatorTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/device/DeviceSyncCoordinatorTest.kt
@@ -1,9 +1,10 @@
 package com.gemwallet.android.data.repositories.device
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -12,21 +13,33 @@ import org.junit.Test
 class DeviceSyncCoordinatorTest {
 
     @Test
-    fun synchronize_joinsConcurrentCallersIntoOneRun() = runTest {
+    fun synchronize_runsEachCallerAfterInFlightRunCompletes() = runTest {
         val coordinator = DeviceSyncCoordinator(this)
-        var runs = 0
+        val firstStarted = CompletableDeferred<Unit>()
+        val firstRelease = CompletableDeferred<Unit>()
+        val runs = mutableListOf<String>()
 
-        repeat(3) {
-            launch {
-                coordinator.synchronize {
-                    delay(100)
-                    runs += 1
-                }
+        launch {
+            coordinator.synchronize {
+                firstStarted.complete(Unit)
+                firstRelease.await()
+                runs += "first"
             }
         }
+        firstStarted.await()
+
+        launch {
+            coordinator.synchronize {
+                runs += "second"
+            }
+        }
+        runCurrent()
+        assertEquals(emptyList<String>(), runs)
+
+        firstRelease.complete(Unit)
         advanceUntilIdle()
 
-        assertEquals(1, runs)
+        assertEquals(listOf("first", "second"), runs)
     }
 
     @Test

--- a/ios/Features/Settings/Package.swift
+++ b/ios/Features/Settings/Package.swift
@@ -69,6 +69,7 @@ let package = Package(
                 "Settings",
                 "Primitives",
                 .product(name: "PriceServiceTestKit", package: "FeatureServices"),
+                .product(name: "DeviceServiceTestKit", package: "FeatureServices"),
             ],
         ),
     ],

--- a/ios/Features/Settings/Sources/Currency/Scenes/CurrencyScene.swift
+++ b/ios/Features/Settings/Sources/Currency/Scenes/CurrencyScene.swift
@@ -44,9 +44,12 @@ extension CurrencyScene {
 
         do {
             try model.setCurrency(currency)
-            dismiss()
         } catch {
             return
         }
+        Task {
+            await model.updateDevice()
+        }
+        dismiss()
     }
 }

--- a/ios/Features/Settings/Sources/Currency/ViewModels/CurrencySceneViewModel.swift
+++ b/ios/Features/Settings/Sources/Currency/ViewModels/CurrencySceneViewModel.swift
@@ -1,15 +1,18 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Components
+import DeviceService
 import Foundation
 import Localization
 import PriceService
 import Primitives
 
 @Observable
+@MainActor
 public final class CurrencySceneViewModel {
     private var currencyStorage: CurrencyStorable
     private let priceService: PriceService
+    private let deviceService: any DeviceServiceable
     private let defaultCurrencies: [Currency] = [.usd, .eur, .gbp, .cny, .jpy, .inr, .rub]
 
     private(set) var currency: Currency {
@@ -27,9 +30,11 @@ public final class CurrencySceneViewModel {
     public init(
         currencyStorage: CurrencyStorable,
         priceService: PriceService,
+        deviceService: any DeviceServiceable,
     ) {
         self.currencyStorage = currencyStorage
         self.priceService = priceService
+        self.deviceService = deviceService
     }
 
     public var selectedCurrencyValue: String {
@@ -65,6 +70,10 @@ public final class CurrencySceneViewModel {
     func setCurrency(_ currency: Currency) throws {
         self.currency = currency
         try priceService.changeCurrency(currency: currency.rawValue)
+    }
+
+    func updateDevice() async {
+        try? await deviceService.update()
     }
 }
 

--- a/ios/Features/Settings/Tests/CurrencyTests/CurrencySceneViewModelTests.swift
+++ b/ios/Features/Settings/Tests/CurrencyTests/CurrencySceneViewModelTests.swift
@@ -1,6 +1,8 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
+import DeviceServiceTestKit
 import Foundation
+import PriceService
 import PriceServiceTestKit
 import Primitives
 @testable import Settings
@@ -13,13 +15,14 @@ private final class MockCurrencyStorage: CurrencyStorable, @unchecked Sendable {
     }
 }
 
+@MainActor
 struct CurrencySceneViewModelTests {
     private var storage = MockCurrencyStorage()
 
     @Test
     func uSDCurrencyValue() {
         let usdCurrencyStorage = MockCurrencyStorage()
-        let viewModel = CurrencySceneViewModel(currencyStorage: usdCurrencyStorage, priceService: .mock())
+        let viewModel = CurrencySceneViewModel(currencyStorage: usdCurrencyStorage, priceService: .mock(), deviceService: DeviceServiceMock())
 
         #expect(viewModel.selectedCurrencyValue == "🇺🇸 USD")
     }
@@ -27,18 +30,23 @@ struct CurrencySceneViewModelTests {
     @Test
     func gBPCurrencyValue() {
         let gbpCurrencyStorage = MockCurrencyStorage(currency: "GBP")
-        let viewModel = CurrencySceneViewModel(currencyStorage: gbpCurrencyStorage, priceService: .mock())
+        let viewModel = CurrencySceneViewModel(currencyStorage: gbpCurrencyStorage, priceService: .mock(), deviceService: DeviceServiceMock())
         #expect(viewModel.selectedCurrencyValue == "🇬🇧 GBP")
     }
 
     @Test
-    func setNewCurrency() {
+    func setNewCurrency() async throws {
+        let priceService: PriceService = .mock()
+        try priceService.addRates([FiatRate(symbol: .ars, rate: 1200)])
         let usdCurrencyStorage = MockCurrencyStorage()
-        let viewModel = CurrencySceneViewModel(currencyStorage: usdCurrencyStorage, priceService: .mock())
+        let deviceService = DeviceServiceMock()
+        let viewModel = CurrencySceneViewModel(currencyStorage: usdCurrencyStorage, priceService: priceService, deviceService: deviceService)
 
-        try? viewModel.setCurrency(.ars)
+        try viewModel.setCurrency(.ars)
+        await viewModel.updateDevice()
 
         #expect(usdCurrencyStorage.currency == Currency.ars.id)
         #expect(usdCurrencyStorage.currency == viewModel.currency.id)
+        #expect(await deviceService.updateCalls == 1)
     }
 }

--- a/ios/Features/WalletTab/Tests/PortfolioDataServiceTests.swift
+++ b/ios/Features/WalletTab/Tests/PortfolioDataServiceTests.swift
@@ -25,7 +25,7 @@ struct PortfolioDataServiceTests {
                 allTimeHigh: .mock(date: date, value: 100),
                 allTimeLow: .mock(date: date, value: 20),
             )),
-            priceService: .mock(priceStore: .mock(db: db)),
+            priceService: .mock(db: db),
         )
 
         let data = try await service.getPortfoliData(input: .wallet(walletId: .mock(), period: .all, currencyCode: currency))

--- a/ios/Gem/Navigation/Settings/SettingsNavigationStack.swift
+++ b/ios/Gem/Navigation/Settings/SettingsNavigationStack.swift
@@ -2,6 +2,7 @@
 
 import Contacts
 import ContactService
+import DeviceService
 import InAppNotifications
 import MarketInsight
 import NotificationService
@@ -22,7 +23,6 @@ import WalletSessionService
 struct SettingsNavigationStack: View {
     @Environment(\.navigationState) private var navigationState
     @Environment(\.navigationHandler) private var navigationHandler
-    @Environment(\.deviceService) private var deviceService
     @Environment(\.transactionsService) private var transactionsService
     @Environment(\.assetsService) private var assetsService
     @Environment(\.stakeService) private var stakeService
@@ -50,20 +50,24 @@ struct SettingsNavigationStack: View {
     @State private var currencyModel: CurrencySceneViewModel
 
     let walletId: WalletId
+    private let deviceService: any DeviceServiceable
     @Binding var isPresentingSupport: Bool
 
     init(
         walletId: WalletId,
         preferences: Preferences = .standard,
         priceService: PriceService,
+        deviceService: any DeviceServiceable,
         isPresentingSupport: Binding<Bool>,
     ) {
         self.walletId = walletId
+        self.deviceService = deviceService
         _isPresentingSupport = isPresentingSupport
         _currencyModel = State(
             initialValue: CurrencySceneViewModel(
                 currencyStorage: preferences,
                 priceService: priceService,
+                deviceService: deviceService,
             ),
         )
     }

--- a/ios/Gem/Views/MainTabView.swift
+++ b/ios/Gem/Views/MainTabView.swift
@@ -16,6 +16,7 @@ struct MainTabView: View {
     @Environment(\.assetDiscoveryService) private var assetDiscoveryService
     @Environment(\.balanceService) private var balanceService
     @Environment(\.bannerService) private var bannerService
+    @Environment(\.deviceService) private var deviceService
     @Environment(\.navigationState) private var navigationState
     @Environment(\.navigationPresenter) private var presenter
     @Environment(\.nftService) private var nftService
@@ -83,6 +84,7 @@ struct MainTabView: View {
             SettingsNavigationStack(
                 walletId: model.wallet.id,
                 priceService: priceService,
+                deviceService: deviceService,
                 isPresentingSupport: presenter.isPresentingSupport,
             )
             .tabItem {

--- a/ios/Packages/FeatureServices/PriceService/TestKit/PriceService+TestKit.swift
+++ b/ios/Packages/FeatureServices/PriceService/TestKit/PriceService+TestKit.swift
@@ -6,13 +6,10 @@ import Store
 import StoreTestKit
 
 public extension PriceService {
-    static func mock(
-        priceStore: PriceStore = .mock(),
-        fiatRateStore: FiatRateStore = .mock(),
-    ) -> Self {
+    static func mock(db: DB = .mock()) -> Self {
         PriceService(
-            priceStore: priceStore,
-            fiatRateStore: fiatRateStore,
+            priceStore: .mock(db: db),
+            fiatRateStore: .mock(db: db),
         )
     }
 }


### PR DESCRIPTION
Changing the fiat currency did not update the device info on the server: iOS never sent an update at all, and Android could lose the change when a sync was already in flight.

Now iOS triggers a device update right after the currency changes, and Android queues sync requests so each one runs against the latest state. Verified live on both platforms.