### PR TITLE
Own confirm fee state and reload only the fee on speed change

### DIFF
--- a/ios/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
@@ -199,14 +199,13 @@ extension TransactionSceneViewModel {
     }
 
     var feeDetailsViewModel: NetworkFeeSceneViewModel {
-        let viewModel = NetworkFeeSceneViewModel(
+        NetworkFeeSceneViewModel(
             chain: model.transaction.transaction.assetId.chain,
             feeAsset: model.transaction.feeAsset,
-            priority: .normal,
             currency: Currency(rawValue: preferences.currency) ?? .usd,
+            selection: .preset(.normal),
+            feeAssetPrice: model.transaction.feePrice,
             feeAmount: BigInt(model.transaction.transaction.fee),
         )
-        viewModel.update(rates: [], feeAssetPrice: model.transaction.feePrice)
-        return viewModel
     }
 }

--- a/ios/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/ios/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -27,7 +27,7 @@ public struct ConfirmTransferScene: View {
             StateButton(model.confirmButtonModel)
         }
         .frame(maxWidth: .infinity)
-        .task(id: model.feeModel.selection) {
+        .task(id: model.feeSelection) {
             await model.fetch()
         }
         .navigationTitle(model.title)

--- a/ios/Features/Transfer/Sources/Services/ConfirmService.swift
+++ b/ios/Features/Transfer/Sources/Services/ConfirmService.swift
@@ -54,14 +54,14 @@ public struct ConfirmService: Sendable {
     }
 
     func load(request: ConfirmTransferRequest, selection: FeeSelection) async throws -> ConfirmTransferData {
-        let metadata = try metadata(request: request)
-        async let input = inputProvider.load(request: request, metadata: metadata, selection: selection)
         async let simulation = simulationService.updateState(data: request.data, simulation: request.simulation)
+        let preload = try await preload(request: request, selection: selection)
 
-        let simulationState = await simulation
-        let inputData = try await input
+        return ConfirmTransferData(preload: preload, simulation: await simulation)
+    }
 
-        return ConfirmTransferData(metadata: metadata, input: inputData, simulation: simulationState)
+    func preload(request: ConfirmTransferRequest, selection: FeeSelection) async throws -> ConfirmTransferPreload {
+        try await inputProvider.load(request: request, metadata: metadata(request: request), selection: selection)
     }
 
     func confirm(request: ConfirmTransferRequest, transactionData: TransactionData, amount: TransferAmount) async throws {

--- a/ios/Features/Transfer/Sources/Services/ConfirmTransferInputProvider.swift
+++ b/ios/Features/Transfer/Sources/Services/ConfirmTransferInputProvider.swift
@@ -16,7 +16,7 @@ public struct ConfirmTransferInputProvider: Sendable {
         request: ConfirmTransferRequest,
         metadata: TransferDataMetadata,
         selection: FeeSelection,
-    ) async throws -> ConfirmTransferInput {
+    ) async throws -> ConfirmTransferPreload {
         do {
             let transactionData = try await transferTransactionProvider.loadTransferTransactionData(
                 wallet: request.wallet,
@@ -24,9 +24,8 @@ public struct ConfirmTransferInputProvider: Sendable {
                 selection: selection,
                 available: metadata.available,
             )
-            return ConfirmTransferInput(
+            let input = ConfirmTransferInput(
                 transactionData: transactionData.transactionData,
-                feeRates: transactionData.rates,
                 transferAmount: TransferAmountCalculator().validate(
                     transferData: request.data,
                     availableValue: request.data.availableValue(metadata: metadata),
@@ -34,6 +33,7 @@ public struct ConfirmTransferInputProvider: Sendable {
                     fee: transactionData.transactionData.fee.fee,
                 ),
             )
+            return ConfirmTransferPreload(metadata: metadata, input: input, feeRates: transactionData.rates)
         } catch {
             throw preloadFailureError(metadata: metadata) ?? error
         }

--- a/ios/Features/Transfer/Sources/Types/ConfirmTransferData.swift
+++ b/ios/Features/Transfer/Sources/Types/ConfirmTransferData.swift
@@ -3,8 +3,7 @@
 import Foundation
 import Primitives
 
-struct ConfirmTransferData: Sendable {
-    let metadata: TransferDataMetadata
-    let input: ConfirmTransferInput
+struct ConfirmTransferData {
+    let preload: ConfirmTransferPreload
     let simulation: ConfirmSimulationState
 }

--- a/ios/Features/Transfer/Sources/Types/ConfirmTransferInput.swift
+++ b/ios/Features/Transfer/Sources/Types/ConfirmTransferInput.swift
@@ -6,16 +6,13 @@ import PrimitivesComponents
 
 public struct ConfirmTransferInput: Sendable {
     public let transactionData: TransactionData
-    public let feeRates: [FeeRate]
     public let transferAmount: TransferAmountValidation
 
     public init(
         transactionData: TransactionData,
-        feeRates: [FeeRate],
         transferAmount: TransferAmountValidation,
     ) {
         self.transactionData = transactionData
-        self.feeRates = feeRates
         self.transferAmount = transferAmount
     }
 }

--- a/ios/Features/Transfer/Sources/Types/ConfirmTransferPreload.swift
+++ b/ios/Features/Transfer/Sources/Types/ConfirmTransferPreload.swift
@@ -1,0 +1,20 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+
+public struct ConfirmTransferPreload: Sendable {
+    public let metadata: TransferDataMetadata
+    public let input: ConfirmTransferInput
+    public let feeRates: [FeeRate]
+
+    public init(
+        metadata: TransferDataMetadata,
+        input: ConfirmTransferInput,
+        feeRates: [FeeRate],
+    ) {
+        self.metadata = metadata
+        self.input = input
+        self.feeRates = feeRates
+    }
+}

--- a/ios/Features/Transfer/Sources/Types/ConfirmTransferState.swift
+++ b/ios/Features/Transfer/Sources/Types/ConfirmTransferState.swift
@@ -4,16 +4,28 @@ import Components
 import Foundation
 import Primitives
 
-struct ConfirmTransferState: Sendable {
+struct ConfirmTransferState {
     var simulation: ConfirmSimulationState
     var metadata: TransferDataMetadata?
+    var feeRates: [FeeRate] = []
     var transaction: StateViewType<ConfirmTransferInput>
     var confirmation: ConfirmationPhase = .idle
 }
 
 extension ConfirmTransferState {
     static func loaded(_ data: ConfirmTransferData) -> ConfirmTransferState {
-        ConfirmTransferState(simulation: data.simulation, metadata: data.metadata, transaction: .data(data.input))
+        ConfirmTransferState(
+            simulation: data.simulation,
+            metadata: data.preload.metadata,
+            feeRates: data.preload.feeRates,
+            transaction: .data(data.preload.input),
+        )
+    }
+
+    mutating func update(_ preload: ConfirmTransferPreload) {
+        metadata = preload.metadata
+        feeRates = preload.feeRates
+        transaction = .data(preload.input)
     }
 
     var transactionError: ConfirmTransferError? {

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmNetworkFeeViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmNetworkFeeViewModel.swift
@@ -2,28 +2,20 @@
 
 import Components
 import Primitives
+import PrimitivesComponents
 
 struct ConfirmNetworkFeeViewModel: ItemModelProvidable {
     private let state: StateViewType<ConfirmTransferInput>
-    private let title: String
-    private let value: String?
-    private let fiatValue: String?
-    private let selectable: Bool
+    private let feeModel: NetworkFeeSceneViewModel
     private let infoAction: VoidAction
 
     init(
         state: StateViewType<ConfirmTransferInput>,
-        title: String,
-        value: String?,
-        fiatValue: String?,
-        selectable: Bool,
+        feeModel: NetworkFeeSceneViewModel,
         infoAction: VoidAction,
     ) {
         self.state = state
-        self.title = title
-        self.value = value
-        self.fiatValue = fiatValue
-        self.selectable = selectable
+        self.feeModel = feeModel
         self.infoAction = infoAction
     }
 }
@@ -34,12 +26,12 @@ extension ConfirmNetworkFeeViewModel {
     var itemModel: ConfirmTransferItemModel {
         .networkFee(
             .init(
-                title: title,
+                title: feeModel.title,
                 subtitle: networkFeeValue,
                 placeholders: [.subtitle],
                 infoAction: infoAction,
             ),
-            selectable: selectable && state.value != nil,
+            selectable: feeModel.showFeeDetails && !state.isError,
         )
     }
 }
@@ -49,6 +41,6 @@ extension ConfirmNetworkFeeViewModel {
 extension ConfirmNetworkFeeViewModel {
     private var networkFeeValue: String? {
         if state.isError { return "-" }
-        return fiatValue ?? value
+        return feeModel.fiatValue ?? feeModel.value
     }
 }

--- a/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
@@ -19,7 +19,7 @@ import WalletConnector
 @Observable
 @MainActor
 public final class ConfirmTransferSceneViewModel {
-    public var feeModel: NetworkFeeSceneViewModel
+    var feeSelection: FeeSelection
     var state: ConfirmTransferState {
         didSet { onStateChange(state: state) }
     }
@@ -58,13 +58,7 @@ public final class ConfirmTransferSceneViewModel {
 
         let currency = Currency(rawValue: Preferences.standard.currency) ?? .usd
         self.currency = currency
-        feeModel = NetworkFeeSceneViewModel(
-            chain: request.data.chain,
-            feeAsset: request.data.type.asset.feeAsset,
-            priority: confirmService.defaultPriority(for: request.data.type),
-            currency: currency,
-            mode: .custom,
-        )
+        feeSelection = .preset(confirmService.defaultPriority(for: request.data.type))
 
         let recipientAddress = request.data.recipientData.recipient.address
         recipientAddressNameQuery = ObservableQuery(
@@ -142,6 +136,19 @@ public final class ConfirmTransferSceneViewModel {
     var balanceChangeModels: [ConfirmBalanceChangeViewModel] {
         state.simulation.balanceChanges.map(ConfirmBalanceChangeViewModel.init)
     }
+
+    public var feeModel: NetworkFeeSceneViewModel {
+        NetworkFeeSceneViewModel(
+            chain: request.data.chain,
+            feeAsset: request.data.type.asset.feeAsset,
+            currency: currency,
+            selection: feeSelection,
+            rates: state.feeRates,
+            feeAssetPrice: state.metadata?.feePrice,
+            feeAmount: state.transaction.value?.transactionData.fee.fee,
+            onSelect: { [weak self] in self?.feeSelection = $0 },
+        )
+    }
 }
 
 // MARK: - ListSectionProvideable
@@ -196,10 +203,7 @@ extension ConfirmTransferSceneViewModel: ListSectionProvideable {
         case .networkFee:
             ConfirmNetworkFeeViewModel(
                 state: state.transaction,
-                title: feeModel.title,
-                value: feeModel.value,
-                fiatValue: feeModel.fiatValue,
-                selectable: feeModel.showFeeDetails,
+                feeModel: feeModel,
                 infoAction: onSelectNetworkFeeInfo,
             )
         case .error:
@@ -286,13 +290,16 @@ extension ConfirmTransferSceneViewModel {
 
     func fetch() async {
         state.transaction = .loading
-        feeModel.reset()
         do {
-            let data = try await confirmService.load(request: request, selection: feeModel.selection)
-            state = .loaded(data)
-            feeModel.update(rates: data.input.feeRates, feeAssetPrice: data.metadata.feePrice)
-            feeModel.update(feeAmount: data.input.transactionData.fee.fee)
+            if state.feeRates.isEmpty {
+                let data = try await confirmService.load(request: request, selection: feeSelection)
+                state = .loaded(data)
+            } else {
+                let preload = try await confirmService.preload(request: request, selection: feeSelection)
+                state.update(preload)
+            }
         } catch {
+            guard !Task.isCancelled else { return }
             state.transaction.setError(error)
             debugLog("preload transaction error: \(error)")
         }

--- a/ios/Features/Transfer/TestKit/ConfirmTransferInput+TestKit.swift
+++ b/ios/Features/Transfer/TestKit/ConfirmTransferInput+TestKit.swift
@@ -10,14 +10,12 @@ import Validators
 public extension ConfirmTransferInput {
     static func mock(
         transactionData: TransactionData = .mock(),
-        feeRates: [FeeRate] = [FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 1))],
         transferAmount: TransferAmountValidation = .success(
             TransferAmount(value: BigInt(100), networkFee: BigInt(21000), useMaxAmount: false),
         ),
     ) -> ConfirmTransferInput {
         ConfirmTransferInput(
             transactionData: transactionData,
-            feeRates: feeRates,
             transferAmount: transferAmount,
         )
     }

--- a/ios/Features/Transfer/Tests/ConfirmTransferStateMocks.swift
+++ b/ios/Features/Transfer/Tests/ConfirmTransferStateMocks.swift
@@ -26,7 +26,8 @@ extension ConfirmTransferState {
         transaction: StateViewType<ConfirmTransferInput> = .loading,
         metadata: TransferDataMetadata? = nil,
         simulation: ConfirmSimulationState = .mock(),
+        feeRates: [FeeRate] = [],
     ) -> ConfirmTransferState {
-        ConfirmTransferState(simulation: simulation, metadata: metadata, transaction: transaction)
+        ConfirmTransferState(simulation: simulation, metadata: metadata, feeRates: feeRates, transaction: transaction)
     }
 }

--- a/ios/Features/Transfer/Tests/Services/ConfirmTransferInputProviderTests.swift
+++ b/ios/Features/Transfer/Tests/Services/ConfirmTransferInputProviderTests.swift
@@ -18,10 +18,10 @@ struct ConfirmTransferInputProviderTests {
             ),
         ))
 
-        let input = try await provider.load(request: .mock(), metadata: .mock(), selection: .preset(.normal))
+        let result = try await provider.load(request: .mock(), metadata: .mock(), selection: .preset(.normal))
 
-        #expect(input.feeRates.count == 1)
-        #expect(input.transactionData.fee.fee == 1)
+        #expect(result.feeRates.count == 1)
+        #expect(result.input.transactionData.fee.fee == 1)
     }
 
     @Test

--- a/ios/Features/Transfer/Tests/Types/ConfirmTransferStateTests.swift
+++ b/ios/Features/Transfer/Tests/Types/ConfirmTransferStateTests.swift
@@ -11,12 +11,20 @@ struct ConfirmTransferStateTests {
 
     @Test
     func loadedCarriesBundle() {
-        let data = ConfirmTransferData(metadata: .mock(), input: .mock(), simulation: .mock(warnings: [warning]))
+        let data = ConfirmTransferData(
+            preload: ConfirmTransferPreload(
+                metadata: .mock(),
+                input: .mock(),
+                feeRates: [FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 1))],
+            ),
+            simulation: .mock(warnings: [warning]),
+        )
 
         let loaded = ConfirmTransferState.loaded(data)
 
         #expect(loaded.transaction.value != nil)
         #expect(loaded.metadata != nil)
+        #expect(loaded.feeRates.count == 1)
         #expect(loaded.simulation.warnings.count == 1)
     }
 }

--- a/ios/Features/Transfer/Tests/ViewModels/ConfirmNetworkFeeViewModelTests.swift
+++ b/ios/Features/Transfer/Tests/ViewModels/ConfirmNetworkFeeViewModelTests.swift
@@ -1,7 +1,9 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
-import Localization
+import BigInt
+import Foundation
 @testable import Primitives
+import PrimitivesComponents
 import PrimitivesTestKit
 import Testing
 @testable import Transfer
@@ -11,35 +13,31 @@ import Validators
 struct ConfirmNetworkFeeViewModelTests {
     @Test
     func loaded() {
-        let fiatValue = "$2.50"
+        let feeModel = feeModel(feeAssetPrice: Price(price: 2500, priceChangePercentage24h: 0, updatedAt: Date()))
         let model = ConfirmNetworkFeeViewModel(
             state: .data(.mock()),
-            title: Localized.Transfer.networkFee,
-            value: "0.001 ETH",
-            fiatValue: fiatValue,
-            selectable: true,
+            feeModel: feeModel,
             infoAction: {},
         )
 
         guard case let .networkFee(item, selectable) = model.itemModel else { return }
-        #expect(item.subtitle == fiatValue)
+        #expect(item.subtitle == feeModel.fiatValue)
+        #expect(item.subtitle != feeModel.value)
         #expect(selectable == true)
     }
 
     @Test
     func loadedWithoutFiat() {
-        let value = "0.001 ETH"
+        let feeModel = feeModel()
         let model = ConfirmNetworkFeeViewModel(
             state: .data(.mock()),
-            title: Localized.Transfer.networkFee,
-            value: value,
-            fiatValue: nil,
-            selectable: true,
+            feeModel: feeModel,
             infoAction: {},
         )
 
         guard case let .networkFee(item, selectable) = model.itemModel else { return }
-        #expect(item.subtitle == value)
+        #expect(feeModel.fiatValue == nil)
+        #expect(item.subtitle == feeModel.value)
         #expect(selectable == true)
     }
 
@@ -47,10 +45,7 @@ struct ConfirmNetworkFeeViewModelTests {
     func error() {
         let model = ConfirmNetworkFeeViewModel(
             state: .error(AnyError("test")),
-            title: Localized.Transfer.networkFee,
-            value: nil,
-            fiatValue: nil,
-            selectable: true,
+            feeModel: feeModel(feeAmount: nil),
             infoAction: {},
         )
 
@@ -61,24 +56,34 @@ struct ConfirmNetworkFeeViewModelTests {
 
     @Test
     func calculatorError() {
-        let value = "0.001 ETH"
-        let fiatValue = "$2.50"
         let input = ConfirmTransferInput.mock(transferAmount: .failure(.insufficientBalance(
             .mock(),
             requirement: BalanceRequirement(required: 1, available: 0),
         )))
+        let feeModel = feeModel(feeAssetPrice: Price(price: 2500, priceChangePercentage24h: 0, updatedAt: Date()))
         let model = ConfirmNetworkFeeViewModel(
             state: .data(input),
-            title: Localized.Transfer.networkFee,
-            value: value,
-            fiatValue: fiatValue,
-            selectable: true,
+            feeModel: feeModel,
             infoAction: {},
         )
 
         guard case let .networkFee(item, selectable) = model.itemModel else { return }
-        #expect(item.subtitle == fiatValue)
+        #expect(item.subtitle == feeModel.fiatValue)
         #expect(item.subtitleExtra == nil)
         #expect(selectable == true)
+    }
+
+    private func feeModel(
+        feeAssetPrice: Price? = nil,
+        feeAmount: BigInt? = BigInt(1_000_000_000_000_000),
+    ) -> NetworkFeeSceneViewModel {
+        NetworkFeeSceneViewModel(
+            chain: .ethereum,
+            feeAsset: .mockEthereum(),
+            currency: .usd,
+            selection: .preset(.normal),
+            feeAssetPrice: feeAssetPrice,
+            feeAmount: feeAmount,
+        )
     }
 }

--- a/ios/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
+++ b/ios/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
@@ -224,7 +224,6 @@ struct ConfirmTransferSceneViewModelTests {
             Issue.record("Expected network fee item model for error state")
         }
 
-        model.feeModel.update(feeAmount: BigInt(1_000_000_000_000_000))
         model.state = .mock(transaction: .data(.mock()))
         let loadedFeeItem = model.itemModel(for: .networkFee) as? ConfirmNetworkFeeViewModel
 
@@ -234,6 +233,62 @@ struct ConfirmTransferSceneViewModelTests {
         } else {
             Issue.record("Expected network fee item model with loaded fee")
         }
+    }
+
+    @Test
+    func networkFeeStaysSelectableWhileReloading() {
+        let rates = [
+            FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 20)),
+            FeeRate(priority: .fast, gasPriceType: .regular(gasPrice: 30)),
+        ]
+        let model = ConfirmTransferSceneViewModel.mock()
+
+        model.state = .mock(transaction: .loading, feeRates: rates)
+        let reloadingFeeItem = model.itemModel(for: .networkFee) as? ConfirmNetworkFeeViewModel
+
+        if case let .networkFee(listItem, selectable) = reloadingFeeItem?.itemModel {
+            #expect(listItem.subtitle == nil)
+            #expect(listItem.hasSubtitlePlaceholder)
+            #expect(selectable)
+        } else {
+            Issue.record("Expected network fee item model while reloading")
+        }
+    }
+
+    @Test
+    func fetchAfterFeeChangeKeepsSimulationState() async {
+        let rates = [
+            FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 20)),
+            FeeRate(priority: .fast, gasPriceType: .regular(gasPrice: 30)),
+        ]
+        let model = ConfirmTransferSceneViewModel.mock(
+            confirmService: .mock(transaction: .success(TransferTransactionData(allRates: rates, transactionData: .mock()))),
+        )
+
+        await model.fetch()
+        #expect(model.state.feeRates == rates)
+
+        let sentinel = ConfirmSimulationState.mock(warnings: [SimulationWarning(severity: .warning, warning: .externallyOwnedSpender, message: nil)])
+        model.state.simulation = sentinel
+        model.feeSelection = .preset(.fast)
+        await model.fetch()
+
+        #expect(model.state.simulation.warnings == sentinel.warnings)
+        #expect(model.state.transaction.value != nil)
+        #expect(model.state.feeRates == rates)
+    }
+
+    @Test
+    func fetchIgnoresErrorAfterCancellation() async {
+        let model = ConfirmTransferSceneViewModel.mock(
+            confirmService: .mock(transaction: .failure(AnyError("network"))),
+        )
+
+        let task = Task { await model.fetch() }
+        task.cancel()
+        await task.value
+
+        #expect(model.state.transaction.isLoading)
     }
 
     @Test
@@ -608,7 +663,40 @@ struct ConfirmTransferSceneViewModelTests {
     }
 }
 
+private extension ConfirmService {
+    static func mock(transaction: Result<TransferTransactionData, Error>) -> ConfirmService {
+        ConfirmService(
+            metadataProvider: TransferMetadataProviderMock(metadataResult: .success(.mock())),
+            inputProvider: ConfirmTransferInputProvider(transferTransactionProvider: TransferTransactionProviderMock(result: transaction)),
+            simulationService: ConfirmSimulationService(addressNameService: .mock(addressStore: .mock()), assetsService: .mock()),
+            transferExecutor: TransferExecutorMock(),
+            activityService: .mock(),
+            eventPresenterService: .mock(),
+            keystore: KeystoreMock(),
+            chainService: ChainServiceMock(),
+            explorerService: MockExplorerLink(),
+            addressNameService: .mock(addressStore: .mock()),
+        )
+    }
+}
+
 private extension ConfirmTransferSceneViewModel {
+    static func mock(
+        wallet: Wallet = .mock(),
+        data: TransferData = .mock(),
+        confirmService: ConfirmService,
+    ) -> ConfirmTransferSceneViewModel {
+        ConfirmTransferSceneViewModel(
+            request: ConfirmTransferRequest(
+                wallet: wallet,
+                data: data,
+                simulation: nil,
+            ),
+            confirmService: confirmService,
+            onComplete: {},
+        )
+    }
+
     static func mock(
         wallet: Wallet = .mock(),
         data: TransferData = .mock(),

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeCustomViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeCustomViewModel.swift
@@ -18,7 +18,7 @@ public final class NetworkFeeCustomViewModel {
     private let baseTotal: BigInt?
     private let normalTotal: BigInt?
     private let decimals: Int
-    private let onSelect: (BigInt) -> Void
+    private let onSelect: @MainActor (BigInt) -> Void
 
     public var input: String = ""
 
@@ -31,7 +31,7 @@ public final class NetworkFeeCustomViewModel {
         baseTotal: BigInt?,
         normalTotal: BigInt?,
         initialRate: BigInt?,
-        onSelect: @escaping (BigInt) -> Void,
+        onSelect: @escaping @MainActor (BigInt) -> Void,
     ) {
         self.chain = chain
         self.feeAsset = feeAsset

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeSceneViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeSceneViewModel.swift
@@ -7,66 +7,44 @@ import Primitives
 import Style
 import SwiftUI
 
-@Observable
-@MainActor
-public final class NetworkFeeSceneViewModel {
-    public enum Mode: Sendable {
-        case standard
-        case custom
-    }
-
+public struct NetworkFeeSceneViewModel {
     private let chain: Chain
     private let feeAsset: Asset
     private let currency: Currency
-    private let mode: Mode
-
-    private var rates: [FeeRate] = []
-    private var feeAssetPrice: Price?
-
-    public var selection: FeeSelection
-    public var feeAmount: BigInt?
+    private let selection: FeeSelection
+    private let rates: [FeeRate]
+    private let feeAssetPrice: Price?
+    private let feeAmount: BigInt?
+    private let onSelect: (@MainActor (FeeSelection) -> Void)?
 
     public init(
         chain: Chain,
         feeAsset: Asset,
-        priority: FeePriority,
         currency: Currency,
+        selection: FeeSelection,
+        rates: [FeeRate] = [],
+        feeAssetPrice: Price? = nil,
         feeAmount: BigInt? = nil,
-        mode: Mode = .standard,
+        onSelect: (@MainActor (FeeSelection) -> Void)? = nil,
     ) {
         self.chain = chain
         self.feeAsset = feeAsset
-        selection = .preset(priority)
         self.currency = currency
+        self.selection = selection
+        self.rates = rates
+        self.feeAssetPrice = feeAssetPrice
         self.feeAmount = feeAmount
-        self.mode = mode
+        self.onSelect = onSelect
     }
 
     // MARK: - Network Fee
 
-    public var title: String {
-        Localized.Transfer.networkFee
-    }
-
-    public var infoIcon: String {
-        Localized.FeeRates.info
-    }
-
-    public var value: String? {
-        feeAmount.map { display(for: $0).amount.text }
-    }
-
-    public var fiatValue: String? {
-        feeAmount.flatMap { display(for: $0).fiat?.text }
-    }
-
-    public var showFeeRates: Bool {
-        rates.count > 1
-    }
-
-    public var showFeeDetails: Bool {
-        showFeeRates || feeAmount != nil
-    }
+    public var title: String { Localized.Transfer.networkFee }
+    public var infoIcon: String { Localized.FeeRates.info }
+    public var value: String? { feeAmount.map { display(for: $0).amount.text } }
+    public var fiatValue: String? { feeAmount.flatMap { display(for: $0).fiat?.text } }
+    public var showFeeRates: Bool { rates.count > 1 }
+    public var showFeeDetails: Bool { showFeeRates || feeAmount != nil }
 
     // MARK: - Fee Rates
 
@@ -101,10 +79,6 @@ public final class NetworkFeeSceneViewModel {
         }
     }
 
-    private var feeRateDecimals: Int {
-        chain.feeRateDecimals(assetDecimals: feeAsset.decimals.asInt)
-    }
-
     public func fiatValueForRate(_ rate: FeeRateViewModel) -> String? {
         estimatedFee(for: rate.feeRate).flatMap { display(for: $0).fiat?.text }
     }
@@ -116,21 +90,11 @@ public final class NetworkFeeSceneViewModel {
 
     // MARK: - Custom Fee
 
-    public var supportsCustomFee: Bool {
-        switch mode {
-        case .standard: false
-        case .custom: chain.customFeeEnabled && showFeeRates
-        }
-    }
+    public var supportsCustomFee: Bool { onSelect != nil && chain.customFeeEnabled && showFeeRates }
+    public var isCustomSelected: Bool { selection.customRate != nil }
+    public var customRowItem: ListItemModel { rowItem(title: Localized.FeeRate.custom, rate: customFeeRateViewModel) }
 
-    public var isCustomSelected: Bool {
-        selection.customRate != nil
-    }
-
-    public var customRowItem: ListItemModel {
-        rowItem(title: Localized.FeeRate.custom, rate: customFeeRateViewModel)
-    }
-
+    @MainActor
     public func customFeeModel() -> NetworkFeeCustomViewModel {
         NetworkFeeCustomViewModel(
             chain: chain,
@@ -141,37 +105,21 @@ public final class NetworkFeeSceneViewModel {
             baseTotal: selectedBaseTotalFee,
             normalTotal: (rates.first(where: { $0.priority == .normal }) ?? rates.first)?.gasPriceType.totalFee ?? selectedBaseTotalFee,
             initialRate: selection.customRate,
-            onSelect: { [weak self] rate in
-                self?.selection = .custom(rate)
-            },
+            onSelect: { onSelect?(.custom($0)) },
         )
     }
-}
 
-// MARK: - Business Logic
-
-public extension NetworkFeeSceneViewModel {
-    func update(rates: [FeeRate], feeAssetPrice: Price?) {
-        self.rates = rates
-        self.feeAssetPrice = feeAssetPrice
-    }
-
-    func update(feeAmount: BigInt?) {
-        self.feeAmount = feeAmount
-    }
-
-    func select(_ selection: FeeSelection) {
-        self.selection = selection
-    }
-
-    func reset() {
-        feeAmount = nil
+    @MainActor
+    public func select(_ selection: FeeSelection) {
+        onSelect?(selection)
     }
 }
 
 // MARK: - Private
 
 private extension NetworkFeeSceneViewModel {
+    var feeRateDecimals: Int { chain.feeRateDecimals(assetDecimals: feeAsset.decimals.asInt) }
+
     var customFeeRateViewModel: FeeRateViewModel? {
         selection.customRate.map {
             FeeRateViewModel(

--- a/ios/Packages/PrimitivesComponents/TestKit/NetworkFeeSceneViewModel+PrimitivesComponentsTestKit.swift
+++ b/ios/Packages/PrimitivesComponents/TestKit/NetworkFeeSceneViewModel+PrimitivesComponentsTestKit.swift
@@ -9,19 +9,22 @@ public extension NetworkFeeSceneViewModel {
     static func mock(
         chain: Chain = .ethereum,
         feeAsset: Asset? = nil,
-        priority: FeePriority = .normal,
         currency: Currency = .usd,
+        selection: FeeSelection = .preset(.normal),
+        rates: [FeeRate] = [],
+        feeAssetPrice: Price? = nil,
         feeAmount: BigInt? = nil,
-        mode: NetworkFeeSceneViewModel.Mode = .standard,
+        onSelect: (@MainActor (FeeSelection) -> Void)? = nil,
     ) -> NetworkFeeSceneViewModel {
-        let feeAsset = feeAsset ?? defaultFeeAsset(for: chain)
-        return NetworkFeeSceneViewModel(
+        NetworkFeeSceneViewModel(
             chain: chain,
-            feeAsset: feeAsset,
-            priority: priority,
+            feeAsset: feeAsset ?? defaultFeeAsset(for: chain),
             currency: currency,
+            selection: selection,
+            rates: rates,
+            feeAssetPrice: feeAssetPrice,
             feeAmount: feeAmount,
-            mode: mode,
+            onSelect: onSelect,
         )
     }
 }

--- a/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ViewModels/NetworkFeeSceneViewModelTests.swift
+++ b/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ViewModels/NetworkFeeSceneViewModelTests.swift
@@ -12,21 +12,17 @@ import Testing
 struct NetworkFeeSceneViewModelTests {
     @Test
     func showFeeRatesSelector() {
-        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum)
-
-        model.update(rates: [.defaultRate()], feeAssetPrice: nil)
-        #expect(model.showFeeRates == false)
-
-        model.update(rates: [.defaultRate(), .defaultRate()], feeAssetPrice: nil)
-        #expect(model.showFeeRates)
+        #expect(NetworkFeeSceneViewModel.mock(chain: .ethereum, rates: [.defaultRate()]).showFeeRates == false)
+        #expect(NetworkFeeSceneViewModel.mock(chain: .ethereum, rates: [.defaultRate(), .defaultRate()]).showFeeRates)
     }
 
     @Test
     func showFeeDetailsForLoadedSingleRate() {
-        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum)
-
-        model.update(rates: [.defaultRate()], feeAssetPrice: nil)
-        model.update(feeAmount: BigInt(1_000_000_000_000_000))
+        let model = NetworkFeeSceneViewModel.mock(
+            chain: .ethereum,
+            rates: [.defaultRate()],
+            feeAmount: BigInt(1_000_000_000_000_000),
+        )
 
         #expect(model.showFeeRates == false)
         #expect(model.showFeeDetails)
@@ -34,9 +30,7 @@ struct NetworkFeeSceneViewModelTests {
 
     @Test
     func showFeeDetailsForMultipleRates() {
-        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum)
-
-        model.update(rates: [.defaultRate(), .defaultRate()], feeAssetPrice: nil)
+        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum, rates: [.defaultRate(), .defaultRate()])
 
         #expect(model.showFeeRates)
         #expect(model.showFeeDetails)
@@ -44,9 +38,7 @@ struct NetworkFeeSceneViewModelTests {
 
     @Test
     func hideFeeDetailsWithoutLoadedSingleRate() {
-        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum)
-
-        model.update(rates: [.defaultRate()], feeAssetPrice: nil)
+        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum, rates: [.defaultRate()])
 
         #expect(model.showFeeRates == false)
         #expect(model.showFeeDetails == false)
@@ -54,40 +46,36 @@ struct NetworkFeeSceneViewModelTests {
 
     @Test
     func valueMatchesSelectedFeeRateEthereumValueText() {
-        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum)
-
-        model.update(rates: [.defaultRate()], feeAssetPrice: nil)
+        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum, rates: [.defaultRate()])
 
         #expect(model.selectedFeeRateViewModel?.valueText == "0.000000001 gwei")
     }
 
     @Test
     func valueMatchesSelectedFeeRateSolanaValueText() {
-        let model = NetworkFeeSceneViewModel.mock(chain: .solana)
-
-        model.update(rates: [FeeRate(priority: .normal, gasPriceType: .eip1559(gasPrice: 5000, priorityFee: 100_000))], feeAssetPrice: nil)
+        let model = NetworkFeeSceneViewModel.mock(
+            chain: .solana,
+            rates: [FeeRate(priority: .normal, gasPriceType: .eip1559(gasPrice: 5000, priorityFee: 100_000))],
+        )
 
         #expect(model.selectedFeeRateViewModel?.valueText == "0.000105 SOL")
     }
 
     @Test
     func valueMatchesSelectedFeeRateBitcoinValueText() {
-        let model = NetworkFeeSceneViewModel.mock(chain: .bitcoin)
-
-        model.update(rates: [.defaultRate()], feeAssetPrice: nil)
+        let model = NetworkFeeSceneViewModel.mock(chain: .bitcoin, rates: [.defaultRate()])
 
         #expect(model.selectedFeeRateViewModel?.valueText == "0.1 sat/vB")
     }
 
     @Test
     func fiatValueForNativeFeeType() throws {
-        let model = NetworkFeeSceneViewModel.mock(chain: .solana)
-        let rate = FeeRate(priority: .normal, gasPriceType: .solana(gasPrice: 5000, priorityFee: 0, unitPrice: 0))
-        let price = Price(price: 150.0, priceChangePercentage24h: 0, updatedAt: Date())
-
-        model.update(rates: [rate], feeAssetPrice: price)
-        model.update(feeAmount: BigInt(5000))
-
+        let model = NetworkFeeSceneViewModel.mock(
+            chain: .solana,
+            rates: [FeeRate(priority: .normal, gasPriceType: .solana(gasPrice: 5000, priorityFee: 0, unitPrice: 0))],
+            feeAssetPrice: Price(price: 150.0, priceChangePercentage24h: 0, updatedAt: Date()),
+            feeAmount: BigInt(5000),
+        )
         let feeRateVM = try #require(model.feeRatesViewModels.first)
 
         #expect(model.fiatValueForRate(feeRateVM) != nil)
@@ -95,12 +83,12 @@ struct NetworkFeeSceneViewModelTests {
 
     @Test
     func fiatValueForNonNativeFeeType() throws {
-        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum)
-        let price = Price(price: 3000.0, priceChangePercentage24h: 0, updatedAt: Date())
-
-        model.update(rates: [.defaultRate()], feeAssetPrice: price)
-        model.update(feeAmount: BigInt(21_000_000_000_000))
-
+        let model = NetworkFeeSceneViewModel.mock(
+            chain: .ethereum,
+            rates: [.defaultRate()],
+            feeAssetPrice: Price(price: 3000.0, priceChangePercentage24h: 0, updatedAt: Date()),
+            feeAmount: BigInt(21_000_000_000_000),
+        )
         let feeRateVM = try #require(model.feeRatesViewModels.first)
 
         #expect(model.fiatValueForRate(feeRateVM) != nil)
@@ -108,12 +96,11 @@ struct NetworkFeeSceneViewModelTests {
 
     @Test
     func fiatValueNilWithoutPriceData() throws {
-        let model = NetworkFeeSceneViewModel.mock(chain: .solana)
-        let rate = FeeRate(priority: .normal, gasPriceType: .solana(gasPrice: 5000, priorityFee: 0, unitPrice: 0))
-
-        model.update(rates: [rate], feeAssetPrice: nil)
-        model.update(feeAmount: BigInt(5000))
-
+        let model = NetworkFeeSceneViewModel.mock(
+            chain: .solana,
+            rates: [FeeRate(priority: .normal, gasPriceType: .solana(gasPrice: 5000, priorityFee: 0, unitPrice: 0))],
+            feeAmount: BigInt(5000),
+        )
         let feeRateVM = try #require(model.feeRatesViewModels.first)
 
         #expect(model.fiatValueForRate(feeRateVM) == nil)
@@ -121,13 +108,11 @@ struct NetworkFeeSceneViewModelTests {
 
     @Test
     func feeAmountScalesProportionallyToSelectedRate() {
-        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum)
         let rates = [
             FeeRate(priority: .normal, gasPriceType: .eip1559(gasPrice: 2, priorityFee: 0)),
             FeeRate(priority: .fast, gasPriceType: .eip1559(gasPrice: 4, priorityFee: 0)),
         ]
-        model.update(rates: rates, feeAssetPrice: nil)
-        model.update(feeAmount: BigInt(1000))
+        let model = NetworkFeeSceneViewModel.mock(chain: .ethereum, rates: rates, feeAmount: BigInt(1000))
 
         #expect(model.estimatedFee(for: rates[0]) == BigInt(1000))
         #expect(model.estimatedFee(for: rates[1]) == BigInt(2000))
@@ -136,15 +121,15 @@ struct NetworkFeeSceneViewModelTests {
     @Test
     func valueForRateUsesScaledLoadedFeeForNativeChain() throws {
         let feeAsset = Asset.mockSUI()
-        let model = NetworkFeeSceneViewModel.mock(chain: .sui, feeAsset: feeAsset)
-        model.update(
+        let model = NetworkFeeSceneViewModel.mock(
+            chain: .sui,
+            feeAsset: feeAsset,
             rates: [
                 FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 110)),
                 FeeRate(priority: .fast, gasPriceType: .regular(gasPrice: 200)),
             ],
-            feeAssetPrice: nil,
+            feeAmount: BigInt(110_000),
         )
-        model.update(feeAmount: BigInt(110_000))
 
         let normalRate = try #require(model.feeRatesViewModels.first { $0.feeRate.priority == .normal })
         let fastRate = try #require(model.feeRatesViewModels.first { $0.feeRate.priority == .fast })
@@ -157,17 +142,17 @@ struct NetworkFeeSceneViewModelTests {
 
     @Test
     func valueForRateUsesGasPriceRateForNonNativeChains() throws {
-        let ethModel = NetworkFeeSceneViewModel.mock(chain: .ethereum)
-        ethModel.update(rates: [FeeRate(priority: .normal, gasPriceType: .eip1559(gasPrice: 1_000_000_000, priorityFee: 0))], feeAssetPrice: nil)
-        ethModel.update(feeAmount: BigInt(21_000_000_000_000))
+        let ethModel = NetworkFeeSceneViewModel.mock(
+            chain: .ethereum,
+            rates: [FeeRate(priority: .normal, gasPriceType: .eip1559(gasPrice: 1_000_000_000, priorityFee: 0))],
+            feeAmount: BigInt(21_000_000_000_000),
+        )
         let ethVM = try #require(ethModel.feeRatesViewModels.first)
 
         #expect(ethModel.valueForRate(ethVM) == ethVM.valueText)
         #expect(ethModel.valueForRate(ethVM) != ethModel.value)
 
-        let bitcoinModel = NetworkFeeSceneViewModel.mock(chain: .bitcoin)
-        bitcoinModel.update(rates: [.defaultRate()], feeAssetPrice: nil)
-        bitcoinModel.update(feeAmount: BigInt(10000))
+        let bitcoinModel = NetworkFeeSceneViewModel.mock(chain: .bitcoin, rates: [.defaultRate()], feeAmount: BigInt(10000))
         let bitcoinVM = try #require(bitcoinModel.feeRatesViewModels.first)
 
         #expect(bitcoinModel.valueForRate(bitcoinVM) == bitcoinVM.valueText)
@@ -183,46 +168,40 @@ struct NetworkFeeSceneViewModelTests {
     }
 
     @Test
-    func prioritySelection() {
-        let model = NetworkFeeSceneViewModel.mock(chain: .solana)
+    func selectedRateFollowsSelection() {
         let rates = [
             FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 2)),
             FeeRate(priority: .fast, gasPriceType: .regular(gasPrice: 3)),
         ]
 
-        model.update(rates: rates, feeAssetPrice: nil)
-
-        #expect(model.selectedFeeRateViewModel?.feeRate.priority == .normal)
-
-        model.select(.preset(.fast))
-        #expect(model.selectedFeeRateViewModel?.feeRate.priority == .fast)
-
-        model.select(.custom(5))
-        #expect(model.selectedFeeRateViewModel == nil)
+        #expect(NetworkFeeSceneViewModel.mock(chain: .solana, rates: rates).selectedFeeRateViewModel?.feeRate.priority == .normal)
+        #expect(NetworkFeeSceneViewModel.mock(chain: .solana, selection: .preset(.fast), rates: rates).selectedFeeRateViewModel?.feeRate.priority == .fast)
+        #expect(NetworkFeeSceneViewModel.mock(chain: .solana, selection: .custom(5), rates: rates).selectedFeeRateViewModel == nil)
     }
 
     @Test
-    func supportsCustomFeeWhenAllowedWithMultipleRates() {
+    func selectForwardsSelectionToOwner() async {
+        await confirmation { selected in
+            NetworkFeeSceneViewModel.mock(chain: .solana, onSelect: {
+                #expect($0 == .preset(.fast))
+                selected()
+            })
+            .select(.preset(.fast))
+        }
+    }
+
+    @Test
+    func supportsCustomFeeWhenSelectableWithMultipleRates() {
         let rates = [
             FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 1)),
             FeeRate(priority: .fast, gasPriceType: .regular(gasPrice: 2)),
         ]
+        let onSelect: @MainActor (FeeSelection) -> Void = { _ in }
 
-        let allowed = NetworkFeeSceneViewModel.mock(chain: .bitcoin, mode: .custom)
-        allowed.update(rates: rates, feeAssetPrice: nil)
-        #expect(allowed.supportsCustomFee)
-
-        let chainNotAllowed = NetworkFeeSceneViewModel.mock(chain: .solana, mode: .custom)
-        chainNotAllowed.update(rates: rates, feeAssetPrice: nil)
-        #expect(chainNotAllowed.supportsCustomFee == false)
-
-        let standardMode = NetworkFeeSceneViewModel.mock(chain: .bitcoin, mode: .standard)
-        standardMode.update(rates: rates, feeAssetPrice: nil)
-        #expect(standardMode.supportsCustomFee == false)
-
-        let singleRate = NetworkFeeSceneViewModel.mock(chain: .bitcoin, mode: .custom)
-        singleRate.update(rates: [rates[0]], feeAssetPrice: nil)
-        #expect(singleRate.supportsCustomFee == false)
+        #expect(NetworkFeeSceneViewModel.mock(chain: .bitcoin, rates: rates, onSelect: onSelect).supportsCustomFee)
+        #expect(NetworkFeeSceneViewModel.mock(chain: .solana, rates: rates, onSelect: onSelect).supportsCustomFee == false)
+        #expect(NetworkFeeSceneViewModel.mock(chain: .bitcoin, rates: rates).supportsCustomFee == false)
+        #expect(NetworkFeeSceneViewModel.mock(chain: .bitcoin, rates: [rates[0]], onSelect: onSelect).supportsCustomFee == false)
     }
 
     @Test
@@ -244,37 +223,38 @@ struct NetworkFeeSceneViewModelTests {
     }
 
     @Test
-    func customFeeConfirmSetsSceneSelection() {
-        let scene = bitcoinScene()
-        let custom = scene.customFeeModel()
-        custom.input = "4"
-        custom.confirm()
-
-        #expect(scene.selection == .custom(40))
-        #expect(scene.isCustomSelected)
-        #expect(scene.customRowItem.subtitle != nil)
+    func customFeeConfirmForwardsSelectionToOwner() async {
+        await confirmation { selected in
+            let custom = bitcoinScene(onSelect: {
+                #expect($0 == .custom(40))
+                selected()
+            }).customFeeModel()
+            custom.input = "4"
+            custom.confirm()
+        }
     }
 
     @Test
-    func customFeeRejectedRateDoesNotConfirm() {
-        let scene = bitcoinScene()
-        let custom = scene.customFeeModel()
-        custom.input = "999"
-        custom.confirm()
-
-        #expect(scene.isCustomSelected == false)
-        #expect(scene.selection == .preset(.normal))
+    func customFeeRejectedRateDoesNotConfirm() async {
+        await confirmation(expectedCount: 0) { selected in
+            let custom = bitcoinScene(onSelect: { _ in selected() }).customFeeModel()
+            custom.input = "999"
+            custom.confirm()
+        }
     }
 
     @Test
-    func customFeeMaxAnchoredToNormalRate() {
-        let scene = bitcoinScene()
-        let selected = scene.customFeeModel()
-        selected.input = "20"
-        selected.confirm()
-        #expect(scene.selection == .custom(200))
+    func customFeeMaxAnchoredToNormalRate() async {
+        await confirmation { selected in
+            let custom = bitcoinScene(onSelect: {
+                #expect($0 == .custom(200))
+                selected()
+            }).customFeeModel()
+            custom.input = "20"
+            custom.confirm()
+        }
 
-        let reopened = scene.customFeeModel()
+        let reopened = bitcoinScene(selection: .custom(200)).customFeeModel()
         reopened.input = "21"
         #expect(reopened.isConfirmEnabled == false)
         #expect(reopened.errorText != nil)
@@ -282,23 +262,26 @@ struct NetworkFeeSceneViewModelTests {
 
     @Test
     func customRowShowsValueOnlyWhenSelected() {
-        let scene = bitcoinScene()
-        let custom = scene.customFeeModel()
-        custom.input = "20"
-        custom.confirm()
-        #expect(scene.isCustomSelected)
-        #expect(scene.customRowItem.subtitle != nil)
+        let selected = bitcoinScene(selection: .custom(200))
+        #expect(selected.isCustomSelected)
+        #expect(selected.customRowItem.subtitle != nil)
 
-        scene.select(.preset(.normal))
-        #expect(scene.isCustomSelected == false)
-        #expect(scene.customRowItem.subtitle == nil)
+        let preset = bitcoinScene()
+        #expect(preset.isCustomSelected == false)
+        #expect(preset.customRowItem.subtitle == nil)
     }
 
-    private func bitcoinScene() -> NetworkFeeSceneViewModel {
-        let model = NetworkFeeSceneViewModel.mock(chain: .bitcoin, mode: .custom)
-        model.update(rates: [FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 20))], feeAssetPrice: nil)
-        model.update(feeAmount: BigInt(1000))
-        return model
+    private func bitcoinScene(
+        selection: FeeSelection = .preset(.normal),
+        onSelect: (@MainActor (FeeSelection) -> Void)? = nil,
+    ) -> NetworkFeeSceneViewModel {
+        .mock(
+            chain: .bitcoin,
+            selection: selection,
+            rates: [FeeRate(priority: .normal, gasPriceType: .regular(gasPrice: 20))],
+            feeAmount: BigInt(1000),
+            onSelect: onSelect,
+        )
     }
 
     @Test


### PR DESCRIPTION
Fee state on the confirm screen now has a single owner: the confirm view model holds the selection, and the fee scene model is derived from loaded state.

Changing the fee speed now reloads only the fee data — the simulation and balance changes stay on screen.