### PR TITLE
Derive transaction filter types from a single map on both platforms

### DIFF
--- a/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/TransactionTypeFilter.kt
+++ b/android/ui-models/src/main/kotlin/com/gemwallet/android/ui/models/TransactionTypeFilter.kt
@@ -2,18 +2,46 @@ package com.gemwallet.android.ui.models
 
 import com.wallet.core.primitives.TransactionType
 
-enum class TransactionTypeFilter(val types: List<TransactionType>) {
-    Transfer(listOf(TransactionType.Transfer, TransactionType.TransferNFT)),
-    Swap(listOf(TransactionType.TokenApproval, TransactionType.Swap)),
-    Stake(
-        listOf(
-            TransactionType.StakeDelegate,
-            TransactionType.StakeRedelegate,
-            TransactionType.StakeUndelegate,
-            TransactionType.StakeRewards,
-            TransactionType.StakeWithdraw,
-        ),
-    ),
-    SmartContract(listOf(TransactionType.SmartContractCall)),
-    Other(listOf(TransactionType.AssetActivation))
+enum class TransactionTypeFilter {
+    Transfer,
+    Swap,
+    Stake,
+    SmartContract,
+    Perpetuals,
+    Other,
+    ;
+
+    val types: List<TransactionType>
+        get() = TransactionType.entries.filter { it.filterType == this }
 }
+
+val TransactionType.filterType: TransactionTypeFilter
+    get() = when (this) {
+        TransactionType.Transfer,
+        TransactionType.TransferNFT,
+        -> TransactionTypeFilter.Transfer
+
+        TransactionType.Swap,
+        TransactionType.TokenApproval,
+        -> TransactionTypeFilter.Swap
+
+        TransactionType.StakeDelegate,
+        TransactionType.StakeUndelegate,
+        TransactionType.StakeRewards,
+        TransactionType.StakeRedelegate,
+        TransactionType.StakeWithdraw,
+        TransactionType.StakeFreeze,
+        TransactionType.StakeUnfreeze,
+        TransactionType.EarnDeposit,
+        TransactionType.EarnWithdraw,
+        -> TransactionTypeFilter.Stake
+
+        TransactionType.SmartContractCall -> TransactionTypeFilter.SmartContract
+
+        TransactionType.PerpetualOpenPosition,
+        TransactionType.PerpetualClosePosition,
+        TransactionType.PerpetualModifyPosition,
+        -> TransactionTypeFilter.Perpetuals
+
+        TransactionType.AssetActivation -> TransactionTypeFilter.Other
+    }

--- a/android/ui-models/src/test/kotlin/com/gemwallet/android/ui/models/TransactionTypeFilterTest.kt
+++ b/android/ui-models/src/test/kotlin/com/gemwallet/android/ui/models/TransactionTypeFilterTest.kt
@@ -1,0 +1,24 @@
+package com.gemwallet.android.ui.models
+
+import com.wallet.core.primitives.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TransactionTypeFilterTest {
+
+    @Test
+    fun everyTransactionTypeIsSelectableByItsOwnGroup() {
+        for (type in TransactionType.entries) {
+            assertTrue(type.name, type.filterType.types.contains(type))
+        }
+    }
+
+    @Test
+    fun groupsCoverAllTypesWithoutOverlap() {
+        val grouped = TransactionTypeFilter.entries.flatMap { it.types }
+
+        assertEquals(TransactionType.entries.toSet(), grouped.toSet())
+        assertEquals(TransactionType.entries.size, grouped.size)
+    }
+}

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/filters/SelectFilterTransactionType.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/filters/SelectFilterTransactionType.kt
@@ -37,5 +37,6 @@ fun TransactionTypeFilter.getLabel() = when (this) {
     TransactionTypeFilter.Swap -> R.string.wallet_swap
     TransactionTypeFilter.Stake -> R.string.wallet_stake
     TransactionTypeFilter.SmartContract -> R.string.transfer_smart_contract_title
+    TransactionTypeFilter.Perpetuals -> R.string.perpetuals_title
     TransactionTypeFilter.Other -> R.string.transfer_other_title
 }

--- a/ios/Features/Transactions/Sources/Types/TransactionFilterType.swift
+++ b/ios/Features/Transactions/Sources/Types/TransactionFilterType.swift
@@ -37,3 +37,9 @@ public extension TransactionType {
         }
     }
 }
+
+public extension TransactionFilterType {
+    var transactionTypes: [TransactionType] {
+        TransactionType.allCases.filter { $0.filterType == self }
+    }
+}

--- a/ios/Features/Transactions/Sources/ViewModels/TransactionFilterTypeViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionFilterTypeViewModel.swift
@@ -21,15 +21,4 @@ struct TransactionFilterTypeViewModel {
         case .others: Localized.Transfer.Other.title
         }
     }
-
-    var filters: [TransactionType] {
-        switch type {
-        case .transfers: [.transfer, .transferNFT]
-        case .smartContract: [.smartContractCall]
-        case .swaps: [.swap, .tokenApproval]
-        case .stake: [.stakeDelegate, .stakeUndelegate, .stakeRewards, .stakeRedelegate, .stakeWithdraw]
-        case .perpetuals: [.perpetualOpenPosition, .perpetualClosePosition]
-        case .others: [.assetActivation]
-        }
-    }
 }

--- a/ios/Features/Transactions/Sources/ViewModels/TransactionTypesFilterViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionTypesFilterViewModel.swift
@@ -12,7 +12,7 @@ public struct TransactionTypesFilterViewModel: Equatable {
     }
 
     public var requestFilters: [TransactionType] {
-        selectedTypes.map { TransactionFilterTypeViewModel(type: $0).filters }.reduce([], +)
+        selectedTypes.flatMap(\.transactionTypes)
     }
 
     public var typeModel: TransactionsFilterTypeViewModel {

--- a/ios/Features/Transactions/Tests/TransactionsTests/TransactionFilterTypeTests.swift
+++ b/ios/Features/Transactions/Tests/TransactionsTests/TransactionFilterTypeTests.swift
@@ -32,11 +32,12 @@ struct TransactionFilterTypeTests {
     }
 
     @Test
-    func perpetualFilterIncludesOpenAndClose() {
+    func everyTransactionTypeIsSelectableByItsOwnGroup() {
         var model = TransactionTypesFilterViewModel(types: TransactionType.allCases)
 
-        model.selectedTypes = [.perpetuals]
-
-        #expect(model.requestFilters == [.perpetualOpenPosition, .perpetualClosePosition])
+        for type in TransactionType.allCases {
+            model.selectedTypes = [type.filterType]
+            #expect(model.requestFilters.contains(type))
+        }
     }
 }


### PR DESCRIPTION
The Stake and Perpetuals filters were hiding transactions that belong to them, because the list of types behind each filter was kept separately from the grouping the app already uses and had fallen behind it. Android had the same gap in its own list, and no Perpetuals filter at all.

Both platforms now derive that list from the grouping, so a newly added transaction type cannot drop out of the filters again.


Closes #868
