### PR TITLE
Fix transaction record mapping for estimated confirmation column

### DIFF
--- a/ios/Packages/Store/Sources/Migrations.swift
+++ b/ios/Packages/Store/Sources/Migrations.swift
@@ -509,7 +509,7 @@ struct Migrations {
 
         migrator.registerMigration("Add estimated confirmation to \(TransactionRecord.databaseTableName)") { db in
             try? db.alter(table: TransactionRecord.databaseTableName) {
-                $0.add(column: TransactionRecord.Columns.confirmationEtaSeconds.name, .integer)
+                $0.add(column: TransactionRecord.Columns.estimatedConfirmationInSeconds.name, .integer)
             }
         }
 

--- a/ios/Packages/Store/Sources/Models/TransactionRecord.swift
+++ b/ios/Packages/Store/Sources/Models/TransactionRecord.swift
@@ -25,7 +25,7 @@ struct TransactionRecord: Codable, TableRecord, FetchableRecord, PersistableReco
         static let sequence = Column("sequence")
         static let date = Column("date")
         static let state = Column("state")
-        static let confirmationEtaSeconds = Column("estimatedConfirmationInSeconds")
+        static let estimatedConfirmationInSeconds = Column("estimatedConfirmationInSeconds")
         static let memo = Column("memo")
         static let metadata = Column("metadata")
         static let direction = Column("direction")
@@ -50,7 +50,7 @@ struct TransactionRecord: Codable, TableRecord, FetchableRecord, PersistableReco
     var sequence: Int
     var date: Date
     var state: String
-    var confirmationEtaSeconds: UInt32?
+    var estimatedConfirmationInSeconds: UInt32?
     var memo: String?
     var direction: TransactionDirection
     var metadata: AnyCodableValue?
@@ -123,7 +123,7 @@ extension TransactionRecord: CreateTable {
                 .notNull()
             $0.column(Columns.state.name, .text)
                 .notNull()
-            $0.column(Columns.confirmationEtaSeconds.name, .integer)
+            $0.column(Columns.estimatedConfirmationInSeconds.name, .integer)
             $0.column(Columns.memo.name, .text)
             $0.column(Columns.metadata.name, .jsonText)
             $0.column(Columns.direction.name, .text)
@@ -184,7 +184,7 @@ extension Transaction {
             sequence: Int(sequence ?? "0") ?? 0,
             date: createdAt,
             state: state.rawValue,
-            confirmationEtaSeconds: nil,
+            estimatedConfirmationInSeconds: nil,
             memo: memo,
             direction: direction,
             metadata: metadata,

--- a/ios/Packages/Store/Sources/Stores/TransactionStore.swift
+++ b/ios/Packages/Store/Sources/Stores/TransactionStore.swift
@@ -99,7 +99,7 @@ public struct TransactionStore: Sendable {
     }
 
     public func updateConfirmationEtaSeconds(transactionId: TransactionId, seconds: UInt32) throws -> Int {
-        try updateValues(id: transactionId, values: [TransactionRecord.Columns.confirmationEtaSeconds.set(to: seconds)])
+        try updateValues(id: transactionId, values: [TransactionRecord.Columns.estimatedConfirmationInSeconds.set(to: seconds)])
     }
 
     public func updateMetadata(transactionId: TransactionId, metadata: AnyCodableValue) throws -> Int {

--- a/ios/Packages/Store/Sources/Types/TransactionInfo.swift
+++ b/ios/Packages/Store/Sources/Types/TransactionInfo.swift
@@ -28,7 +28,7 @@ extension TransactionInfo {
             prices: prices.compactMap { $0.mapToAssetPrice() },
             fromAddress: fromAddress?.mapToAddressName(),
             toAddress: toAddress?.mapToAddressName(),
-            confirmationEtaSeconds: transaction.confirmationEtaSeconds,
+            confirmationEtaSeconds: transaction.estimatedConfirmationInSeconds,
         )
     }
 }


### PR DESCRIPTION
iOS stopped saving transactions after the estimated confirmation time change: the record property name did not match the database column, so every transaction insert failed and transaction tests went red on main. Renamed the record property to match the column.

A fundamental fix that makes this class of bugs impossible to compile is tracked in #877.