### PR TITLE
Resolve name only for address import

### DIFF
--- a/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/views/ImportScreen.kt
+++ b/android/features/import_wallet/presents/src/main/kotlin/com/gemwallet/android/features/import_wallet/views/ImportScreen.kt
@@ -59,6 +59,7 @@ import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.models.buttonState
 import com.gemwallet.android.ui.components.list_item.listItem
+import com.gemwallet.android.ui.components.list_item.sectionHeaderItem
 import com.gemwallet.android.ui.components.parseMarkdownToAnnotatedString
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.ListPosition
@@ -224,6 +225,18 @@ private fun ImportScene(
                     ErrorMessage(dataErrorState)
                 }
             }
+            if (importType.walletType == WalletType.View) {
+                item {
+                    Text(
+                        modifier = Modifier.sectionHeaderItem(),
+                        text = parseMarkdownToAnnotatedString(
+                            stringResource(R.string.wallet_import_address_warning)
+                        ),
+                        color = MaterialTheme.colorScheme.secondary,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
             item { Spacer(modifier = Modifier.size(it.calculateBottomPadding())) }
         }
     }
@@ -268,16 +281,6 @@ private fun DataInput(
         },
     )
 
-    if (importType.walletType == WalletType.View) {
-        Text(
-            modifier = Modifier.fillMaxWidth(),
-            text = parseMarkdownToAnnotatedString(
-                stringResource(R.string.wallet_import_address_warning)
-            ),
-            color = MaterialTheme.colorScheme.secondary,
-            style = MaterialTheme.typography.bodySmall,
-        )
-    }
     if (suggestions.isNotEmpty() && supportsPhraseSuggestions(importType.walletType)) {
         LazyRow(
             horizontalArrangement = Arrangement.spacedBy(8.dp)

--- a/android/features/import_wallet/viewmodels/build.gradle.kts
+++ b/android/features/import_wallet/viewmodels/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.mockk.android)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/android/features/import_wallet/viewmodels/src/main/kotlin/com/gemwallet/android/features/import_wallet/viewmodels/ImportViewModel.kt
+++ b/android/features/import_wallet/viewmodels/src/main/kotlin/com/gemwallet/android/features/import_wallet/viewmodels/ImportViewModel.kt
@@ -53,7 +53,7 @@ class ImportViewModel @Inject constructor(
     fun onInput(value: String) {
         val importType = state.value.importType
         when (importType.walletType) {
-            WalletType.View, WalletType.PrivateKey -> resolver.resolve(value, importType.chain)
+            WalletType.View -> resolver.resolve(value, importType.chain)
             else -> resolver.reset()
         }
     }

--- a/android/features/import_wallet/viewmodels/src/test/kotlin/com/gemwallet/android/features/import_wallet/viewmodels/ImportViewModelTest.kt
+++ b/android/features/import_wallet/viewmodels/src/test/kotlin/com/gemwallet/android/features/import_wallet/viewmodels/ImportViewModelTest.kt
@@ -1,0 +1,95 @@
+package com.gemwallet.android.features.import_wallet.viewmodels
+
+import com.gemwallet.android.cases.name.ResolveName
+import com.gemwallet.android.ext.networkName
+import com.gemwallet.android.model.ImportType
+import com.gemwallet.android.ui.models.name.NameRecordState
+import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.NameProvider
+import com.wallet.core.primitives.NameRecord
+import com.wallet.core.primitives.WalletType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ImportViewModelTest {
+
+    private val chain = Chain.Ethereum
+    private val record = NameRecord(
+        name = "vitalik.eth",
+        chain = chain,
+        address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        provider = NameProvider.Ens,
+    )
+
+    private class FakeResolveName(private val result: NameRecord?) : ResolveName {
+        val requests = mutableListOf<Pair<String, Chain>>()
+
+        override suspend fun resolveName(name: String, chain: Chain): NameRecord? {
+            requests.add(name to chain)
+            return result
+        }
+    }
+
+    private fun viewModel(resolveName: ResolveName) = ImportViewModel(
+        walletsRepository = mockk(relaxed = true),
+        importWalletService = mockk(relaxed = true),
+        setCurrentWallet = mockk(relaxed = true),
+        resolveName = resolveName,
+    )
+
+    @Before
+    fun setUp() {
+        mockkStatic("com.gemwallet.android.ext.ChainKt")
+        every { any<Chain>().networkName() } returns "Ethereum"
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun privateKeyInputNeverReachesTheResolver() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val resolveName = FakeResolveName(record)
+        val viewModel = viewModel(resolveName)
+
+        viewModel.importSelect(ImportType(WalletType.PrivateKey, chain))
+        advanceUntilIdle()
+        viewModel.onInput("vitalik.eth")
+        advanceUntilIdle()
+
+        assertEquals(emptyList<Pair<String, Chain>>(), resolveName.requests)
+        assertEquals(NameRecordState.None, viewModel.nameResolveState.value)
+    }
+
+    @Test
+    fun viewAddressInputResolves() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val resolveName = FakeResolveName(record)
+        val viewModel = viewModel(resolveName)
+
+        viewModel.importSelect(ImportType(WalletType.View, chain))
+        advanceUntilIdle()
+        viewModel.onInput("vitalik.eth")
+        advanceUntilIdle()
+
+        assertEquals(listOf("vitalik.eth" to chain), resolveName.requests)
+        assertEquals(NameRecordState.Complete(record), viewModel.nameResolveState.value)
+    }
+}

--- a/ios/Features/Onboarding/Sources/ViewModels/ImportWalletSceneViewModel.swift
+++ b/ios/Features/Onboarding/Sources/ViewModels/ImportWalletSceneViewModel.swift
@@ -126,8 +126,13 @@ extension ImportWalletSceneViewModel {
 
     func onChangeInput(_: String, newValue: String) {
         wordsSuggestion = wordSuggester.wordSuggestionCalculate(value: newValue)
-        if let chain {
-            nameRecordViewModel?.resolve(name: newValue, chain: chain)
+        switch importType {
+        case .address:
+            if let chain {
+                nameRecordViewModel?.resolve(name: newValue, chain: chain)
+            }
+        case .phrase, .privateKey:
+            nameRecordViewModel?.reset()
         }
     }
 

--- a/ios/Features/Onboarding/Tests/ImportWalletSceneViewModelTests.swift
+++ b/ios/Features/Onboarding/Tests/ImportWalletSceneViewModelTests.swift
@@ -36,16 +36,52 @@ struct ImportWalletSceneViewModelTests {
 
         #expect(walletSessionService.currentWalletId == walletB.id)
 
-        let model = ImportWalletSceneViewModel(
+        let model = ImportWalletSceneViewModel.mock(
             walletService: service,
             walletSessionService: walletSessionService,
-            nameService: MockNameService(),
-            type: .chain(.ethereum),
-            onComplete: nil,
         )
         model.input = LocalKeystore.words.joined(separator: " ")
         await model.onSelectActionButton()
 
         #expect(walletSessionService.currentWalletId == walletA.id)
+    }
+
+    @Test
+    func resolvesNameOnlyForAddressImport() async throws {
+        let nameService = MockNameService()
+        let model = ImportWalletSceneViewModel.mock(nameService: nameService)
+
+        try await enterName(in: model, importType: .privateKey)
+
+        #expect(await nameService.requests.isEmpty)
+
+        try await enterName(in: model, importType: .address)
+
+        #expect(await nameService.requests == ["vitalik.eth"])
+    }
+
+    private func enterName(in model: ImportWalletSceneViewModel, importType: WalletImportType) async throws {
+        model.importType = importType
+        model.onChangeInput("", newValue: "vitalik.eth")
+        try await Task.sleep(for: .milliseconds(500))
+    }
+}
+
+@MainActor
+private extension ImportWalletSceneViewModel {
+    static func mock(
+        walletService: WalletService? = nil,
+        walletSessionService: (any WalletSessionManageable)? = nil,
+        nameService: any NameServiceable = MockNameService(),
+    ) -> ImportWalletSceneViewModel {
+        let walletStore = WalletStore.mock(db: .mockWithChains([.ethereum]))
+        let sessionService = walletSessionService ?? WalletSessionService.mock(store: walletStore)
+        return ImportWalletSceneViewModel(
+            walletService: walletService ?? .mock(walletStore: walletStore, walletSessionService: sessionService),
+            walletSessionService: sessionService,
+            nameService: nameService,
+            type: .chain(.ethereum),
+            onComplete: nil,
+        )
     }
 }

--- a/ios/Packages/Primitives/TestKit/NameServiceable+PrimitivesTestKit.swift
+++ b/ios/Packages/Primitives/TestKit/NameServiceable+PrimitivesTestKit.swift
@@ -9,14 +9,16 @@ public extension NameServiceable where Self == MockNameService {
     }
 }
 
-public struct MockNameService: NameServiceable {
+public actor MockNameService: NameServiceable {
     let nameRecord: NameRecord?
+    public private(set) var requests: [String] = []
 
     public init(nameRecord: NameRecord? = nil) {
         self.nameRecord = nameRecord
     }
 
-    public func getName(name _: String, chain _: String) async throws -> NameRecord? {
-        nameRecord ?? NameRecord.mock()
+    public func getName(name: String, chain _: String) async throws -> NameRecord? {
+        requests.append(name)
+        return nameRecord ?? NameRecord.mock()
     }
 }


### PR DESCRIPTION
Typing a name like vitalik.eth on the Private Key tab no longer shows a resolve checkmark — name resolution now runs only for address imports, on both platforms.

The watch-only warning on Android moved below the input card, matching iOS.

<!-- screenshots -->