### PR TITLE
Center the watch wallet banner text

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_head/AmountListHead.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_head/AmountListHead.kt
@@ -295,8 +295,9 @@ private fun AssetWatchOnly() {
             )
             Spacer8()
             Text(
-                modifier = Modifier.weight(1f, fill = false),
+                modifier = Modifier.weight(1f),
                 text = stringResource(id = R.string.wallet_watch_tooltip_title),
+                textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.W400,
             )

--- a/ios/Packages/PrimitivesComponents/Sources/Components/ValueHeaderView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Components/ValueHeaderView.swift
@@ -112,10 +112,12 @@ public struct ValueHeaderView: View {
                     HStack {
                         Images.System.eye
 
+                        Spacer(minLength: .zero)
+
                         Text(Localized.Wallet.Watch.Tooltip.title)
                             .foregroundStyle(Colors.black)
                             .font(.callout)
-                            .multilineTextAlignment(.leading)
+                            .multilineTextAlignment(.center)
                             .fixedSize(horizontal: false, vertical: true)
 
                         Spacer(minLength: .zero)


### PR DESCRIPTION
Follow-up on the watch wallet banner: the eye and info icons now sit at the card edges with equal insets, and the text is centered between them on both platforms.

<img width="320" alt="watch-banner-android" src="https://github.com/user-attachments/assets/8d1415e3-230f-471d-b4bb-b7d2b5548f8f" />
<img width="320" alt="watch-banner-ios" src="https://github.com/user-attachments/assets/bcd9784c-d866-4901-85f3-96a65fa6e3b0" />
