### PR TITLE
Remove ValidateAddressOperator and call Chain.isValidAddress directly

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/di/InteractsModule.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/di/InteractsModule.kt
@@ -8,11 +8,9 @@ import com.gemwallet.android.blockchain.operators.AddAccountsOperator
 import com.gemwallet.android.blockchain.operators.CreateAccountOperator
 import com.gemwallet.android.blockchain.operators.CreateWalletOperator
 import com.gemwallet.android.blockchain.operators.DeleteKeyStoreOperator
-import com.gemwallet.android.blockchain.operators.GemValidateAddressOperator
 import com.gemwallet.android.blockchain.operators.LoadPrivateDataOperator
 import com.gemwallet.android.blockchain.operators.MigrateKeystoreOperator
 import com.gemwallet.android.blockchain.operators.StorePhraseOperator
-import com.gemwallet.android.blockchain.operators.ValidateAddressOperator
 import com.gemwallet.android.blockchain.operators.ValidatePhraseOperator
 import com.gemwallet.android.blockchain.operators.gemstone.GemAddAccountsOperator
 import com.gemwallet.android.blockchain.operators.gemstone.GemCreateAccountOperator
@@ -43,10 +41,6 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 @Module
 object InteractsModule {
-
-    @Singleton
-    @Provides
-    fun provideValidateAddressInteract(): ValidateAddressOperator = GemValidateAddressOperator()
 
     @Singleton
     @Provides
@@ -131,7 +125,6 @@ object InteractsModule {
         sessionRepository: SessionRepository,
         storePhraseOperator: StorePhraseOperator,
         phraseValidate: ValidatePhraseOperator,
-        addressValidate: ValidateAddressOperator,
         passwordStore: PasswordStore,
         syncDevice: SyncDevice,
         walletImportSync: SyncWalletImport,
@@ -141,7 +134,6 @@ object InteractsModule {
         sessionRepository = sessionRepository,
         storePhraseOperator = storePhraseOperator,
         phraseValidate = phraseValidate,
-        addressValidate = addressValidate,
         passwordStore = passwordStore,
         syncDevice = syncDevice,
         walletImportSync = walletImportSync,

--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/operators/GemValidateAddressOperator.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/operators/GemValidateAddressOperator.kt
@@ -1,9 +1,0 @@
-package com.gemwallet.android.blockchain.operators
-
-import com.gemwallet.android.ext.isValidAddress
-import com.wallet.core.primitives.Chain
-
-class GemValidateAddressOperator : ValidateAddressOperator {
-    override operator fun invoke(address: String, chain: Chain): Result<Boolean> =
-        Result.success(chain.isValidAddress(address))
-}

--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/operators/ValidateAddressOperator.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/operators/ValidateAddressOperator.kt
@@ -1,7 +1,0 @@
-package com.gemwallet.android.blockchain.operators
-
-import com.wallet.core.primitives.Chain
-
-interface ValidateAddressOperator {
-    operator fun invoke(address: String, chain: Chain): Result<Boolean>
-}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/wallets/PhraseAddressImportWalletService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/wallets/PhraseAddressImportWalletService.kt
@@ -5,7 +5,6 @@ import com.gemwallet.android.application.wallet_import.coordinators.SyncWalletIm
 import com.gemwallet.android.blockchain.operators.InvalidPhrase
 import com.gemwallet.android.blockchain.operators.InvalidWords
 import com.gemwallet.android.blockchain.operators.StorePhraseOperator
-import com.gemwallet.android.blockchain.operators.ValidateAddressOperator
 import com.gemwallet.android.blockchain.operators.ValidatePhraseOperator
 import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.cases.wallet.ImportError
@@ -13,6 +12,7 @@ import com.gemwallet.android.cases.wallet.ImportWalletService
 import com.gemwallet.android.cases.wallet.WalletImportResult
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.ext.isValidAddress
 import com.gemwallet.android.ext.words
 import com.gemwallet.android.math.hex
 import com.gemwallet.android.model.ImportType
@@ -27,7 +27,6 @@ class PhraseAddressImportWalletService(
     private val sessionRepository: SessionRepository,
     private val storePhraseOperator: StorePhraseOperator,
     private val phraseValidate: ValidatePhraseOperator,
-    private val addressValidate: ValidateAddressOperator,
     private val passwordStore: PasswordStore,
     private val syncDevice: SyncDevice,
     private val walletImportSync: SyncWalletImport,
@@ -91,7 +90,7 @@ class PhraseAddressImportWalletService(
     }
 
     private suspend fun handleAddress(chain: Chain, walletName: String, data: String): Wallet {
-        if (addressValidate(data, chain).getOrNull() != true) {
+        if (!chain.isValidAddress(data)) {
             throw ImportError.InvalidAddress
         }
         return try {

--- a/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/RecipientValidation.kt
+++ b/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/RecipientValidation.kt
@@ -1,6 +1,5 @@
 package com.gemwallet.android.features.recipient.viewmodel
 
-import com.gemwallet.android.blockchain.operators.ValidateAddressOperator
 import com.gemwallet.android.ext.matchesRecipient
 import com.gemwallet.android.model.DestinationAddress
 import com.wallet.core.primitives.Chain
@@ -10,6 +9,6 @@ internal fun DestinationAddress.isValidRecipient(
     inputAddress: String,
     chain: Chain,
     nameRecord: NameRecord?,
-    validateAddress: ValidateAddressOperator,
-): Boolean = validateAddress(address, chain).getOrNull() == true &&
+    validateAddress: (address: String, chain: Chain) -> Boolean,
+): Boolean = validateAddress(address, chain) &&
     (nameRecord == null || nameRecord.matchesRecipient(inputAddress, address, chain))

--- a/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/RecipientViewModel.kt
+++ b/android/features/recipient/viewmodels/src/main/kotlin/com/gemwallet/android/features/recipient/viewmodel/RecipientViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.assets.coordinators.GetAssetInfo
 import com.gemwallet.android.application.recipient.coordinators.GetWallets
 import com.gemwallet.android.application.session.coordinators.GetSession
-import com.gemwallet.android.blockchain.operators.ValidateAddressOperator
 import com.gemwallet.android.cases.contacts.ContactRecipient
 import com.gemwallet.android.cases.contacts.GetContacts
 import com.gemwallet.android.cases.name.ResolveName
@@ -16,6 +15,7 @@ import com.gemwallet.android.ext.asset
 import com.gemwallet.android.ext.checksumAddress
 import com.gemwallet.android.ext.getAccount
 import com.gemwallet.android.ext.isMemoSupport
+import com.gemwallet.android.ext.isValidAddress
 import com.gemwallet.android.features.recipient.viewmodel.models.QrScanField
 import com.gemwallet.android.features.recipient.viewmodel.models.RecipientError
 import com.gemwallet.android.features.recipient.viewmodel.models.RecipientState
@@ -67,15 +67,17 @@ class RecipientViewModel @Inject constructor(
     private val getContacts: GetContacts,
     private val getAssetInfo: GetAssetInfo,
     private val getAssetNft: GetAssetNft,
-    private val validateAddressOperator: ValidateAddressOperator,
     private val resolveName: ResolveName,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
+    private val validateAddress: (address: String, chain: Chain) -> Boolean =
+        { address, chain -> chain.isValidAddress(address) }
+
     private val addressInput = AddressInputModel(
         resolveName = resolveName,
         scope = viewModelScope,
-        validateAddress = { address, chain -> validateAddressOperator(address, chain).getOrNull() == true },
+        validateAddress = validateAddress,
     )
 
     val address: StateFlow<String> = addressInput.text
@@ -184,7 +186,7 @@ class RecipientViewModel @Inject constructor(
     ) {
         val asset = type.assetInfo.asset
         destination.copy(address = asset.chain.checksumAddress(destination.address)).let { destination ->
-            if (!destination.isValidRecipient(address.value, asset.chain, nameRecord, validateAddressOperator)) {
+            if (!destination.isValidRecipient(address.value, asset.chain, nameRecord, validateAddress)) {
                 if (!resolveName.canResolveName(destination.address)) {
                     addressInput.markInvalid()
                 }

--- a/android/features/recipient/viewmodels/src/test/kotlin/com/gemwallet/android/features/recipient/viewmodel/RecipientValidationTest.kt
+++ b/android/features/recipient/viewmodels/src/test/kotlin/com/gemwallet/android/features/recipient/viewmodel/RecipientValidationTest.kt
@@ -1,6 +1,5 @@
 package com.gemwallet.android.features.recipient.viewmodel
 
-import com.gemwallet.android.blockchain.operators.ValidateAddressOperator
 import com.gemwallet.android.model.DestinationAddress
 import com.gemwallet.android.testkit.mockNameRecord
 import com.wallet.core.primitives.Chain
@@ -49,7 +48,5 @@ class RecipientValidationTest {
         )
     }
 
-    private fun addressValidator(result: Boolean) = object : ValidateAddressOperator {
-        override fun invoke(address: String, chain: Chain): Result<Boolean> = Result.success(result)
-    }
+    private fun addressValidator(result: Boolean): (String, Chain) -> Boolean = { _, _ -> result }
 }

--- a/android/features/settings/contacts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/contacts/viewmodels/ManageContactViewModel.kt
+++ b/android/features/settings/contacts/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/contacts/viewmodels/ManageContactViewModel.kt
@@ -3,11 +3,11 @@ package com.gemwallet.android.features.settings.contacts.viewmodels
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.gemwallet.android.blockchain.operators.ValidateAddressOperator
 import com.gemwallet.android.cases.contacts.AddContact
 import com.gemwallet.android.cases.contacts.GetContacts
 import com.gemwallet.android.cases.contacts.UpdateContact
 import com.gemwallet.android.cases.name.ResolveName
+import com.gemwallet.android.ext.isValidAddress
 import com.gemwallet.android.ui.models.name.AddressInputModel
 import com.gemwallet.android.features.settings.contacts.viewmodels.models.ContactAddressForm
 import com.gemwallet.android.features.settings.contacts.viewmodels.models.ContactAddressInput
@@ -35,7 +35,6 @@ class ManageContactViewModel @Inject constructor(
     private val getContacts: GetContacts,
     private val addContactCase: AddContact,
     private val updateContactCase: UpdateContact,
-    private val validateAddress: ValidateAddressOperator,
     resolveName: ResolveName,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -55,7 +54,7 @@ class ManageContactViewModel @Inject constructor(
     private val addressInput = AddressInputModel(
         resolveName = resolveName,
         scope = viewModelScope,
-        validateAddress = { address, chain -> validateAddress(address, chain).getOrNull() == true },
+        validateAddress = { address, chain -> chain.isValidAddress(address) },
     )
 
     private val state = MutableStateFlow(ManageContactState(isEdit = mode is Mode.Edit))


### PR DESCRIPTION
Removes the ValidateAddressOperator interface and its single implementation, which only wrapped Chain.isValidAddress in a Result that never failed. Callers now use the boolean check directly.