### PR TITLE
Deduplicate the WalletConnect review screen

### DIFF
--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/AuthRequestScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/AuthRequestScene.kt
@@ -2,9 +2,6 @@ package com.gemwallet.android.features.bridge.views
 
 import android.widget.Toast
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -18,26 +15,17 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.features.bridge.viewmodels.AuthSceneState
 import com.gemwallet.android.features.bridge.viewmodels.WCAuthViewModel
-import com.gemwallet.android.model.AuthRequest
 import com.gemwallet.android.data.repositories.bridge.WalletConnectAuthenticationRequest
 import com.gemwallet.android.data.repositories.bridge.WalletConnectVerifyContext
 import com.gemwallet.android.ui.R
-import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.models.ButtonState
-import com.gemwallet.android.ui.components.list_head.CenteredListHead
-import com.gemwallet.android.ui.components.list_head.CenteredListHeadSubtitleLayout
 import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
 import com.gemwallet.android.ui.components.list_item.property.PropertyDataText
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
-import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyTitleText
 import com.gemwallet.android.ui.components.screen.FatalStateScene
 import com.gemwallet.android.ui.components.screen.LoadingScene
-import com.gemwallet.android.ui.components.screen.Scene
-import com.gemwallet.android.ui.components.simulation.simulationPayloadFieldsContent
 import com.gemwallet.android.ui.models.ListPosition
-import com.gemwallet.android.ui.requestAuth
-import com.gemwallet.android.ui.theme.paddingDefault
 
 @Composable
 fun AuthRequestScene(
@@ -99,92 +87,36 @@ private fun AuthRequestContent(
     onReject: () -> Unit,
     onWalletSelected: (com.wallet.core.primitives.WalletId) -> Unit,
 ) {
-    val context = LocalContext.current
     var isShowSelectWallets by remember { mutableStateOf(false) }
-    var sheetType by remember { mutableStateOf<AuthRequestSheetType?>(null) }
     val canSelectWallet = state.availableWallets.size > 1
 
-    Scene(
-        title = stringResource(id = R.string.transfer_review_request),
-        backHandle = true,
-        closeIcon = true,
-        mainAction = {
-            MainActionButton(
-                title = stringResource(id = R.string.transfer_confirm),
-                state = buttonState,
-            ) {
-                context.requestAuth(AuthRequest.Confirmation) {
-                    onApprove()
-                }
-            }
+    WalletConnectReviewScene(
+        model = state,
+        buttonState = buttonState,
+        walletRow = {
+            PropertyItem(
+                modifier = if (canSelectWallet && state !is AuthSceneState.Approving) {
+                    Modifier.clickable { isShowSelectWallets = true }
+                } else {
+                    Modifier
+                },
+                title = { PropertyTitleText(R.string.common_wallet) },
+                data = {
+                    PropertyDataText(
+                        text = state.selectedWallet.name,
+                        badge = if (canSelectWallet) {
+                            { DataBadgeChevron() }
+                        } else {
+                            null
+                        },
+                    )
+                },
+                listPosition = ListPosition.First,
+            )
         },
-        onClose = onReject,
-    ) { paddingValues ->
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = paddingValues.calculateBottomPadding() + paddingDefault),
-        ) {
-            item {
-                CenteredListHead(
-                    icon = state.peer.icon,
-                    title = state.peer.name,
-                    subtitle = state.peer.uri,
-                    contentDescription = "wallet_connect_app_icon",
-                    subtitleLayout = CenteredListHeadSubtitleLayout.Vertical,
-                )
-            }
-            item {
-                PropertyItem(
-                    modifier = if (canSelectWallet && state !is AuthSceneState.Approving) {
-                        Modifier.clickable { isShowSelectWallets = true }
-                    } else {
-                        Modifier
-                    },
-                    title = { PropertyTitleText(R.string.common_wallet) },
-                    data = {
-                        PropertyDataText(
-                            text = state.selectedWallet.name,
-                            badge = if (canSelectWallet) {
-                                { DataBadgeChevron() }
-                            } else {
-                                null
-                            },
-                        )
-                    },
-                    listPosition = ListPosition.First,
-                )
-            }
-            item {
-                PropertyNetworkItem(state.approval.chain, listPosition = ListPosition.Last)
-            }
-            if (state.approval.hasPayload) {
-                simulationPayloadFieldsContent(
-                    fields = state.approval.primaryPayloadFields,
-                    onDetailsClick = { sheetType = AuthRequestSheetType.Details },
-                )
-            } else {
-                walletConnectTextMessage(state.approval.message)
-            }
-        }
-    }
-
-    when (sheetType) {
-        AuthRequestSheetType.Details -> {
-            WalletConnectPayloadDetailsSheet(
-                primaryFields = state.approval.primaryPayloadFields,
-                secondaryFields = state.approval.secondaryPayloadFields,
-                onViewFullMessage = { sheetType = AuthRequestSheetType.FullMessage },
-                onDismissRequest = { sheetType = null },
-            )
-        }
-        AuthRequestSheetType.FullMessage -> {
-            WalletConnectFullMessageSheet(
-                message = state.approval.message,
-                onDismissRequest = { sheetType = null },
-            )
-        }
-        null -> Unit
-    }
+        onApprove = onApprove,
+        onReject = onReject,
+    )
 
     WalletSelectionSheet(
         isVisible = isShowSelectWallets,
@@ -193,9 +125,4 @@ private fun AuthRequestContent(
         onWalletSelected = onWalletSelected,
         onDismissRequest = { isShowSelectWallets = false },
     )
-}
-
-private enum class AuthRequestSheetType {
-    Details,
-    FullMessage,
 }

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
@@ -1,16 +1,9 @@
 package com.gemwallet.android.features.bridge.views
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -22,21 +15,10 @@ import com.gemwallet.android.features.bridge.viewmodels.WCRequestViewModel
 import com.gemwallet.android.features.bridge.viewmodels.model.BridgeRequestError
 import com.gemwallet.android.features.bridge.viewmodels.model.WCRequest
 import com.gemwallet.android.features.confirm.presents.ConfirmScreen
-import com.gemwallet.android.model.AuthRequest
 import com.gemwallet.android.ui.R
-import com.gemwallet.android.ui.components.buttons.MainActionButton
-import com.gemwallet.android.ui.models.ButtonState
-import com.gemwallet.android.ui.components.list_head.CenteredListHead
-import com.gemwallet.android.ui.components.list_head.CenteredListHeadSubtitleLayout
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
-import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkItem
 import com.gemwallet.android.ui.components.screen.LoadingScene
-import com.gemwallet.android.ui.components.screen.Scene
-import com.gemwallet.android.ui.components.simulation.simulationPayloadFieldsContent
-import com.gemwallet.android.ui.components.simulation.simulationWarningsContent
 import com.gemwallet.android.ui.models.ListPosition
-import com.gemwallet.android.ui.requestAuth
-import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.features.confirm.presents.AcquireAssetAction
 import com.wallet.core.primitives.AssetId
 
@@ -83,10 +65,10 @@ fun RequestScene(
         is RequestSceneState.Content -> (sceneState as RequestSceneState.Content).let { sceneState ->
             val request = sceneState.request
             when (request) {
-                is WCRequest.SignMessage -> SignMessageScene(
-                    state = sceneState,
-                    request = request,
+                is WCRequest.SignMessage -> WalletConnectReviewScene(
+                    model = request,
                     buttonState = buttonState,
+                    walletRow = { PropertyItem(R.string.common_wallet, sceneState.walletName, listPosition = ListPosition.First) },
                     onApprove = { viewModel.onSign(onError) },
                     onReject = viewModel::onReject,
                 )
@@ -102,86 +84,4 @@ fun RequestScene(
         }
         RequestSceneState.Cancel -> onCancel()
     }
-}
-
-@Composable
-private fun SignMessageScene(
-    state: RequestSceneState.Content,
-    request: WCRequest.SignMessage,
-    buttonState: ButtonState,
-    onApprove: () -> Unit,
-    onReject: () -> Unit,
-) {
-    val context = LocalContext.current
-    var sheetType by remember { mutableStateOf<SignMessageSheetType?>(null) }
-
-    Scene(
-        title = stringResource(id = R.string.transfer_review_request),
-        backHandle = true,
-        closeIcon = true,
-        mainAction = {
-            MainActionButton(
-                title = stringResource(id = R.string.transfer_confirm),
-                state = buttonState,
-            ) {
-                context.requestAuth(AuthRequest.Confirmation) {
-                    onApprove()
-                }
-            }
-        },
-        onClose = onReject,
-    ) { paddingValues ->
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = paddingValues.calculateBottomPadding() + paddingDefault),
-        ) {
-            item {
-                CenteredListHead(
-                    icon = request.icon,
-                    title = request.name,
-                    subtitle = request.uri,
-                    contentDescription = "wallet_connect_app_icon",
-                    subtitleLayout = CenteredListHeadSubtitleLayout.Vertical,
-                )
-            }
-            item { PropertyItem(R.string.common_wallet, state.walletName, listPosition = ListPosition.First) }
-            item { PropertyNetworkItem(request.chain, listPosition = ListPosition.Last) }
-            simulationWarningsContent(request.simulation.warnings)
-            if (request.hasPayload) {
-                simulationPayloadFieldsContent(
-                    fields = request.primaryPayloadFields,
-                    onDetailsClick = { sheetType = SignMessageSheetType.Details },
-                )
-            }
-
-            if (!request.hasPayload) {
-                walletConnectTextMessage(request.plainMessage)
-            }
-        }
-
-        when (sheetType) {
-            SignMessageSheetType.Details -> {
-                WalletConnectPayloadDetailsSheet(
-                    primaryFields = request.primaryPayloadFields,
-                    secondaryFields = request.secondaryPayloadFields,
-                    onViewFullMessage = { sheetType = SignMessageSheetType.FullMessage },
-                    onDismissRequest = { sheetType = null },
-                )
-            }
-
-            SignMessageSheetType.FullMessage -> {
-                WalletConnectFullMessageSheet(
-                    message = request.plainMessage,
-                    onDismissRequest = { sheetType = null },
-                )
-            }
-
-            null -> Unit
-        }
-    }
-}
-
-private enum class SignMessageSheetType {
-    Details,
-    FullMessage,
 }

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/WalletConnectReviewScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/WalletConnectReviewScene.kt
@@ -1,0 +1,107 @@
+package com.gemwallet.android.features.bridge.views
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectReviewModel
+import com.gemwallet.android.model.AuthRequest
+import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.components.list_head.CenteredListHead
+import com.gemwallet.android.ui.components.list_head.CenteredListHeadSubtitleLayout
+import com.gemwallet.android.ui.components.list_item.property.PropertyNetworkItem
+import com.gemwallet.android.ui.components.screen.Scene
+import com.gemwallet.android.ui.components.simulation.simulationPayloadFieldsContent
+import com.gemwallet.android.ui.components.simulation.simulationWarningsContent
+import com.gemwallet.android.ui.models.ButtonState
+import com.gemwallet.android.ui.models.ListPosition
+import com.gemwallet.android.ui.requestAuth
+import com.gemwallet.android.ui.theme.paddingDefault
+
+@Composable
+internal fun WalletConnectReviewScene(
+    model: WalletConnectReviewModel,
+    buttonState: ButtonState,
+    walletRow: @Composable () -> Unit,
+    onApprove: () -> Unit,
+    onReject: () -> Unit,
+) {
+    val context = LocalContext.current
+    var sheetType by remember { mutableStateOf<WalletConnectReviewSheetType?>(null) }
+
+    Scene(
+        title = stringResource(id = R.string.transfer_review_request),
+        backHandle = true,
+        closeIcon = true,
+        mainAction = {
+            MainActionButton(
+                title = stringResource(id = R.string.transfer_confirm),
+                state = buttonState,
+            ) {
+                context.requestAuth(AuthRequest.Confirmation) {
+                    onApprove()
+                }
+            }
+        },
+        onClose = onReject,
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = paddingValues.calculateBottomPadding() + paddingDefault),
+        ) {
+            item {
+                CenteredListHead(
+                    icon = model.icon,
+                    title = model.name,
+                    subtitle = model.uri,
+                    contentDescription = "wallet_connect_app_icon",
+                    subtitleLayout = CenteredListHeadSubtitleLayout.Vertical,
+                )
+            }
+            item { walletRow() }
+            item {
+                PropertyNetworkItem(model.chain, listPosition = ListPosition.Last)
+            }
+            simulationWarningsContent(model.warnings)
+            if (model.hasPayload) {
+                simulationPayloadFieldsContent(
+                    fields = model.primaryPayloadFields,
+                    onDetailsClick = { sheetType = WalletConnectReviewSheetType.Details },
+                )
+            } else {
+                walletConnectTextMessage(model.message)
+            }
+        }
+    }
+
+    when (sheetType) {
+        WalletConnectReviewSheetType.Details -> {
+            WalletConnectPayloadDetailsSheet(
+                primaryFields = model.primaryPayloadFields,
+                secondaryFields = model.secondaryPayloadFields,
+                onViewFullMessage = { sheetType = WalletConnectReviewSheetType.FullMessage },
+                onDismissRequest = { sheetType = null },
+            )
+        }
+        WalletConnectReviewSheetType.FullMessage -> {
+            WalletConnectFullMessageSheet(
+                message = model.message,
+                onDismissRequest = { sheetType = null },
+            )
+        }
+        null -> Unit
+    }
+}
+
+private enum class WalletConnectReviewSheetType {
+    Details,
+    FullMessage,
+}

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCAuthViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCAuthViewModel.kt
@@ -18,6 +18,7 @@ import com.gemwallet.android.ext.toChainType
 import com.gemwallet.android.ext.walletConnectAppName
 import com.gemwallet.android.features.bridge.viewmodels.model.SessionUI
 import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectOriginVerifier
+import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectReviewModel
 import com.gemwallet.android.features.bridge.viewmodels.model.toSessionUI
 import com.gemwallet.android.ui.models.ButtonState
 import com.gemwallet.android.ui.models.PayloadField
@@ -336,11 +337,19 @@ sealed interface AuthSceneState {
 
     class Error(val message: String) : AuthSceneState
 
-    sealed interface Content : AuthSceneState {
+    sealed interface Content : AuthSceneState, WalletConnectReviewModel {
         val peer: SessionUI
         val availableWallets: List<Wallet>
         val selectedWallet: Wallet
         val approval: AuthApproval
+
+        override val icon: String get() = peer.icon
+        override val name: String get() = peer.name
+        override val uri: String get() = peer.uri
+        override val chain: Chain get() = approval.chain
+        override val primaryPayloadFields: List<PayloadField> get() = approval.primaryPayloadFields
+        override val secondaryPayloadFields: List<PayloadField> get() = approval.secondaryPayloadFields
+        override val message: String get() = approval.message
     }
 
     data class Request(
@@ -370,7 +379,6 @@ data class AuthApproval(
     val secondaryPayloadFields: List<PayloadField>,
 ) {
     val chain: Chain get() = account.chain
-    val hasPayload: Boolean get() = primaryPayloadFields.isNotEmpty() || secondaryPayloadFields.isNotEmpty()
 }
 
 private data class AuthAccount(

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WCRequest.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WCRequest.kt
@@ -19,6 +19,7 @@ import com.gemwallet.android.blockchain.services.GemSignMessageOperator
 import com.gemwallet.android.blockchain.gemstone.toGem
 import com.gemwallet.android.blockchain.gemstone.toPrimitives
 import com.wallet.core.primitives.SimulationResult
+import com.wallet.core.primitives.SimulationWarning
 import uniffi.gemstone.TransferDataOutputType
 import uniffi.gemstone.WalletConnect
 import uniffi.gemstone.WalletConnectAction
@@ -53,7 +54,7 @@ sealed class WCRequest(
         val action: WalletConnectAction.SignMessage,
         val simulation: SimulationResult,
         private val explorerName: String?,
-    ) : WCRequest(sessionRequest, account, appMetadata) {
+    ) : WCRequest(sessionRequest, account, appMetadata), WalletConnectReviewModel {
 
         private val signer by lazy {
             runCatching {
@@ -67,25 +68,25 @@ sealed class WCRequest(
             }
         }
 
-        val plainMessage: String
+        override val message: String
             get() = signer.getOrNull()?.plainPreview() ?: action.data
 
-        val primaryPayloadFields: List<PayloadField> by lazy {
+        override val warnings: List<SimulationWarning>
+            get() = simulation.warnings
+
+        override val primaryPayloadFields: List<PayloadField> by lazy {
             payloadPreview?.primary
                 ?.map { it.toPrimitives() }
                 .orEmpty()
                 .withExplorerLinks(chain, explorerName)
         }
 
-        val secondaryPayloadFields: List<PayloadField> by lazy {
+        override val secondaryPayloadFields: List<PayloadField> by lazy {
             payloadPreview?.secondary
                 ?.map { it.toPrimitives() }
                 .orEmpty()
                 .withExplorerLinks(chain, explorerName)
         }
-
-        val hasPayload: Boolean
-            get() = primaryPayloadFields.isNotEmpty() || secondaryPayloadFields.isNotEmpty()
 
         suspend fun execute(
             signMessageOperator: GemSignMessageOperator,

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WalletConnectReviewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/model/WalletConnectReviewModel.kt
@@ -1,0 +1,17 @@
+package com.gemwallet.android.features.bridge.viewmodels.model
+
+import com.gemwallet.android.ui.models.PayloadField
+import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.SimulationWarning
+
+interface WalletConnectReviewModel {
+    val icon: String
+    val name: String
+    val uri: String
+    val chain: Chain
+    val primaryPayloadFields: List<PayloadField>
+    val secondaryPayloadFields: List<PayloadField>
+    val message: String
+    val warnings: List<SimulationWarning> get() = emptyList()
+    val hasPayload: Boolean get() = primaryPayloadFields.isNotEmpty() || secondaryPayloadFields.isNotEmpty()
+}


### PR DESCRIPTION
The WalletConnect auth and sign message screens were two near-identical copies of the same review screen and had already started to drift apart. Now there is a single shared review scene, and both screens provide their data through a common model contract.