### PR TITLE
Remove dead wallet sync API from CollectionsViewable

### DIFF
--- a/ios/Features/NFT/Package.swift
+++ b/ios/Features/NFT/Package.swift
@@ -41,7 +41,6 @@ let package = Package(
                 .product(name: "NFTService", package: "FeatureServices"),
                 "Store",
                 .product(name: "ImageGalleryService", package: "SystemServices"),
-                .product(name: "WalletSessionService", package: "FeatureServices"),
                 "GemstonePrimitives",
                 .product(name: "ExplorerService", package: "ChainServices"),
                 .product(name: "AvatarService", package: "FeatureServices"),

--- a/ios/Features/NFT/Sources/Protocols/CollectionsViewable.swift
+++ b/ios/Features/NFT/Sources/Protocols/CollectionsViewable.swift
@@ -10,19 +10,15 @@ import SwiftUI
 @MainActor
 public protocol CollectionsViewable: AnyObject, Observable {
     var query: ObservableQuery<NFTRequest> { get }
-    var nftDataList: [NFTData] { get }
 
     var title: String { get }
     var columns: [GridItem] { get }
     var content: CollectionsContent { get }
     var emptyContentModel: EmptyContentTypeViewModel { get }
 
-    var wallet: Wallet { get set }
-
     var isPresentingReceiveSelectAssetType: SelectAssetType? { get set }
 
     func fetch() async
-    func onChangeWallet(_ oldWallet: Wallet?, _ newWallet: Wallet?)
     func onSelectReceive()
 }
 
@@ -39,13 +35,6 @@ public extension CollectionsViewable {
 
     func onSelectReceive() {
         isPresentingReceiveSelectAssetType = .receive(.collection)
-    }
-
-    func onChangeWallet(_: Wallet?, _ newWallet: Wallet?) {
-        if let newWallet, wallet != newWallet {
-            wallet = newWallet
-            query.request = NFTRequest(walletId: newWallet.id, filter: .all)
-        }
     }
 
     func buildGridItem(from data: NFTData) -> GridPosterViewItem {

--- a/ios/Features/NFT/Sources/ViewModels/CollectionViewModel.swift
+++ b/ios/Features/NFT/Sources/ViewModels/CollectionViewModel.swift
@@ -13,20 +13,14 @@ public final class CollectionViewModel: CollectionsViewable, Sendable {
     private let collectionName: String
 
     public let query: ObservableQuery<NFTRequest>
-    public var nftDataList: [NFTData] {
-        query.value
-    }
 
     public var isPresentingReceiveSelectAssetType: SelectAssetType?
-
-    public var wallet: Wallet
 
     public init(
         wallet: Wallet,
         collectionId: String,
         collectionName: String,
     ) {
-        self.wallet = wallet
         self.collectionName = collectionName
         query = ObservableQuery(NFTRequest(walletId: wallet.id, filter: .collection(id: collectionId)), initialValue: [])
     }
@@ -37,7 +31,7 @@ public final class CollectionViewModel: CollectionsViewable, Sendable {
 
     public var content: CollectionsContent {
         CollectionsContent(
-            items: nftDataList.flatMap { data in
+            items: query.value.flatMap { data in
                 data.assets.map { buildGridItem(collection: data.collection, asset: $0) }
             },
         )

--- a/ios/Features/NFT/Sources/ViewModels/CollectionsViewModel.swift
+++ b/ios/Features/NFT/Sources/ViewModels/CollectionsViewModel.swift
@@ -8,18 +8,13 @@ import Primitives
 import PrimitivesComponents
 import Store
 import SwiftUI
-import WalletSessionService
 
 @Observable
 @MainActor
 public final class CollectionsViewModel: CollectionsViewable, Sendable {
-    private let walletSessionService: any WalletSessionManageable
     private let nftService: NFTService
 
     public let query: ObservableQuery<NFTRequest>
-    public var nftDataList: [NFTData] {
-        query.value
-    }
 
     public var isPresentingReceiveSelectAssetType: SelectAssetType?
 
@@ -27,21 +22,15 @@ public final class CollectionsViewModel: CollectionsViewable, Sendable {
 
     public init(
         nftService: NFTService,
-        walletSessionService: any WalletSessionManageable,
         wallet: Wallet,
     ) {
         self.nftService = nftService
-        self.walletSessionService = walletSessionService
         self.wallet = wallet
         query = ObservableQuery(NFTRequest(walletId: wallet.id, filter: .all), initialValue: [])
     }
 
     public var title: String {
         Localized.Nft.collections
-    }
-
-    public var currentWallet: Wallet? {
-        walletSessionService.currentWallet
     }
 
     public var content: CollectionsContent {
@@ -52,6 +41,10 @@ public final class CollectionsViewModel: CollectionsViewable, Sendable {
     }
 
     // MARK: - Private
+
+    private var nftDataList: [NFTData] {
+        query.value
+    }
 
     private var verifiedItems: [GridPosterViewItem] {
         nftDataList

--- a/ios/Features/NFT/Sources/ViewModels/UnverifiedCollectionsViewModel.swift
+++ b/ios/Features/NFT/Sources/ViewModels/UnverifiedCollectionsViewModel.swift
@@ -12,16 +12,10 @@ import SwiftUI
 @MainActor
 public final class UnverifiedCollectionsViewModel: CollectionsViewable, Sendable {
     public let query: ObservableQuery<NFTRequest>
-    public var nftDataList: [NFTData] {
-        query.value
-    }
 
     public var isPresentingReceiveSelectAssetType: SelectAssetType?
 
-    public var wallet: Wallet
-
     public init(wallet: Wallet) {
-        self.wallet = wallet
         query = ObservableQuery(NFTRequest(walletId: wallet.id, filter: .unverified), initialValue: [])
     }
 
@@ -30,6 +24,6 @@ public final class UnverifiedCollectionsViewModel: CollectionsViewable, Sendable
     }
 
     public var content: CollectionsContent {
-        CollectionsContent(items: nftDataList.map { buildGridItem(from: $0) })
+        CollectionsContent(items: query.value.map { buildGridItem(from: $0) })
     }
 }

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -65,7 +65,6 @@ public final class WalletSceneViewModel: Sendable, AssetBalanceActions {
         self.observablePreferences = observablePreferences
         self.collectionsModel = CollectionsViewModel(
             nftService: nftService,
-            walletSessionService: walletSessionService,
             wallet: wallet,
         )
 

--- a/ios/Gem/Navigation/Wallet/WalletNavigationStack.swift
+++ b/ios/Gem/Navigation/Wallet/WalletNavigationStack.swift
@@ -39,7 +39,6 @@ struct WalletNavigationStack: View {
     @Environment(\.viewModelFactory) private var viewModelFactory
     @Environment(\.avatarService) private var avatarService
     @Environment(\.nftService) private var nftService
-    @Environment(\.walletSessionService) private var walletSessionService
     @Environment(\.observablePreferences) private var preferences
 
     @State private var model: WalletSceneViewModel
@@ -150,7 +149,6 @@ struct WalletNavigationStack: View {
                 CollectionsSceneNavigationView(
                     model: CollectionsViewModel(
                         nftService: nftService,
-                        walletSessionService: walletSessionService,
                         wallet: model.wallet,
                     ),
                 )


### PR DESCRIPTION
Removes protocol requirements nothing uses polymorphically: `nftDataList`, `wallet`, and the never-called `onChangeWallet` with its default implementation. Also deletes the unused `currentWallet` property from `CollectionsViewModel`, which drops the NFT package's dependency on `WalletSessionService` entirely.

Wallet switching keeps working through the existing `WalletSceneViewModel.refresh(for:)` path, which is untouched.