### PR TITLE
Count only Activity-visible transactions in the pending badge

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionsRepositoryImpl.kt
@@ -86,7 +86,10 @@ class TransactionsRepositoryImpl(
 
     override fun getPendingTransactionsCount(): Flow<Int?> {
         return currentWalletId().flatMapLatest { walletId ->
-            transactionsDao.getTransactionsCount(walletId, pollingTransactionStates)
+            transactionsDao.getTransactionsCount(
+                walletId,
+                TransactionsRequestFilter.activityDefaults() + TransactionsRequestFilter.States(pollingTransactionStates),
+            )
         }
     }
 

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsDao.kt
@@ -93,8 +93,18 @@ interface TransactionsDao {
         filters: List<TransactionsRequestFilter> = emptyList(),
     ): Flow<List<DbTransactionExtended>> = getExtendedTransactions(buildExtendedTransactionsSql(walletId, filters).toSupportSQLiteQuery())
 
-    @Query("SELECT COUNT(*) $EXTENDED_SOURCE AND tx.state IN (:states)")
-    fun getTransactionsCount(walletId: WalletId, states: List<TransactionState>): Flow<Int?>
+    @RawQuery(
+        observedEntities = [
+            DbTransaction::class,
+            DbAsset::class,
+        ]
+    )
+    fun getTransactionsCount(query: SupportSQLiteQuery): Flow<Int?>
+
+    fun getTransactionsCount(
+        walletId: WalletId,
+        filters: List<TransactionsRequestFilter>,
+    ): Flow<Int?> = getTransactionsCount(buildTransactionsCountSql(walletId, filters).toSupportSQLiteQuery())
 
     @Query("SELECT $EXTENDED_COLUMNS $EXTENDED_SOURCE AND tx.id = :id")
     fun getExtendedTransaction(walletId: WalletId, id: TransactionId): Flow<DbTransactionExtended?>

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsQueryBuilder.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/TransactionsQueryBuilder.kt
@@ -25,3 +25,13 @@ fun buildExtendedTransactionsSql(
         .orderBy("tx.createdAt DESC")
         .build()
 }
+
+fun buildTransactionsCountSql(
+    walletId: WalletId,
+    filters: List<TransactionsRequestFilter>,
+): SqlQuery {
+    val source = EXTENDED_SOURCE.replace(":walletId", "?")
+    return SqlQueryBuilder(baseSql = "SELECT COUNT(DISTINCT tx.id) $source", baseArgs = listOf(walletId.id))
+        .whereAll(filters.map { it.toSqlClause() })
+        .build()
+}

--- a/android/data/services/store/src/test/kotlin/com/gemwallet/android/data/service/store/database/TransactionsQueryBuilderTest.kt
+++ b/android/data/services/store/src/test/kotlin/com/gemwallet/android/data/service/store/database/TransactionsQueryBuilderTest.kt
@@ -7,6 +7,7 @@ import com.wallet.core.primitives.TransactionState
 import com.wallet.core.primitives.TransactionType
 import com.wallet.core.primitives.WalletId
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -114,6 +115,20 @@ class TransactionsQueryBuilderTest {
         assertEquals(Chain.Ethereum.string, query.args[baseArgCount])
         assertEquals("Transfer", query.args[baseArgCount + 1])
         assertEquals(15, query.args[baseArgCount + 2])
+    }
+
+    @Test
+    fun countSql_sharesFilterClausesWithExtendedSql() {
+        val filters = listOf(
+            TransactionsRequestFilter.AssetRankGreaterThan(15),
+            TransactionsRequestFilter.States(listOf(TransactionState.Pending, TransactionState.InTransit)),
+        )
+        val query = buildTransactionsCountSql(walletId, filters)
+        assertTrue(query.sql.trimStart().startsWith("SELECT COUNT(DISTINCT tx.id)"))
+        assertTrue(query.sql.contains("AND asset.rank > ?"))
+        assertTrue(query.sql.contains("AND tx.state IN (?,?)"))
+        assertFalse(query.sql.contains("ORDER BY"))
+        assertEquals(listOf<Any>(walletId.id, 15, "Pending", "InTransit"), query.args)
     }
 
     @Test

--- a/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModel.kt
+++ b/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModel.kt
@@ -55,7 +55,8 @@ class TransactionsViewModel @Inject constructor(
         chainsFilter,
         typeFilter,
     ) { chains, types ->
-        buildList<TransactionsRequestFilter> {
+        buildList {
+            addAll(TransactionsRequestFilter.activityDefaults())
             if (chains.isNotEmpty()) add(TransactionsRequestFilter.Chains(chains))
             val allowedTypes = types.flatMap { it.types }
             if (allowedTypes.isNotEmpty()) add(TransactionsRequestFilter.Types(allowedTypes))

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/transactions/coordinators/TransactionsRequestFilter.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/transactions/coordinators/TransactionsRequestFilter.kt
@@ -4,6 +4,7 @@ import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.TransactionState
 import com.wallet.core.primitives.TransactionType
+import uniffi.gemstone.defaultTokenRank
 
 sealed interface TransactionsRequestFilter {
     data class Chains(val chains: List<Chain>) : TransactionsRequestFilter
@@ -11,4 +12,10 @@ sealed interface TransactionsRequestFilter {
     data class AssetRankGreaterThan(val rank: Int) : TransactionsRequestFilter
     data class Asset(val assetId: AssetId) : TransactionsRequestFilter
     data class States(val states: List<TransactionState>) : TransactionsRequestFilter
+
+    companion object {
+        fun activityDefaults(): List<TransactionsRequestFilter> = listOf(
+            AssetRankGreaterThan(defaultTokenRank()),
+        )
+    }
 }

--- a/ios/Features/Transactions/Sources/Types/TransactionsRequestFilter+Activity.swift
+++ b/ios/Features/Transactions/Sources/Types/TransactionsRequestFilter+Activity.swift
@@ -1,0 +1,12 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import PrimitivesComponents
+import Store
+
+public extension TransactionsRequestFilter {
+    static var activityDefaults: [TransactionsRequestFilter] {
+        [.assetRankGreaterThan(AssetScore.defaultScore)]
+    }
+}

--- a/ios/Features/Transactions/Sources/ViewModels/TransactionsFilterViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionsFilterViewModel.swift
@@ -24,9 +24,7 @@ public final class TransactionsFilterViewModel {
 
     private let transactionTypes = TransactionType.allCases
 
-    private let defaultFilters: [TransactionsRequestFilter] = [
-        .assetRankGreaterThan(AssetScore.defaultScore),
-    ]
+    private let defaultFilters = TransactionsRequestFilter.activityDefaults
 
     var isPresentingChains: Bool = false
     var isPresentingTypes: Bool = false

--- a/ios/Gem/ViewModels/MainTabViewModel.swift
+++ b/ios/Gem/ViewModels/MainTabViewModel.swift
@@ -5,6 +5,7 @@ import Foundation
 import Preferences
 import Primitives
 import Store
+import Transactions
 
 @Observable
 @MainActor
@@ -20,7 +21,10 @@ final class MainTabViewModel {
 
     init(wallet: Wallet) {
         self.wallet = wallet
-        transactionsQuery = ObservableQuery(TransactionsCountRequest(walletId: wallet.id, states: [.pending, .inTransit]), initialValue: 0)
+        transactionsQuery = ObservableQuery(
+            TransactionsCountRequest(walletId: wallet.id, type: .pending, filters: TransactionsRequestFilter.activityDefaults),
+            initialValue: 0,
+        )
     }
 
     var walletId: WalletId {

--- a/ios/Packages/Store/Sources/Requests/TransactionsCountRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/TransactionsCountRequest.swift
@@ -6,27 +6,21 @@ import Primitives
 
 public struct TransactionsCountRequest: DatabaseQueryable {
     public var walletId: WalletId
-    private let states: [TransactionState]
+    private let type: TransactionsRequestType
+    private let filters: [TransactionsRequestFilter]
 
     public init(
         walletId: WalletId,
-        state: TransactionState,
-    ) {
-        self.init(walletId: walletId, states: [state])
-    }
-
-    public init(
-        walletId: WalletId,
-        states: [TransactionState],
+        type: TransactionsRequestType,
+        filters: [TransactionsRequestFilter] = [],
     ) {
         self.walletId = walletId
-        self.states = states
+        self.type = type
+        self.filters = filters
     }
 
     public func fetch(_ db: Database) throws -> Int {
-        try TransactionRecord
-            .filter(TransactionRecord.Columns.walletId == walletId.id)
-            .filter(states.map(\.rawValue).contains(TransactionRecord.Columns.state))
+        try TransactionsRequest.query(walletId: walletId, type: type, filters: filters)
             .fetchCount(db)
     }
 }

--- a/ios/Packages/Store/Sources/Requests/TransactionsRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/TransactionsRequest.swift
@@ -30,12 +30,7 @@ public struct TransactionsRequest: DatabaseQueryable {
         filters: [TransactionsRequestFilter],
         walletId: WalletId,
     ) throws -> [TransactionExtended] {
-        let states = states(type: type)
-        let types = types(type: type)
-        var request = TransactionRecord
-            .filter(TransactionRecord.Columns.walletId == walletId.id)
-            .filter(states.contains(TransactionRecord.Columns.state))
-            .filter(types.contains(TransactionRecord.Columns.type))
+        try query(walletId: walletId, type: type, filters: filters)
             .including(required: TransactionRecord.asset)
             .including(required: TransactionRecord.feeAsset)
             .including(optional: TransactionRecord.price)
@@ -45,6 +40,22 @@ public struct TransactionsRequest: DatabaseQueryable {
             .including(optional: TransactionRecord.fromAddress)
             .including(optional: TransactionRecord.toAddress)
             .order(TransactionRecord.Columns.date.desc)
+            .asRequest(of: TransactionInfo.self)
+            .fetchAll(db)
+            .compactMap { $0.mapToTransactionExtended() }
+    }
+
+    static func query(
+        walletId: WalletId,
+        type: TransactionsRequestType,
+        filters: [TransactionsRequestFilter],
+    ) -> QueryInterfaceRequest<TransactionRecord> {
+        let states = states(type: type)
+        let types = types(type: type)
+        var request = TransactionRecord
+            .filter(TransactionRecord.Columns.walletId == walletId.id)
+            .filter(states.contains(TransactionRecord.Columns.state))
+            .filter(types.contains(TransactionRecord.Columns.type))
             .distinct()
 
         switch type {
@@ -64,9 +75,7 @@ public struct TransactionsRequest: DatabaseQueryable {
             request = Self.applyFilter(request: request, filter)
         }
 
-        return try request.asRequest(of: TransactionInfo.self)
-            .fetchAll(db)
-            .compactMap { $0.mapToTransactionExtended() }
+        return request
     }
 }
 
@@ -89,7 +98,7 @@ extension TransactionsRequest {
     private static func states(type: TransactionsRequestType) -> [String] {
         switch type {
         case .pending:
-            [TransactionState.pending.rawValue]
+            [TransactionState.pending, TransactionState.inTransit].map(\.rawValue)
         case .all, .asset, .transaction:
             TransactionState.allCases.map(\.rawValue)
         case let .assetsTransactionType(_, _, states):

--- a/ios/Packages/Store/Tests/StoreTests/Requests/TransactionsCountRequestTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/Requests/TransactionsCountRequestTests.swift
@@ -1,14 +1,18 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Primitives
+import PrimitivesTestKit
 @testable import Store
 import StoreTestKit
 import Testing
 
 struct TransactionsCountRequestTests {
     @Test
-    func countsSelectedStates() throws {
-        let db = DB.mockAssets()
+    func countMatchesActivityList() throws {
+        let db = DB.mockAssets(assets: [
+            .mock(asset: .mock(), score: .mock(rank: 20)),
+            .mock(asset: .mockBNB(), score: .mock(rank: 0)),
+        ])
         let walletId = WalletId.multicoin(address: "0x0000000000000000000000000000000000000000")
         let store = TransactionStore(db: db)
 
@@ -16,12 +20,19 @@ struct TransactionsCountRequestTests {
             .mock(transactionId: TransactionId(chain: .bitcoin, hash: "1"), state: .pending),
             .mock(transactionId: TransactionId(chain: .bitcoin, hash: "2"), state: .inTransit),
             .mock(transactionId: TransactionId(chain: .bitcoin, hash: "3"), state: .confirmed),
+            .mock(transactionId: TransactionId(chain: .smartChain, hash: "4"), state: .pending, assetId: AssetId(chain: .smartChain)),
         ])
 
-        let count = try db.dbQueue.read { db in
-            try TransactionsCountRequest(walletId: walletId, states: [.pending, .inTransit]).fetch(db)
+        let filters: [TransactionsRequestFilter] = [.assetRankGreaterThan(15)]
+        let (count, listed) = try db.dbQueue.read { db in
+            try (
+                TransactionsCountRequest(walletId: walletId, type: .pending, filters: filters).fetch(db),
+                TransactionsRequest.fetch(db, type: .pending, filters: filters, walletId: walletId),
+            )
         }
 
         #expect(count == 2)
+        #expect(listed.map(\.transaction.state).asSet() == [.pending, .inTransit])
+        #expect(count == listed.count)
     }
 }


### PR DESCRIPTION
A pending transaction that the Activity list hides no longer shows up in the tab badge, so the badge always matches what is actually in the list. Android Activity now hides the same transactions as iOS.

Closes #835