### PR TITLE
Fix perpetuals withdraw and deposit buttons spread across the screen

### DIFF
--- a/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/components/MarketHeadActions.kt
+++ b/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/components/MarketHeadActions.kt
@@ -1,7 +1,9 @@
 package com.gemwallet.android.features.perpetual.views.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,6 +27,7 @@ fun MarketHeadActions(
 ) {
     var actionFontSize by remember { mutableStateOf(16.sp) }
     Row(
+        modifier = Modifier.width(IntrinsicSize.Min),
         horizontalArrangement = Arrangement.spacedBy(paddingDefault),
         verticalAlignment = Alignment.CenterVertically,
     ) {


### PR DESCRIPTION
On the Android Perpetuals screen the Withdraw and Deposit buttons were pushed to the opposite edges of the screen. Now they sit next to each other in the center, matching the main wallet screen buttons.

| Before | After |
|---|---|
| <img width="320" alt="perpetuals-buttons-before" src="https://github.com/user-attachments/assets/441f3179-9fb2-4909-8413-5a4a7dd026fa" /> | <img width="320" alt="Screenshot_1786691715" src="https://github.com/user-attachments/assets/b7466e4e-5032-4c8a-9112-2fbf3d8bf36b" /> |