### PR TITLE
Own asset price alerts in a dedicated view model

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PriceAlertModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/PriceAlertModule.kt
@@ -8,6 +8,7 @@ import com.gemwallet.android.application.pricealerts.coordinators.HasAssetPriceA
 import com.gemwallet.android.application.pricealerts.coordinators.IncludePriceAlert
 import com.gemwallet.android.application.pricealerts.coordinators.SetAssetPriceAlertEnabled
 import com.gemwallet.android.application.pricealerts.coordinators.SetPriceAlertsEnabled
+import com.gemwallet.android.application.pricealerts.coordinators.SyncAssetPriceAlerts
 import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAlerts
 import com.gemwallet.android.cases.device.SyncDevice
 import com.gemwallet.android.data.coordinators.pricealerts.ExcludePriceAlertImpl
@@ -18,6 +19,7 @@ import com.gemwallet.android.data.coordinators.pricealerts.HasAssetPriceAlertsIm
 import com.gemwallet.android.data.coordinators.pricealerts.IncludePriceAlertImpl
 import com.gemwallet.android.data.coordinators.pricealerts.SetAssetPriceAlertEnabledImpl
 import com.gemwallet.android.data.coordinators.pricealerts.SetPriceAlertsEnabledImpl
+import com.gemwallet.android.data.coordinators.pricealerts.SyncAssetPriceAlertsImpl
 import com.gemwallet.android.data.coordinators.pricealerts.UpdatePriceAlertsImpl
 import com.gemwallet.android.data.repositories.assets.AssetsRepository
 import com.gemwallet.android.data.repositories.pricealerts.PriceAlertRepository
@@ -134,4 +136,15 @@ object PriceAlertModule {
     fun provideHasAssetPriceAlerts(
         priceAlertRepository: PriceAlertRepository,
     ): HasAssetPriceAlerts = HasAssetPriceAlertsImpl(priceAlertRepository)
+
+    @Provides
+    fun provideSyncAssetPriceAlerts(
+        hasAssetPriceAlerts: HasAssetPriceAlerts,
+        updatePriceAlerts: UpdatePriceAlerts,
+    ): SyncAssetPriceAlerts {
+        return SyncAssetPriceAlertsImpl(
+            hasAssetPriceAlerts = hasAssetPriceAlerts,
+            updatePriceAlerts = updatePriceAlerts,
+        )
+    }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/pricealerts/SyncAssetPriceAlertsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/pricealerts/SyncAssetPriceAlertsImpl.kt
@@ -1,0 +1,18 @@
+package com.gemwallet.android.data.coordinators.pricealerts
+
+import com.gemwallet.android.application.pricealerts.coordinators.HasAssetPriceAlerts
+import com.gemwallet.android.application.pricealerts.coordinators.SyncAssetPriceAlerts
+import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAlerts
+import com.wallet.core.primitives.AssetId
+
+class SyncAssetPriceAlertsImpl(
+    private val hasAssetPriceAlerts: HasAssetPriceAlerts,
+    private val updatePriceAlerts: UpdatePriceAlerts,
+) : SyncAssetPriceAlerts {
+
+    override suspend fun invoke(assetId: AssetId) {
+        if (hasAssetPriceAlerts(assetId)) {
+            runCatching { updatePriceAlerts.update(assetId) }
+        }
+    }
+}

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/AssetDetailsScreen.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/AssetDetailsScreen.kt
@@ -9,19 +9,21 @@ import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.rememberNotificationPermissionGate
 import com.gemwallet.android.ui.components.screen.LoadingScene
 import com.gemwallet.android.features.asset.viewmodels.details.viewmodels.AssetDetailsViewModel
+import com.gemwallet.android.features.asset.viewmodels.details.viewmodels.AssetPriceAlertsViewModel
 
 @Composable
 fun AssetDetailsScreen(
     onAction: (AssetDetailsAction.Navigation) -> Unit,
 ) {
     val viewModel: AssetDetailsViewModel = hiltViewModel()
+    val priceAlertsViewModel: AssetPriceAlertsViewModel = hiltViewModel()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val transactions by viewModel.transactions.collectAsStateWithLifecycle()
-    val priceAlertEnabled by viewModel.priceAlertEnabled.collectAsStateWithLifecycle()
-    val priceAlertsCount by viewModel.priceAlertsCount.collectAsStateWithLifecycle()
+    val priceAlertEnabled by priceAlertsViewModel.isEnabled.collectAsStateWithLifecycle()
+    val priceAlertsCount by priceAlertsViewModel.alertsCount.collectAsStateWithLifecycle()
     val uiModel by viewModel.uiModel.collectAsStateWithLifecycle()
     val isOperationEnabled by viewModel.isOperationEnabled.collectAsStateWithLifecycle()
-    val requestNotificationPermission = rememberNotificationPermissionGate(onGranted = viewModel::onPushNotificationGranted)
+    val requestNotificationPermission = rememberNotificationPermissionGate(onGranted = priceAlertsViewModel::onPushNotificationGranted)
 
     if (uiModel != null) {
         AssetDetailsScene(
@@ -37,7 +39,7 @@ fun AssetDetailsScreen(
                     AssetDetailsAction.Refresh -> viewModel.refresh()
                     AssetDetailsAction.Pin -> viewModel.pin()
                     AssetDetailsAction.Add -> viewModel.add()
-                    is AssetDetailsAction.TogglePriceAlert -> viewModel.enablePriceAlert(action.assetId)
+                    is AssetDetailsAction.TogglePriceAlert -> priceAlertsViewModel.toggle(action.assetId)
                     is AssetDetailsAction.Navigation -> onAction(action)
                 }
             },

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetDetailsViewModel.kt
@@ -7,12 +7,7 @@ import com.gemwallet.android.application.assets.coordinators.EnableAsset
 import com.gemwallet.android.application.assets.coordinators.GetChainAssetInfo
 import com.gemwallet.android.application.assets.coordinators.SyncAssetInfo
 import com.gemwallet.android.application.assets.coordinators.ToggleAssetPin
-import com.gemwallet.android.application.device.coordinators.EnableDevicePush
-import com.gemwallet.android.application.pricealerts.coordinators.GetAssetPriceAlertState
-import com.gemwallet.android.application.pricealerts.coordinators.GetPriceAlerts
-import com.gemwallet.android.application.pricealerts.coordinators.HasAssetPriceAlerts
-import com.gemwallet.android.application.pricealerts.coordinators.SetAssetPriceAlertEnabled
-import com.gemwallet.android.application.pricealerts.coordinators.UpdatePriceAlerts
+import com.gemwallet.android.application.pricealerts.coordinators.SyncAssetPriceAlerts
 import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.application.transactions.coordinators.GetTransactions
 import com.gemwallet.android.application.transactions.coordinators.SyncAssetTransactions
@@ -38,7 +33,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
@@ -57,12 +51,7 @@ class AssetDetailsViewModel @Inject constructor(
     private val enableAsset: EnableAsset,
     private val syncAssetInfo: SyncAssetInfo,
     private val getTransactions: GetTransactions,
-    private val getAssetPriceAlertState: GetAssetPriceAlertState,
-    private val setAssetPriceAlertEnabled: SetAssetPriceAlertEnabled,
-    private val hasAssetPriceAlerts: HasAssetPriceAlerts,
-    private val updatePriceAlerts: UpdatePriceAlerts,
-    private val getPriceAlerts: GetPriceAlerts,
-    private val enableDevicePush: EnableDevicePush,
+    private val syncAssetPriceAlerts: SyncAssetPriceAlerts,
     private val getCurrentBlockExplorer: GetCurrentBlockExplorer,
     private val hasMultiSign: HasMultiSign,
     private val syncAssetTransactions: SyncAssetTransactions,
@@ -75,13 +64,10 @@ class AssetDetailsViewModel @Inject constructor(
 
     private val assetId = savedStateHandle.requireAssetId()
 
-    private val observedPriceAlertAssetId = MutableStateFlow<AssetId?>(null)
-
     private val chainAssetInfo = getChainAssetInfo(assetId)
         .onStart {
             val wallet = session.value?.wallet ?: return@onStart
-            observedPriceAlertAssetId.value = assetId
-            syncAssetDetails(wallet, assetId, shouldRefreshPriceAlerts = true)
+            restartAssetSync(wallet)
         }
         .filterNotNull()
 
@@ -101,19 +87,6 @@ class AssetDetailsViewModel @Inject constructor(
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    val priceAlertEnabled = observedPriceAlertAssetId.flatMapLatest { observedAssetId ->
-        if (observedAssetId == null) {
-            flowOf<Boolean?>(null)
-        } else {
-            getAssetPriceAlertState.isAssetPriceAlertEnabled(observedAssetId)
-        }
-    }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
-
-    val priceAlertsCount = getPriceAlerts(assetId)
-        .map { it.size }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, 0)
-
     val transactions = getTransactions.getTransactions(listOf(TransactionsRequestFilter.Asset(assetId)))
         .map { it.toImmutableList() }
         .flowOn(Dispatchers.IO)
@@ -126,63 +99,38 @@ class AssetDetailsViewModel @Inject constructor(
 
     fun refresh() {
         val wallet = session.value?.wallet ?: return
-        syncAssetDetails(wallet, assetId, showLoading = true, shouldRefreshPriceAlerts = true)
-    }
-
-    private fun syncAssetDetails(
-        wallet: Wallet,
-        assetId: AssetId,
-        showLoading: Boolean = false,
-        shouldRefreshPriceAlerts: Boolean = false,
-    ) {
-        val previousJob = syncJob
-        if (previousJob?.isActive == true) {
-            if (showLoading) {
-                return
-            }
+        if (syncJob?.isActive == true) {
+            return
         }
 
-        if (showLoading) {
-            isRefreshing.value = true
-        }
-
-        if (shouldRefreshPriceAlerts) {
-            refreshPriceAlertsIfNeeded(assetId)
-        }
-
+        isRefreshing.value = true
+        syncPriceAlerts()
         syncJob = viewModelScope.launch(Dispatchers.IO) {
-            if (previousJob?.isActive == true) {
-                previousJob.cancelAndJoin()
-            }
-
             try {
-                refreshAssetDetails(wallet, assetId)
+                syncAssetDetails(wallet)
             } finally {
-                if (showLoading) {
-                    isRefreshing.value = false
-                }
+                isRefreshing.value = false
             }
         }
     }
 
-    private suspend fun refreshAssetDetails(wallet: Wallet, assetId: AssetId) = coroutineScope {
+    private fun restartAssetSync(wallet: Wallet) {
+        val previousJob = syncJob
+
+        syncPriceAlerts()
+        syncJob = viewModelScope.launch(Dispatchers.IO) {
+            previousJob?.cancelAndJoin()
+            syncAssetDetails(wallet)
+        }
+    }
+
+    private fun syncPriceAlerts() = viewModelScope.launch(Dispatchers.IO) {
+        syncAssetPriceAlerts(assetId)
+    }
+
+    private suspend fun syncAssetDetails(wallet: Wallet) = coroutineScope {
         launch { syncAssetInfo.syncAssetInfo(assetId = assetId, wallet = wallet) }
         launch { syncAssetTransactions.syncAssetTransactions(assetId) }
-    }
-
-    private fun refreshPriceAlertsIfNeeded(assetId: AssetId) = viewModelScope.launch(Dispatchers.IO) {
-        if (hasAssetPriceAlerts(assetId)) {
-            runCatching { updatePriceAlerts.update(assetId) }
-        }
-    }
-
-    fun enablePriceAlert(assetId: AssetId) = viewModelScope.launch {
-        val enabled = priceAlertEnabled.value ?: return@launch
-        setAssetPriceAlertEnabled(assetId, !enabled)
-    }
-
-    fun onPushNotificationGranted() = viewModelScope.launch(Dispatchers.IO) {
-        enableDevicePush()
     }
 
     fun pin() = viewModelScope.launch(Dispatchers.IO) {

--- a/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetPriceAlertsViewModel.kt
+++ b/android/features/asset/viewmodels/src/main/kotlin/com/gemwallet/android/features/asset/viewmodels/details/viewmodels/AssetPriceAlertsViewModel.kt
@@ -1,0 +1,57 @@
+package com.gemwallet.android.features.asset.viewmodels.details.viewmodels
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.application.device.coordinators.EnableDevicePush
+import com.gemwallet.android.application.pricealerts.coordinators.GetAssetPriceAlertState
+import com.gemwallet.android.application.pricealerts.coordinators.GetPriceAlerts
+import com.gemwallet.android.application.pricealerts.coordinators.SetAssetPriceAlertEnabled
+import com.gemwallet.android.application.session.coordinators.GetSession
+import com.gemwallet.android.ui.models.navigation.requireAssetId
+import com.wallet.core.primitives.AssetId
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AssetPriceAlertsViewModel @Inject constructor(
+    getSession: GetSession,
+    savedStateHandle: SavedStateHandle,
+    getAssetPriceAlertState: GetAssetPriceAlertState,
+    getPriceAlerts: GetPriceAlerts,
+    private val setAssetPriceAlertEnabled: SetAssetPriceAlertEnabled,
+    private val enableDevicePush: EnableDevicePush,
+) : ViewModel() {
+
+    private val assetId = savedStateHandle.requireAssetId()
+
+    private val observedAssetId = assetId.takeIf { getSession().value?.wallet != null }
+
+    private val enabledState: Flow<Boolean?> = observedAssetId
+        ?.let { getAssetPriceAlertState.isAssetPriceAlertEnabled(it) }
+        ?: flowOf(null)
+
+    val isEnabled: StateFlow<Boolean?> = enabledState
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val alertsCount = getPriceAlerts(assetId)
+        .map { it.size }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, 0)
+
+    fun toggle(assetId: AssetId) = viewModelScope.launch {
+        val enabled = isEnabled.value ?: return@launch
+        setAssetPriceAlertEnabled(assetId, !enabled)
+    }
+
+    fun onPushNotificationGranted() = viewModelScope.launch(Dispatchers.IO) {
+        enableDevicePush()
+    }
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/pricealerts/coordinators/SyncAssetPriceAlerts.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/pricealerts/coordinators/SyncAssetPriceAlerts.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.pricealerts.coordinators
+
+import com.wallet.core.primitives.AssetId
+
+interface SyncAssetPriceAlerts {
+    suspend operator fun invoke(assetId: AssetId)
+}


### PR DESCRIPTION
The asset details screen kept price alerts, device push, transactions and sync in one view model with sixteen dependencies.

Price alerts now live in their own view model, and the rule for refreshing them moved next to the other price alert coordinators. Behaviour on the screen is unchanged.