### PR TITLE
Own perpetual enablement in a single service

### DIFF
--- a/ios/Features/Perpetuals/Sources/ViewModels/PerpetualsSceneViewModel.swift
+++ b/ios/Features/Perpetuals/Sources/ViewModels/PerpetualsSceneViewModel.swift
@@ -5,7 +5,6 @@ import Components
 import Foundation
 import Localization
 import PerpetualService
-import Preferences
 import Primitives
 import PrimitivesComponents
 import Recents
@@ -16,11 +15,12 @@ import SwiftUI
 @Observable
 @MainActor
 final class PerpetualsSceneViewModel {
+    private static let marketsUpdateIntervalHours = 1
+
     private let observerService: any PerpetualObservable
     let perpetualService: PerpetualServiceable
     let activityService: ActivityService
 
-    let preferences: Preferences = .standard
     let wallet: Wallet
 
     let positionsQuery: ObservableQuery<PerpetualPositionsRequest>
@@ -156,11 +156,10 @@ extension PerpetualsSceneViewModel {
     }
 
     func updateMarkets() async {
-        guard preferences.perpetualMarketsUpdatedAt.isOutdated(byHours: 1) else { return }
+        guard perpetualService.marketsUpdatedAt.isOutdated(byHours: Self.marketsUpdateIntervalHours) else { return }
 
         do {
             try await perpetualService.updateMarkets()
-            preferences.perpetualMarketsUpdatedAt = .now
         } catch {
             debugLog("Failed to update markets: \(error)")
         }

--- a/ios/Features/Settings/Sources/Settings/ViewModels/DeveloperViewModel.swift
+++ b/ios/Features/Settings/Sources/Settings/ViewModels/DeveloperViewModel.swift
@@ -142,8 +142,7 @@ public final class DeveloperViewModel {
 
     func clearPerpetuals() {
         performAction {
-            try perpetualService.clear()
-            Preferences.standard.perpetualMarketsUpdatedAt = .none
+            try perpetualService.clearMarkets()
         }
     }
 

--- a/ios/Gem/Navigation/Settings/SettingsNavigationView.swift
+++ b/ios/Gem/Navigation/Settings/SettingsNavigationView.swift
@@ -38,7 +38,6 @@ struct SettingsNavigationView: View {
     @Environment(\.observablePreferences) private var observablePreferences
     @Environment(\.releaseService) private var releaseService
     @Environment(\.perpetualService) private var perpetualService
-    @Environment(\.hyperliquidObserverService) private var hyperliquidObserverService
     @Environment(\.walletConnectorManager) private var walletConnectorManager
     @Environment(\.rewardsService) private var rewardsService
     @Environment(\.inAppNotificationService) private var inAppNotificationService
@@ -167,7 +166,6 @@ struct SettingsNavigationView: View {
         }
         .navigationDestination(for: Scenes.Preferences.self) { _ in
             PreferencesScene(model: PreferencesViewModel(currencyModel: currencyModel))
-                .onChange(of: observablePreferences.isPerpetualEnabled, onChangePerpetualEnabled)
         }
         .navigationDestination(for: Scenes.Referral.self) { scene in
             let wallets = walletSessionService.wallets.filter { $0.type == .multicoin }
@@ -212,23 +210,3 @@ struct SettingsNavigationView: View {
 }
 
 extension Preferences: @retroactive CurrencyStorable {}
-
-private extension SettingsNavigationView {
-    func onChangePerpetualEnabled(_: Bool, _ newValue: Bool) {
-        if newValue {
-            Task {
-                if let wallet = walletSessionService.currentWallet {
-                    await hyperliquidObserverService.setup(for: wallet)
-                }
-                try? await perpetualService.updateMarkets()
-            }
-        } else {
-            Task {
-                await hyperliquidObserverService.disconnect()
-                try? perpetualService.clear()
-                try? perpetualService.clearBalance()
-                observablePreferences.preferences.perpetualMarketsUpdatedAt = nil
-            }
-        }
-    }
-}

--- a/ios/Gem/Services/ServicesFactory.swift
+++ b/ios/Gem/Services/ServicesFactory.swift
@@ -312,6 +312,11 @@ struct ServicesFactory {
 
         let contactService = ContactService(store: storeManager.contactStore, addressStore: storeManager.addressStore)
 
+        let perpetualEnablerService = PerpetualEnablerService(
+            observer: hyperliquidObserverService,
+            service: perpetualService,
+            preferences: preferences,
+        )
         let appLifecycleService = AppLifecycleService(
             preferences: preferences,
             connectionsService: connectionsService,
@@ -319,7 +324,7 @@ struct ServicesFactory {
             deviceObserverService: deviceObserverService,
             streamObserverService: streamObserverService,
             streamSubscriptionService: streamSubscriptionService,
-            hyperliquidObserverService: hyperliquidObserverService,
+            perpetualEnablerService: perpetualEnablerService,
         )
 
         let viewModelFactory = ViewModelFactory(

--- a/ios/Packages/FeatureServices/AppService/AppLifecycleService.swift
+++ b/ios/Packages/FeatureServices/AppService/AppLifecycleService.swift
@@ -1,9 +1,9 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import ConnectionsService
+import ConnectionStatusService
 import DeviceService
 import Foundation
-import ConnectionStatusService
 import PerpetualService
 import Preferences
 import Primitives
@@ -17,7 +17,7 @@ public actor AppLifecycleService: Sendable {
     private let deviceObserverService: DeviceObserverService
     private let streamObserverService: StreamObserverService
     private let streamSubscriptionService: StreamSubscriptionService
-    private let hyperliquidObserverService: any PerpetualObservable
+    private let perpetualEnablerService: PerpetualEnablerService
 
     private var currentWallet: Wallet?
 
@@ -28,7 +28,7 @@ public actor AppLifecycleService: Sendable {
         deviceObserverService: DeviceObserverService,
         streamObserverService: StreamObserverService,
         streamSubscriptionService: StreamSubscriptionService,
-        hyperliquidObserverService: any PerpetualObservable,
+        perpetualEnablerService: PerpetualEnablerService,
     ) {
         self.preferences = preferences
         self.connectionsService = connectionsService
@@ -36,7 +36,7 @@ public actor AppLifecycleService: Sendable {
         self.deviceObserverService = deviceObserverService
         self.streamObserverService = streamObserverService
         self.streamSubscriptionService = streamSubscriptionService
-        self.hyperliquidObserverService = hyperliquidObserverService
+        self.perpetualEnablerService = perpetualEnablerService
     }
 
     public func setup() async {
@@ -56,7 +56,7 @@ public actor AppLifecycleService: Sendable {
     }
 
     public func updatePerpetualConnection() async {
-        await connectPerpetual()
+        await perpetualEnablerService.updateEnablement(wallet: currentWallet)
     }
 
     public func handleScenePhase(_ phase: ScenePhase) async {
@@ -127,17 +127,13 @@ extension AppLifecycleService {
     }
 
     private func connectPerpetual() async {
-        if let wallet = currentWallet, preferences.showPerpetuals(for: wallet) {
-            await hyperliquidObserverService.setup(for: wallet)
-        } else {
-            await hyperliquidObserverService.disconnect()
-        }
+        await perpetualEnablerService.updateConnection(wallet: currentWallet)
     }
 
     private func disconnectObservers() async {
         async let connection: () = connectionStatusObserver.stop()
         async let price: () = streamObserverService.disconnect()
-        async let perpetual: () = hyperliquidObserverService.disconnect()
+        async let perpetual: () = perpetualEnablerService.disconnect()
         async let nodeAuthToken: () = deviceObserverService.stopNodeAuthTokenUpdates()
         _ = await (connection, price, perpetual, nodeAuthToken)
     }

--- a/ios/Packages/FeatureServices/AppService/TestKit/AppLifecycleService+TestKit.swift
+++ b/ios/Packages/FeatureServices/AppService/TestKit/AppLifecycleService+TestKit.swift
@@ -23,6 +23,7 @@ public extension AppLifecycleService {
         streamObserverService: StreamObserverService = .mock(),
         streamSubscriptionService: StreamSubscriptionService = .mock(),
         hyperliquidObserverService: PerpetualObserverMock = PerpetualObserverMock(),
+        perpetualService: any PerpetualServiceable = PerpetualServiceMock(),
     ) -> AppLifecycleService {
         AppLifecycleService(
             preferences: preferences,
@@ -31,7 +32,11 @@ public extension AppLifecycleService {
             deviceObserverService: deviceObserverService,
             streamObserverService: streamObserverService,
             streamSubscriptionService: streamSubscriptionService,
-            hyperliquidObserverService: hyperliquidObserverService,
+            perpetualEnablerService: PerpetualEnablerService(
+                observer: hyperliquidObserverService,
+                service: perpetualService,
+                preferences: preferences,
+            ),
         )
     }
 }

--- a/ios/Packages/FeatureServices/AppService/Tests/AppLifecycleServiceTests.swift
+++ b/ios/Packages/FeatureServices/AppService/Tests/AppLifecycleServiceTests.swift
@@ -1,18 +1,21 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 @testable import AppService
+import Foundation
 import PerpetualService
 import PerpetualServiceTestKit
 import Preferences
 import PreferencesTestKit
 import Primitives
 import PrimitivesTestKit
+import Store
+import StoreTestKit
 import Testing
 
 struct AppLifecycleServiceTests {
     @Test
-    func setupWalletConnectsHyperliquidForMultiCoinWallet() async {
-        let (service, observer, _) = makeService(perpetualEnabled: true)
+    func setupWalletConnectsHyperliquidForMultiCoinWallet() async throws {
+        let (service, observer, _) = try makeService(perpetualEnabled: true)
 
         await service.setupWallet(.mock(type: .multicoin, accounts: [.mock(chain: .hyperliquid)]))
 
@@ -20,8 +23,8 @@ struct AppLifecycleServiceTests {
     }
 
     @Test
-    func setupWalletSkipsHyperliquidForSingleChainWallet() async {
-        let (service, observer, _) = makeService(perpetualEnabled: true)
+    func setupWalletSkipsHyperliquidForSingleChainWallet() async throws {
+        let (service, observer, _) = try makeService(perpetualEnabled: true)
 
         await service.setupWallet(.mock(type: .single))
 
@@ -29,8 +32,8 @@ struct AppLifecycleServiceTests {
     }
 
     @Test
-    func setupWalletDisconnectsWhenSwitchingToSingleChainWallet() async {
-        let (service, observer, _) = makeService(perpetualEnabled: true)
+    func setupWalletDisconnectsWhenSwitchingToSingleChainWallet() async throws {
+        let (service, observer, _) = try makeService(perpetualEnabled: true)
         await service.setupWallet(.mock(type: .multicoin, accounts: [.mock(chain: .hyperliquid)]))
 
         await service.setupWallet(.mock(type: .single))
@@ -39,8 +42,8 @@ struct AppLifecycleServiceTests {
     }
 
     @Test
-    func setupWalletSkipsHyperliquidWhenDisabled() async {
-        let (service, observer, _) = makeService(perpetualEnabled: false)
+    func setupWalletSkipsHyperliquidWhenDisabled() async throws {
+        let (service, observer, _) = try makeService(perpetualEnabled: false)
 
         await service.setupWallet(.mock(type: .multicoin, accounts: [.mock(chain: .hyperliquid)]))
 
@@ -48,8 +51,8 @@ struct AppLifecycleServiceTests {
     }
 
     @Test
-    func updatePerpetualConnectionDisconnectsWhenDisabled() async {
-        let (service, observer, preferences) = makeService(perpetualEnabled: true)
+    func updatePerpetualConnectionDisconnectsWhenDisabled() async throws {
+        let (service, observer, preferences) = try makeService(perpetualEnabled: true)
         await service.setupWallet(.mock(type: .multicoin, accounts: [.mock(chain: .hyperliquid)]))
 
         preferences.isPerpetualEnabled = false
@@ -59,22 +62,56 @@ struct AppLifecycleServiceTests {
     }
 
     @Test
-    func updatePerpetualConnectionSkipsForSingleChainWallet() async {
-        let (service, observer, _) = makeService(perpetualEnabled: true)
+    func updatePerpetualConnectionSkipsForSingleChainWallet() async throws {
+        let (service, observer, _) = try makeService(perpetualEnabled: true)
         await service.setupWallet(.mock(type: .single))
 
         await service.updatePerpetualConnection()
 
         #expect(await observer.isConnected == false)
     }
+
+    @Test
+    func updatePerpetualConnectionUpdatesMarketsWhenEnabled() async throws {
+        let (service, _, preferences) = try makeService(perpetualEnabled: true)
+
+        await service.updatePerpetualConnection()
+
+        #expect(preferences.perpetualMarketsUpdatedAt != nil)
+    }
+
+    @Test
+    func updatePerpetualConnectionClearsMarketsWhenDisabled() async throws {
+        let (service, _, preferences) = try makeService(perpetualEnabled: false)
+        preferences.perpetualMarketsUpdatedAt = .now
+
+        await service.updatePerpetualConnection()
+
+        #expect(preferences.perpetualMarketsUpdatedAt == nil)
+    }
+
+    @Test
+    func setupWalletKeepsMarketsUntouched() async throws {
+        let (service, _, preferences) = try makeService(perpetualEnabled: true)
+        let updatedAt = Date(timeIntervalSince1970: 0)
+        preferences.perpetualMarketsUpdatedAt = updatedAt
+
+        await service.setupWallet(.mock(type: .multicoin, accounts: [.mock(chain: .hyperliquid)]))
+
+        #expect(preferences.perpetualMarketsUpdatedAt == updatedAt)
+    }
 }
 
 extension AppLifecycleServiceTests {
-    func makeService(perpetualEnabled: Bool) -> (AppLifecycleService, PerpetualObserverMock, Preferences) {
+    func makeService(perpetualEnabled: Bool) throws -> (AppLifecycleService, PerpetualObserverMock, Preferences) {
         let preferences = Preferences.mock()
         preferences.isPerpetualEnabled = perpetualEnabled
         let observer = PerpetualObserverMock()
-        let service = AppLifecycleService.mock(preferences: preferences, hyperliquidObserverService: observer)
+        let service = try AppLifecycleService.mock(
+            preferences: preferences,
+            hyperliquidObserverService: observer,
+            perpetualService: PerpetualService.mock(db: DB.mockPerpetualAssets(), preferences: preferences),
+        )
         return (service, observer, preferences)
     }
 }

--- a/ios/Packages/FeatureServices/PerpetualService/PerpetualEnablerService.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/PerpetualEnablerService.swift
@@ -1,0 +1,58 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Preferences
+import Primitives
+
+public struct PerpetualEnablerService: Sendable {
+    private let observer: any PerpetualObservable
+    private let service: any PerpetualServiceable
+    private let preferences: Preferences
+
+    public init(
+        observer: any PerpetualObservable,
+        service: any PerpetualServiceable,
+        preferences: Preferences,
+    ) {
+        self.observer = observer
+        self.service = service
+        self.preferences = preferences
+    }
+
+    public func updateConnection(wallet: Wallet?) async {
+        if let wallet, preferences.showPerpetuals(for: wallet) {
+            await observer.setup(for: wallet)
+        } else {
+            await observer.disconnect()
+        }
+    }
+
+    public func disconnect() async {
+        await observer.disconnect()
+    }
+
+    public func updateEnablement(wallet: Wallet?) async {
+        if preferences.isPerpetualEnabled {
+            await updateMarkets()
+            await updateConnection(wallet: wallet)
+        } else {
+            await disconnect()
+            await clearMarkets()
+        }
+    }
+
+    private func updateMarkets() async {
+        do {
+            try await service.updateMarkets()
+        } catch {
+            debugLog("PerpetualEnablerService updateMarkets error: \(error)")
+        }
+    }
+
+    private func clearMarkets() async {
+        do {
+            try service.clearMarkets()
+        } catch {
+            debugLog("PerpetualEnablerService clearMarkets error: \(error)")
+        }
+    }
+}

--- a/ios/Packages/FeatureServices/PerpetualService/PerpetualService.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/PerpetualService.swift
@@ -34,6 +34,10 @@ public struct PerpetualService: PerpetualServiceable {
         self.preferences = preferences
     }
 
+    public var marketsUpdatedAt: Date? {
+        preferences.perpetualMarketsUpdatedAt
+    }
+
     public func updateMarkets() async throws {
         let perpetualsData = try await provider.getPerpetualsData()
         let perpetuals = perpetualsData.map(\.perpetual)
@@ -48,6 +52,13 @@ public struct PerpetualService: PerpetualServiceable {
             priceChangePercentage24h: 0,
             updatedAt: .now,
         ), currency: Currency.usd.rawValue)
+        preferences.perpetualMarketsUpdatedAt = .now
+    }
+
+    public func clearMarkets() throws {
+        try clear()
+        try clearBalance()
+        preferences.perpetualMarketsUpdatedAt = nil
     }
 
     public func candlesticks(symbol: String, period: ChartPeriod) async throws -> [ChartCandleStick] {
@@ -72,15 +83,15 @@ public struct PerpetualService: PerpetualServiceable {
         try syncProviderBalances(walletId: walletId, balance: summary.balance)
     }
 
-    public func clear() throws {
+    // MARK: - Private
+
+    private func clear() throws {
         try store.clear()
     }
 
-    public func clearBalance() throws {
+    private func clearBalance() throws {
         try balanceStore.deleteBalance(assetId: Asset.hypercoreUSDC().id)
     }
-
-    // MARK: - Private
 
     private func syncProviderBalances(walletId: WalletId, balance: PerpetualBalance) throws {
         let usd = Asset.hypercoreUSDC()

--- a/ios/Packages/FeatureServices/PerpetualService/Protocols/PerpetualServiceable.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/Protocols/PerpetualServiceable.swift
@@ -4,7 +4,9 @@ import Foundation
 import Primitives
 
 public protocol PerpetualServiceable: Sendable {
+    var marketsUpdatedAt: Date? { get }
     func updateMarkets() async throws
+    func clearMarkets() throws
     func candlesticks(symbol: String, period: ChartPeriod) async throws -> [ChartCandleStick]
     func portfolio(address: String) async throws -> PerpetualPortfolio
     func setPinned(_ isPinned: Bool, perpetualId: PerpetualId) throws

--- a/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualService+TestKit.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualService+TestKit.swift
@@ -9,18 +9,15 @@ import StoreTestKit
 
 public extension PerpetualService {
     static func mock(
-        store: PerpetualStore = .mock(),
-        assetStore: AssetStore = .mock(),
-        priceStore: PriceStore = .mock(),
-        balanceStore: BalanceStore = .mock(),
+        db: DB = .mock(),
         provider: PerpetualProvidable = PerpetualProviderMock(),
         preferences: Preferences = .mock(),
     ) -> PerpetualService {
         PerpetualService(
-            store: store,
-            assetStore: assetStore,
-            priceStore: priceStore,
-            balanceStore: balanceStore,
+            store: PerpetualStore(db: db),
+            assetStore: AssetStore(db: db),
+            priceStore: PriceStore(db: db),
+            balanceStore: BalanceStore(db: db),
             provider: provider,
             preferences: preferences,
         )

--- a/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualServiceMock.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/TestKit/PerpetualServiceMock.swift
@@ -1,5 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
+import Foundation
 import struct Gemstone.GemPerpetualBalance
 import struct Gemstone.GemPerpetualMarketData
 import struct Gemstone.GemPerpetualPosition
@@ -9,7 +10,11 @@ import Primitives
 public struct PerpetualServiceMock: PerpetualServiceable {
     public init() {}
 
+    public var marketsUpdatedAt: Date? { nil }
+
     public func updateMarkets() async throws {}
+
+    public func clearMarkets() throws {}
 
     public func candlesticks(symbol _: String, period _: ChartPeriod) async throws -> [ChartCandleStick] {
         []

--- a/ios/Packages/Store/TestKit/DB+StoreTestKit.swift
+++ b/ios/Packages/Store/TestKit/DB+StoreTestKit.swift
@@ -46,6 +46,13 @@ public extension DB {
         return db
     }
 
+    static func mockPerpetualAssets() throws -> DB {
+        let db = Self.mock()
+        try FiatRateStore(db: db).add([FiatRate(symbol: .usd, rate: 1)])
+        try AssetStore(db: db).add(assets: [.mock(asset: .hypercoreUSDC())])
+        return db
+    }
+
     static func mockAssetsWithPerpetualCollateralBalance() throws -> DB {
         let ethereum = Asset.mockEthereum()
         let bnb = Asset.mockBNB()


### PR DESCRIPTION
Turning perpetuals on or off now goes through a single owner, no matter where the switch happens. Enabling loads markets before the Hyperliquid socket connects, disabling disconnects first and then clears local data.

This removes the second observer of the setting, a duplicate markets request after enabling, and a foreign key error on the first enable.