### PR TITLE
Center multiline button titles

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/buttons/MainActionButton.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/buttons/MainActionButton.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.gemwallet.android.ui.components.progress.CircularProgressIndicator20
@@ -36,6 +37,7 @@ fun MainActionButton(
                 modifier = Modifier.padding(4.dp),
                 text = title,
                 fontSize = 18.sp,
+                textAlign = TextAlign.Center,
             )
         }
     }

--- a/ios/Packages/Components/Sources/Buttons/StateButton.swift
+++ b/ios/Packages/Components/Sources/Buttons/StateButton.swift
@@ -61,6 +61,7 @@ public struct StateButton: View {
                     Text(textValue.text)
                         .foregroundStyle(textValue.style.color)
                         .truncationMode(textValue.truncationMode)
+                        .multilineTextAlignment(.center)
                 }
                 .font(textValue.style.font)
             }


### PR DESCRIPTION
Button titles that wrap to a second line now render centered instead of left-aligned, matching the design.

<!-- screenshot placeholder -->