### PR TITLE
Finish WalletConnect requests through the active request owner

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/WalletConnectContent.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/WalletConnectContent.kt
@@ -1,7 +1,5 @@
 package com.gemwallet.android
 
-import android.widget.Toast
-import android.widget.Toast.makeText
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.AlertDialog
@@ -9,11 +7,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.data.repositories.bridge.ActiveWalletConnectRequest
@@ -76,19 +72,16 @@ private fun WalletConnectOverlay(
             is WalletConnectUserRequest.AuthenticationRequest -> AuthRequestScene(
                 request = current.request,
                 verifyContext = current.verifyContext,
-                onCancel = activeRequest::finish,
             )
             is WalletConnectUserRequest.SessionProposal -> ProposalScene(
                 proposal = current.proposal,
                 verifyContext = current.verifyContext,
-                onCancel = activeRequest::finish,
                 onError = onError,
             )
             is WalletConnectUserRequest.SessionRequest -> RequestScene(
                 request = current.request,
                 verifyContext = current.verifyContext,
                 onAcquireAsset = onAcquireAsset,
-                onCancel = activeRequest::finish,
                 onError = onError,
             )
         }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/ActiveWalletConnectRequest.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/bridge/ActiveWalletConnectRequest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -29,7 +30,21 @@ class ActiveWalletConnectRequest(
     fun finish() {
         _current.update { null }
     }
+
+    fun finish(payload: Any): Boolean {
+        val previous = _current.getAndUpdate { current ->
+            if (current?.payload === payload) null else current
+        }
+        return previous?.payload === payload
+    }
 }
+
+private val WalletConnectUserRequest.payload: Any
+    get() = when (this) {
+        is WalletConnectUserRequest.SessionRequest -> request
+        is WalletConnectUserRequest.AuthenticationRequest -> request
+        is WalletConnectUserRequest.SessionProposal -> proposal
+    }
 
 sealed interface WalletConnectUserRequest {
 

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/bridge/ActiveWalletConnectRequestTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/bridge/ActiveWalletConnectRequestTest.kt
@@ -1,0 +1,69 @@
+package com.gemwallet.android.data.repositories.bridge
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ActiveWalletConnectRequestTest {
+
+    private val events = MutableSharedFlow<WalletConnectEvent>()
+
+    private fun proposal(name: String) = WalletConnectSessionProposal(
+        name = name,
+        description = "",
+        url = "https://example.com",
+        icons = emptyList(),
+        requiredNamespaces = emptyMap(),
+        optionalNamespaces = emptyMap(),
+        proposerPublicKey = "key-$name",
+        properties = null,
+    )
+
+    private fun sessionRequest(id: Long) = WalletConnectSessionRequest(
+        topic = "topic",
+        chainId = "eip155:1",
+        request = WalletConnectJsonRpcRequest(id = id, method = "personal_sign", params = ""),
+    )
+
+    private val verifyContext = WalletConnectVerifyContext(
+        origin = "https://example.com",
+        validation = WalletConnectValidation.Valid,
+        isScam = false,
+    )
+
+    @Test
+    fun finishWithPayloadClearsOnlyTheRequestThatProducedIt() = runTest {
+        val activeRequest = ActiveWalletConnectRequest(events, backgroundScope)
+        testScheduler.runCurrent()
+        val first = proposal("first")
+        val second = sessionRequest(1)
+
+        events.emit(WalletConnectEvent.SessionProposal(first, verifyContext))
+        events.emit(WalletConnectEvent.SessionRequest(second, verifyContext))
+        testScheduler.runCurrent()
+
+        assertFalse(activeRequest.finish(first))
+        assertEquals(second, (activeRequest.current.value as WalletConnectUserRequest.SessionRequest).request)
+
+        assertTrue(activeRequest.finish(second))
+        assertNull(activeRequest.current.value)
+        assertFalse(activeRequest.finish(second))
+    }
+
+    @Test
+    fun finishWithoutPayloadClearsUnconditionally() = runTest {
+        val activeRequest = ActiveWalletConnectRequest(events, backgroundScope)
+        testScheduler.runCurrent()
+        events.emit(WalletConnectEvent.SessionProposal(proposal("only"), verifyContext))
+        testScheduler.runCurrent()
+        checkNotNull(activeRequest.current.value)
+
+        activeRequest.finish()
+
+        assertNull(activeRequest.current.value)
+    }
+}

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/AuthRequestScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/AuthRequestScene.kt
@@ -15,6 +15,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.features.bridge.viewmodels.AuthSceneState
 import com.gemwallet.android.features.bridge.viewmodels.WCAuthViewModel
+import com.gemwallet.android.features.bridge.viewmodels.model.BridgeRequestError
 import com.gemwallet.android.data.repositories.bridge.WalletConnectAuthenticationRequest
 import com.gemwallet.android.data.repositories.bridge.WalletConnectVerifyContext
 import com.gemwallet.android.ui.R
@@ -31,7 +32,6 @@ import com.gemwallet.android.ui.models.ListPosition
 fun AuthRequestScene(
     request: WalletConnectAuthenticationRequest,
     verifyContext: WalletConnectVerifyContext,
-    onCancel: () -> Unit,
 ) {
     val context = LocalContext.current
     val viewModel: WCAuthViewModel = hiltViewModel()
@@ -39,26 +39,19 @@ fun AuthRequestScene(
     val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
 
     LaunchedEffect(request.id) {
-        viewModel.onRequest(request, verifyContext)
+        viewModel.onRequest(request, verifyContext) { error ->
+            when (error) {
+                BridgeRequestError.MaliciousSession -> Toast.makeText(
+                    context,
+                    R.string.errors_connections_malicious_origin,
+                    Toast.LENGTH_LONG
+                ).show()
+                else -> Unit
+            }
+        }
     }
 
     when (val currentState = state) {
-        AuthSceneState.Canceled -> {
-            LaunchedEffect(currentState) {
-                onCancel()
-            }
-        }
-        AuthSceneState.ScamCanceled -> {
-            val maliciousOriginMessage = stringResource(R.string.errors_connections_malicious_origin)
-            LaunchedEffect(currentState) {
-                Toast.makeText(
-                    context,
-                    maliciousOriginMessage,
-                    Toast.LENGTH_LONG
-                ).show()
-                onCancel()
-            }
-        }
         is AuthSceneState.Error -> FatalStateScene(
             title = stringResource(id = R.string.wallet_connect_connect_title),
             message = currentState.message,

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/ProposalScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/ProposalScene.kt
@@ -26,6 +26,7 @@ import com.gemwallet.android.data.repositories.bridge.WalletConnectSessionPropos
 import com.gemwallet.android.data.repositories.bridge.WalletConnectVerifyContext
 import com.gemwallet.android.features.bridge.viewmodels.ProposalSceneState
 import com.gemwallet.android.features.bridge.viewmodels.ProposalSceneViewModel
+import com.gemwallet.android.features.bridge.viewmodels.model.BridgeRequestError
 import com.gemwallet.android.features.bridge.viewmodels.model.SessionUI
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.buttons.MainActionButton
@@ -55,7 +56,6 @@ import uniffi.gemstone.WalletConnectionVerificationStatus
 fun ProposalScene(
     proposal: WalletConnectSessionProposal,
     verifyContext: WalletConnectVerifyContext,
-    onCancel: () -> Unit,
     onError: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -65,50 +65,35 @@ fun ProposalScene(
     val selectedWallet by viewModel.selectedWallet.collectAsStateWithLifecycle()
     val availableWallets by viewModel.availableWallets.collectAsStateWithLifecycle()
     val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
+    val unknownErrorMessage = stringResource(id = R.string.errors_unknown_try_again)
 
     LaunchedEffect(proposal) {
-        viewModel.onProposal(proposal, verifyContext)
-    }
-
-    val contentState = state as? ProposalSceneState.Content
-
-    when {
-        state is ProposalSceneState.Canceled -> LaunchedEffect(state) {
-            onCancel()
-        }
-        state is ProposalSceneState.ScamCanceled -> {
-            val message = stringResource(R.string.errors_connections_malicious_origin)
-            LaunchedEffect(state) {
-                Toast.makeText(
+        viewModel.onProposal(proposal, verifyContext) { error ->
+            when (error) {
+                BridgeRequestError.MaliciousSession -> Toast.makeText(
                     context,
-                    message,
+                    R.string.errors_connections_malicious_origin,
                     Toast.LENGTH_LONG
                 ).show()
-                onCancel()
+                else -> Unit
             }
         }
-        state is ProposalSceneState.Fail -> {
-            val message = (state as ProposalSceneState.Fail).message.ifBlank {
-                stringResource(id = R.string.errors_unknown_try_again)
-            }
-            LaunchedEffect(message) {
-                onError(message)
-                onCancel()
-            }
-        }
-        peer == null || contentState == null -> LoadingScene(
+    }
+
+    when (val currentPeer = peer) {
+        null -> LoadingScene(
             title = stringResource(id = R.string.wallet_connect_connect_title),
-            onCancel = onCancel,
+            onCancel = viewModel::onReject,
             closeIcon = true,
         )
         else -> Proposal(
-            peer = peer!!,
-            state = contentState,
+            peer = currentPeer,
+            state = state,
             selectedWallet = selectedWallet,
             availableWallets = availableWallets,
             buttonState = buttonState,
             onReject = viewModel::onReject,
-            onApprove = viewModel::onApprove,
+            onApprove = { viewModel.onApprove { message -> onError(message.ifBlank { unknownErrorMessage }) } },
             onWalletSelected = viewModel::onWalletSelected
         )
     }
@@ -117,7 +102,7 @@ fun ProposalScene(
 @Composable
 private fun Proposal(
     peer: SessionUI,
-    state: ProposalSceneState.Content,
+    state: ProposalSceneState,
     selectedWallet: com.wallet.core.primitives.Wallet?,
     availableWallets: List<com.wallet.core.primitives.Wallet>,
     buttonState: ButtonState,

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/RequestScene.kt
@@ -27,7 +27,6 @@ fun RequestScene(
     request: WalletConnectSessionRequest,
     verifyContext: WalletConnectVerifyContext,
     onAcquireAsset: (AcquireAssetAction, AssetId) -> Unit,
-    onCancel: () -> Unit,
     onError: (String) -> Unit,
 ) {
     val viewModel: WCRequestViewModel = hiltViewModel()
@@ -82,6 +81,5 @@ fun RequestScene(
                 )
             }
         }
-        RequestSceneState.Cancel -> onCancel()
     }
 }

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/ProposalSceneViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/ProposalSceneViewModel.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.features.bridge.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gemwallet.android.data.repositories.bridge.ActiveWalletConnectRequest
 import com.gemwallet.android.data.repositories.bridge.BridgesRepository
 import com.gemwallet.android.data.repositories.bridge.WalletConnectSessionProposal
 import com.gemwallet.android.data.repositories.bridge.WalletConnectVerifyContext
@@ -9,6 +10,7 @@ import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.ext.walletConnectAppName
 import com.gemwallet.android.ext.walletConnectIcon
+import com.gemwallet.android.features.bridge.viewmodels.model.BridgeRequestError
 import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectOriginVerifier
 import com.gemwallet.android.features.bridge.viewmodels.model.toSessionUI
 import com.gemwallet.android.ui.models.ButtonState
@@ -39,6 +41,7 @@ class ProposalSceneViewModel @Inject constructor(
     private val bridgesRepository: BridgesRepository,
     private val walletsRepository: WalletsRepository,
     private val originVerifier: WalletConnectOriginVerifier,
+    private val activeRequest: ActiveWalletConnectRequest,
 ) : ViewModel() {
 
     val state = MutableStateFlow<ProposalSceneState>(ProposalSceneState.Init(WalletConnectionVerificationStatus.UNKNOWN))
@@ -82,40 +85,41 @@ class ProposalSceneViewModel @Inject constructor(
 
     fun onProposal(
         proposal: WalletConnectSessionProposal,
-        verifyContext: WalletConnectVerifyContext
+        verifyContext: WalletConnectVerifyContext,
+        onNotify: (BridgeRequestError) -> Unit,
     ) {
         val verification = originVerifier.verify(proposal.url, verifyContext)
         if (verification.isScam) {
-            onReject(proposal, ProposalSceneState.ScamCanceled)
+            onNotify(BridgeRequestError.MaliciousSession)
+            reject(proposal)
             return
         }
         state.update { ProposalSceneState.Init(verification.status) }
         _proposal.update { proposal }
     }
 
-    fun onApprove() {
+    fun onApprove(onError: (String) -> Unit) {
         val wallet = selectedWallet.value
         val proposal = _proposal.value
-        val currentState = state.value as? ProposalSceneState.Content ?: return
-        if (currentState is ProposalSceneState.Approving) {
+        if (state.value is ProposalSceneState.Approving) {
             return
         }
 
         if (wallet == null || proposal == null) {
-            state.update { ProposalSceneState.Canceled }
+            finish()
             return
         }
-        state.update { ProposalSceneState.Approving(currentState.verificationStatus) }
+        state.update { ProposalSceneState.Approving(it.verificationStatus) }
         viewModelScope.launch(Dispatchers.IO) {
             val result = runCatching {
                 bridgesRepository.approveConnection(
                     wallet = wallet,
                     proposal = proposal,
-                    onSuccess = { state.update { ProposalSceneState.Canceled } },
-                    onError = { message -> state.update { ProposalSceneState.Fail(message) } }
+                    onSuccess = { finish(proposal) },
+                    onError = { message -> fail(proposal, message, onError) }
                 )
             }
-            result.onFailure { err -> state.update { ProposalSceneState.Fail(err.message ?: "Connection failed") } }
+            result.onFailure { err -> fail(proposal, err.message ?: "Connection failed", onError) }
         }
     }
 
@@ -123,15 +127,12 @@ class ProposalSceneViewModel @Inject constructor(
         if (state.value is ProposalSceneState.Approving) {
             return
         }
-        onReject(_proposal.value ?: return)
-    }
-
-    fun onReject(proposal: WalletConnectSessionProposal, withState: ProposalSceneState = ProposalSceneState.Canceled) = viewModelScope.launch(Dispatchers.IO) {
-        bridgesRepository.rejectConnection(
-            proposal = proposal,
-            onSuccess = { state.update { withState } },
-            onError = { state.update { withState } }
-        )
+        val proposal = _proposal.value
+        if (proposal == null) {
+            finish()
+            return
+        }
+        reject(proposal)
     }
 
     fun onWalletSelected(walletId: WalletId) {
@@ -141,24 +142,50 @@ class ProposalSceneViewModel @Inject constructor(
         _selectedWallet.update { availableWallets.value.firstOrNull { it.id == walletId } }
     }
 
+    private fun reject(proposal: WalletConnectSessionProposal) {
+        viewModelScope.launch(Dispatchers.IO) {
+            bridgesRepository.rejectConnection(
+                proposal = proposal,
+                onSuccess = { finish(proposal) },
+                onError = { finish(proposal) }
+            )
+        }
+    }
+
+    private fun fail(proposal: WalletConnectSessionProposal, message: String, onError: (String) -> Unit) {
+        if (activeRequest.finish(proposal)) {
+            reset()
+            onError(message)
+        }
+    }
+
+    private fun finish(proposal: WalletConnectSessionProposal) {
+        if (activeRequest.finish(proposal)) {
+            reset()
+        }
+    }
+
+    private fun finish() {
+        reset()
+        activeRequest.finish()
+    }
+
+    private fun reset() {
+        _proposal.update { null }
+        _selectedWallet.update { null }
+        state.update { ProposalSceneState.Init(WalletConnectionVerificationStatus.UNKNOWN) }
+    }
+
 }
 
 sealed interface ProposalSceneState {
-    sealed interface Content : ProposalSceneState {
-        val verificationStatus: WalletConnectionVerificationStatus
-    }
+    val verificationStatus: WalletConnectionVerificationStatus
 
     data class Init(
         override val verificationStatus: WalletConnectionVerificationStatus,
-    ) : Content
+    ) : ProposalSceneState
 
     data class Approving(
         override val verificationStatus: WalletConnectionVerificationStatus,
-    ) : Content
-
-    data object Canceled : ProposalSceneState
-
-    data object ScamCanceled : ProposalSceneState
-
-    class Fail(val message: String) : ProposalSceneState
+    ) : ProposalSceneState
 }

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCAuthViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCAuthViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.PasswordStore
 import com.gemwallet.android.blockchain.gemstone.toPrimitives
 import com.gemwallet.android.blockchain.services.GemSignMessageOperator
+import com.gemwallet.android.data.repositories.bridge.ActiveWalletConnectRequest
 import com.gemwallet.android.data.repositories.bridge.BridgesRepository
 import com.gemwallet.android.data.repositories.bridge.ChainNamespace
 import com.gemwallet.android.data.repositories.bridge.WalletConnectAuthPayloadParams
@@ -16,6 +17,7 @@ import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import com.gemwallet.android.ext.getAccount
 import com.gemwallet.android.ext.toChainType
 import com.gemwallet.android.ext.walletConnectAppName
+import com.gemwallet.android.features.bridge.viewmodels.model.BridgeRequestError
 import com.gemwallet.android.features.bridge.viewmodels.model.SessionUI
 import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectOriginVerifier
 import com.gemwallet.android.features.bridge.viewmodels.model.WalletConnectReviewModel
@@ -54,6 +56,7 @@ class WCAuthViewModel @Inject constructor(
     private val passwordStore: PasswordStore,
     private val signMessageOperator: GemSignMessageOperator,
     private val originVerifier: WalletConnectOriginVerifier,
+    private val activeRequest: ActiveWalletConnectRequest,
 ) : ViewModel() {
 
     private var authRequest: WalletConnectAuthenticationRequest? = null
@@ -69,21 +72,21 @@ class WCAuthViewModel @Inject constructor(
     fun onRequest(
         request: WalletConnectAuthenticationRequest,
         verifyContext: WalletConnectVerifyContext,
+        onNotify: (BridgeRequestError) -> Unit,
     ) {
         authRequest = request
         hasResponded = false
         _state.update { AuthSceneState.Loading }
+        val verification = originVerifier.verify(request.metadata?.url, verifyContext)
+        if (verification.isScam) {
+            onNotify(BridgeRequestError.MaliciousSession)
+            hasResponded = true
+            bridgesRepository.rejectAuthentication(request)
+            finish(request)
+            return
+        }
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                val verification = originVerifier.verify(request.metadata?.url, verifyContext)
-                if (!isActiveRequest(request)) {
-                    return@launch
-                }
-                if (verification.isScam) {
-                    rejectRequest(request, AuthSceneState.ScamCanceled)
-                    return@launch
-                }
-
                 val availableWallets = (walletsRepository.getAll().firstOrNull() ?: emptyList())
                     .filter { wallet ->
                         wallet.type != WalletType.View && supportedAccounts(wallet, request).isNotEmpty()
@@ -174,7 +177,7 @@ class WCAuthViewModel @Inject constructor(
                     onSuccess = {
                         if (authRequest?.id == request.id) {
                             hasResponded = true
-                            _state.update { AuthSceneState.Canceled }
+                            finish(request)
                         }
                     },
                     onError = { message ->
@@ -196,33 +199,45 @@ class WCAuthViewModel @Inject constructor(
             return
         }
         val request = authRequest
-        if (request == null) {
-            _state.update { AuthSceneState.Canceled }
-            return
-        }
-        if (hasResponded) {
-            _state.update { AuthSceneState.Canceled }
+        if (request == null || hasResponded) {
+            finish()
             return
         }
         hasResponded = true
         bridgesRepository.rejectAuthentication(request)
-        _state.update { AuthSceneState.Canceled }
+        finish()
     }
 
     private fun rejectRequest(
         request: WalletConnectAuthenticationRequest,
-        state: AuthSceneState,
+        errorState: AuthSceneState.Error,
     ) {
         if (!isActiveRequest(request)) {
             return
         }
         hasResponded = true
         bridgesRepository.rejectAuthentication(request)
-        _state.update { state }
+        _state.update { errorState }
     }
 
     private fun isActiveRequest(request: WalletConnectAuthenticationRequest): Boolean {
         return authRequest?.id == request.id && !hasResponded
+    }
+
+    private fun finish(request: WalletConnectAuthenticationRequest) {
+        if (activeRequest.finish(request)) {
+            reset()
+        }
+    }
+
+    private fun finish() {
+        reset()
+        activeRequest.finish()
+    }
+
+    private fun reset() {
+        authRequest = null
+        _state.update { AuthSceneState.Loading }
     }
 
     private fun buildApproval(
@@ -330,10 +345,6 @@ class WCAuthViewModel @Inject constructor(
 sealed interface AuthSceneState {
 
     data object Loading : AuthSceneState
-
-    data object Canceled : AuthSceneState
-
-    data object ScamCanceled : AuthSceneState
 
     class Error(val message: String) : AuthSceneState
 

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.PasswordStore
 import com.gemwallet.android.blockchain.services.GemSignMessageOperator
 import com.gemwallet.android.cases.nodes.GetCurrentBlockExplorer
+import com.gemwallet.android.data.repositories.bridge.ActiveWalletConnectRequest
 import com.gemwallet.android.data.repositories.bridge.BridgesRepository
 import com.gemwallet.android.data.repositories.bridge.WalletConnectJsonRpcResponse
 import com.gemwallet.android.data.repositories.bridge.WalletConnectSessionRequest
@@ -53,6 +54,7 @@ class WCRequestViewModel @Inject constructor(
     private val simulationService: com.gemwallet.android.blockchain.services.WalletConnectSimulationService,
     private val getCurrentBlockExplorer: GetCurrentBlockExplorer,
     private val originVerifier: WalletConnectOriginVerifier,
+    private val activeRequest: ActiveWalletConnectRequest,
 ) : ViewModel() {
 
     private val walletConnect = WalletConnect()
@@ -161,7 +163,7 @@ class WCRequestViewModel @Inject constructor(
         when (action.operation) {
             uniffi.gemstone.WalletConnectChainOperation.AddChain,
             is uniffi.gemstone.WalletConnectChainOperation.SwitchChain -> {
-                response(sessionRequest.topic, sessionRequest.request.id, "null", onError)
+                response(sessionRequest, "null", onError)
             }
 
             uniffi.gemstone.WalletConnectChainOperation.GetChainId -> {
@@ -182,7 +184,7 @@ class WCRequestViewModel @Inject constructor(
         val accounts = connection.wallet.accounts
             .filter { it.chain == chain }
             .map { it.toGem() }
-        response(sessionRequest.topic, sessionRequest.request.id, walletConnect.encodeGetAccounts(action.chain, accounts).payload(), onError)
+        response(sessionRequest, walletConnect.encodeGetAccounts(action.chain, accounts).payload(), onError)
     }
 
     private suspend fun buildRequest(
@@ -252,7 +254,7 @@ class WCRequestViewModel @Inject constructor(
                 rejectRequest(request.sessionRequest)
                 return@launch
             }
-            response(request.topic, request.requestId, response, onError)
+            response(request.sessionRequest, response, onError)
         }
     }
 
@@ -277,16 +279,16 @@ class WCRequestViewModel @Inject constructor(
                 rejectRequest(request.sessionRequest)
                 return@launch
             }
-            response(request.sessionRequest.topic, request.sessionRequest.request.id, sign, onError)
+            response(request.sessionRequest, sign, onError)
         }
     }
 
-    private fun response(topic: String, id: Long, payload: String, onError: (String) -> Unit) {
+    private fun response(sessionRequest: WalletConnectSessionRequest, payload: String, onError: (String) -> Unit) {
         bridgeRepository.respondSessionRequest(
-            topic = topic,
-            id = id,
+            topic = sessionRequest.topic,
+            id = sessionRequest.request.id,
             response = WalletConnectJsonRpcResponse.Result(payload),
-            onSuccess = { state.update { it.copy(canceled = true) } },
+            onSuccess = { activeRequest.finish(sessionRequest) },
             onError = { error ->
                 state.update { it.copy(responseState = RequestResponseState.Idle) }
                 onError(error.ifBlank { "Request failed" })
@@ -294,20 +296,19 @@ class WCRequestViewModel @Inject constructor(
         )
     }
 
-    private fun respondError(topic: String, id: Long, code: Int, message: String, onError: (String) -> Unit) {
+    private fun respondError(sessionRequest: WalletConnectSessionRequest, code: Int, message: String, onError: (String) -> Unit) {
         bridgeRepository.respondSessionRequest(
-            topic = topic,
-            id = id,
+            topic = sessionRequest.topic,
+            id = sessionRequest.request.id,
             response = WalletConnectJsonRpcResponse.Error(code, message),
-            onSuccess = { state.update { it.copy(canceled = true) } },
+            onSuccess = { activeRequest.finish(sessionRequest) },
             onError = { error -> onError(error.ifBlank { "Request failed" }) },
         )
     }
 
     private fun respondMethodNotFound(sessionRequest: WalletConnectSessionRequest, onError: (String) -> Unit) {
         respondError(
-            topic = sessionRequest.topic,
-            id = sessionRequest.request.id,
+            sessionRequest = sessionRequest,
             code = -32601,
             message = "Method not found",
             onError = onError,
@@ -343,7 +344,7 @@ class WCRequestViewModel @Inject constructor(
                 code = 4001,
                 message = "User rejected the request",
             ),
-            onSuccess = { state.update { it.copy(canceled = true) } },
+            onSuccess = { activeRequest.finish(sessionRequest) },
             onError = { error -> Log.e(TAG, "Request rejection failed id=${sessionRequest.request.id}: $error") },
         )
     }
@@ -367,16 +368,12 @@ class WCRequestViewModel @Inject constructor(
 
 private data class RequestViewModelState(
     val sessionRequest: WalletConnectSessionRequest? = null,
-    val canceled: Boolean = false,
     val wallet: com.wallet.core.primitives.Wallet? = null,
     val request: WCRequest? = null,
     val chain: Chain? = null,
     val responseState: RequestResponseState = RequestResponseState.Idle,
 ) {
     fun toSceneState(): RequestSceneState {
-        if (canceled) {
-            return RequestSceneState.Cancel
-        }
         if (request == null) {
             return RequestSceneState.Loading
         }
@@ -398,8 +395,6 @@ private enum class RequestResponseState {
 sealed interface RequestSceneState {
 
     data object Loading : RequestSceneState
-
-    data object Cancel : RequestSceneState
 
     sealed interface Content : RequestSceneState {
         val walletName: String


### PR DESCRIPTION
A finished WalletConnect screen could silently cancel the next incoming request, so after rejecting a connection the next pairing sometimes never showed up. Now the request is closed by its owner, and only by the request that produced the result.

Closes #906