### PR TITLE
Remove unused assetsTransactionType request type

### DIFF
--- a/ios/Packages/Store/Sources/Requests/TransactionsRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/TransactionsRequest.swift
@@ -51,20 +51,14 @@ public struct TransactionsRequest: DatabaseQueryable {
         filters: [TransactionsRequestFilter],
     ) -> QueryInterfaceRequest<TransactionRecord> {
         let states = states(type: type)
-        let types = types(type: type)
         var request = TransactionRecord
             .filter(TransactionRecord.Columns.walletId == walletId.id)
             .filter(states.contains(TransactionRecord.Columns.state))
-            .filter(types.contains(TransactionRecord.Columns.type))
             .distinct()
 
         switch type {
         case let .asset(assetId):
             request = request.joining(required: TransactionRecord.assetsAssociation.filter(TransactionAssetAssociationRecord.Columns.assetId == assetId.identifier))
-        case let .assetsTransactionType(assetIds, _, _):
-            if !assetIds.isEmpty {
-                request = request.joining(required: TransactionRecord.assetsAssociation.filter(assetIds.map(\.identifier).contains(TransactionAssetAssociationRecord.Columns.assetId)))
-            }
         case let .transaction(id):
             request = request.filter(TransactionRecord.Columns.transactionId == id)
         case .all, .pending:
@@ -101,17 +95,6 @@ extension TransactionsRequest {
             [TransactionState.pending, TransactionState.inTransit].map(\.rawValue)
         case .all, .asset, .transaction:
             TransactionState.allCases.map(\.rawValue)
-        case let .assetsTransactionType(_, _, states):
-            states.map(\.rawValue)
-        }
-    }
-
-    private static func types(type: TransactionsRequestType) -> [String] {
-        switch type {
-        case let .assetsTransactionType(_, type, _):
-            [type.rawValue]
-        case .pending, .all, .asset, .transaction:
-            TransactionType.allCases.map(\.rawValue)
         }
     }
 }

--- a/ios/Packages/Store/Sources/Types/TransactionsRequestType.swift
+++ b/ios/Packages/Store/Sources/Types/TransactionsRequestType.swift
@@ -7,7 +7,6 @@ public enum TransactionsRequestType: Equatable {
     case all
     case pending
     case asset(assetId: AssetId)
-    case assetsTransactionType(assetIds: [AssetId], type: TransactionType, states: [TransactionState])
     case transaction(id: String)
 }
 
@@ -18,8 +17,6 @@ extension TransactionsRequestType: Identifiable {
         case .pending: "pending"
         case let .transaction(id): id
         case let .asset(asset): asset.identifier
-        case let .assetsTransactionType(assetIds, type, _):
-            assetIds.map(\.identifier).joined() + type.rawValue
         }
     }
 }


### PR DESCRIPTION
Deletes a transactions request type that nothing creates anymore.

Its only user was the swap token approval request, removed a year and a half ago when approval and swap became one transaction. Because of it every transaction query carried a filter that always matched everything.

No behaviour changes.