### PR TITLE
Show the wallet avatar on the confirm screen

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/confirm/BuildConfirmPropertiesImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/confirm/BuildConfirmPropertiesImpl.kt
@@ -34,7 +34,7 @@ class BuildConfirmPropertiesImpl(
         val explorerName = getCurrentBlockExplorer.getCurrentBlockExplorer(chain)
         val chainExplorer = Explorer(chain.string)
         return mutableListOf<ConfirmProperty?>().apply {
-            add(ConfirmProperty.Source(wallet.name, wallet.type, assetInfo.owner?.chain))
+            add(ConfirmProperty.Source(wallet.name, wallet.type, assetInfo.owner?.chain, wallet.imageUrl))
             val destination = ConfirmProperty.Destination.map(request, getValidator(request), addressName)
             add(
                 when (destination) {

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -49,6 +49,7 @@ import com.gemwallet.android.ui.components.perpetual.title
 import com.wallet.core.primitives.PerpetualType
 import com.wallet.core.primitives.AssetId
 import com.gemwallet.android.ui.components.buttons.MainActionButton
+import com.gemwallet.android.ui.components.image.walletImageModel
 import com.gemwallet.android.ui.components.list_head.AmountListHead
 import com.gemwallet.android.ui.components.list_head.NftHead
 import com.gemwallet.android.ui.components.list_head.SwapListHead
@@ -205,7 +206,8 @@ fun ConfirmScreen(
                     is ConfirmProperty.Source -> PropertyItem(
                         title = { PropertyTitleText(R.string.common_wallet) },
                         data = {
-                            val walletIcon = walletItemIconModel(item.walletType, item.walletChain)
+                            val walletIcon = walletImageModel(context, item.walletImageUrl)
+                                ?: walletItemIconModel(item.walletType, item.walletChain)
                             PropertyDataText(
                                 text = item.data,
                                 badge = walletIcon?.let { { DataBadgeChevron(icon = it, isShowChevron = false) } },

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/ConfirmProperty.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/confirm/ConfirmProperty.kt
@@ -10,7 +10,7 @@ import com.wallet.core.primitives.DelegationValidator
 import com.wallet.core.primitives.WalletType
 
 sealed interface ConfirmProperty {
-    class Source(val data: String, val walletType: WalletType, val walletChain: Chain?) : ConfirmProperty
+    class Source(val data: String, val walletType: WalletType, val walletChain: Chain?, val walletImageUrl: String?) : ConfirmProperty
     class Network(val data: Asset) : ConfirmProperty
     class Memo(memo: String) : ConfirmProperty {
         val data: String = memo.ifEmpty { "-" }


### PR DESCRIPTION
The Wallet row on the confirm screen always showed the default wallet icon, even when the wallet had a custom emoji or image avatar. Now it shows the avatar, and falls back to the default icon when there is none — same as iOS and the same as every other wallet row in the app.

Closes #921

<img width="320" alt="Screenshot_1787201646" src="https://github.com/user-attachments/assets/209c7b1a-5db9-4a4f-aff7-20663f050e0f" />
