### PR TITLE
Add receive, buy and sell deep links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ If a task spans multiple platforms, read every affected guide. Do not treat ever
 
 Cross-platform subsystem references live in [docs/](docs). Read the relevant one before changing that area:
 
+- [Deep links](docs/DEEPLINKS.md) — deep link URL contract, support-chat links, and the web association requirements
 - [Device and subscriptions](docs/DEVICE_SUBSCRIPTIONS.md) — device registration, subscription sync, and the iOS/Android contract
 - [Payments](docs/PAYMENTS.md) — payment decoding flow, implementation map, and QR test cases
 - [Swapper](docs/SWAPPER.md) — quote flow, route preloading, and the shared route cache

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="gem" android:host="wc" />
+                <data android:scheme="gem" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -64,6 +64,10 @@
                 <data android:scheme="https" android:host="gemwallet.com" android:path="/join" />
                 <data android:scheme="https" android:host="gemwallet.com" android:pathPrefix="/join/" />
                 <data android:scheme="https" android:host="gemwallet.com" android:pathPrefix="/tokens/" />
+                <data android:scheme="https" android:host="gemwallet.com" android:path="/receive" />
+                <data android:scheme="https" android:host="gemwallet.com" android:pathPrefix="/receive/" />
+                <data android:scheme="https" android:host="gemwallet.com" android:pathPrefix="/buy/" />
+                <data android:scheme="https" android:host="gemwallet.com" android:pathPrefix="/sell/" />
             </intent-filter>
         </activity>
         <provider

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -64,10 +64,6 @@
                 <data android:scheme="https" android:host="gemwallet.com" android:path="/join" />
                 <data android:scheme="https" android:host="gemwallet.com" android:pathPrefix="/join/" />
                 <data android:scheme="https" android:host="gemwallet.com" android:pathPrefix="/tokens/" />
-                <data android:scheme="https" android:host="gemwallet.com" android:path="/receive" />
-                <data android:scheme="https" android:host="gemwallet.com" android:pathPrefix="/receive/" />
-                <data android:scheme="https" android:host="gemwallet.com" android:pathPrefix="/buy/" />
-                <data android:scheme="https" android:host="gemwallet.com" android:pathPrefix="/sell/" />
             </intent-filter>
         </activity>
         <provider

--- a/android/app/src/main/kotlin/com/gemwallet/android/WebDeepLinks.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/WebDeepLinks.kt
@@ -5,21 +5,19 @@ import com.gemwallet.android.ext.toAssetId
 import com.gemwallet.android.ui.navigation.routes.AssetRoute
 import com.gemwallet.android.ui.navigation.routes.FiatInputRoute
 import com.gemwallet.android.ui.navigation.routes.ReceiveRoute
-import com.gemwallet.android.ui.navigation.routes.ReceiveSelectRoute
 import com.gemwallet.android.ui.navigation.routes.ReferralRoute
+import com.gemwallet.android.ui.navigation.routes.SwapPairRoute
 import com.wallet.core.primitives.FiatQuoteType
 import uniffi.gemstone.Deeplink
 
 internal fun Deeplink.toRoute(): NavKey? {
     return when (this) {
-        is Deeplink.Asset -> assetId.toAssetId()?.let { AssetRoute(it) }
+        is Deeplink.Asset -> assetId.toAssetId()?.let(::AssetRoute)
         is Deeplink.Rewards -> ReferralRoute(code = code?.takeIf(String::isNotBlank))
-        is Deeplink.Receive -> when (val identifier = assetId) {
-            null -> ReceiveSelectRoute
-            else -> identifier.toAssetId()?.let(::ReceiveRoute)
-        }
+        is Deeplink.Receive -> assetId.toAssetId()?.let(::ReceiveRoute)
         is Deeplink.Buy -> assetId.toAssetId()?.let { FiatInputRoute(it, amount, FiatQuoteType.Buy) }
         is Deeplink.Sell -> assetId.toAssetId()?.let { FiatInputRoute(it, amount, FiatQuoteType.Sell) }
+        is Deeplink.Swap -> assetId.toAssetId()?.let { SwapPairRoute(it, null) }
         Deeplink.Perpetuals -> null
     }
 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/WebDeepLinks.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/WebDeepLinks.kt
@@ -3,13 +3,23 @@ package com.gemwallet.android
 import androidx.navigation3.runtime.NavKey
 import com.gemwallet.android.ext.toAssetId
 import com.gemwallet.android.ui.navigation.routes.AssetRoute
+import com.gemwallet.android.ui.navigation.routes.FiatInputRoute
+import com.gemwallet.android.ui.navigation.routes.ReceiveRoute
+import com.gemwallet.android.ui.navigation.routes.ReceiveSelectRoute
 import com.gemwallet.android.ui.navigation.routes.ReferralRoute
+import com.wallet.core.primitives.FiatQuoteType
 import uniffi.gemstone.Deeplink
 
 internal fun Deeplink.toRoute(): NavKey? {
     return when (this) {
         is Deeplink.Asset -> assetId.toAssetId()?.let { AssetRoute(it) }
         is Deeplink.Rewards -> ReferralRoute(code = code?.takeIf(String::isNotBlank))
-        else -> null
+        is Deeplink.Receive -> when (val identifier = assetId) {
+            null -> ReceiveSelectRoute
+            else -> identifier.toAssetId()?.let(::ReceiveRoute)
+        }
+        is Deeplink.Buy -> assetId.toAssetId()?.let { FiatInputRoute(it, amount, FiatQuoteType.Buy) }
+        is Deeplink.Sell -> assetId.toAssetId()?.let { FiatInputRoute(it, amount, FiatQuoteType.Sell) }
+        Deeplink.Perpetuals -> null
     }
 }

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/RootRoute.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/RootRoute.kt
@@ -82,6 +82,7 @@ import com.gemwallet.android.ui.navigation.routes.WalletsRoute
 import com.gemwallet.android.ext.toIdentifier
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.Chain
+import com.wallet.core.primitives.FiatQuoteType
 import com.wallet.core.primitives.NFTAssetId
 import com.wallet.core.primitives.PaymentRequest
 import com.wallet.core.primitives.PortfolioType
@@ -279,10 +280,10 @@ class WalletNavigator(
     private fun clearSwapSelections() = swapSelections.clear()
     fun openBuy() = push(FiatSelectRoute)
     fun openBuy(assetId: AssetId) = openBuy(assetId, amount = null)
-    fun openBuy(assetId: AssetId, amount: Double?) = push(FiatInputRoute(assetId, amount))
+    fun openBuy(assetId: AssetId, amount: Int?) = push(FiatInputRoute(assetId, amount, FiatQuoteType.Buy))
     fun openAcquireAsset(action: AcquireAssetAction, assetId: AssetId) {
         when (action) {
-            is AcquireAssetAction.Buy -> openBuy(assetId, amount = action.amount?.toDouble())
+            is AcquireAssetAction.Buy -> openBuy(assetId, amount = action.amount)
             AcquireAssetAction.Swap -> openSwapTo(assetId)
             AcquireAssetAction.Receive -> openReceive(assetId)
         }

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/RouteArgumentsNavEntryDecorator.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/RouteArgumentsNavEntryDecorator.kt
@@ -46,7 +46,7 @@ internal fun routeArguments(vararg arguments: Pair<RouteArgument, Any?>): Map<St
 internal fun assetIdArgument(assetId: AssetId): Pair<RouteArgument, String> =
     RouteArgument.AssetId to assetId.toIdentifier()
 
-internal fun fiatAmountArgument(amount: Double?): Pair<RouteArgument, Double?> =
+internal fun fiatAmountArgument(amount: Int?): Pair<RouteArgument, Int?> =
     RouteArgument.FiatAmount to amount
 
 internal fun contactIdArgument(contactId: String): Pair<RouteArgument, String> =

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/routes/Buy.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/routes/Buy.kt
@@ -6,14 +6,20 @@ import com.gemwallet.android.features.asset_select.presents.views.SelectBuyScree
 import com.gemwallet.android.features.buy.views.FiatNavScreen
 import com.gemwallet.android.features.buy.views.FiatTransactionsNavScreen
 import com.gemwallet.android.ui.models.actions.CancelAction
+import com.gemwallet.android.ui.models.navigation.RouteArgument
 import com.gemwallet.android.ui.navigation.assetIdArgument
 import com.gemwallet.android.ui.navigation.fiatAmountArgument
 import com.gemwallet.android.ui.navigation.routeArguments
 import com.wallet.core.primitives.AssetId
+import com.wallet.core.primitives.FiatQuoteType
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class FiatInputRoute(val assetId: AssetId, val amount: Double? = null) : NavKey
+data class FiatInputRoute(
+    val assetId: AssetId,
+    val amount: Int? = null,
+    val type: FiatQuoteType = FiatQuoteType.Buy,
+) : NavKey
 
 @Serializable
 data object FiatSelectRoute : NavKey
@@ -27,7 +33,13 @@ fun EntryProviderScope<NavKey>.fiatScreen(
     onFiatTransactions: () -> Unit,
 ) {
     entry<FiatInputRoute>(
-        metadata = { key -> routeArguments(assetIdArgument(key.assetId), fiatAmountArgument(key.amount)) },
+        metadata = { key ->
+            routeArguments(
+                assetIdArgument(key.assetId),
+                fiatAmountArgument(key.amount),
+                RouteArgument.Type to key.type,
+            )
+        },
     ) {
         FiatNavScreen(
             cancelAction = cancelAction,

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/routes/Settings.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/routes/Settings.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import androidx.navigation3.runtime.EntryProviderScope
@@ -25,6 +26,7 @@ import com.gemwallet.android.features.settings.settings.presents.views.Preferenc
 import com.gemwallet.android.features.settings.settings.presents.views.SupportChatNavScreen
 import com.gemwallet.android.ui.navigation.assetIdArgument
 import com.gemwallet.android.ui.navigation.routeArguments
+import com.gemwallet.android.ui.open
 import com.wallet.core.primitives.AssetId
 import kotlinx.serialization.Serializable
 
@@ -168,13 +170,14 @@ fun EntryProviderScope<NavKey>.settingsScreen(
     }
 
     entry<SupportRoute> {
+        val context = LocalContext.current
         val defaultUriHandler = LocalUriHandler.current
         val currentOnOpenUrl by rememberUpdatedState(onOpenUrl)
-        val uriHandler = remember(defaultUriHandler) {
+        val uriHandler = remember(defaultUriHandler, context) {
             object : UriHandler {
                 override fun openUri(uri: String) {
                     if (!currentOnOpenUrl(uri)) {
-                        defaultUriHandler.openUri(uri)
+                        defaultUriHandler.open(context, uri)
                     }
                 }
             }

--- a/android/features/buy/viewmodels/src/main/kotlin/com/gemwallet/android/features/buy/viewmodels/FiatViewModel.kt
+++ b/android/features/buy/viewmodels/src/main/kotlin/com/gemwallet/android/features/buy/viewmodels/FiatViewModel.kt
@@ -72,18 +72,18 @@ class FiatViewModel @Inject constructor(
     private val currency = Currency.USD
     private val currencySymbol = java.util.Currency.getInstance(currency.name).symbol
 
-    val type = MutableStateFlow(FiatQuoteType.Buy)
+    private val initialType = savedStateHandle.get<FiatQuoteType>(RouteArgument.Type.key) ?: FiatQuoteType.Buy
+    private val initialAmount = savedStateHandle.get<Int>(RouteArgument.FiatAmount.key)?.toString()
+
+    val type = MutableStateFlow(initialType)
     val assetId = MutableStateFlow(savedStateHandle.requireAssetId(RouteArgument.AssetId))
-    private val initialBuyAmount = savedStateHandle.get<Double>(RouteArgument.FiatAmount.key)
-        ?.toAmountText()
-        ?: FiatConfig.defaultBuyAmount.toString()
 
     val buyOperation = FiatOperationState(
-        defaultAmount = initialBuyAmount,
+        defaultAmount = defaultAmount(FiatQuoteType.Buy, FiatConfig.defaultBuyAmount),
         minFiatAmount = FiatConfig.minimumAmount.toDouble(),
     )
     val sellOperation = FiatOperationState(
-        defaultAmount = FiatConfig.defaultSellAmount.toString(),
+        defaultAmount = defaultAmount(FiatQuoteType.Sell, FiatConfig.defaultSellAmount),
         minFiatAmount = FiatConfig.minimumAmount.toDouble(),
     )
 
@@ -92,12 +92,15 @@ class FiatViewModel @Inject constructor(
         FiatQuoteType.Sell -> sellOperation
     }
 
+    private fun defaultAmount(type: FiatQuoteType, fallback: Int): String =
+        initialAmount?.takeIf { type == initialType } ?: fallback.toString()
+
     val amount: StateFlow<String> = type.flatMapLatest {
         when (it) {
             FiatQuoteType.Buy -> buyOperation.amount
             FiatQuoteType.Sell -> sellOperation.amount
         }
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, initialBuyAmount)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, currentOperation().defaultAmount)
 
     private val assetData: StateFlow<AssetData?> = assetId
         .flatMapLatest { getBuyAssetInfo(it) }
@@ -119,7 +122,8 @@ class FiatViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     val showFiatTypePicker = assetData
-        .map { it?.showFiatTypePicker() == true }
+        .filterNotNull()
+        .map { it.showFiatTypePicker() }
         .distinctUntilChanged()
         .onEach { showFiatTypePicker ->
             if (!showFiatTypePicker && type.value == FiatQuoteType.Sell) {
@@ -275,9 +279,6 @@ class FiatViewModel @Inject constructor(
     )
 
 }
-
-private fun Double.toAmountText(): String =
-    BigDecimal.valueOf(this).stripTrailingZeros().toPlainString()
 
 private fun AssetData.showFiatTypePicker() =
     metadata?.isSellEnabled == true

--- a/android/features/buy/viewmodels/src/test/kotlin/com/gemwallet/android/features/buy/viewmodels/FiatViewModelTest.kt
+++ b/android/features/buy/viewmodels/src/test/kotlin/com/gemwallet/android/features/buy/viewmodels/FiatViewModelTest.kt
@@ -164,7 +164,7 @@ class FiatViewModelTest {
 
     @Test
     fun `initial route amount overrides buy default`() = runTest(testDispatcher) {
-        val viewModel = createViewModel(initialAmount = 10.0)
+        val viewModel = createViewModel(initialAmount = 10)
 
         try {
             runCurrent()
@@ -239,6 +239,26 @@ class FiatViewModelTest {
     }
 
     @Test
+    fun `sell route arguments open sell with the requested amount`() = runTest(testDispatcher) {
+        assetDataFlow.value = null
+        val viewModel = createViewModel(initialAmount = 25, initialType = FiatQuoteType.Sell)
+
+        try {
+            runCurrent()
+            assertEquals(FiatQuoteType.Sell, viewModel.type.value)
+            assertEquals("25", viewModel.amount.value)
+
+            assetDataFlow.value = assetData(price = 100.0, isSellEnabled = true, available = OneBitcoin)
+            runCurrent()
+            assertEquals(FiatQuoteType.Sell, viewModel.type.value)
+            assertEquals("25", viewModel.amount.value)
+            assertEquals(FiatConfig.defaultBuyAmount.toString(), viewModel.buyOperation.amount.value)
+        } finally {
+            viewModel.viewModelScope.cancel()
+        }
+    }
+
+    @Test
     fun `random amount remains valid when current amount is at maximum`() = runTest(testDispatcher) {
         val viewModel = createViewModel()
 
@@ -270,11 +290,12 @@ class FiatViewModelTest {
         }
     }
 
-    private fun createViewModel(initialAmount: Double? = null): FiatViewModel {
+    private fun createViewModel(initialAmount: Int? = null, initialType: FiatQuoteType? = null): FiatViewModel {
         val arguments = mutableMapOf<String, Any>(
             RouteArgument.AssetId.key to asset.id.toIdentifier(),
         )
         initialAmount?.let { arguments[RouteArgument.FiatAmount.key] = it }
+        initialType?.let { arguments[RouteArgument.Type.key] = it }
         return FiatViewModel(
             getBuyQuotes = getBuyQuotes,
             getBuyQuoteUrl = getBuyQuoteUrl,

--- a/android/features/settings/settings/presents/src/main/kotlin/com/gemwallet/android/features/settings/settings/presents/views/SupportMessageBubble.kt
+++ b/android/features/settings/settings/presents/src/main/kotlin/com/gemwallet/android/features/settings/settings/presents/views/SupportMessageBubble.kt
@@ -48,7 +48,6 @@ import com.gemwallet.android.ui.components.list_item.ChevronIcon
 import com.gemwallet.android.ui.components.list_item.DropDownContextItem
 import com.gemwallet.android.ui.components.parseMarkdownToAnnotatedString
 import com.gemwallet.android.ui.icons.AppIcons
-import com.gemwallet.android.ui.open
 import com.gemwallet.android.ui.theme.compactIconSize
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.paddingHalfSmall
@@ -149,7 +148,7 @@ internal fun SupportMessageBubble(
                                     linkColor = linkColor,
                                     metaColor = metaColor,
                                     showTopDivider = hasText,
-                                    onClick = { uriHandler.open(context, it) },
+                                    onClick = uriHandler::openUri,
                                 )
                                 if (!hasText) {
                                     Box(

--- a/core/crates/primitives/src/deeplink.rs
+++ b/core/crates/primitives/src/deeplink.rs
@@ -9,9 +9,10 @@ const PATH_TOKENS: &str = "tokens";
 const PATH_PERPETUALS: &str = "perpetuals";
 const PATH_REWARDS: &str = "rewards";
 const PATH_JOIN: &str = "join";
-const PATH_RECEIVE: &str = "receive";
-const PATH_BUY: &str = "buy";
-const PATH_SELL: &str = "sell";
+const ACTION_RECEIVE: &str = "receive";
+const ACTION_BUY: &str = "buy";
+const ACTION_SELL: &str = "sell";
+const ACTION_SWAP: &str = "swap";
 
 const QUERY_CODE: &str = "code";
 const QUERY_AMOUNT: &str = "amount";
@@ -21,9 +22,10 @@ pub enum Deeplink {
     Asset { asset_id: AssetId },
     Perpetuals,
     Rewards { code: Option<String> },
-    Receive { asset_id: Option<AssetId> },
+    Receive { asset_id: AssetId },
     Buy { asset_id: AssetId, amount: Option<i32> },
     Sell { asset_id: AssetId, amount: Option<i32> },
+    Swap { asset_id: AssetId },
 }
 
 impl Deeplink {
@@ -45,25 +47,41 @@ impl Deeplink {
         let (component, params) = segments.split_first()?;
 
         let deeplink = match component.as_str() {
-            PATH_TOKENS => Deeplink::Asset {
-                asset_id: asset_id_from_segments(params)?,
-            },
+            PATH_TOKENS => Self::from_asset_segments(url, params)?,
             PATH_PERPETUALS => Deeplink::Perpetuals,
             PATH_REWARDS | PATH_JOIN => Deeplink::Rewards {
                 code: params.first().cloned().or_else(|| query_value(url, QUERY_CODE)),
             },
-            PATH_RECEIVE if params.is_empty() => Deeplink::Receive { asset_id: None },
-            PATH_RECEIVE => Deeplink::Receive {
-                asset_id: Some(asset_id_from_segments(params)?),
-            },
-            PATH_BUY => Deeplink::Buy {
-                asset_id: asset_id_from_segments(params)?,
+            _ => return None,
+        };
+        Some(deeplink)
+    }
+
+    fn from_asset_segments(url: &Url, segments: &[String]) -> Option<Self> {
+        match segments.split_last() {
+            Some((action, asset_segments)) if !asset_segments.is_empty() => Self::from_asset_action(url, asset_segments, action),
+            _ => None,
+        }
+        .or_else(|| {
+            Some(Deeplink::Asset {
+                asset_id: asset_id_from_segments(segments)?,
+            })
+        })
+    }
+
+    fn from_asset_action(url: &Url, segments: &[String], action: &str) -> Option<Self> {
+        let asset_id = asset_id_from_segments(segments)?;
+        let deeplink = match action {
+            ACTION_RECEIVE => Deeplink::Receive { asset_id },
+            ACTION_BUY => Deeplink::Buy {
+                asset_id,
                 amount: amount_from_query(url),
             },
-            PATH_SELL => Deeplink::Sell {
-                asset_id: asset_id_from_segments(params)?,
+            ACTION_SELL => Deeplink::Sell {
+                asset_id,
                 amount: amount_from_query(url),
             },
+            ACTION_SWAP => Deeplink::Swap { asset_id },
             _ => return None,
         };
         Some(deeplink)
@@ -71,12 +89,13 @@ impl Deeplink {
 
     fn path(&self) -> String {
         match self {
-            Deeplink::Asset { asset_id } => format!("/{PATH_TOKENS}{}", asset_path(asset_id)),
+            Deeplink::Asset { asset_id } => asset_path(asset_id, None, None),
             Deeplink::Perpetuals => format!("/{PATH_PERPETUALS}"),
             Deeplink::Rewards { code } => path_with_query(PATH_REWARDS, QUERY_CODE, code.clone()),
-            Deeplink::Receive { asset_id } => format!("/{PATH_RECEIVE}{}", asset_id.as_ref().map(asset_path).unwrap_or_default()),
-            Deeplink::Buy { asset_id, amount } => fiat_path(PATH_BUY, asset_id, *amount),
-            Deeplink::Sell { asset_id, amount } => fiat_path(PATH_SELL, asset_id, *amount),
+            Deeplink::Receive { asset_id } => asset_path(asset_id, Some(ACTION_RECEIVE), None),
+            Deeplink::Buy { asset_id, amount } => asset_path(asset_id, Some(ACTION_BUY), *amount),
+            Deeplink::Sell { asset_id, amount } => asset_path(asset_id, Some(ACTION_SELL), *amount),
+            Deeplink::Swap { asset_id } => asset_path(asset_id, Some(ACTION_SWAP), None),
         }
     }
 }
@@ -89,15 +108,15 @@ fn amount_from_query(url: &Url) -> Option<i32> {
     query_value(url, QUERY_AMOUNT)?.parse().ok().filter(|amount: &i32| *amount > 0)
 }
 
-fn asset_path(asset_id: &AssetId) -> String {
-    match &asset_id.token_id {
-        Some(token_id) => format!("/{}/{token_id}", asset_id.chain.as_ref()),
-        None => format!("/{}", asset_id.chain.as_ref()),
-    }
-}
-
-fn fiat_path(component: &str, asset_id: &AssetId, amount: Option<i32>) -> String {
-    let path = format!("/{component}{}", asset_path(asset_id));
+fn asset_path(asset_id: &AssetId, action: Option<&str>, amount: Option<i32>) -> String {
+    let asset = match &asset_id.token_id {
+        Some(token_id) => format!("{}/{token_id}", asset_id.chain.as_ref()),
+        None => asset_id.chain.as_ref().to_string(),
+    };
+    let path = match action {
+        Some(action) => format!("/{PATH_TOKENS}/{asset}/{action}"),
+        None => format!("/{PATH_TOKENS}/{asset}"),
+    };
     match amount {
         Some(amount) => format!("{path}?{QUERY_AMOUNT}={amount}"),
         None => path,
@@ -163,13 +182,12 @@ mod tests {
             .to_url(),
             "https://gemwallet.com/rewards?code=gemcoder"
         );
-        assert_eq!(Deeplink::Receive { asset_id: None }.to_url(), "https://gemwallet.com/receive");
         assert_eq!(
             Deeplink::Receive {
-                asset_id: Some(AssetId::from_chain(Chain::Bitcoin)),
+                asset_id: AssetId::from_chain(Chain::Bitcoin),
             }
             .to_url(),
-            "https://gemwallet.com/receive/bitcoin"
+            "https://gemwallet.com/tokens/bitcoin/receive"
         );
         assert_eq!(
             Deeplink::Buy {
@@ -177,15 +195,22 @@ mod tests {
                 amount: Some(100),
             }
             .to_url(),
-            "https://gemwallet.com/buy/bitcoin?amount=100"
+            "https://gemwallet.com/tokens/bitcoin/buy?amount=100"
         );
         assert_eq!(
             Deeplink::Sell {
-                asset_id: AssetId::from_chain(Chain::Solana),
+                asset_id: AssetId::token(Chain::Ethereum, "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
                 amount: None,
             }
             .to_url(),
-            "https://gemwallet.com/sell/solana"
+            "https://gemwallet.com/tokens/ethereum/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/sell"
+        );
+        assert_eq!(
+            Deeplink::Swap {
+                asset_id: AssetId::from_chain(Chain::Solana),
+            }
+            .to_url(),
+            "https://gemwallet.com/tokens/solana/swap"
         );
     }
 
@@ -260,36 +285,41 @@ mod tests {
         assert_eq!(Deeplink::from_url("not a url"), None);
     }
     #[test]
-    fn test_from_url_receive_buy_sell() {
-        assert_eq!(Deeplink::from_url("gem://receive"), Some(Deeplink::Receive { asset_id: None }));
+    fn test_from_url_asset_actions() {
         assert_eq!(
-            Deeplink::from_url("gem://receive/bitcoin"),
+            Deeplink::from_url("gem://tokens/bitcoin/receive"),
             Some(Deeplink::Receive {
-                asset_id: Some(AssetId::from_chain(Chain::Bitcoin)),
+                asset_id: AssetId::from_chain(Chain::Bitcoin),
             })
         );
         assert_eq!(
-            Deeplink::from_url("gem://buy/bitcoin?amount=100"),
+            Deeplink::from_url("gem://tokens/bitcoin/buy?amount=100"),
             Some(Deeplink::Buy {
                 asset_id: AssetId::from_chain(Chain::Bitcoin),
                 amount: Some(100),
             })
         );
         assert_eq!(
-            Deeplink::from_url("gem://sell/ethereum/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            Deeplink::from_url("gem://tokens/ethereum/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/sell"),
             Some(Deeplink::Sell {
                 asset_id: AssetId::token(Chain::Ethereum, "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
                 amount: None,
             })
         );
         assert_eq!(
-            Deeplink::from_url("gem://buy/bitcoin?amount=49.5"),
+            Deeplink::from_url("https://gemwallet.com/en/tokens/solana/swap"),
+            Some(Deeplink::Swap {
+                asset_id: AssetId::from_chain(Chain::Solana),
+            })
+        );
+        assert_eq!(
+            Deeplink::from_url("gem://tokens/bitcoin/buy?amount=49.5"),
             Some(Deeplink::Buy {
                 asset_id: AssetId::from_chain(Chain::Bitcoin),
                 amount: None,
             })
         );
-        assert_eq!(Deeplink::from_url("gem://receive/notachain"), None);
-        assert_eq!(Deeplink::from_url("gem://buy"), None);
+        assert_eq!(Deeplink::from_url("gem://tokens/buy"), None);
+        assert_eq!(Deeplink::from_url("gem://tokens/notachain/buy"), None);
     }
 }

--- a/core/crates/primitives/src/deeplink.rs
+++ b/core/crates/primitives/src/deeplink.rs
@@ -9,14 +9,21 @@ const PATH_TOKENS: &str = "tokens";
 const PATH_PERPETUALS: &str = "perpetuals";
 const PATH_REWARDS: &str = "rewards";
 const PATH_JOIN: &str = "join";
+const PATH_RECEIVE: &str = "receive";
+const PATH_BUY: &str = "buy";
+const PATH_SELL: &str = "sell";
 
 const QUERY_CODE: &str = "code";
+const QUERY_AMOUNT: &str = "amount";
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Deeplink {
     Asset { asset_id: AssetId },
     Perpetuals,
     Rewards { code: Option<String> },
+    Receive { asset_id: Option<AssetId> },
+    Buy { asset_id: AssetId, amount: Option<i32> },
+    Sell { asset_id: AssetId, amount: Option<i32> },
 }
 
 impl Deeplink {
@@ -39,11 +46,23 @@ impl Deeplink {
 
         let deeplink = match component.as_str() {
             PATH_TOKENS => Deeplink::Asset {
-                asset_id: AssetId::from(params.first()?.parse().ok()?, params.get(1).cloned()),
+                asset_id: asset_id_from_segments(params)?,
             },
             PATH_PERPETUALS => Deeplink::Perpetuals,
             PATH_REWARDS | PATH_JOIN => Deeplink::Rewards {
                 code: params.first().cloned().or_else(|| query_value(url, QUERY_CODE)),
+            },
+            PATH_RECEIVE if params.is_empty() => Deeplink::Receive { asset_id: None },
+            PATH_RECEIVE => Deeplink::Receive {
+                asset_id: Some(asset_id_from_segments(params)?),
+            },
+            PATH_BUY => Deeplink::Buy {
+                asset_id: asset_id_from_segments(params)?,
+                amount: amount_from_query(url),
+            },
+            PATH_SELL => Deeplink::Sell {
+                asset_id: asset_id_from_segments(params)?,
+                amount: amount_from_query(url),
             },
             _ => return None,
         };
@@ -52,13 +71,36 @@ impl Deeplink {
 
     fn path(&self) -> String {
         match self {
-            Deeplink::Asset { asset_id } => match &asset_id.token_id {
-                Some(token_id) => format!("/{PATH_TOKENS}/{}/{token_id}", asset_id.chain.as_ref()),
-                None => format!("/{PATH_TOKENS}/{}", asset_id.chain.as_ref()),
-            },
+            Deeplink::Asset { asset_id } => format!("/{PATH_TOKENS}{}", asset_path(asset_id)),
             Deeplink::Perpetuals => format!("/{PATH_PERPETUALS}"),
             Deeplink::Rewards { code } => path_with_query(PATH_REWARDS, QUERY_CODE, code.clone()),
+            Deeplink::Receive { asset_id } => format!("/{PATH_RECEIVE}{}", asset_id.as_ref().map(asset_path).unwrap_or_default()),
+            Deeplink::Buy { asset_id, amount } => fiat_path(PATH_BUY, asset_id, *amount),
+            Deeplink::Sell { asset_id, amount } => fiat_path(PATH_SELL, asset_id, *amount),
         }
+    }
+}
+
+fn asset_id_from_segments(segments: &[String]) -> Option<AssetId> {
+    Some(AssetId::from(segments.first()?.parse().ok()?, segments.get(1).cloned()))
+}
+
+fn amount_from_query(url: &Url) -> Option<i32> {
+    query_value(url, QUERY_AMOUNT)?.parse().ok().filter(|amount: &i32| *amount > 0)
+}
+
+fn asset_path(asset_id: &AssetId) -> String {
+    match &asset_id.token_id {
+        Some(token_id) => format!("/{}/{token_id}", asset_id.chain.as_ref()),
+        None => format!("/{}", asset_id.chain.as_ref()),
+    }
+}
+
+fn fiat_path(component: &str, asset_id: &AssetId, amount: Option<i32>) -> String {
+    let path = format!("/{component}{}", asset_path(asset_id));
+    match amount {
+        Some(amount) => format!("{path}?{QUERY_AMOUNT}={amount}"),
+        None => path,
     }
 }
 
@@ -120,6 +162,30 @@ mod tests {
             }
             .to_url(),
             "https://gemwallet.com/rewards?code=gemcoder"
+        );
+        assert_eq!(Deeplink::Receive { asset_id: None }.to_url(), "https://gemwallet.com/receive");
+        assert_eq!(
+            Deeplink::Receive {
+                asset_id: Some(AssetId::from_chain(Chain::Bitcoin)),
+            }
+            .to_url(),
+            "https://gemwallet.com/receive/bitcoin"
+        );
+        assert_eq!(
+            Deeplink::Buy {
+                asset_id: AssetId::from_chain(Chain::Bitcoin),
+                amount: Some(100),
+            }
+            .to_url(),
+            "https://gemwallet.com/buy/bitcoin?amount=100"
+        );
+        assert_eq!(
+            Deeplink::Sell {
+                asset_id: AssetId::from_chain(Chain::Solana),
+                amount: None,
+            }
+            .to_url(),
+            "https://gemwallet.com/sell/solana"
         );
     }
 
@@ -192,5 +258,38 @@ mod tests {
         assert_eq!(Deeplink::from_url("https://example.com/tokens/bitcoin"), None);
         assert_eq!(Deeplink::from_url("https://gemwallet.com/unknown"), None);
         assert_eq!(Deeplink::from_url("not a url"), None);
+    }
+    #[test]
+    fn test_from_url_receive_buy_sell() {
+        assert_eq!(Deeplink::from_url("gem://receive"), Some(Deeplink::Receive { asset_id: None }));
+        assert_eq!(
+            Deeplink::from_url("gem://receive/bitcoin"),
+            Some(Deeplink::Receive {
+                asset_id: Some(AssetId::from_chain(Chain::Bitcoin)),
+            })
+        );
+        assert_eq!(
+            Deeplink::from_url("gem://buy/bitcoin?amount=100"),
+            Some(Deeplink::Buy {
+                asset_id: AssetId::from_chain(Chain::Bitcoin),
+                amount: Some(100),
+            })
+        );
+        assert_eq!(
+            Deeplink::from_url("gem://sell/ethereum/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            Some(Deeplink::Sell {
+                asset_id: AssetId::token(Chain::Ethereum, "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+                amount: None,
+            })
+        );
+        assert_eq!(
+            Deeplink::from_url("gem://buy/bitcoin?amount=49.5"),
+            Some(Deeplink::Buy {
+                asset_id: AssetId::from_chain(Chain::Bitcoin),
+                amount: None,
+            })
+        );
+        assert_eq!(Deeplink::from_url("gem://receive/notachain"), None);
+        assert_eq!(Deeplink::from_url("gem://buy"), None);
     }
 }

--- a/core/crates/support/src/text.rs
+++ b/core/crates/support/src/text.rs
@@ -243,10 +243,10 @@ mod tests {
             }
         );
         assert_eq!(
-            parse_support_message_display_content("You can top up here: [Buy Bitcoin](gem://buy/bitcoin?amount=100)"),
+            parse_support_message_display_content("You can top up here: [Buy Bitcoin](gem://tokens/bitcoin/buy?amount=100)"),
             SupportMessageDisplayContent {
                 text: "You can top up here:".to_string(),
-                links: vec![link("Buy Bitcoin", "gem://buy/bitcoin?amount=100", None)],
+                links: vec![link("Buy Bitcoin", "gem://tokens/bitcoin/buy?amount=100", None)],
             }
         );
         assert_eq!(

--- a/core/crates/support/src/text.rs
+++ b/core/crates/support/src/text.rs
@@ -243,6 +243,13 @@ mod tests {
             }
         );
         assert_eq!(
+            parse_support_message_display_content("You can top up here: [Buy Bitcoin](gem://buy/bitcoin?amount=100)"),
+            SupportMessageDisplayContent {
+                text: "You can top up here:".to_string(),
+                links: vec![link("Buy Bitcoin", "gem://buy/bitcoin?amount=100", None)],
+            }
+        );
+        assert_eq!(
             parse_support_message_display_content("Here's the Bitcoin page: [Bitcoin](https://gemwallet.com/tokens/bitcoin)"),
             SupportMessageDisplayContent {
                 text: "Here's the Bitcoin page:".to_string(),

--- a/core/gemstone/src/deeplink.rs
+++ b/core/gemstone/src/deeplink.rs
@@ -5,6 +5,9 @@ pub enum Deeplink {
     Asset { asset_id: AssetId },
     Perpetuals,
     Rewards { code: Option<String> },
+    Receive { asset_id: Option<AssetId> },
+    Buy { asset_id: AssetId, amount: Option<i32> },
+    Sell { asset_id: AssetId, amount: Option<i32> },
 }
 
 #[uniffi::export]
@@ -20,6 +23,7 @@ pub fn deeplink_build_gem_url(deeplink: Deeplink) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use primitives::Chain;
 
     #[test]
     fn test_deeplink() {
@@ -28,5 +32,13 @@ mod tests {
         };
         assert_eq!(deeplink_build_url(rewards), "https://gemwallet.com/rewards?code=gemcoder");
         assert_eq!(deeplink_build_gem_url(Deeplink::Perpetuals), "gem://perpetuals");
+        assert_eq!(deeplink_build_gem_url(Deeplink::Receive { asset_id: None }), "gem://receive");
+        assert_eq!(
+            deeplink_build_gem_url(Deeplink::Buy {
+                asset_id: AssetId::from_chain(Chain::Bitcoin),
+                amount: Some(100),
+            }),
+            "gem://buy/bitcoin?amount=100"
+        );
     }
 }

--- a/core/gemstone/src/deeplink.rs
+++ b/core/gemstone/src/deeplink.rs
@@ -5,9 +5,10 @@ pub enum Deeplink {
     Asset { asset_id: AssetId },
     Perpetuals,
     Rewards { code: Option<String> },
-    Receive { asset_id: Option<AssetId> },
+    Receive { asset_id: AssetId },
     Buy { asset_id: AssetId, amount: Option<i32> },
     Sell { asset_id: AssetId, amount: Option<i32> },
+    Swap { asset_id: AssetId },
 }
 
 #[uniffi::export]
@@ -32,13 +33,12 @@ mod tests {
         };
         assert_eq!(deeplink_build_url(rewards), "https://gemwallet.com/rewards?code=gemcoder");
         assert_eq!(deeplink_build_gem_url(Deeplink::Perpetuals), "gem://perpetuals");
-        assert_eq!(deeplink_build_gem_url(Deeplink::Receive { asset_id: None }), "gem://receive");
         assert_eq!(
             deeplink_build_gem_url(Deeplink::Buy {
                 asset_id: AssetId::from_chain(Chain::Bitcoin),
                 amount: Some(100),
             }),
-            "gem://buy/bitcoin?amount=100"
+            "gem://tokens/bitcoin/buy?amount=100"
         );
     }
 }

--- a/docs/DEEPLINKS.md
+++ b/docs/DEEPLINKS.md
@@ -4,26 +4,29 @@ A deep link opens a screen inside the app. The same paths are served under two s
 
 ## Supported links
 
+An asset is written as `{chain}` for a coin and `{chain}/{token_id}` for a token. A screen for that asset is an action appended to its path.
+
 | Screen | Path | Parameters |
 |---|---|---|
-| Asset | `/tokens/{chain}[/{token_id}]` | Asset is required |
+| Asset | `/tokens/{asset}` | — |
+| Receive | `/tokens/{asset}/receive` | — |
+| Buy | `/tokens/{asset}/buy?amount={fiat}` | Amount is optional |
+| Sell | `/tokens/{asset}/sell?amount={fiat}` | Amount is optional |
+| Swap | `/tokens/{asset}/swap` | Opens swap with the asset to pay from |
 | Perpetuals | `/perpetuals` | — |
 | Rewards | `/rewards?code={code}`, `/join/{code}` | Referral code is optional |
-| Receive | `/receive[/{chain}[/{token_id}]]` | Without an asset the receive asset list opens |
-| Buy | `/buy/{chain}[/{token_id}]?amount={fiat}` | Asset is required, amount is optional |
-| Sell | `/sell/{chain}[/{token_id}]?amount={fiat}` | Asset is required, amount is optional |
 
 Examples:
 
 ```
-gem://receive
-gem://receive/bitcoin
-gem://buy/bitcoin?amount=100
-gem://sell/ethereum/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48?amount=49
-https://gemwallet.com/buy/solana?amount=25
+gem://tokens/bitcoin/receive
+gem://tokens/bitcoin/buy?amount=100
+gem://tokens/ethereum/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/sell?amount=49
+gem://tokens/solana/swap
+https://gemwallet.com/tokens/solana/buy?amount=25
 ```
 
-`amount` is a fiat amount in whole USD, not a crypto amount. Values that are not a positive whole number, including fractional ones like `49.5`, are ignored and the screen opens with its default amount. A locale segment in front of the path is accepted and skipped, so `https://gemwallet.com/zh-cn/buy/bitcoin` resolves like `https://gemwallet.com/buy/bitcoin`. A link with an unknown path, an unknown chain, or a missing required asset is not a deep link and opens in the browser.
+`amount` is a fiat amount in whole USD, not a crypto amount. Values that are not a positive whole number, including fractional ones like `49.5`, are ignored and the screen opens with its default amount. A locale segment in front of the path is accepted and skipped, so `https://gemwallet.com/zh-cn/tokens/bitcoin/buy` resolves like `https://gemwallet.com/tokens/bitcoin/buy`. Every action requires an asset. A link with an unknown path, an unknown chain, an unknown action, or a missing asset is not a deep link and opens in the browser.
 
 Sell also requires the asset to be sellable. A sell link for an asset without sell support falls back to buy on the same screen.
 
@@ -32,7 +35,7 @@ Sell also requires the asset to be sellable. A sell link for an asset without se
 Support chat messages are parsed in Core, and a link whose URL is a deep link is rendered as an in-app row and opens inside the app instead of the browser. This is the path chat agents use: emit a normal markdown link with a `gem://` or `https://gemwallet.com/` URL and the app routes it.
 
 ```markdown
-[Buy Bitcoin](gem://buy/bitcoin?amount=100)
+[Buy Bitcoin](gem://tokens/bitcoin/buy?amount=100)
 ```
 
 ## Implementation
@@ -48,6 +51,6 @@ Support chat messages are parsed in Core, and a link whose URL is a deep link is
 
 `https://gemwallet.com/` links only reach the app when the website serves them and publishes the app association files. Both platforms verify the association from the domain, so a new path works as a web link before it works as an app link.
 
-- `https://gemwallet.com/.well-known/apple-app-site-association` must list the paths for the iOS app
+- `https://gemwallet.com/.well-known/apple-app-site-association` must list `/tokens/*` for the iOS app
 - `https://gemwallet.com/.well-known/assetlinks.json` must list the Android package and signing certificate
-- The site should serve `/receive`, `/buy/*`, and `/sell/*` so the link is not a dead page for people without the app
+- The action paths hang off `/tokens/*`, which the site already serves, so `/tokens/bitcoin/buy` should resolve rather than 404 for people without the app

--- a/docs/DEEPLINKS.md
+++ b/docs/DEEPLINKS.md
@@ -1,0 +1,53 @@
+# Deep links
+
+A deep link opens a screen inside the app. The same paths are served under two schemes: `gem://` is handled only by the app, `https://gemwallet.com/` is a universal link on iOS and an Android App Link.
+
+## Supported links
+
+| Screen | Path | Parameters |
+|---|---|---|
+| Asset | `/tokens/{chain}[/{token_id}]` | Asset is required |
+| Perpetuals | `/perpetuals` | — |
+| Rewards | `/rewards?code={code}`, `/join/{code}` | Referral code is optional |
+| Receive | `/receive[/{chain}[/{token_id}]]` | Without an asset the receive asset list opens |
+| Buy | `/buy/{chain}[/{token_id}]?amount={fiat}` | Asset is required, amount is optional |
+| Sell | `/sell/{chain}[/{token_id}]?amount={fiat}` | Asset is required, amount is optional |
+
+Examples:
+
+```
+gem://receive
+gem://receive/bitcoin
+gem://buy/bitcoin?amount=100
+gem://sell/ethereum/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48?amount=49
+https://gemwallet.com/buy/solana?amount=25
+```
+
+`amount` is a fiat amount in whole USD, not a crypto amount. Values that are not a positive whole number, including fractional ones like `49.5`, are ignored and the screen opens with its default amount. A locale segment in front of the path is accepted and skipped, so `https://gemwallet.com/zh-cn/buy/bitcoin` resolves like `https://gemwallet.com/buy/bitcoin`. A link with an unknown path, an unknown chain, or a missing required asset is not a deep link and opens in the browser.
+
+Sell also requires the asset to be sellable. A sell link for an asset without sell support falls back to buy on the same screen.
+
+## Links in the support chat
+
+Support chat messages are parsed in Core, and a link whose URL is a deep link is rendered as an in-app row and opens inside the app instead of the browser. This is the path chat agents use: emit a normal markdown link with a `gem://` or `https://gemwallet.com/` URL and the app routes it.
+
+```markdown
+[Buy Bitcoin](gem://buy/bitcoin?amount=100)
+```
+
+## Implementation
+
+- [Deep link parsing and building](../core/crates/primitives/src/deeplink.rs)
+- [URL action routing](../core/crates/primitives/src/url_action.rs) — WalletConnect and deep links are routed before payments
+- [UniFFI bridge](../core/gemstone/src/deeplink.rs)
+- [Support message links](../core/crates/support/src/text.rs)
+- iOS: [`NavigationHandler`](../ios/Gem/Navigation/NavigationHandler.swift), schemes and associated domains in `ios/Gem/Resources/Info.plist` and `ios/Gem/Resources/Gem.entitlements`
+- Android: [`WebDeepLinks`](../android/app/src/main/kotlin/com/gemwallet/android/WebDeepLinks.kt), intent filters in `android/app/src/main/AndroidManifest.xml`
+
+## Web requirements
+
+`https://gemwallet.com/` links only reach the app when the website serves them and publishes the app association files. Both platforms verify the association from the domain, so a new path works as a web link before it works as an app link.
+
+- `https://gemwallet.com/.well-known/apple-app-site-association` must list the paths for the iOS app
+- `https://gemwallet.com/.well-known/assetlinks.json` must list the Android package and signing certificate
+- The site should serve `/receive`, `/buy/*`, and `/sell/*` so the link is not a dead page for people without the app

--- a/ios/Gem/Navigation/NavigationHandler.swift
+++ b/ios/Gem/Navigation/NavigationHandler.swift
@@ -108,6 +108,15 @@ extension NavigationHandler {
 
         case let .rewards(code):
             navigationState.settings.append(Scenes.Referral(code: code))
+
+        case let .receive(assetId):
+            try await presentReceive(assetId: assetId)
+
+        case let .buy(assetId, amount):
+            try await presentFiat(type: .buy, assetId: assetId, amount: amount)
+
+        case let .sell(assetId, amount):
+            try await presentFiat(type: .sell, assetId: assetId, amount: amount)
         }
 
         selectTab(for: deeplink.selectTab)
@@ -167,7 +176,7 @@ extension NavigationHandler {
         case let .priceAlert(assetId):
             try await navigateToAsset(assetId)
         case let .buyAsset(assetId, amount):
-            try await presentBuy(assetId: assetId, amount: amount)
+            try await presentFiat(type: .buy, assetId: assetId, amount: amount)
         case let .swapAsset(fromId, toId):
             try await presentSwap(from: fromId, to: toId)
         case .support:
@@ -266,9 +275,22 @@ extension NavigationHandler {
         try await presenter.presentSwap(from: fromId, to: toId, wallet: wallet, assetsService: assetsService)
     }
 
-    private func presentBuy(assetId: AssetId, amount: Int?) async throws {
+    private func presentFiat(type: FiatQuoteType, assetId: AssetId, amount: Int?) async throws {
         let asset = try await assetsService.getOrFetchAsset(for: assetId)
-        try presentAssetInput(type: .buy(asset, amount: amount), for: asset)
+        let selectedType: SelectedAssetType = switch type {
+        case .buy: .buy(asset, amount: amount)
+        case .sell: .sell(asset, amount: amount)
+        }
+        try presentAssetInput(type: selectedType, for: asset)
+    }
+
+    private func presentReceive(assetId: AssetId?) async throws {
+        guard let assetId else {
+            presenter.isPresentingPayment.wrappedValue = .selectAsset(.receive(.asset), chains: [])
+            return
+        }
+        let asset = try await assetsService.getOrFetchAsset(for: assetId)
+        try presentAssetInput(type: .receive(.asset), for: asset)
     }
 
     private func presentAssetInput(type: SelectedAssetType, for asset: Asset) throws {
@@ -289,6 +311,7 @@ private extension DeepLink {
         switch self {
         case .asset, .perpetuals: .wallet
         case .rewards: .settings
+        case .receive, .buy, .sell: nil
         }
     }
 }

--- a/ios/Gem/Navigation/NavigationHandler.swift
+++ b/ios/Gem/Navigation/NavigationHandler.swift
@@ -117,6 +117,9 @@ extension NavigationHandler {
 
         case let .sell(assetId, amount):
             try await presentFiat(type: .sell, assetId: assetId, amount: amount)
+
+        case let .swap(assetId):
+            try await presentSwap(from: assetId, to: .none)
         }
 
         selectTab(for: deeplink.selectTab)
@@ -284,11 +287,7 @@ extension NavigationHandler {
         try presentAssetInput(type: selectedType, for: asset)
     }
 
-    private func presentReceive(assetId: AssetId?) async throws {
-        guard let assetId else {
-            presenter.isPresentingPayment.wrappedValue = .selectAsset(.receive(.asset), chains: [])
-            return
-        }
+    private func presentReceive(assetId: AssetId) async throws {
         let asset = try await assetsService.getOrFetchAsset(for: assetId)
         try presentAssetInput(type: .receive(.asset), for: asset)
     }
@@ -311,7 +310,7 @@ private extension DeepLink {
         switch self {
         case .asset, .perpetuals: .wallet
         case .rewards: .settings
-        case .receive, .buy, .sell: nil
+        case .receive, .buy, .sell, .swap: nil
         }
     }
 }

--- a/ios/Gem/Navigation/NavigationPresenter.swift
+++ b/ios/Gem/Navigation/NavigationPresenter.swift
@@ -46,7 +46,7 @@ extension NavigationPresenter {
         let account = try wallet.account(for: asset.chain)
         isPresentingAssetInput.wrappedValue = SelectedAssetInput(
             type: type,
-            assetData: .with(asset: account.chain.asset, account: account),
+            assetData: .with(asset: asset, account: account),
         )
     }
 

--- a/ios/Packages/GemstonePrimitives/Sources/Extensions/DeepLink+GemstoneSwift.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/Extensions/DeepLink+GemstoneSwift.swift
@@ -18,9 +18,10 @@ public extension Primitives.DeepLink {
         case let .asset(assetId): .asset(assetId: assetId.identifier)
         case .perpetuals: .perpetuals
         case let .rewards(code): .rewards(code: code)
-        case let .receive(assetId): .receive(assetId: assetId?.identifier)
+        case let .receive(assetId): .receive(assetId: assetId.identifier)
         case let .buy(assetId, amount): .buy(assetId: assetId.identifier, amount: amount.map(\.asInt32))
         case let .sell(assetId, amount): .sell(assetId: assetId.identifier, amount: amount.map(\.asInt32))
+        case let .swap(assetId): .swap(assetId: assetId.identifier)
         }
     }
 }
@@ -31,9 +32,10 @@ public extension Gemstone.Deeplink {
         case let .asset(assetId): try .asset(AssetId(id: assetId))
         case .perpetuals: .perpetuals
         case let .rewards(code): .rewards(code: code)
-        case let .receive(assetId): try .receive(assetId.map { try AssetId(id: $0) })
+        case let .receive(assetId): try .receive(AssetId(id: assetId))
         case let .buy(assetId, amount): try .buy(AssetId(id: assetId), amount: amount.map(\.asInt))
         case let .sell(assetId, amount): try .sell(AssetId(id: assetId), amount: amount.map(\.asInt))
+        case let .swap(assetId): try .swap(AssetId(id: assetId))
         }
     }
 }

--- a/ios/Packages/GemstonePrimitives/Sources/Extensions/DeepLink+GemstoneSwift.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/Extensions/DeepLink+GemstoneSwift.swift
@@ -18,6 +18,9 @@ public extension Primitives.DeepLink {
         case let .asset(assetId): .asset(assetId: assetId.identifier)
         case .perpetuals: .perpetuals
         case let .rewards(code): .rewards(code: code)
+        case let .receive(assetId): .receive(assetId: assetId?.identifier)
+        case let .buy(assetId, amount): .buy(assetId: assetId.identifier, amount: amount.map(\.asInt32))
+        case let .sell(assetId, amount): .sell(assetId: assetId.identifier, amount: amount.map(\.asInt32))
         }
     }
 }
@@ -28,6 +31,9 @@ public extension Gemstone.Deeplink {
         case let .asset(assetId): try .asset(AssetId(id: assetId))
         case .perpetuals: .perpetuals
         case let .rewards(code): .rewards(code: code)
+        case let .receive(assetId): try .receive(assetId.map { try AssetId(id: $0) })
+        case let .buy(assetId, amount): try .buy(AssetId(id: assetId), amount: amount.map(\.asInt))
+        case let .sell(assetId, amount): try .sell(AssetId(id: assetId), amount: amount.map(\.asInt))
         }
     }
 }

--- a/ios/Packages/Primitives/Sources/DeepLink.swift
+++ b/ios/Packages/Primitives/Sources/DeepLink.swift
@@ -6,7 +6,8 @@ public enum DeepLink: Equatable, Sendable {
     case asset(AssetId)
     case perpetuals
     case rewards(code: String?)
-    case receive(AssetId?)
+    case receive(AssetId)
     case buy(AssetId, amount: Int?)
     case sell(AssetId, amount: Int?)
+    case swap(AssetId)
 }

--- a/ios/Packages/Primitives/Sources/DeepLink.swift
+++ b/ios/Packages/Primitives/Sources/DeepLink.swift
@@ -6,4 +6,7 @@ public enum DeepLink: Equatable, Sendable {
     case asset(AssetId)
     case perpetuals
     case rewards(code: String?)
+    case receive(AssetId?)
+    case buy(AssetId, amount: Int?)
+    case sell(AssetId, amount: Int?)
 }


### PR DESCRIPTION
Adds deep links that open the receive, buy, sell and swap screens for an asset.

An asset is written as it already is in a link, `tokens/bitcoin` for a coin or `tokens/ethereum/<contract>` for a token, and the screen is an action on the end of it:

- `gem://tokens/bitcoin/receive` opens the address
- `gem://tokens/bitcoin/buy?amount=100` and `gem://tokens/bitcoin/sell?amount=25` open the fiat screen with the asset and the amount already filled in
- `gem://tokens/bitcoin/swap` opens swap with the asset to pay from
- the same paths work under `gemwallet.com`

An asset is required, the amount is optional and is a whole number of dollars.

Links like these in the support chat now open inside the app instead of the browser.

<img width="320" alt="Buy USDC from a deep link" src="" />
<img width="320" alt="Sell Bitcoin from a deep link" src="" />

Closes #901