### PR TITLE
Reuse AssetSelectScreen in manage and swap asset select

### DIFF
--- a/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/AssetSelectScreen.kt
+++ b/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/AssetSelectScreen.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.asset_select.presents.views
 
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -11,6 +12,7 @@ import com.gemwallet.android.domains.asset.aggregates.AssetInfoDataAggregate
 import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.features.asset_select.viewmodels.BaseAssetSelectViewModel
 import com.gemwallet.android.features.asset_select.viewmodels.RecentsSheetViewModel
+import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.AssetSubtype
 import kotlinx.collections.immutable.toImmutableList
@@ -27,6 +29,7 @@ fun AssetSelectScreen(
     itemTrailing: (@Composable (AssetInfoDataAggregate) -> Unit)? = null,
     itemSupport: ((AssetInfoDataAggregate) -> (@Composable () -> Unit)?)? = null,
     onAddAsset: (() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {},
     viewModel: BaseAssetSelectViewModel,
     recentsViewModel: RecentsSheetViewModel = hiltViewModel(),
 ) {
@@ -66,7 +69,11 @@ fun AssetSelectScreen(
             emptyList<AssetInfoDataAggregate>().toImmutableList()
         },
         unpinned = unpinned,
-        recent = recent,
+        recent = if (onSelectRecent == null) {
+            emptyList<Asset>().toImmutableList()
+        } else {
+            recent
+        },
         state = uiStates,
         isAddAvailable = isAddAvailable && onAddAsset != null,
         availableChains = availableChains,
@@ -79,7 +86,7 @@ fun AssetSelectScreen(
                 AssetSelectAction.ClearFilters -> viewModel.onClearFilters()
                 is AssetSelectAction.Select -> selectAsset?.invoke(action.assetId)
                 is AssetSelectAction.SelectRecent -> onSelectRecent?.invoke(action.assetId)
-                AssetSelectAction.OpenRecentsSheet -> recentsViewModel.show(filters = viewModel.assetFilters())
+                AssetSelectAction.OpenRecentsSheet -> recentsViewModel.show(filters = viewModel.assetFilters(), types = viewModel.recentTypes)
                 AssetSelectAction.Cancel -> onCancel()
                 AssetSelectAction.AddAsset -> onAddAsset?.invoke()
                 AssetSelectAction.ShowAllAssets -> Unit
@@ -87,6 +94,7 @@ fun AssetSelectScreen(
         },
         recentsSheetEnabled = onSelectRecent != null,
         itemTrailing = itemTrailing,
+        actions = actions,
     )
 
     if (onSelectRecent != null) {

--- a/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/AssetsManageScreen.kt
+++ b/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/AssetsManageScreen.kt
@@ -3,27 +3,17 @@ package com.gemwallet.android.features.asset_select.presents.views
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.gemwallet.android.ext.networkName
-import com.gemwallet.android.ext.type
 import com.gemwallet.android.ui.R
-import com.gemwallet.android.ui.components.list_item.AssetContextActions
-import com.gemwallet.android.domains.asset.aggregates.AssetInfoDataAggregate
-import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.ui.icons.AppIcons
-import com.wallet.core.primitives.Asset
 import com.gemwallet.android.features.asset_select.viewmodels.AssetSelectViewModel
 import com.wallet.core.primitives.AssetId
-import com.wallet.core.primitives.AssetSubtype
 import com.wallet.core.primitives.Chain
-import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun AssetsManageScreen(
@@ -38,52 +28,12 @@ fun AssetsManageScreen(
     }
 
     val isAddAssetAvailable by viewModel.isAddAssetAvailable.collectAsStateWithLifecycle()
-    val uiStates by viewModel.uiState.collectAsStateWithLifecycle()
-    val pinned by viewModel.pinned.collectAsStateWithLifecycle()
-    val unpinned by viewModel.unpinned.collectAsStateWithLifecycle()
 
-    val availableChains by viewModel.availableChains.collectAsStateWithLifecycle()
-    val chainsFilter by viewModel.chainFilter.collectAsStateWithLifecycle()
-    val balanceFilter by viewModel.balanceFilter.collectAsStateWithLifecycle()
-
-    AssetSelectScene(
-        title = {
-            Text(
-                text = stringResource(id = R.string.wallet_manage_token_list),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        },
+    AssetSelectScreen(
+        title = stringResource(id = R.string.wallet_manage_token_list),
         titleBadge = ::getAssetBadge,
-        support = {
-            if (it.asset.id.type() == AssetSubtype.NATIVE) null else {
-                { ListItemSupportText(it.asset.id.chain.networkName()) }
-            }
-        },
-        query = viewModel.queryState,
-        pinned = pinned,
-        popular = emptyList<AssetInfoDataAggregate>().toImmutableList(),
-        unpinned = unpinned,
-        recent = emptyList<Asset>().toImmutableList(),
-        state = uiStates,
-        isAddAvailable = isAddAssetAvailable,
-        availableChains = availableChains,
-        chainsFilter = chainsFilter,
-        balanceFilter = balanceFilter,
-        searchable = true,
-        onAction = { action ->
-            when (action) {
-                is AssetSelectAction.ChainFilter -> viewModel.onChainFilter(action.chain)
-                is AssetSelectAction.BalanceFilter -> viewModel.onBalanceFilter(action.onlyWithBalance)
-                AssetSelectAction.ClearFilters -> viewModel.onClearFilters()
-                AssetSelectAction.Cancel -> onCancel()
-                AssetSelectAction.AddAsset -> onAddAsset()
-                is AssetSelectAction.Select,
-                is AssetSelectAction.SelectRecent,
-                AssetSelectAction.OpenRecentsSheet,
-                AssetSelectAction.ShowAllAssets -> Unit
-            }
-        },
+        onCancel = onCancel,
+        onAddAsset = onAddAsset,
         actions = {
             if (isAddAssetAvailable) {
                 IconButton(onClick = onAddAsset) {
@@ -97,6 +47,6 @@ fun AssetsManageScreen(
                 onCheckedChange = { viewModel.onChangeVisibility(asset.asset.id, it) },
             )
         },
-        contextActions = AssetContextActions.Empty,
+        viewModel = viewModel,
     )
 }

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapSelectScreen.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapSelectScreen.kt
@@ -5,22 +5,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.gemwallet.android.ext.networkName
-import com.gemwallet.android.ext.type
 import com.gemwallet.android.ui.R
-import com.gemwallet.android.domains.asset.aggregates.AssetInfoDataAggregate
-import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.ui.components.list_item.getBalanceInfo
-import com.gemwallet.android.features.asset_select.presents.views.AssetSelectAction
-import com.gemwallet.android.features.asset_select.presents.views.AssetSelectScene
-import com.gemwallet.android.features.asset_select.presents.views.RecentsSheetHost
+import com.gemwallet.android.features.asset_select.presents.views.AssetSelectScreen
 import com.gemwallet.android.features.asset_select.viewmodels.RecentsSheetViewModel
 import com.gemwallet.android.features.swap.viewmodels.SwapSelectViewModel
 import com.gemwallet.android.domains.swap.SwapItemType
 import com.gemwallet.android.model.RecentType
 import com.wallet.core.primitives.AssetId
-import com.wallet.core.primitives.AssetSubtype
-import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun SwapSelectScreen(
@@ -29,13 +21,6 @@ fun SwapSelectScreen(
     viewModel: SwapSelectViewModel = hiltViewModel(),
     recentsViewModel: RecentsSheetViewModel = hiltViewModel(),
 ) {
-    val uiStates by viewModel.uiState.collectAsStateWithLifecycle()
-    val pinned by viewModel.pinned.collectAsStateWithLifecycle()
-    val unpinned by viewModel.unpinned.collectAsStateWithLifecycle()
-    val recent by viewModel.recent.collectAsStateWithLifecycle()
-    val availableChains by viewModel.availableChains.collectAsStateWithLifecycle()
-    val chainsFilter by viewModel.chainFilter.collectAsStateWithLifecycle()
-    val balanceFilter by viewModel.balanceFilter.collectAsStateWithLifecycle()
     val select by viewModel.select.collectAsStateWithLifecycle()
     val payId by viewModel.payAssetId.collectAsStateWithLifecycle()
     val receiveId by viewModel.receiveAssetId.collectAsStateWithLifecycle()
@@ -47,45 +32,18 @@ fun SwapSelectScreen(
         }
     }
 
-    AssetSelectScene(
+    AssetSelectScreen(
         title = when (select) {
             SwapItemType.Pay -> stringResource(id = R.string.swap_you_pay)
             SwapItemType.Receive -> stringResource(id = R.string.swap_you_receive)
         },
         titleBadge = { null },
-        query = viewModel.queryState,
-        popular = emptyList<AssetInfoDataAggregate>().toImmutableList(),
-        pinned = pinned,
-        unpinned = unpinned,
-        recent = recent,
-        state = uiStates,
-        availableChains = availableChains,
-        chainsFilter = chainsFilter,
-        balanceFilter = balanceFilter,
-        onAction = { action ->
-            when (action) {
-                is AssetSelectAction.ChainFilter -> viewModel.onChainFilter(action.chain)
-                is AssetSelectAction.BalanceFilter -> viewModel.onBalanceFilter(action.onlyWithBalance)
-                AssetSelectAction.ClearFilters -> viewModel.onClearFilters()
-                is AssetSelectAction.Select -> {
-                    viewModel.updateRecent(action.assetId, RecentType.SwapSelect)
-                    onSelectAsset(action.assetId)
-                }
-                is AssetSelectAction.SelectRecent -> onSelectAsset(action.assetId)
-                AssetSelectAction.OpenRecentsSheet -> recentsViewModel.show(filters = viewModel.assetFilters(), types = viewModel.recentTypes)
-                AssetSelectAction.Cancel -> onCancel()
-                AssetSelectAction.AddAsset,
-                AssetSelectAction.ShowAllAssets -> Unit
-            }
-        },
-        recentsSheetEnabled = true,
+        recentType = RecentType.SwapSelect,
+        onCancel = onCancel,
+        onSelect = onSelectAsset,
+        onSelectRecent = onSelectAsset,
         itemTrailing = { getBalanceInfo(it)() },
-        support = {
-            if (it.asset.id.type() == AssetSubtype.NATIVE) null else {
-                @Composable { ListItemSupportText(it.asset.id.chain.networkName()) }
-            }
-        },
+        viewModel = viewModel,
+        recentsViewModel = recentsViewModel,
     )
-
-    RecentsSheetHost(viewModel = recentsViewModel, onSelect = onSelectAsset)
 }


### PR DESCRIPTION
The manage tokens screen and the swap asset select screen each rebuilt the wiring that AssetSelectScreen already does. Both now go through it, so there is one place connecting the asset select view model to the screen.

No visible changes.