### PR TITLE
Fix Rewards input hidden by keyboard

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/filters/FormDialog.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/filters/FormDialog.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -98,7 +97,7 @@ fun FormDialog(
             }
         },
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
+        Column {
             if (bottomAction == null) {
                 content()
             } else {


### PR DESCRIPTION
On the Rewards screen the username and referral code sheets opened at half the screen and stayed there when the keyboard appeared, so the input ended up under the keyboard. Reported on a Samsung device, but it happens on any phone with a tall keyboard or a larger display size.

The sheet is now sized by its content, so it sits right above the keyboard.

<img width="320" alt="pr940-create-username" src="https://github.com/user-attachments/assets/98f5916a-2d62-47c2-8ece-974809d82288" />
<img width="320" alt="pr940-redeem-code" src="https://github.com/user-attachments/assets/300c1bba-938e-4219-a6a7-f096f1b90232" />
