### PR TITLE
Keep selected swap provider across quote refresh

### DIFF
--- a/ios/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
+++ b/ios/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
@@ -424,7 +424,7 @@ extension SwapSceneViewModel {
 
             guard !isTransferDataLoading, currentInput == input else { return }
             swapState.quotes = .data(swapQuotes)
-            selectedSwapQuote = swapQuotes.first(where: { $0 == selectedSwapQuote }) ?? swapQuotes.first
+            selectedSwapQuote = swapQuotes.first(where: { $0.data.provider.id == selectedSwapQuote?.data.provider.id }) ?? swapQuotes.first
             if let selectedSwapQuote, let asset = toAsset?.asset {
                 applyQuote(selectedSwapQuote, asset: asset)
             }

--- a/ios/Features/Swap/Tests/SwapTests/SwapSceneViewModelTests.swift
+++ b/ios/Features/Swap/Tests/SwapTests/SwapSceneViewModelTests.swift
@@ -266,6 +266,34 @@ struct SwapSceneViewModelTests {
     }
 
     @Test
+    func refreshedQuotesKeepSelectedProvider() async {
+        let swapper = GemSwapperMock(
+            quotes: [
+                .mock(toValue: "260000000000", provider: .uniswapV3),
+                .mock(toValue: "250000000000", provider: .thorchain),
+            ],
+        )
+        let model = SwapSceneViewModel.mock(swapper: swapper)
+
+        model.onFinishSwapProviderSelection(.mock(toValue: "249000000000", provider: .thorchain))
+        await model.fetch()
+
+        #expect(model.selectedSwapQuote?.data.provider.id == .thorchain)
+        #expect(model.selectedSwapQuote?.toValue == "250000000000")
+    }
+
+    @Test
+    func refreshedQuotesFallBackWhenSelectedProviderDisappears() async {
+        let swapper = GemSwapperMock(quotes: [.mock(toValue: "260000000000", provider: .uniswapV3)])
+        let model = SwapSceneViewModel.mock(swapper: swapper)
+
+        model.onFinishSwapProviderSelection(.mock(toValue: "249000000000", provider: .thorchain))
+        await model.fetch()
+
+        #expect(model.selectedSwapQuote?.data.provider.id == .uniswapV3)
+    }
+
+    @Test
     func slippagePersistsAcrossSessions() {
         let preferences = Preferences.mock()
         let model = SwapSceneViewModel.mock(preferences: preferences)

--- a/ios/Packages/FeatureServices/SwapService/TestKit/Types+Mock/SwapperProviderData+TestKit.swift
+++ b/ios/Packages/FeatureServices/SwapService/TestKit/Types+Mock/SwapperProviderData+TestKit.swift
@@ -1,13 +1,14 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
+import enum Gemstone.SwapperProvider
 import struct Gemstone.SwapperProviderData
 import struct Gemstone.SwapperRoute
 
 extension SwapperProviderData {
-    static func mock() -> SwapperProviderData {
+    static func mock(provider: SwapperProvider = .pancakeswapV3) -> SwapperProviderData {
         SwapperProviderData(
-            provider: .mock(),
+            provider: .mock(id: provider),
             slippageBps: 50,
             routes: [.mock()],
         )

--- a/ios/Packages/FeatureServices/SwapService/TestKit/Types+Mock/SwapperProviderType+TestKit.swift
+++ b/ios/Packages/FeatureServices/SwapService/TestKit/Types+Mock/SwapperProviderType+TestKit.swift
@@ -5,9 +5,9 @@ import enum Gemstone.SwapperProvider
 import struct Gemstone.SwapperProviderType
 
 public extension SwapperProviderType {
-    static func mock() -> SwapperProviderType {
+    static func mock(id: SwapperProvider = .pancakeswapV3) -> SwapperProviderType {
         SwapperProviderType(
-            id: .pancakeswapV3,
+            id: id,
             name: "PancakeSwap",
             protocol: "v3",
             protocolId: "pancakeswap_v3",

--- a/ios/Packages/FeatureServices/SwapService/TestKit/Types+Mock/SwapperQuote+TestKit.swift
+++ b/ios/Packages/FeatureServices/SwapService/TestKit/Types+Mock/SwapperQuote+TestKit.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
+import enum Gemstone.SwapperProvider
 import struct Gemstone.SwapperQuote
 
 public extension SwapperQuote {
@@ -8,13 +9,14 @@ public extension SwapperQuote {
         fromValue: String = "1000000000000000000",
         minFromValue: String? = nil,
         toValue: String = "250000000000",
+        provider: SwapperProvider = .pancakeswapV3,
         etaInSeconds: UInt32? = nil,
     ) -> SwapperQuote {
         SwapperQuote(
             fromValue: fromValue,
             minFromValue: minFromValue,
             toValue: toValue,
-            data: .mock(),
+            data: .mock(provider: provider),
             request: .mock(),
             etaInSeconds: etaInSeconds,
         )


### PR DESCRIPTION
Picking a swap provider no longer gets undone by the automatic quote refresh.

Before this, the choice was matched against the whole previous quote, so any change in the rate made it stop matching and the app silently fell back to the best-rate quote. Now the choice is matched by the provider itself, and the fallback only happens when that provider is missing from the new quotes.