### PR TITLE
Keep two decimals in abbreviated values

### DIFF
--- a/android/blockchain/src/androidTest/kotlin/com/gemwallet/android/blockchain/TestFormatter.kt
+++ b/android/blockchain/src/androidTest/kotlin/com/gemwallet/android/blockchain/TestFormatter.kt
@@ -5,6 +5,7 @@ import com.gemwallet.android.model.ValueFormatter
 import com.wallet.core.primitives.Currency
 import junit.framework.TestCase.assertEquals
 import org.junit.Test
+import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.Locale
 
@@ -12,24 +13,35 @@ class TestFormatter {
     @Test
     fun testCompactFormat_Italy() {
         val formatter = CurrencyFormatter(type = CurrencyFormatter.Type.Abbreviated, currency = Currency.EUR, locale = Locale.ITALY)
-        assertEquals("5 Mio €", formatter.string(5_000_000.0))
-        assertEquals("7,9 Mrd €", formatter.string(7_890_000_000.0))
-        assertEquals("1,2 Bln €", formatter.string(1_200_000_000_000.0))
+        assertEquals("5\u00A0Mln\u00A0€", formatter.string(5_000_000.0))
+        assertEquals("7,89\u00A0Mld\u00A0€", formatter.string(7_890_000_000.0))
+        assertEquals("1,2\u00A0Bln\u00A0€", formatter.string(1_200_000_000_000.0))
     }
 
     @Test
     fun testCompactFormat_Usd() {
         val formatter = CurrencyFormatter(type = CurrencyFormatter.Type.Abbreviated, currency = Currency.USD, locale = Locale.US)
         assertEquals("\$5M", formatter.string(5_000_000.0))
-        assertEquals("\$7.9B", formatter.string(7_890_000_000.0))
+        assertEquals("\$7.89B", formatter.string(7_890_000_000.0))
         assertEquals("\$1.2T", formatter.string(1_200_000_000_000.0))
-        assertEquals("\$20M", formatter.string(1.9876725E7))
+        assertEquals("\$19.87M", formatter.string(1.9876725E7))
     }
 
     @Test
     fun testCompactBalance_Usd() {
         val formatter = ValueFormatter(style = ValueFormatter.Style.Short, locale = Locale.US)
-        assertEquals("120K USDC", formatter.string(BigInteger.valueOf(123_456_789_100L), decimals = 6, currency = "USDC"))
+        assertEquals("123.45K USDC", formatter.string(BigInteger.valueOf(123_456_789_100L), decimals = 6, currency = "USDC"))
         assertEquals("1.5M USDC", formatter.string(BigInteger.valueOf(1_500_000_000_000L), decimals = 6, currency = "USDC"))
+    }
+
+    @Test
+    fun testCompactKeepsDigitsWithoutRounding() {
+        val formatter = ValueFormatter(style = ValueFormatter.Style.Short, locale = Locale.US)
+        assertEquals("267.12K BTC", formatter.string(BigDecimal("267123.456"), currency = "BTC"))
+        assertEquals("20.07M BTC", formatter.string(BigDecimal("20070000"), currency = "BTC"))
+        assertEquals("19.87M BTC", formatter.string(BigDecimal("19876725"), currency = "BTC"))
+
+        val currencyFormatter = CurrencyFormatter(type = CurrencyFormatter.Type.Abbreviated, currency = Currency.USD, locale = Locale.US)
+        assertEquals("\$267.12K", currencyFormatter.string(267_123.0))
     }
 }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/CurrencyFormatter.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/CurrencyFormatter.kt
@@ -25,7 +25,10 @@ class CurrencyFormatter(
     private val abbreviatedFormatter: CompactDecimalFormat by lazy {
         CompactDecimalFormat.getInstance(locale, CompactDecimalFormat.CompactStyle.SHORT).apply {
             currency = android.icu.util.Currency.getInstance(this@CurrencyFormatter.currency.string)
-            maximumSignificantDigits = 2
+            setSignificantDigitsUsed(false)
+            minimumFractionDigits = 0
+            maximumFractionDigits = 2
+            roundingMode = android.icu.math.BigDecimal.ROUND_DOWN
         }
     }
 

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/ValueFormatter.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/ValueFormatter.kt
@@ -53,7 +53,10 @@ class ValueFormatter(
 
     private fun abbreviated(decimal: BigDecimal): String {
         val formatter = CompactDecimalFormat.getInstance(locale, CompactDecimalFormat.CompactStyle.SHORT)
-        formatter.maximumSignificantDigits = 2
+        formatter.setSignificantDigitsUsed(false)
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        formatter.roundingMode = android.icu.math.BigDecimal.ROUND_DOWN
         return formatter.format(decimal)
     }
 

--- a/ios/Features/Perpetuals/Tests/CandleTooltipViewModelTests.swift
+++ b/ios/Features/Perpetuals/Tests/CandleTooltipViewModelTests.swift
@@ -29,7 +29,7 @@ struct CandleTooltipViewModelTests {
         #expect(model.changeField.value.text == "+0.55%")
 
         #expect(model.volumeField.title.text == Localized.Perpetual.volume)
-        #expect(model.volumeField.value.text == "$34M")
+        #expect(model.volumeField.value.text == "$34.04M")
     }
 
     @Test

--- a/ios/Features/Perpetuals/Tests/PerpetualViewModelTests.swift
+++ b/ios/Features/Perpetuals/Tests/PerpetualViewModelTests.swift
@@ -19,7 +19,7 @@ struct PerpetualViewModelTests {
 
     @Test
     func openInterestField() {
-        #expect(PerpetualViewModel(perpetual: .mock(openInterest: 5_250_000)).openInterestField.value.text == "$5.2M")
+        #expect(PerpetualViewModel(perpetual: .mock(openInterest: 5_250_000)).openInterestField.value.text == "$5.25M")
     }
 
     @Test

--- a/ios/Packages/Formatters/Sources/AbbreviatedFormatter.swift
+++ b/ios/Packages/Formatters/Sources/AbbreviatedFormatter.swift
@@ -33,7 +33,8 @@ public struct AbbreviatedFormatter {
             .number
                 .notation(.compactName)
                 .locale(locale)
-                .precision(.significantDigits(1 ... 2)),
+                .precision(.fractionLength(0 ... 2))
+                .rounded(rule: .towardZero),
         )
     }
 
@@ -46,7 +47,8 @@ public struct AbbreviatedFormatter {
             .currency(code: currency)
                 .notation(.compactName)
                 .locale(locale)
-                .precision(.significantDigits(1 ... 2)),
+                .precision(.fractionLength(0 ... 2))
+                .rounded(rule: .towardZero),
         )
     }
 }

--- a/ios/Packages/Formatters/Tests/FormattersTests/AbbreviatedFormatterTests.swift
+++ b/ios/Packages/Formatters/Tests/FormattersTests/AbbreviatedFormatterTests.swift
@@ -11,13 +11,21 @@ struct AbbreviatedFormatterTests {
     func abbreviatedFormatter() {
         #expect(formatter.string(from: 99999.0) == nil)
         #expect(formatter.string(from: 100000.0) == "100K")
-        #expect(formatter.string(from: 123456.0) == "120K")
+        #expect(formatter.string(from: 123456.0) == "123.45K")
         #expect(formatter.string(from: 1_500_000.0) == "1.5M")
         #expect(formatter.string(from: 2_300_000_000.0) == "2.3B")
         #expect(formatter.string(from: 1_200_000_000_000.0) == "1.2T")
         #expect(formatter.string(from: 100000.0, currency: "USD") == "$100K")
         #expect(formatter.string(from: 2_000_000.0, currency: "EUR") == "€2M")
         #expect(formatter.string(from: 2_500_000.0, currency: "USD") == "$2.5M")
+    }
+
+    @Test
+    func keepsDigitsWithoutRounding() {
+        #expect(formatter.string(from: 267_123.0) == "267.12K")
+        #expect(formatter.string(from: 20_070_000.0) == "20.07M")
+        #expect(formatter.string(from: 19_876_725.0) == "19.87M")
+        #expect(formatter.string(from: 267_123.0, currency: "USD") == "$267.12K")
     }
 
     @Test

--- a/ios/Packages/Formatters/Tests/FormattersTests/CurrencyFormatterTests.swift
+++ b/ios/Packages/Formatters/Tests/FormattersTests/CurrencyFormatterTests.swift
@@ -59,10 +59,10 @@ final class CurrencyFormatterTests {
         #expect(abbreviatedFormatterUS.string(-10000) == "-$10,000.00")
         #expect(abbreviatedFormatterUS.string(-5_600_000) == "-$5.6M")
 
-        #expect(abbreviatedFormatterUK.string(123_456) == "£120k")
+        #expect(abbreviatedFormatterUK.string(123_456) == "£123.45k")
         #expect(abbreviatedFormatterUK.string(5_000_000) == "£5m")
-        #expect(abbreviatedFormatterUK.string(7_890_000_000) == "£7.9bn")
+        #expect(abbreviatedFormatterUK.string(7_890_000_000) == "£7.89bn")
         #expect(abbreviatedFormatterUK.string(1_200_000_000_000) == "£1.2tn")
-        #expect(abbreviatedFormatterUK.string(-9_999_999_999) == "-£10bn")
+        #expect(abbreviatedFormatterUK.string(-9_999_999_999) == "-£9.99bn")
     }
 }


### PR DESCRIPTION
Large numbers were rounded to two significant digits, so a 267,123 balance showed as 270K and a 20.07M supply as 20M.

Abbreviated values now keep up to two decimals and are never rounded up, on both iOS and Android.

Closes #946