### PR TITLE
Add bottom spacing to referral form dialogs

### DIFF
--- a/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/dialogs/GetStartedDialog.kt
+++ b/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/dialogs/GetStartedDialog.kt
@@ -25,6 +25,7 @@ import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.GemTextField
 import com.gemwallet.android.ui.components.filters.FormDialog
 import com.gemwallet.android.ui.components.progress.CircularProgressIndicator16
+import com.gemwallet.android.ui.theme.Spacer16
 import com.gemwallet.android.ui.theme.Spacer8
 import com.gemwallet.android.ui.theme.paddingDefault
 
@@ -96,6 +97,7 @@ internal fun GetStartedDialog(
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Companion.Center
         )
+        Spacer16()
     }
 
     if (showError != null) {

--- a/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/dialogs/ReferralCodeDialog.kt
+++ b/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/dialogs/ReferralCodeDialog.kt
@@ -23,6 +23,7 @@ import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.GemTextField
 import com.gemwallet.android.ui.components.filters.FormDialog
 import com.gemwallet.android.ui.components.progress.CircularProgressIndicator16
+import com.gemwallet.android.ui.theme.Spacer16
 
 @Composable
 fun ReferralCodeDialog(
@@ -84,6 +85,7 @@ fun ReferralCodeDialog(
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             singleLine = true,
         )
+        Spacer16()
     }
     if (showError != null) {
         AlertDialog(


### PR DESCRIPTION
The username and referral code sheets on the Rewards screen sat flush against the keyboard. Both now keep a small gap below the form.