### PR TITLE
Own the app update offer in one coordinator

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/AppViewModel.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/AppViewModel.kt
@@ -2,23 +2,22 @@ package com.gemwallet.android.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.gemwallet.android.BuildConfig
 import com.gemwallet.android.application.assets.coordinators.GetWalletSummary
-import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
+import com.gemwallet.android.application.update.coordinators.SkipAppUpdate
+import com.gemwallet.android.application.update.coordinators.SyncAppUpdate
 import com.gemwallet.android.cases.device.GetPushEnabled
 import com.gemwallet.android.cases.device.SwitchPushEnabled
 import com.gemwallet.android.data.repositories.config.UserConfig
-import com.gemwallet.android.model.AppUpdateInfo
+import com.gemwallet.android.model.AppUpdateChannel
+import com.gemwallet.android.model.AppUpdateOffer
 import com.gemwallet.android.data.repositories.session.SessionRepository
 import com.gemwallet.android.data.repositories.wallets.WalletsRepository
-import com.gemwallet.android.ext.VersionCheck
 import androidx.navigation3.runtime.NavKey
 import com.gemwallet.android.features.onboarding.OnboardingRoute
 import com.gemwallet.android.model.Session
 import com.gemwallet.android.model.NotificationsAvailable
 import com.gemwallet.android.PendingNavigationCoordinator
 import com.gemwallet.android.ui.navigation.WalletRootRoute
-import com.wallet.core.primitives.PlatformStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,8 +40,8 @@ class AppViewModel @Inject constructor(
     private val getPushEnabled: GetPushEnabled,
     private val switchPushEnabled: SwitchPushEnabled,
     private val walletsRepository: WalletsRepository,
-    private val getRemoteConfig: GetRemoteConfig,
-    private val platformStore: PlatformStore,
+    private val syncAppUpdate: SyncAppUpdate,
+    private val skipAppUpdate: SkipAppUpdate,
     private val notificationsAvailable: NotificationsAvailable,
     private val pendingNavigationCoordinator: PendingNavigationCoordinator,
     getWalletSummary: GetWalletSummary,
@@ -99,7 +98,7 @@ class AppViewModel @Inject constructor(
         if (update.isRequired) {
             return@launch
         }
-        userConfig.setAppVersionSkip(update.version)
+        skipAppUpdate.skipAppUpdate(update.version)
         state.update { it.copy(update = null) }
     }
 
@@ -110,48 +109,12 @@ class AppViewModel @Inject constructor(
         state.update { it.copy(update = null) }
     }
 
-    private suspend fun handleAppVersion() = withContext(Dispatchers.IO) {
-        if (BuildConfig.DEBUG) {
-            return@withContext
+    private suspend fun handleAppVersion() {
+        val offer = syncAppUpdate.syncAppUpdate() ?: return
+        if (offer.channel != AppUpdateChannel.Store) {
+            return
         }
-        val config = runCatching {
-            getRemoteConfig.getRemoteConfig()
-        }.getOrNull() ?: return@withContext
-
-        val lastRelease = config.releases
-            .filter {
-                val versionFlavor = when (it.store) {
-                    PlatformStore.GooglePlay -> "google"
-                    PlatformStore.Fdroid -> "fdroid"
-                    PlatformStore.Huawei -> "huawei"
-                    PlatformStore.SolanaStore -> "solana"
-                    PlatformStore.SamsungStore -> "samsung"
-                    PlatformStore.ApkUniversal -> "universal"
-                    PlatformStore.AppStore -> it.store.string
-                    PlatformStore.Emerald -> "emerald"
-                    PlatformStore.Local -> "local"
-                }
-                BuildConfig.FLAVOR == versionFlavor
-            }
-            .firstOrNull() ?: return@withContext
-
-        val skipVersion = userConfig.getAppVersionSkip().firstOrNull()
-        val lastVersion = lastRelease.version
-        val appUpdate = AppUpdateInfo(
-            version = lastVersion,
-            isRequired = lastRelease.upgradeRequired,
-        )
-        userConfig.setLatestAppUpdate(appUpdate)
-        if (VersionCheck.isVersionHigher(new = lastVersion, current = BuildConfig.VERSION_NAME)
-            && (lastRelease.upgradeRequired || skipVersion != lastVersion)
-            && platformStore != PlatformStore.ApkUniversal
-        ) {
-            state.update {
-                it.copy(
-                    update = appUpdate,
-                )
-            }
-        }
+        state.update { it.copy(update = offer) }
     }
 
     fun acceptTerms() {
@@ -213,7 +176,7 @@ class AppViewModel @Inject constructor(
 data class AppState(
     val session: Session? = null,
     val intent: AppIntent = AppIntent.None,
-    val update: AppUpdateInfo? = null,
+    val update: AppUpdateOffer? = null,
 )
 
 enum class AppIntent {

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/UpdateModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/UpdateModule.kt
@@ -1,0 +1,45 @@
+package com.gemwallet.android.data.coordinators.di
+
+import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
+import com.gemwallet.android.application.update.coordinators.ObserveAppUpdateOffer
+import com.gemwallet.android.application.update.coordinators.SkipAppUpdate
+import com.gemwallet.android.application.update.coordinators.SyncAppUpdate
+import com.gemwallet.android.data.coordinators.update.AppUpdateCoordinator
+import com.gemwallet.android.data.repositories.config.UserConfig
+import com.gemwallet.android.model.BuildInfo
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object UpdateModule {
+
+    @Provides
+    @Singleton
+    fun provideAppUpdateCoordinator(
+        getRemoteConfig: GetRemoteConfig,
+        userConfig: UserConfig,
+        buildInfo: BuildInfo,
+    ): AppUpdateCoordinator {
+        return AppUpdateCoordinator(
+            getRemoteConfig = getRemoteConfig,
+            userConfig = userConfig,
+            buildInfo = buildInfo,
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideSyncAppUpdate(coordinator: AppUpdateCoordinator): SyncAppUpdate = coordinator
+
+    @Provides
+    @Singleton
+    fun provideObserveAppUpdateOffer(coordinator: AppUpdateCoordinator): ObserveAppUpdateOffer = coordinator
+
+    @Provides
+    @Singleton
+    fun provideSkipAppUpdate(coordinator: AppUpdateCoordinator): SkipAppUpdate = coordinator
+}

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/update/AppUpdateCoordinator.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/update/AppUpdateCoordinator.kt
@@ -1,0 +1,66 @@
+package com.gemwallet.android.data.coordinators.update
+
+import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
+import com.gemwallet.android.application.update.coordinators.ObserveAppUpdateOffer
+import com.gemwallet.android.application.update.coordinators.SkipAppUpdate
+import com.gemwallet.android.application.update.coordinators.SyncAppUpdate
+import com.gemwallet.android.data.repositories.config.UserConfig
+import com.gemwallet.android.ext.VersionCheck
+import com.gemwallet.android.model.AppUpdateChannel
+import com.gemwallet.android.model.AppUpdateInfo
+import com.gemwallet.android.model.AppUpdateOffer
+import com.gemwallet.android.model.BuildInfo
+import com.wallet.core.primitives.PlatformStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.firstOrNull
+
+class AppUpdateCoordinator(
+    private val getRemoteConfig: GetRemoteConfig,
+    private val userConfig: UserConfig,
+    private val buildInfo: BuildInfo,
+) : SyncAppUpdate, ObserveAppUpdateOffer, SkipAppUpdate {
+
+    override suspend fun syncAppUpdate(): AppUpdateOffer? {
+        if (buildInfo.platformStore == PlatformStore.Local) {
+            return null
+        }
+        val config = runCatching { getRemoteConfig.getRemoteConfig() }.getOrNull() ?: return null
+        val release = config.releases.firstOrNull { it.store == buildInfo.platformStore } ?: return null
+        val skippedVersion = userConfig.getAppVersionSkip().firstOrNull().orEmpty()
+        val update = AppUpdateInfo(version = release.version, isRequired = release.upgradeRequired)
+        userConfig.setLatestAppUpdate(update)
+        return buildOffer(update, skippedVersion)
+    }
+
+    override fun observeAppUpdateOffer(): Flow<AppUpdateOffer?> = combine(
+        userConfig.getLatestAppUpdate(),
+        userConfig.getAppVersionSkip(),
+    ) { update, skippedVersion -> buildOffer(update, skippedVersion) }
+
+    override suspend fun skipAppUpdate(version: String) {
+        userConfig.setAppVersionSkip(version)
+    }
+
+    private fun buildOffer(update: AppUpdateInfo?, skippedVersion: String): AppUpdateOffer? {
+        if (update == null) {
+            return null
+        }
+        if (!VersionCheck.isVersionHigher(new = update.version, current = buildInfo.versionName)) {
+            return null
+        }
+        if (!update.isRequired && update.version == skippedVersion) {
+            return null
+        }
+        return AppUpdateOffer(
+            version = update.version,
+            isRequired = update.isRequired,
+            channel = deliveryChannel(),
+        )
+    }
+
+    private fun deliveryChannel(): AppUpdateChannel = when (buildInfo.platformStore) {
+        PlatformStore.ApkUniversal -> AppUpdateChannel.InAppApk
+        else -> AppUpdateChannel.Store
+    }
+}

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/update/AppUpdateCoordinatorTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/update/AppUpdateCoordinatorTest.kt
@@ -1,0 +1,139 @@
+package com.gemwallet.android.data.coordinators.update
+
+import com.gemwallet.android.application.config.coordinators.GetRemoteConfig
+import com.gemwallet.android.cases.device.RequestPushToken
+import com.gemwallet.android.data.repositories.config.UserConfig
+import com.gemwallet.android.model.AppUpdateChannel
+import com.gemwallet.android.model.AppUpdateInfo
+import com.gemwallet.android.model.BuildInfo
+import com.wallet.core.primitives.ConfigResponse
+import com.wallet.core.primitives.ConfigVersions
+import com.wallet.core.primitives.PlatformStore
+import com.wallet.core.primitives.Release
+import com.wallet.core.primitives.SwapConfig
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppUpdateCoordinatorTest {
+
+    private val skippedVersion = MutableStateFlow("")
+    private val latestAppUpdate = MutableStateFlow<AppUpdateInfo?>(null)
+    private val userConfig = mockk<UserConfig>(relaxed = true)
+    private val getRemoteConfig = mockk<GetRemoteConfig>()
+    private val requestPushToken = mockk<RequestPushToken>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        every { userConfig.getAppVersionSkip() } returns skippedVersion
+        every { userConfig.getLatestAppUpdate() } returns latestAppUpdate
+    }
+
+    @Test
+    fun `sync persists the release of the current store and offers it`() = runTest {
+        remoteReleases(
+            Release(version = "2.0.0", store = PlatformStore.Huawei, upgradeRequired = false),
+            Release(version = "3.0.0", store = PlatformStore.GooglePlay, upgradeRequired = false),
+        )
+
+        val offer = coordinator(PlatformStore.GooglePlay).syncAppUpdate()
+
+        assertEquals("3.0.0", offer?.version)
+        assertEquals(AppUpdateChannel.Store, offer?.channel)
+        coVerify { userConfig.setLatestAppUpdate(AppUpdateInfo(version = "3.0.0", isRequired = false)) }
+    }
+
+    @Test
+    fun `sync offers the universal apk build through the in app channel`() = runTest {
+        remoteReleases(Release(version = "3.0.0", store = PlatformStore.ApkUniversal, upgradeRequired = false))
+
+        val offer = coordinator(PlatformStore.ApkUniversal).syncAppUpdate()
+
+        assertEquals(AppUpdateChannel.InAppApk, offer?.channel)
+    }
+
+    @Test
+    fun `sync ignores releases published for another store`() = runTest {
+        remoteReleases(Release(version = "3.0.0", store = PlatformStore.Fdroid, upgradeRequired = false))
+
+        val offer = coordinator(PlatformStore.GooglePlay).syncAppUpdate()
+
+        assertNull(offer)
+        coVerify(exactly = 0) { userConfig.setLatestAppUpdate(any()) }
+    }
+
+    @Test
+    fun `sync never reaches the network for local builds`() = runTest {
+        val offer = coordinator(PlatformStore.Local).syncAppUpdate()
+
+        assertNull(offer)
+        coVerify(exactly = 0) { getRemoteConfig.getRemoteConfig() }
+    }
+
+    @Test
+    fun `sync persists an older release without offering it`() = runTest {
+        remoteReleases(Release(version = "0.9.0", store = PlatformStore.GooglePlay, upgradeRequired = false))
+
+        val offer = coordinator(PlatformStore.GooglePlay).syncAppUpdate()
+
+        assertNull(offer)
+        coVerify { userConfig.setLatestAppUpdate(AppUpdateInfo(version = "0.9.0", isRequired = false)) }
+    }
+
+    @Test
+    fun `sync skips an already skipped optional release`() = runTest {
+        skippedVersion.value = "3.0.0"
+        remoteReleases(Release(version = "3.0.0", store = PlatformStore.GooglePlay, upgradeRequired = false))
+
+        assertNull(coordinator(PlatformStore.GooglePlay).syncAppUpdate())
+    }
+
+    @Test
+    fun `sync offers a skipped release when the upgrade is required`() = runTest {
+        skippedVersion.value = "3.0.0"
+        remoteReleases(Release(version = "3.0.0", store = PlatformStore.GooglePlay, upgradeRequired = true))
+
+        assertEquals("3.0.0", coordinator(PlatformStore.GooglePlay).syncAppUpdate()?.version)
+    }
+
+    @Test
+    fun `observed offer disappears once the version is skipped`() = runTest {
+        latestAppUpdate.value = AppUpdateInfo(version = "3.0.0", isRequired = false)
+        val coordinator = coordinator(PlatformStore.ApkUniversal)
+
+        assertEquals("3.0.0", coordinator.observeAppUpdateOffer().first()?.version)
+
+        skippedVersion.value = "3.0.0"
+
+        assertNull(coordinator.observeAppUpdateOffer().first())
+    }
+
+    private fun remoteReleases(vararg releases: Release) {
+        coEvery { getRemoteConfig.getRemoteConfig() } returns ConfigResponse(
+            releases = releases.toList(),
+            versions = ConfigVersions(fiatOnRampAssets = 0, fiatOffRampAssets = 0, swapAssets = 0),
+            swap = SwapConfig(enabledProviders = emptyList()),
+        )
+    }
+
+    private fun coordinator(platformStore: PlatformStore) = AppUpdateCoordinator(
+        getRemoteConfig = getRemoteConfig,
+        userConfig = userConfig,
+        buildInfo = BuildInfo(
+            platformStore = platformStore,
+            versionName = "1.0.0",
+            versionCode = 1,
+            requestPushToken = requestPushToken,
+        ),
+    )
+}

--- a/android/features/update_app/presents/src/main/kotlin/com/gemwallet/android/features/update_app/presents/InAppUpdateBanner.kt
+++ b/android/features/update_app/presents/src/main/kotlin/com/gemwallet/android/features/update_app/presents/InAppUpdateBanner.kt
@@ -33,7 +33,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gemwallet.android.features.update_app.viewmodels.DownloadState
 import com.gemwallet.android.features.update_app.viewmodels.InAppUpdateViewModel
-import com.gemwallet.android.model.AppUpdateInfo
+import com.gemwallet.android.model.AppUpdateOffer
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.list_item.DropDownContextItem
 import com.gemwallet.android.ui.components.list_item.listItem
@@ -139,7 +139,7 @@ fun InAppUpdateBanner() {
 private fun UpdateInfo(
     modifier: Modifier = Modifier,
     state: DownloadState,
-    updateAvailable: AppUpdateInfo,
+    updateAvailable: AppUpdateOffer,
     onAction: () -> Unit,
 ) {
     Row(

--- a/android/features/update_app/viewmodels/build.gradle.kts
+++ b/android/features/update_app/viewmodels/build.gradle.kts
@@ -49,9 +49,9 @@ android {
 
 dependencies {
     api(project(":ui-models"))
-    implementation(project(":data:repositories"))
 
     implementation(libs.ktx.core)
+    implementation(libs.okhttp)
     implementation(libs.lifecycle.runtime.ktx)
     implementation(libs.lifecycle.viewmodel.savedstate)
 

--- a/android/features/update_app/viewmodels/src/main/java/com/gemwallet/android/features/update_app/viewmodels/InAppUpdateViewModel.kt
+++ b/android/features/update_app/viewmodels/src/main/java/com/gemwallet/android/features/update_app/viewmodels/InAppUpdateViewModel.kt
@@ -2,43 +2,30 @@ package com.gemwallet.android.features.update_app.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.gemwallet.android.data.repositories.config.UserConfig
-import com.gemwallet.android.ext.VersionCheck
-import com.gemwallet.android.model.AppUpdateInfo
-import com.gemwallet.android.model.BuildInfo
-import com.wallet.core.primitives.PlatformStore
+import com.gemwallet.android.application.update.coordinators.ObserveAppUpdateOffer
+import com.gemwallet.android.application.update.coordinators.SkipAppUpdate
+import com.gemwallet.android.model.AppUpdateChannel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class InAppUpdateViewModel @Inject constructor(
-    private val buildInfo: BuildInfo,
-    private val userConfig: UserConfig,
+    observeAppUpdateOffer: ObserveAppUpdateOffer,
+    private val skipAppUpdate: SkipAppUpdate,
     private val updateService: InAppUpdateService,
 ) : ViewModel() {
 
-    val updateAvailable = userConfig.getAppVersionSkip()
-        .combine(userConfig.getLatestAppUpdate()) { skip, update ->
-            availableUpdate(update, skip)
-        }
+    val updateAvailable = observeAppUpdateOffer.observeAppUpdateOffer()
+        .map { offer -> offer?.takeIf { it.channel == AppUpdateChannel.InAppApk } }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
-
-    internal fun availableUpdate(
-        update: AppUpdateInfo?,
-        skipVersion: String,
-    ): AppUpdateInfo? = update?.takeIf {
-        VersionCheck.isVersionHigher(new = it.version, current = buildInfo.versionName)
-            && buildInfo.platformStore == PlatformStore.ApkUniversal
-            && (it.isRequired || it.version != skipVersion)
-    }
 
     private val _downloadState = MutableStateFlow<DownloadState>(DownloadState.Idle)
     val downloadState = _downloadState.asStateFlow()
@@ -102,7 +89,7 @@ class InAppUpdateViewModel @Inject constructor(
             return
         }
         viewModelScope.launch {
-            userConfig.setAppVersionSkip(update.version)
+            skipAppUpdate.skipAppUpdate(update.version)
         }
     }
 

--- a/android/features/update_app/viewmodels/src/test/kotlin/com/gemwallet/android/features/update_app/viewmodels/InAppUpdateViewModelsTest.kt
+++ b/android/features/update_app/viewmodels/src/test/kotlin/com/gemwallet/android/features/update_app/viewmodels/InAppUpdateViewModelsTest.kt
@@ -1,15 +1,12 @@
 package com.gemwallet.android.features.update_app.viewmodels
 
-import com.gemwallet.android.cases.device.RequestPushToken
-import com.gemwallet.android.data.repositories.config.UserConfig
-import com.gemwallet.android.model.AppUpdateInfo
-import com.gemwallet.android.model.BuildInfo
-import com.wallet.core.primitives.PlatformStore
-import io.mockk.coVerify
-import io.mockk.every
-import io.mockk.mockk
+import com.gemwallet.android.application.update.coordinators.ObserveAppUpdateOffer
+import com.gemwallet.android.application.update.coordinators.SkipAppUpdate
+import com.gemwallet.android.model.AppUpdateChannel
+import com.gemwallet.android.model.AppUpdateOffer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -19,6 +16,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -27,17 +25,14 @@ import org.junit.Test
 class InAppUpdateViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
-    private val skippedVersion = MutableStateFlow("")
-    private val latestAppUpdate = MutableStateFlow<AppUpdateInfo?>(null)
-    private val userConfig = mockk<UserConfig>(relaxed = true)
-    private val requestPushToken = mockk<RequestPushToken>(relaxed = true)
+    private val offer = MutableStateFlow<AppUpdateOffer?>(null)
+    private lateinit var skipAppUpdate: FakeSkipAppUpdate
     private lateinit var updateService: FakeInAppUpdateService
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        every { userConfig.getAppVersionSkip() } returns skippedVersion
-        every { userConfig.getLatestAppUpdate() } returns latestAppUpdate
+        skipAppUpdate = FakeSkipAppUpdate()
         updateService = FakeInAppUpdateService()
     }
 
@@ -47,9 +42,8 @@ class InAppUpdateViewModelTest {
     }
 
     @Test
-    fun `required update remains available even when skipped`() = runTest(testDispatcher) {
-        skippedVersion.value = "2.0.0"
-        latestAppUpdate.value = AppUpdateInfo(version = "2.0.0", isRequired = true)
+    fun `in app apk offer is available`() = runTest(testDispatcher) {
+        offer.value = AppUpdateOffer("2.0.0", isRequired = true, channel = AppUpdateChannel.InAppApk)
 
         val viewModel = createViewModel()
         advanceUntilIdle()
@@ -61,8 +55,18 @@ class InAppUpdateViewModelTest {
     }
 
     @Test
+    fun `store offer is not shown as an in app update`() = runTest(testDispatcher) {
+        offer.value = AppUpdateOffer("2.0.0", isRequired = false, channel = AppUpdateChannel.Store)
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertNull(viewModel.updateAvailable.value)
+    }
+
+    @Test
     fun `skip ignores required update`() = runTest(testDispatcher) {
-        latestAppUpdate.value = AppUpdateInfo(version = "2.0.0", isRequired = true)
+        offer.value = AppUpdateOffer("2.0.0", isRequired = true, channel = AppUpdateChannel.InAppApk)
 
         val viewModel = createViewModel()
         advanceUntilIdle()
@@ -70,12 +74,25 @@ class InAppUpdateViewModelTest {
         viewModel.skip()
         advanceUntilIdle()
 
-        coVerify(exactly = 0) { userConfig.setAppVersionSkip(any()) }
+        assertTrue(skipAppUpdate.skippedVersions.isEmpty())
+    }
+
+    @Test
+    fun `skip stores the optional update version`() = runTest(testDispatcher) {
+        offer.value = AppUpdateOffer("2.0.0", isRequired = false, channel = AppUpdateChannel.InAppApk)
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.skip()
+        advanceUntilIdle()
+
+        assertEquals(listOf("2.0.0"), skipAppUpdate.skippedVersions)
     }
 
     @Test
     fun `update does not launch overlapping downloads and cancel marks canceled`() = runTest(testDispatcher) {
-        latestAppUpdate.value = AppUpdateInfo(version = "2.0.0", isRequired = false)
+        offer.value = AppUpdateOffer("2.0.0", isRequired = false, channel = AppUpdateChannel.InAppApk)
 
         val viewModel = createViewModel()
         advanceUntilIdle()
@@ -107,15 +124,20 @@ class InAppUpdateViewModelTest {
     }
 
     private fun createViewModel() = InAppUpdateViewModel(
-        buildInfo = BuildInfo(
-            platformStore = PlatformStore.ApkUniversal,
-            versionName = "1.0.0",
-            versionCode = 1,
-            requestPushToken = requestPushToken,
-        ),
-        userConfig = userConfig,
+        observeAppUpdateOffer = object : ObserveAppUpdateOffer {
+            override fun observeAppUpdateOffer(): Flow<AppUpdateOffer?> = offer
+        },
+        skipAppUpdate = skipAppUpdate,
         updateService = updateService,
     )
+
+    private class FakeSkipAppUpdate : SkipAppUpdate {
+        val skippedVersions = mutableListOf<String>()
+
+        override suspend fun skipAppUpdate(version: String) {
+            skippedVersions.add(version)
+        }
+    }
 
     private class FakeInAppUpdateService : InAppUpdateService {
         var downloadCalls = 0

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/update/coordinators/ObserveAppUpdateOffer.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/update/coordinators/ObserveAppUpdateOffer.kt
@@ -1,0 +1,8 @@
+package com.gemwallet.android.application.update.coordinators
+
+import com.gemwallet.android.model.AppUpdateOffer
+import kotlinx.coroutines.flow.Flow
+
+interface ObserveAppUpdateOffer {
+    fun observeAppUpdateOffer(): Flow<AppUpdateOffer?>
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/update/coordinators/SkipAppUpdate.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/update/coordinators/SkipAppUpdate.kt
@@ -1,0 +1,5 @@
+package com.gemwallet.android.application.update.coordinators
+
+interface SkipAppUpdate {
+    suspend fun skipAppUpdate(version: String)
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/update/coordinators/SyncAppUpdate.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/update/coordinators/SyncAppUpdate.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.application.update.coordinators
+
+import com.gemwallet.android.model.AppUpdateOffer
+
+interface SyncAppUpdate {
+    suspend fun syncAppUpdate(): AppUpdateOffer?
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/model/AppUpdateOffer.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/model/AppUpdateOffer.kt
@@ -1,0 +1,12 @@
+package com.gemwallet.android.model
+
+data class AppUpdateOffer(
+    val version: String,
+    val isRequired: Boolean,
+    val channel: AppUpdateChannel,
+)
+
+enum class AppUpdateChannel {
+    Store,
+    InAppApk,
+}


### PR DESCRIPTION
The rule that decides whether to offer an app update was written in three places at once, and the mapping between build flavor and store was kept twice in opposite directions. Changing anything about updates meant editing several unrelated files, and nothing warned you if you missed one.

Now a single component answers that question and says which way the update should be offered — a dialog for store builds, the in-app banner for the universal APK. Both screens just use its answer.

Behaviour is unchanged.