### PR TITLE
Keep stored delegations when the delegations request fails

### DIFF
--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/services/StakeService.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/services/StakeService.kt
@@ -66,33 +66,33 @@ class StakeService(
     suspend fun getStakeDelegations(
         chain: Chain,
         address: String,
-    ): List<DelegationBase> {
-        return try {
-            val result = gateway.getStakingDelegations(
+    ): List<DelegationBase>? {
+        val result = try {
+            gateway.getStakingDelegations(
                 chain = chain.string,
                 address,
             )
-            result.mapNotNull { item ->
-                DelegationBase(
-                    assetId = item.assetId.toAssetId() ?: return@mapNotNull null,
-                    state = when (item.state) {
-                        GemDelegationState.ACTIVE -> DelegationState.Active
-                        GemDelegationState.PENDING -> DelegationState.Pending
-                        GemDelegationState.INACTIVE -> DelegationState.Inactive
-                        GemDelegationState.ACTIVATING -> DelegationState.Activating
-                        GemDelegationState.DEACTIVATING -> DelegationState.Deactivating
-                        GemDelegationState.AWAITING_WITHDRAWAL -> DelegationState.AwaitingWithdrawal
-                    },
-                    balance = item.balance,
-                    rewards = item.rewards,
-                    completionDate = item.completionDate,
-                    delegationId = item.delegationId,
-                    validatorId = item.validatorId,
-                    shares = item.shares,
-                )
-            }
         } catch (_: Throwable) {
-            emptyList()
+            return null
+        }
+        return result.mapNotNull { item ->
+            DelegationBase(
+                assetId = item.assetId.toAssetId() ?: return@mapNotNull null,
+                state = when (item.state) {
+                    GemDelegationState.ACTIVE -> DelegationState.Active
+                    GemDelegationState.PENDING -> DelegationState.Pending
+                    GemDelegationState.INACTIVE -> DelegationState.Inactive
+                    GemDelegationState.ACTIVATING -> DelegationState.Activating
+                    GemDelegationState.DEACTIVATING -> DelegationState.Deactivating
+                    GemDelegationState.AWAITING_WITHDRAWAL -> DelegationState.AwaitingWithdrawal
+                },
+                balance = item.balance,
+                rewards = item.rewards,
+                completionDate = item.completionDate,
+                delegationId = item.delegationId,
+                validatorId = item.validatorId,
+                shares = item.shares,
+            )
         }
     }
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stake/StakeRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stake/StakeRepository.kt
@@ -95,8 +95,7 @@ class StakeRepository(
         address: String,
         validatorNamesById: Map<String, String>,
     ) {
-        val delegations = runCatching { stakeService.getStakeDelegations(assetId.chain, address) }
-            .getOrNull() ?: return
+        val delegations = stakeService.getStakeDelegations(assetId.chain, address) ?: return
         val existingValidators = stakeDao.getValidators(assetId, StakeProviderType.Stake)
             .first()
             .toDTO()

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/stake/StakeRepositoryTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/stake/StakeRepositoryTest.kt
@@ -15,6 +15,7 @@ import com.wallet.core.primitives.StakeProviderType
 import com.wallet.core.primitives.StakeValidator
 import com.wallet.core.primitives.WalletId
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -96,6 +97,57 @@ class StakeRepositoryTest {
             .sync(walletId, assetId, address = "address", apr = 0.0)
 
         assertTrue(savedValidators.isEmpty())
+    }
+
+    @Test
+    fun sync_keepsStoredDelegationsWhenFetchFails() = runTest {
+        val walletId = WalletId("wallet")
+        val assetId = mockAssetId(chain = Chain.Celestia)
+
+        val gemApiStaticClient = mockk<GemApiStaticClient> {
+            coEvery { getValidators(Chain.Celestia.string) } returns emptyList()
+        }
+        val stakeService = mockk<StakeService> {
+            coEvery { getValidators(Chain.Celestia, any()) } returns emptyList()
+            coEvery { getDelegationValidators(Chain.Celestia, any()) } returns emptyList()
+            coEvery { getStakeDelegations(Chain.Celestia, any()) } returns null
+        }
+        val stakeDao = mockk<StakeDao> {
+            every { getValidators(assetId, StakeProviderType.Stake) } returns flowOf(emptyList())
+            coEvery { getDelegationIds(walletId, assetId) } returns listOf("stored")
+            coEvery { updateAndDeleteDelegations(walletId, any(), any()) } just runs
+        }
+
+        StakeRepository(gemApiStaticClient, stakeService, stakeDao)
+            .sync(walletId, assetId, address = "address", apr = 0.0)
+
+        coVerify(exactly = 0) { stakeDao.updateAndDeleteDelegations(any(), any(), any()) }
+    }
+
+    @Test
+    fun sync_deletesStoredDelegationsWhenFetchReturnsEmpty() = runTest {
+        val walletId = WalletId("wallet")
+        val assetId = mockAssetId(chain = Chain.Celestia)
+        val deletedIds = mutableListOf<List<String>>()
+
+        val gemApiStaticClient = mockk<GemApiStaticClient> {
+            coEvery { getValidators(Chain.Celestia.string) } returns emptyList()
+        }
+        val stakeService = mockk<StakeService> {
+            coEvery { getValidators(Chain.Celestia, any()) } returns emptyList()
+            coEvery { getDelegationValidators(Chain.Celestia, any()) } returns emptyList()
+            coEvery { getStakeDelegations(Chain.Celestia, any()) } returns emptyList()
+        }
+        val stakeDao = mockk<StakeDao> {
+            every { getValidators(assetId, StakeProviderType.Stake) } returns flowOf(emptyList())
+            coEvery { getDelegationIds(walletId, assetId) } returns listOf("stored")
+            coEvery { updateAndDeleteDelegations(walletId, emptyList(), capture(deletedIds)) } just runs
+        }
+
+        StakeRepository(gemApiStaticClient, stakeService, stakeDao)
+            .sync(walletId, assetId, address = "address", apr = 0.0)
+
+        assertEquals(listOf("stored"), deletedIds.single())
     }
 
     @Test


### PR DESCRIPTION
On Android, a failed request for staking delegations was treated as "this wallet has no delegations", and the sync deleted every delegation it had stored.

A single network hiccup was enough to make a user's stake disappear from the app, most likely right after staking or unstaking, when the sync runs again immediately.

Now a failure is kept separate from an empty result, and nothing is deleted unless the request actually succeeded. iOS already behaved this way.