### PR TITLE
Fix screen content cut off by system navigation bar

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/features/main/views/MainScreen.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/main/views/MainScreen.kt
@@ -4,6 +4,8 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -182,7 +184,12 @@ fun MainScreen(
             }
         }
     ) {
-        Box(modifier = Modifier.padding(bottom = it.calculateBottomPadding())) {
+        val bottomPadding = it.calculateBottomPadding()
+        Box(
+            modifier = Modifier
+                .padding(bottom = bottomPadding)
+                .consumeWindowInsets(PaddingValues(bottom = bottomPadding))
+        ) {
             CompositionLocalProvider(LocalConnectionBannerHandled provides true) {
             AnimatedContent(
                 targetState = currentTab.value,

--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
@@ -59,7 +59,6 @@ internal fun TransactionsScene(
                 )
             }
         },
-        navigationBarPadding = false,
     ) {
         PullToRefreshBox(
             isRefreshing = isRefreshing,

--- a/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
+++ b/android/features/nft/presents/src/main/kotlin/com/gemwallet/android/features/nft/presents/NftListScene.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
@@ -106,7 +105,6 @@ internal fun NftListScene(
 ) {
     Scene(
         title = title,
-        navigationBarPadding = false,
         actions = {
             if (showReceiveAction) {
                 IconButton(onClick = { onAction(NftListAction.Receive) }) {
@@ -189,19 +187,17 @@ internal fun NftListScene(
                     }
                 }
                 if (showUnverifiedRow) {
-                    Box(modifier = Modifier.navigationBarsPadding()) {
-                        LinkItem(
-                            title = stringResource(R.string.asset_verification_unverified),
-                            listPosition = ListPosition.Single,
-                            trailingContent = {
-                                PropertyDataText(
-                                    text = unverifiedCount.toString(),
-                                    badge = { DataBadgeChevron() },
-                                )
-                            },
-                            onClick = { onAction(NftListAction.OpenUnverified) },
-                        )
-                    }
+                    LinkItem(
+                        title = stringResource(R.string.asset_verification_unverified),
+                        listPosition = ListPosition.Single,
+                        trailingContent = {
+                            PropertyDataText(
+                                text = unverifiedCount.toString(),
+                                badge = { DataBadgeChevron() },
+                            )
+                        },
+                        onClick = { onAction(NftListAction.OpenUnverified) },
+                    )
                 }
             }
         }

--- a/android/features/settings/settings/presents/src/main/kotlin/com/gemwallet/android/features/settings/settings/presents/views/SettingsScene.kt
+++ b/android/features/settings/settings/presents/src/main/kotlin/com/gemwallet/android/features/settings/settings/presents/views/SettingsScene.kt
@@ -60,7 +60,6 @@ fun SettingsScene(
     Scene(
         title = stringResource(id = R.string.settings_title),
         mainActionPadding = PaddingValues(0.dp),
-        navigationBarPadding = false,
     ) {
         Column(
             modifier = Modifier

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/ConnectionStatusBanner.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/ConnectionStatusBanner.kt
@@ -2,11 +2,9 @@ package com.gemwallet.android.ui.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -25,7 +23,6 @@ import com.gemwallet.android.ui.theme.iconSize
 import com.gemwallet.android.ui.theme.padding16
 import com.gemwallet.android.ui.theme.paddingSmall
 import com.gemwallet.android.ui.theme.pendingColor
-import com.gemwallet.android.ui.theme.space0
 import com.gemwallet.android.ui.theme.space10
 import com.gemwallet.android.ui.theme.tinyIconSize
 
@@ -34,7 +31,6 @@ fun ConnectionStatusBanner(
     title: String,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
-    windowInsets: WindowInsets = WindowInsets(space0),
 ) {
     Surface(
         modifier = modifier
@@ -44,7 +40,6 @@ fun ConnectionStatusBanner(
     ) {
         Row(
             modifier = Modifier
-                .windowInsetsPadding(windowInsets)
                 .padding(horizontal = padding16, vertical = space10),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/ConnectionStatusBannerHost.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/ConnectionStatusBannerHost.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
@@ -15,7 +14,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.gemwallet.android.ui.theme.space0
 
 @Stable
 class ConnectionBannerState {
@@ -46,7 +44,6 @@ val LocalConnectionBannerHandled = compositionLocalOf { false }
 @Composable
 fun ConnectionStatusBannerHost(
     modifier: Modifier = Modifier,
-    windowInsets: WindowInsets = WindowInsets(space0),
 ) {
     if (LocalConnectionBannerHandled.current) return
     val state = LocalConnectionBannerState.current
@@ -63,7 +60,6 @@ fun ConnectionStatusBannerHost(
             title = displayTitle,
             onDismiss = state::dismiss,
             modifier = modifier,
-            windowInsets = windowInsets,
         )
     }
 }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/Scene.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/Scene.kt
@@ -8,13 +8,14 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -38,7 +39,6 @@ import com.gemwallet.android.ui.theme.WindowDimension
 import com.gemwallet.android.ui.theme.isCompactDimension
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.sceneContentPadding
-import com.gemwallet.android.ui.theme.space0
 
 enum class MainActionWidth {
     Constrained,
@@ -66,7 +66,6 @@ fun Scene(
     },
     mainActionWidth: MainActionWidth = MainActionWidth.Constrained,
     snackbar: SnackbarHostState? = null,
-    navigationBarPadding: Boolean = true,
     content: @Composable ColumnScope.(PaddingValues) -> Unit,
 ) {
     Scene(
@@ -87,7 +86,6 @@ fun Scene(
         mainActionPadding = mainActionPadding,
         mainActionWidth = mainActionWidth,
         snackbar = snackbar,
-        navigationBarPadding = navigationBarPadding,
         content = content,
     )
 }
@@ -105,7 +103,6 @@ fun Scene(
     mainActionPadding: PaddingValues = PaddingValues(horizontal = sceneContentPadding(), vertical = paddingDefault),
     mainActionWidth: MainActionWidth = MainActionWidth.Constrained,
     snackbar: SnackbarHostState? = null,
-    navigationBarPadding: Boolean = true,
     progress: (() -> Float)? = null,
     content: @Composable ColumnScope.(PaddingValues) -> Unit,
 ) {
@@ -113,7 +110,6 @@ fun Scene(
         onClose?.invoke()
     }
     Scaffold(
-        modifier = Modifier.imePadding(),
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
             Box(
@@ -143,20 +139,17 @@ fun Scene(
             }
         },
         bottomBar = {
-            Column {
-                ConnectionStatusBannerHost(
-                    windowInsets = if (mainAction == null) {
-                        WindowInsets.navigationBars
-                    } else {
-                        WindowInsets(space0)
-                    },
-                )
+            Column(
+                modifier = Modifier.windowInsetsPadding(
+                    WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)
+                ),
+            ) {
+                ConnectionStatusBannerHost()
                 if (mainAction != null) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(MaterialTheme.colorScheme.surface)
-                            .navigationBarsPadding(),
+                            .background(MaterialTheme.colorScheme.surface),
                         contentAlignment = Alignment.Center,
                     ) {
                         Box(
@@ -185,7 +178,7 @@ fun Scene(
             modifier = Modifier
                 .padding(
                     top = paddingValues.calculateTopPadding(),
-                    bottom = if (navigationBarPadding) paddingValues.calculateBottomPadding() else 0.dp,
+                    bottom = paddingValues.calculateBottomPadding(),
                 )
                 .fillMaxSize(),
         ) {


### PR DESCRIPTION
On devices with a system navigation bar the bottom of the app was cut off — last list rows and their controls could not be tapped. Now every screen keeps its content above the navigation bar, and above the keyboard when it is open.

Closes #950

<img width="250" alt="buttons-1-list-end" src="https://github.com/user-attachments/assets/0f7dfe94-b1b6-496f-83e6-4c6a59019599" />
<img width="250" alt="buttons-2-main-button" src="https://github.com/user-attachments/assets/16a55708-3303-4f55-b1d2-1203409387d8" />
<img width="250" alt="buttons-3-keyboard" src="https://github.com/user-attachments/assets/43f7c506-6c74-434b-b8f9-1fc06dc654bf" />

<img width="250" alt="gestures-1-list-end" src="https://github.com/user-attachments/assets/448848ec-7afd-402f-aacd-24a348b20fed" />

<img width="250" alt="gestures-2-main-button" src="https://github.com/user-attachments/assets/8bb978d7-ef68-48d3-8736-7193d7bc2e4f" />
<img width="250" alt="gestures-3-keyboard" src="https://github.com/user-attachments/assets/d4fa11ef-ff6e-4f12-b5bb-2a2a394b6731" />
