### PR TITLE
Move Gem staking mapping into extensions

### DIFF
--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/gemstone/GemStakeMapper.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/gemstone/GemStakeMapper.kt
@@ -1,0 +1,45 @@
+package com.gemwallet.android.blockchain.gemstone
+
+import com.gemwallet.android.ext.toAssetId
+import com.gemwallet.android.ext.toChain
+import com.wallet.core.primitives.DelegationBase
+import com.wallet.core.primitives.DelegationState
+import com.wallet.core.primitives.DelegationValidator
+import com.wallet.core.primitives.StakeProviderType
+import uniffi.gemstone.GemDelegationBase
+import uniffi.gemstone.GemDelegationState
+import uniffi.gemstone.GemDelegationValidator
+
+internal fun GemDelegationValidator.toDTO(): DelegationValidator? {
+    return DelegationValidator(
+        chain = chain.toChain() ?: return null,
+        id = id,
+        name = name,
+        isActive = isActive,
+        commission = commission,
+        apr = apr,
+        providerType = StakeProviderType.Stake,
+    )
+}
+
+internal fun GemDelegationBase.toDTO(): DelegationBase? {
+    return DelegationBase(
+        assetId = assetId.toAssetId() ?: return null,
+        state = state.toDTO(),
+        balance = balance,
+        rewards = rewards,
+        completionDate = completionDate,
+        delegationId = delegationId,
+        validatorId = validatorId,
+        shares = shares,
+    )
+}
+
+internal fun GemDelegationState.toDTO(): DelegationState = when (this) {
+    GemDelegationState.ACTIVE -> DelegationState.Active
+    GemDelegationState.PENDING -> DelegationState.Pending
+    GemDelegationState.INACTIVE -> DelegationState.Inactive
+    GemDelegationState.ACTIVATING -> DelegationState.Activating
+    GemDelegationState.DEACTIVATING -> DelegationState.Deactivating
+    GemDelegationState.AWAITING_WITHDRAWAL -> DelegationState.AwaitingWithdrawal
+}

--- a/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/services/StakeService.kt
+++ b/android/blockchain/src/main/kotlin/com/gemwallet/android/blockchain/services/StakeService.kt
@@ -1,13 +1,9 @@
 package com.gemwallet.android.blockchain.services
 
-import com.gemwallet.android.ext.toAssetId
-import com.gemwallet.android.ext.toChain
+import com.gemwallet.android.blockchain.gemstone.toDTO
 import com.wallet.core.primitives.Chain
 import com.wallet.core.primitives.DelegationBase
-import com.wallet.core.primitives.DelegationState
 import com.wallet.core.primitives.DelegationValidator
-import com.wallet.core.primitives.StakeProviderType
-import uniffi.gemstone.GemDelegationState
 import uniffi.gemstone.GemGateway
 
 class StakeService(
@@ -17,50 +13,30 @@ class StakeService(
         chain: Chain,
         apr: Double
     ): List<DelegationValidator> {
-        return try {
-            val result = gateway.getStakingValidators(
+        val result = try {
+            gateway.getStakingValidators(
                 chain = chain.string,
                 apr,
             )
-            result.mapNotNull { item ->
-                DelegationValidator(
-                    chain = item.chain.toChain() ?: return@mapNotNull null,
-                    id = item.id,
-                    name = item.name,
-                    isActive = item.isActive,
-                    commission = item.commission,
-                    apr = item.apr,
-                    providerType = StakeProviderType.Stake,
-                )
-            }
         } catch (_: Throwable) {
-            emptyList()
+            return emptyList()
         }
+        return result.mapNotNull { it.toDTO() }
     }
 
     suspend fun getDelegationValidators(
         chain: Chain,
         address: String,
     ): List<DelegationValidator> {
-        return try {
-            val result = gateway.getStakingDelegationValidators(
+        val result = try {
+            gateway.getStakingDelegationValidators(
                 chain = chain.string,
                 address = address,
             )
-            result.mapNotNull { item ->
-                DelegationValidator(
-                    chain = item.chain.toChain() ?: return@mapNotNull null,
-                    id = item.id,
-                    name = item.name,
-                    isActive = item.isActive,
-                    commission = item.commission,
-                    apr = item.apr,
-                    providerType = StakeProviderType.Stake,
-                )
-            }
         } catch (_: Throwable) {
-            emptyList()
+            return emptyList()
         }
+        return result.mapNotNull { it.toDTO() }
     }
 
     suspend fun getStakeDelegations(
@@ -75,24 +51,6 @@ class StakeService(
         } catch (_: Throwable) {
             return null
         }
-        return result.mapNotNull { item ->
-            DelegationBase(
-                assetId = item.assetId.toAssetId() ?: return@mapNotNull null,
-                state = when (item.state) {
-                    GemDelegationState.ACTIVE -> DelegationState.Active
-                    GemDelegationState.PENDING -> DelegationState.Pending
-                    GemDelegationState.INACTIVE -> DelegationState.Inactive
-                    GemDelegationState.ACTIVATING -> DelegationState.Activating
-                    GemDelegationState.DEACTIVATING -> DelegationState.Deactivating
-                    GemDelegationState.AWAITING_WITHDRAWAL -> DelegationState.AwaitingWithdrawal
-                },
-                balance = item.balance,
-                rewards = item.rewards,
-                completionDate = item.completionDate,
-                delegationId = item.delegationId,
-                validatorId = item.validatorId,
-                shares = item.shares,
-            )
-        }
+        return result.mapNotNull { it.toDTO() }
     }
 }


### PR DESCRIPTION
The staking service built the domain objects inline, and the validator mapping was written out twice in two of its methods.

The mapping now lives next to the other Gem mappers, so the service only calls the gateway and maps the result. No behaviour changes.