### PR TITLE
Fix delegation details showing another wallet's stake

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/stake/GetDelegationImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/stake/GetDelegationImpl.kt
@@ -3,11 +3,12 @@ package com.gemwallet.android.data.coordinators.stake
 import com.gemwallet.android.application.stake.coordinators.GetDelegation
 import com.gemwallet.android.data.repositories.stake.StakeRepository
 import com.wallet.core.primitives.Delegation
+import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.flow.Flow
 
 class GetDelegationImpl(
     private val stakeRepository: StakeRepository,
 ) : GetDelegation {
-    override fun invoke(validatorId: String, delegationId: String): Flow<Delegation?> =
-        stakeRepository.getDelegation(validatorId = validatorId, delegationId = delegationId)
+    override fun invoke(walletId: WalletId, validatorId: String, delegationId: String): Flow<Delegation?> =
+        stakeRepository.getDelegation(walletId = walletId, validatorId = validatorId, delegationId = delegationId)
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stake/StakeRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/stake/StakeRepository.kt
@@ -58,8 +58,8 @@ class StakeRepository(
             }
     }
 
-    fun getDelegation(validatorId: String, delegationId: String): Flow<Delegation?> {
-        return stakeDao.getDelegation(validatorId, delegationId).map { it?.toModel() }
+    fun getDelegation(walletId: WalletId, validatorId: String, delegationId: String): Flow<Delegation?> {
+        return stakeDao.getDelegation(walletId, validatorId, delegationId).map { it?.toModel() }
     }
 
     suspend fun getRewards(walletId: WalletId, assetId: AssetId): List<Delegation> {

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionBalanceService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionBalanceService.kt
@@ -32,9 +32,9 @@ class TransactionBalanceService @Inject constructor(
     suspend fun getContext(assetInfo: AssetInfo, params: ConfirmParams): TransactionBalanceContext {
         return when (params) {
             is ConfirmParams.Stake.Unfreeze -> TransactionBalanceContext(resource = params.resource)
-            is ConfirmParams.Stake.RedelegateParams -> delegationContext(params.delegation)
-            is ConfirmParams.Stake.UndelegateParams -> delegationContext(params.delegation)
-            is ConfirmParams.Stake.WithdrawParams -> delegationContext(params.delegation)
+            is ConfirmParams.Stake.RedelegateParams -> delegationContext(assetInfo, params.delegation)
+            is ConfirmParams.Stake.UndelegateParams -> delegationContext(assetInfo, params.delegation)
+            is ConfirmParams.Stake.WithdrawParams -> delegationContext(assetInfo, params.delegation)
             is ConfirmParams.Stake.RewardsParams -> TransactionBalanceContext(
                 rewardsBalance = getRewardsBalance(assetInfo),
             )
@@ -45,11 +45,17 @@ class TransactionBalanceService @Inject constructor(
         }
     }
 
-    private suspend fun delegationContext(delegation: Delegation): TransactionBalanceContext {
-        val currentDelegation = stakeRepository.getDelegation(
-            validatorId = delegation.base.validatorId,
-            delegationId = delegation.base.delegationId,
-        ).firstOrNull() ?: delegation
+    private suspend fun delegationContext(assetInfo: AssetInfo, delegation: Delegation): TransactionBalanceContext {
+        val walletId = assetInfo.walletId
+        val currentDelegation = if (walletId == null) {
+            delegation
+        } else {
+            stakeRepository.getDelegation(
+                walletId = walletId,
+                validatorId = delegation.base.validatorId,
+                delegationId = delegation.base.delegationId,
+            ).firstOrNull() ?: delegation
+        }
         return TransactionBalanceContext(
             delegationBalance = currentDelegation.base.balance.toBigIntegerOrNull() ?: BigInteger.ZERO,
         )

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionBalanceServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/transactions/TransactionBalanceServiceTest.kt
@@ -11,6 +11,7 @@ import com.gemwallet.android.testkit.mockAssetInfo
 import com.gemwallet.android.testkit.mockDelegation
 import com.gemwallet.android.testkit.mockDelegationValidator
 import com.gemwallet.android.testkit.mockAssetMonad
+import com.gemwallet.android.testkit.mockWalletId
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -77,7 +78,7 @@ class TransactionBalanceServiceTest {
             validatorId = "validator-1",
         )
         every {
-            stakeRepository.getDelegation("validator-1", "delegation-1")
+            stakeRepository.getDelegation(requireNotNull(assetInfo.walletId), "validator-1", "delegation-1")
         } returns flowOf(
             mockDelegation(
                 assetId = asset.id,
@@ -112,7 +113,7 @@ class TransactionBalanceServiceTest {
             validatorId = "validator-1",
         )
         every {
-            stakeRepository.getDelegation("validator-1", "delegation-1")
+            stakeRepository.getDelegation(requireNotNull(assetInfo.walletId), "validator-1", "delegation-1")
         } returns flowOf(
             mockDelegation(
                 assetId = asset.id,
@@ -129,6 +130,44 @@ class TransactionBalanceServiceTest {
             destinationValidator = mockDelegationValidator(chain = asset.id.chain, id = "validator-2"),
             delegation = delegation,
         )
+
+        assertEquals(
+            BigInteger("44"),
+            subject.getBalance(assetInfo, params),
+        )
+    }
+
+    @Test
+    fun getBalance_withdraw_scopesFreshDelegationLookupToOwningWallet() = runBlocking {
+        val asset = mockAssetCosmos()
+        val ownWalletId = mockWalletId("wallet-own")
+        val otherWalletId = mockWalletId("wallet-other")
+        val assetInfo = mockAssetInfo(
+            asset = asset,
+            balance = AssetBalance.create(asset = asset, frozen = "0"),
+            walletId = ownWalletId,
+        )
+        val delegation = mockDelegation(
+            assetId = asset.id,
+            balance = "10",
+            delegationId = "delegation-1",
+            validatorId = "validator-1",
+        )
+        every {
+            stakeRepository.getDelegation(ownWalletId, "validator-1", "delegation-1")
+        } returns flowOf(
+            mockDelegation(assetId = asset.id, balance = "44", delegationId = "delegation-1", validatorId = "validator-1")
+        )
+        every {
+            stakeRepository.getDelegation(otherWalletId, "validator-1", "delegation-1")
+        } returns flowOf(
+            mockDelegation(assetId = asset.id, balance = "999999", delegationId = "delegation-1", validatorId = "validator-1")
+        )
+
+        val params = ConfirmParams.Builder(
+            asset = asset,
+            from = requireNotNull(assetInfo.owner),
+        ).withdraw(delegation)
 
         assertEquals(
             BigInteger("44"),

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/StakeDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/StakeDao.kt
@@ -57,7 +57,7 @@ interface StakeDao {
     @Query(
         "SELECT base.* FROM stake_delegations as base " +
             "INNER JOIN stake_validators as validator ON base.validatorId=validator.id " +
-            "WHERE base.delegationId=:delegationId AND validator.validatorId=:validatorId LIMIT 1"
+            "WHERE base.walletId=:walletId AND base.delegationId=:delegationId AND validator.validatorId=:validatorId LIMIT 1"
     )
-    fun getDelegation(validatorId: String, delegationId: String): Flow<DbDelegationData?>
+    fun getDelegation(walletId: WalletId, validatorId: String, delegationId: String): Flow<DbDelegationData?>
 }

--- a/android/features/earn/delegation/viewmodels/build.gradle.kts
+++ b/android/features/earn/delegation/viewmodels/build.gradle.kts
@@ -58,7 +58,9 @@ dependencies {
     implementation(libs.lifecycle.runtime.ktx)
     implementation(libs.lifecycle.viewmodel.savedstate)
 
+    testImplementation(testFixtures(project(":gemcore")))
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockk.android)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/viewmodels/DelegationViewModel.kt
+++ b/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/viewmodels/DelegationViewModel.kt
@@ -53,10 +53,13 @@ class DelegationViewModel @Inject constructor(
     val validatorId = MutableStateFlow(savedStateHandle.requireString(RouteArgument.ValidatorId))
     val delegationId = MutableStateFlow(savedStateHandle.getString(RouteArgument.DelegationId))
 
-    val delegation = combine(validatorId, delegationId) { validatorId, delegationId -> Pair(validatorId, delegationId) }
-        .flatMapLatest {
-            val (validatorId, delegationId) = it
-            stakeRepository.getDelegation(delegationId = delegationId, validatorId = validatorId)
+    val delegation = combine(
+        validatorId,
+        delegationId,
+        sessionRepository.session().filterNotNull(),
+    ) { validatorId, delegationId, session -> Triple(validatorId, delegationId, session.wallet.id) }
+        .flatMapLatest { (validatorId, delegationId, walletId) ->
+            stakeRepository.getDelegation(walletId = walletId, validatorId = validatorId, delegationId = delegationId)
         }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 

--- a/android/features/earn/delegation/viewmodels/src/test/kotlin/com/gemwallet/android/features/earn/delegation/viewmodels/DelegationViewModelTest.kt
+++ b/android/features/earn/delegation/viewmodels/src/test/kotlin/com/gemwallet/android/features/earn/delegation/viewmodels/DelegationViewModelTest.kt
@@ -1,0 +1,81 @@
+package com.gemwallet.android.features.earn.delegation.viewmodels
+
+import androidx.lifecycle.SavedStateHandle
+import com.gemwallet.android.cases.nodes.GetCurrentBlockExplorer
+import com.gemwallet.android.data.repositories.assets.AssetsRepository
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.data.repositories.stake.StakeRepository
+import com.gemwallet.android.testkit.mockAssetCosmos
+import com.gemwallet.android.testkit.mockAssetInfo
+import com.gemwallet.android.testkit.mockDelegation
+import com.gemwallet.android.testkit.mockSession
+import com.gemwallet.android.testkit.mockWallet
+import com.gemwallet.android.testkit.mockWalletId
+import com.gemwallet.android.ui.models.navigation.RouteArgument
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DelegationViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val asset = mockAssetCosmos()
+
+    private val assetsRepository = mockk<AssetsRepository> {
+        every { getAssetInfo(asset.id) } returns flowOf(mockAssetInfo(asset = asset))
+    }
+    private val stakeRepository = mockk<StakeRepository>()
+    private val getCurrentBlockExplorer = mockk<GetCurrentBlockExplorer>(relaxed = true) {
+        every { getCurrentBlockExplorer(asset.id.chain) } returns "Mintscan"
+    }
+
+    @Before
+    fun setUp() = Dispatchers.setMain(testDispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `delegation lookup is scoped to the session wallet, not just validator and delegation id`() = runTest(testDispatcher) {
+        val ownWalletId = mockWalletId("wallet-own")
+        val otherWalletId = mockWalletId("wallet-other")
+        val ownDelegation = mockDelegation(assetId = asset.id, balance = "77", validatorId = "v1", delegationId = "d1")
+        val otherWalletDelegation = mockDelegation(assetId = asset.id, balance = "999999", validatorId = "v1", delegationId = "d1")
+
+        every { stakeRepository.getDelegation(ownWalletId, "v1", "d1") } returns flowOf(ownDelegation)
+        every { stakeRepository.getDelegation(otherWalletId, "v1", "d1") } returns flowOf(otherWalletDelegation)
+
+        val sessionRepository = mockk<SessionRepository> {
+            every { session() } returns MutableStateFlow(mockSession(wallet = mockWallet(id = ownWalletId.id)))
+        }
+
+        val viewModel = DelegationViewModel(
+            assetsRepository = assetsRepository,
+            stakeRepository = stakeRepository,
+            getCurrentBlockExplorer = getCurrentBlockExplorer,
+            sessionRepository = sessionRepository,
+            savedStateHandle = SavedStateHandle(
+                mapOf(
+                    RouteArgument.ValidatorId.key to "v1",
+                    RouteArgument.DelegationId.key to "d1",
+                )
+            ),
+        )
+        runCurrent()
+
+        assertEquals(ownDelegation, viewModel.delegation.value)
+    }
+}

--- a/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/providers/AmountStakeProvider.kt
+++ b/android/features/transfer_amount/viewmodels/src/main/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/providers/AmountStakeProvider.kt
@@ -139,15 +139,26 @@ class AmountStakeProvider(
         else -> MutableStateFlow(emptyList())
     }
 
+    private data class DelegationIdentity(val validatorId: String, val delegationId: String)
+
+    private val delegationIdentity: DelegationIdentity? = when (params) {
+        is AmountParams.Stake.Undelegate -> DelegationIdentity(params.validatorId, params.delegationId)
+        is AmountParams.Stake.Redelegate -> DelegationIdentity(params.validatorId, params.delegationId)
+        is AmountParams.Stake.Withdraw -> DelegationIdentity(params.validatorId, params.delegationId)
+        else -> null
+    }
+
     private val delegation: StateFlow<Delegation?> = run {
-        val source = when (params) {
-            is AmountParams.Stake.Undelegate ->
-                getDelegation(validatorId = params.validatorId, delegationId = params.delegationId)
-            is AmountParams.Stake.Redelegate ->
-                getDelegation(validatorId = params.validatorId, delegationId = params.delegationId)
-            is AmountParams.Stake.Withdraw ->
-                getDelegation(validatorId = params.validatorId, delegationId = params.delegationId)
-            is AmountParams.Stake.Rewards ->
+        val source = when {
+            delegationIdentity != null -> assetInfo.filterNotNull().flatMapLatest { current ->
+                val walletId = current.walletId ?: return@flatMapLatest flowOf(null)
+                getDelegation(
+                    walletId = walletId,
+                    validatorId = delegationIdentity.validatorId,
+                    delegationId = delegationIdentity.delegationId,
+                )
+            }
+            params is AmountParams.Stake.Rewards ->
                 combine(rewardsDelegations, selectedValidatorId) { withRewards, pickedId ->
                     withRewards.firstOrNull { it.validator.id == pickedId } ?: withRewards.firstOrNull()
                 }

--- a/android/features/transfer_amount/viewmodels/src/test/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/providers/AmountProviderFactoryTest.kt
+++ b/android/features/transfer_amount/viewmodels/src/test/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/providers/AmountProviderFactoryTest.kt
@@ -34,7 +34,7 @@ class AmountProviderFactoryTest {
             every { this@mockk.invoke(any()) } returns flowOf(null)
         },
         getDelegation = mockk<GetDelegation>(relaxed = true) {
-            every { this@mockk.invoke(any(), any()) } returns flowOf(null)
+            every { this@mockk.invoke(any(), any(), any()) } returns flowOf(null)
         },
         getDelegations = mockk<GetDelegations>(relaxed = true) {
             every { this@mockk.invoke(any(), any()) } returns flowOf(emptyList())

--- a/android/features/transfer_amount/viewmodels/src/test/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/providers/AmountStakeProviderTest.kt
+++ b/android/features/transfer_amount/viewmodels/src/test/kotlin/com/gemwallet/android/features/transfer_amount/viewmodels/providers/AmountStakeProviderTest.kt
@@ -14,6 +14,7 @@ import com.gemwallet.android.testkit.mockAssetCosmos
 import com.gemwallet.android.testkit.mockAssetInfo
 import com.gemwallet.android.testkit.mockDelegation
 import com.gemwallet.android.testkit.mockDelegationValidator
+import com.gemwallet.android.testkit.mockWalletId
 import com.wallet.core.primitives.Resource
 import io.mockk.coEvery
 import io.mockk.every
@@ -48,7 +49,7 @@ class AmountStakeProviderTest {
         every { this@mockk.invoke(asset.id) } returns flowOf(assetInfo)
     }
     private val getDelegation = mockk<GetDelegation> {
-        every { this@mockk.invoke(any(), any()) } returns flowOf(delegation)
+        every { this@mockk.invoke(any(), any(), any()) } returns flowOf(delegation)
     }
     private val getDelegations = mockk<GetDelegations> {
         every { this@mockk.invoke(any(), any()) } returns flowOf(listOf(delegation))
@@ -86,7 +87,7 @@ class AmountStakeProviderTest {
     @Test
     fun `delegate without validator throws NoValidatorSelected`() = runBlocking {
         coEvery { getStakeValidator(any(), any()) } returns null
-        every { getDelegation(any(), any()) } returns flowOf(null)
+        every { getDelegation(any(), any(), any()) } returns flowOf(null)
         val provider = makeProvider(AmountParams.Stake.Delegate(asset.id, validatorId = null))
         provider.assetInfo.filterNotNull().first()
         assertThrows(AmountError.NoValidatorSelected::class.java) {
@@ -102,6 +103,38 @@ class AmountStakeProviderTest {
         provider.validatorState.filterNotNull().first()
         val confirm = provider.buildConfirmParams(Crypto(BigInteger.ONE), isMax = false)
         assertTrue(confirm is ConfirmParams.Stake.UndelegateParams)
+    }
+
+    @Test
+    fun `undelegate delegation lookup is scoped to the asset's owning wallet`() = runBlocking {
+        val ownWalletId = mockWalletId("wallet-own")
+        val otherWalletId = mockWalletId("wallet-other")
+        val ownDelegation = mockDelegation(
+            assetId = asset.id,
+            balance = "77",
+            validatorId = "v1",
+            delegationId = "d1",
+        )
+        val otherWalletDelegation = mockDelegation(
+            assetId = asset.id,
+            balance = "999999",
+            validatorId = "v1",
+            delegationId = "d1",
+        )
+        every { getAssetInfo(asset.id) } returns flowOf(mockAssetInfo(asset = asset, walletId = ownWalletId))
+        every { getDelegation(ownWalletId, "v1", "d1") } returns flowOf(ownDelegation)
+        every { getDelegation(otherWalletId, "v1", "d1") } returns flowOf(otherWalletDelegation)
+        coEvery {
+            balanceService.getBalance(any(), any<AmountParams>(), delegation = ownDelegation, resource = any())
+        } returns BigInteger("77")
+
+        val provider = makeProvider(AmountParams.Stake.Undelegate(asset.id, validatorId = "v1", delegationId = "d1"))
+        provider.assetInfo.filterNotNull().first()
+        provider.validatorState.filterNotNull().first()
+
+        assertEquals(BigInteger("77"), provider.availableBalance.first { it != BigInteger.ZERO })
+        val confirm = provider.buildConfirmParams(Crypto(BigInteger.ONE), isMax = false) as ConfirmParams.Stake.UndelegateParams
+        assertEquals("77", confirm.delegation.base.balance)
     }
 
     @Test

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/stake/coordinators/GetDelegation.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/stake/coordinators/GetDelegation.kt
@@ -1,8 +1,9 @@
 package com.gemwallet.android.application.stake.coordinators
 
 import com.wallet.core.primitives.Delegation
+import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.flow.Flow
 
 interface GetDelegation {
-    operator fun invoke(validatorId: String, delegationId: String): Flow<Delegation?>
+    operator fun invoke(walletId: WalletId, validatorId: String, delegationId: String): Flow<Delegation?>
 }


### PR DESCRIPTION
Opening a staked delegation could show the balance and rewards of a different wallet if two wallets had staked with the same validator. The delegation detail screen looked up the stake without checking which wallet it belonged to.

Now the lookup is scoped to the wallet you're currently viewing.