### PR TITLE
Own Hyperliquid subscription state in core

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/PerpetualModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/PerpetualModule.kt
@@ -28,6 +28,7 @@ import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import javax.inject.Singleton
 import uniffi.gemstone.Hyperliquid
+import uniffi.gemstone.HyperliquidSubscriptions
 
 @InstallIn(SingletonComponent::class)
 @Module
@@ -67,10 +68,8 @@ object PerpetualModule {
 
     @Provides
     @Singleton
-    fun provideHyperliquidSubscriptionService(
-        hyperliquid: Hyperliquid,
-    ): HyperliquidSubscriptionService =
-        HyperliquidSubscriptionService(hyperliquid::websocketRequest)
+    fun provideHyperliquidSubscriptionService(): HyperliquidSubscriptionService =
+        HyperliquidSubscriptionService(HyperliquidSubscriptions())
 
     @Provides
     @Singleton
@@ -79,7 +78,6 @@ object PerpetualModule {
         syncPerpetuals: SyncPerpetuals,
         syncPerpetualPositions: SyncPerpetualPositions,
         getPerpetualAccountMode: GetPerpetualAccountMode,
-        hyperliquid: Hyperliquid,
         eventHandler: HyperliquidEventHandler,
         subscriptionService: HyperliquidSubscriptionService,
         getNodeUrlCase: GetNodeUrlCase,
@@ -89,7 +87,6 @@ object PerpetualModule {
         syncPerpetuals = syncPerpetuals,
         syncPerpetualPositions = syncPerpetualPositions,
         getPerpetualAccountMode = getPerpetualAccountMode,
-        hyperliquid = hyperliquid,
         eventHandler = eventHandler,
         subscriptionService = subscriptionService,
         connection = WebSocketConnection(

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidEventHandler.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidEventHandler.kt
@@ -44,6 +44,7 @@ class HyperliquidEventHandler(
                 is GemHyperliquidSocketMessage.MarketData -> perpetualRepository.updateMarket(message.market.toDTO())
                 is GemHyperliquidSocketMessage.MarketPrices -> handleMarketPrices(message.prices)
                 is GemHyperliquidSocketMessage.SubscriptionResponse -> Log.d(TAG, "Subscription response: ${message.subscriptionType}")
+                is GemHyperliquidSocketMessage.Error -> Log.e(TAG, "Error message: ${message.message}")
                 GemHyperliquidSocketMessage.Unknown -> Log.d(TAG, "Unknown message: ${text.take(100)}")
             }
         }.onFailure { Log.e(TAG, "Handle message error: ${text.take(100)}", it) }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverService.kt
@@ -23,14 +23,12 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 import uniffi.gemstone.GemPerpetualSubscription
-import uniffi.gemstone.Hyperliquid
 
 class HyperliquidObserverService(
     private val observePerpetualWallet: ObservePerpetualWallet,
     private val syncPerpetuals: SyncPerpetuals,
     private val syncPerpetualPositions: SyncPerpetualPositions,
     private val getPerpetualAccountMode: GetPerpetualAccountMode,
-    private val hyperliquid: Hyperliquid,
     private val eventHandler: HyperliquidEventHandler,
     private val subscriptionService: HyperliquidSubscriptionService,
     private val connection: WebSocketConnectable,
@@ -84,9 +82,9 @@ class HyperliquidObserverService(
         launch { sendSubscriptionRequests() }
         connection.connect().collect { event ->
             when (event) {
-                WebSocketEvent.Connected -> subscriptionService.resubscribe(hyperliquid.accountSubscriptions(address, mode.toGem()))
+                WebSocketEvent.Connected -> subscriptionService.connected(address, mode.toGem())
                 is WebSocketEvent.Message -> eventHandler.handle(walletId, mode, event.text)
-                WebSocketEvent.Disconnected -> Unit
+                WebSocketEvent.Disconnected -> subscriptionService.disconnected()
             }
         }
     }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidSubscriptionService.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidSubscriptionService.kt
@@ -1,32 +1,41 @@
 package com.gemwallet.android.data.repositories.perpetual
 
+import android.util.Log
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
+import uniffi.gemstone.GemPerpetualAccountMode
 import uniffi.gemstone.GemPerpetualSubscription
-import uniffi.gemstone.GemSubscriptionMethod
-import java.util.concurrent.ConcurrentHashMap
+import uniffi.gemstone.HyperliquidSubscriptions
 
 class HyperliquidSubscriptionService(
-    private val encodeRequest: (GemSubscriptionMethod, GemPerpetualSubscription) -> String,
+    private val subscriptions: HyperliquidSubscriptions,
 ) {
     private val outgoing = Channel<String>(Channel.UNLIMITED)
     val messages: ReceiveChannel<String> = outgoing
 
-    private val activeSubscriptions = ConcurrentHashMap.newKeySet<GemPerpetualSubscription>()
-
     fun subscribe(subscription: GemPerpetualSubscription) {
-        activeSubscriptions.add(subscription)
-        outgoing.trySend(encodeRequest(GemSubscriptionMethod.SUBSCRIBE, subscription))
+        send { subscriptions.subscribe(subscription) }
     }
 
     fun unsubscribe(subscription: GemPerpetualSubscription) {
-        activeSubscriptions.remove(subscription)
-        outgoing.trySend(encodeRequest(GemSubscriptionMethod.UNSUBSCRIBE, subscription))
+        send { subscriptions.unsubscribe(subscription) }
     }
 
-    suspend fun resubscribe(defaultSubscriptions: List<GemPerpetualSubscription>) {
-        (defaultSubscriptions + activeSubscriptions).distinct().forEach {
-            outgoing.send(encodeRequest(GemSubscriptionMethod.SUBSCRIBE, it))
-        }
+    fun connected(address: String, mode: GemPerpetualAccountMode) {
+        send { subscriptions.connected(address, mode) }
+    }
+
+    fun disconnected() {
+        subscriptions.disconnected()
+    }
+
+    private fun send(requests: () -> List<String>) {
+        runCatching(requests)
+            .onSuccess { it.forEach(outgoing::trySend) }
+            .onFailure { Log.e(TAG, "Subscription request error", it) }
+    }
+
+    companion object {
+        private const val TAG = "HyperliquidSubscriptions"
     }
 }

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidObserverServiceTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import uniffi.gemstone.GemPerpetualSubscription
+import uniffi.gemstone.HyperliquidSubscriptions
 
 class HyperliquidObserverServiceTest {
 
@@ -49,14 +50,8 @@ class HyperliquidObserverServiceTest {
             syncPerpetuals = mockk(relaxed = true),
             syncPerpetualPositions = mockk(relaxed = true),
             getPerpetualAccountMode = mockk { coEvery { getPerpetualAccountMode(any(), any()) } returns PerpetualAccountMode.Standard },
-            hyperliquid = mockk {
-                every { accountSubscriptions(any(), any()) } returns listOf(
-                    GemPerpetualSubscription.AccountState(ADDRESS),
-                    GemPerpetualSubscription.OpenOrders(ADDRESS),
-                )
-            },
             eventHandler = eventHandler,
-            subscriptionService = HyperliquidSubscriptionService { _, _ -> SUBSCRIBE_REQUEST },
+            subscriptionService = HyperliquidSubscriptionService(HyperliquidSubscriptions()),
             connection = connection,
             scope = scope,
         )
@@ -64,8 +59,52 @@ class HyperliquidObserverServiceTest {
         observer.start()
         advanceUntilIdle()
 
-        assertEquals(listOf(SUBSCRIBE_REQUEST, SUBSCRIBE_REQUEST), connection.sent)
+        assertEquals(
+            setOf(
+                """{"method":"subscribe","subscription":{"type":"clearinghouseState","user":"0xabc"}}""",
+                """{"method":"subscribe","subscription":{"type":"openOrders","user":"0xabc"}}""",
+            ),
+            connection.sent.toSet(),
+        )
         coVerify { eventHandler.handle(wallet.id, PerpetualAccountMode.Standard, MESSAGE) }
+        scope.cancel()
+    }
+
+
+    @Test
+    fun `subscription requested before connect is sent only once on connect`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val wallet = mockWallet(accounts = listOf(mockAccount(chain = Chain.HyperCore, address = ADDRESS)))
+        val connection = RecordingConnection(listOf(WebSocketEvent.Connected))
+        val eventHandler = mockk<HyperliquidEventHandler>(relaxed = true) {
+            every { chartUpdates } returns emptyFlow()
+        }
+        val observePerpetualWallet = mockk<ObservePerpetualWallet>()
+        every { observePerpetualWallet() } returns flowOf(wallet)
+        val observer = HyperliquidObserverService(
+            observePerpetualWallet = observePerpetualWallet,
+            syncPerpetuals = mockk(relaxed = true),
+            syncPerpetualPositions = mockk(relaxed = true),
+            getPerpetualAccountMode = mockk { coEvery { getPerpetualAccountMode(any(), any()) } returns PerpetualAccountMode.Standard },
+            eventHandler = eventHandler,
+            subscriptionService = HyperliquidSubscriptionService(HyperliquidSubscriptions()),
+            connection = connection,
+            scope = scope,
+        )
+
+        observer.subscribe(GemPerpetualSubscription.MarketData("UNI"))
+        observer.start()
+        advanceUntilIdle()
+
+        assertEquals(
+            setOf(
+                """{"method":"subscribe","subscription":{"type":"clearinghouseState","user":"0xabc"}}""",
+                """{"method":"subscribe","subscription":{"type":"openOrders","user":"0xabc"}}""",
+                """{"method":"subscribe","subscription":{"type":"activeAssetCtx","coin":"UNI"}}""",
+            ),
+            connection.sent.toSet(),
+        )
+        assertEquals(3, connection.sent.size)
         scope.cancel()
     }
 
@@ -81,6 +120,5 @@ class HyperliquidObserverServiceTest {
     private companion object {
         const val ADDRESS = "0xabc"
         const val MESSAGE = "message"
-        const val SUBSCRIBE_REQUEST = "subscribe-request"
     }
 }

--- a/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidSubscriptionServiceTest.kt
+++ b/android/data/repositories/src/test/kotlin/com/gemwallet/android/data/repositories/perpetual/HyperliquidSubscriptionServiceTest.kt
@@ -2,66 +2,36 @@ package com.gemwallet.android.data.repositories.perpetual
 
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import uniffi.gemstone.GemPerpetualAccountMode
 import uniffi.gemstone.GemPerpetualSubscription
-import uniffi.gemstone.GemSubscriptionMethod
+import uniffi.gemstone.HyperliquidSubscriptions
 
 class HyperliquidSubscriptionServiceTest {
 
     @Test
-    fun `subscribe and unsubscribe encode matching commands`() = runTest {
-        val encoded = mutableListOf<Pair<GemSubscriptionMethod, GemPerpetualSubscription>>()
-        val service = subscriptionService(encoded)
+    fun `requests reach the outgoing channel only once connected`() = runTest {
+        val service = HyperliquidSubscriptionService(HyperliquidSubscriptions())
 
         service.subscribe(GemPerpetualSubscription.MarketPrices)
-        assertEquals(REQUEST, service.messages.receive())
+        assertTrue(service.messages.tryReceive().isFailure)
 
-        service.unsubscribe(GemPerpetualSubscription.MarketPrices)
-        assertEquals(REQUEST, service.messages.receive())
+        service.connected(ADDRESS, GemPerpetualAccountMode.STANDARD)
 
-        assertEquals(
-            listOf(
-                GemSubscriptionMethod.SUBSCRIBE to GemPerpetualSubscription.MarketPrices,
-                GemSubscriptionMethod.UNSUBSCRIBE to GemPerpetualSubscription.MarketPrices,
-            ),
-            encoded,
-        )
-    }
-
-    @Test
-    fun `resubscribe replays default subscriptions and the active set`() = runTest {
-        val encoded = mutableListOf<Pair<GemSubscriptionMethod, GemPerpetualSubscription>>()
-        val service = subscriptionService(encoded)
-        service.subscribe(GemPerpetualSubscription.MarketPrices)
-        service.messages.receive() // drain the subscribe command
-        encoded.clear()
-
-        service.resubscribe(
-            listOf(
-                GemPerpetualSubscription.AccountState(ADDRESS),
-                GemPerpetualSubscription.SpotState(ADDRESS),
-            ),
-        )
-        repeat(3) { service.messages.receive() }
-
+        val sent = generateSequence { service.messages.tryReceive().getOrNull() }.toList()
         assertEquals(
             setOf(
-                GemSubscriptionMethod.SUBSCRIBE to GemPerpetualSubscription.AccountState(ADDRESS),
-                GemSubscriptionMethod.SUBSCRIBE to GemPerpetualSubscription.SpotState(ADDRESS),
-                GemSubscriptionMethod.SUBSCRIBE to GemPerpetualSubscription.MarketPrices,
+                """{"method":"subscribe","subscription":{"type":"clearinghouseState","user":"0xabc"}}""",
+                """{"method":"subscribe","subscription":{"type":"openOrders","user":"0xabc"}}""",
+                """{"method":"subscribe","subscription":{"type":"allMids"}}""",
             ),
-            encoded.toSet(),
+            sent.toSet(),
         )
+        assertEquals(3, sent.size)
     }
-
-    private fun subscriptionService(encoded: MutableList<Pair<GemSubscriptionMethod, GemPerpetualSubscription>>) =
-        HyperliquidSubscriptionService { method, subscription ->
-            encoded += method to subscription
-            REQUEST
-        }
 
     private companion object {
         const val ADDRESS = "0xabc"
-        const val REQUEST = "request"
     }
 }

--- a/core/crates/gem_hypercore/src/models/websocket.rs
+++ b/core/crates/gem_hypercore/src/models/websocket.rs
@@ -35,6 +35,9 @@ pub enum RawSocketMessage {
     #[serde(rename = "subscriptionResponse")]
     SubscriptionResponse(SubscriptionResponseData),
 
+    #[serde(rename = "error")]
+    Error(String),
+
     #[serde(other)]
     Unknown,
 }
@@ -180,6 +183,9 @@ pub enum HyperliquidSocketMessage {
     },
     SubscriptionResponse {
         subscription_type: String,
+    },
+    Error {
+        message: String,
     },
     Unknown,
 }

--- a/core/crates/gem_hypercore/src/provider/mod.rs
+++ b/core/crates/gem_hypercore/src/provider/mod.rs
@@ -21,6 +21,7 @@ pub mod transaction_state_mapper;
 pub mod transactions;
 pub mod transactions_mapper;
 pub mod websocket_mapper;
+pub mod websocket_subscriptions;
 
 pub struct BroadcastProvider;
 

--- a/core/crates/gem_hypercore/src/provider/websocket_mapper.rs
+++ b/core/crates/gem_hypercore/src/provider/websocket_mapper.rs
@@ -52,6 +52,7 @@ pub fn parse_websocket_data(data: &[u8], mode: PerpetualAccountMode) -> Result<H
         RawSocketMessage::SubscriptionResponse(data) => Ok(HyperliquidSocketMessage::SubscriptionResponse {
             subscription_type: data.subscription.subscription_type,
         }),
+        RawSocketMessage::Error(message) => Ok(HyperliquidSocketMessage::Error { message }),
         RawSocketMessage::Unknown => Ok(HyperliquidSocketMessage::Unknown),
     }
 }
@@ -288,5 +289,17 @@ mod tests {
                 HyperliquidSubscription::SpotState { address },
             ]
         );
+    }
+
+    #[test]
+    fn test_parse_error_channel() {
+        let json = br#"{"channel":"error","data":"Already subscribed: {\"type\":\"candle\",\"interval\":\"30m\",\"coin\":\"UNI\"}"}"#;
+
+        match parse_websocket_data(json, PerpetualAccountMode::Standard).unwrap() {
+            HyperliquidSocketMessage::Error { message } => {
+                assert_eq!(message, r#"Already subscribed: {"type":"candle","interval":"30m","coin":"UNI"}"#);
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
     }
 }

--- a/core/crates/gem_hypercore/src/provider/websocket_subscriptions.rs
+++ b/core/crates/gem_hypercore/src/provider/websocket_subscriptions.rs
@@ -1,0 +1,162 @@
+use std::collections::HashSet;
+
+use crate::models::websocket::{HyperliquidMethod, HyperliquidRequest, HyperliquidSubscription};
+
+#[derive(Debug, Default)]
+pub struct WebSocketSubscriptions {
+    requested: HashSet<HyperliquidSubscription>,
+    subscribed: Option<HashSet<HyperliquidSubscription>>,
+}
+
+impl WebSocketSubscriptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn subscribe(&mut self, subscription: HyperliquidSubscription) -> Vec<HyperliquidRequest> {
+        self.requested.insert(subscription.clone());
+
+        match &mut self.subscribed {
+            None => Vec::new(),
+            Some(subscribed) => match subscribed.insert(subscription.clone()) {
+                true => vec![request(HyperliquidMethod::Subscribe, subscription)],
+                false => Vec::new(),
+            },
+        }
+    }
+
+    pub fn unsubscribe(&mut self, subscription: &HyperliquidSubscription) -> Vec<HyperliquidRequest> {
+        self.requested.remove(subscription);
+
+        match &mut self.subscribed {
+            None => Vec::new(),
+            Some(subscribed) => match subscribed.remove(subscription) {
+                true => vec![request(HyperliquidMethod::Unsubscribe, subscription.clone())],
+                false => Vec::new(),
+            },
+        }
+    }
+
+    pub fn connected(&mut self, account_subscriptions: Vec<HyperliquidSubscription>) -> Vec<HyperliquidRequest> {
+        let subscribed = self.subscribed.insert(HashSet::new());
+
+        account_subscriptions
+            .into_iter()
+            .chain(self.requested.iter().cloned())
+            .filter(|subscription| subscribed.insert(subscription.clone()))
+            .map(|subscription| request(HyperliquidMethod::Subscribe, subscription))
+            .collect()
+    }
+
+    pub fn disconnected(&mut self) {
+        self.subscribed = None;
+    }
+}
+
+fn request(method: HyperliquidMethod, subscription: HyperliquidSubscription) -> HyperliquidRequest {
+    HyperliquidRequest { method, subscription }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candle(symbol: &str) -> HyperliquidSubscription {
+        HyperliquidSubscription::Candle {
+            symbol: symbol.to_string(),
+            interval: "30m".to_string(),
+        }
+    }
+
+    fn account_state() -> HyperliquidSubscription {
+        HyperliquidSubscription::AccountState { address: "0xabc".to_string() }
+    }
+
+    fn subscriptions(requests: &[HyperliquidRequest]) -> Vec<(HyperliquidMethod, HyperliquidSubscription)> {
+        requests.iter().map(|request| (request.method, request.subscription.clone())).collect()
+    }
+
+    #[test]
+    fn test_subscribe_before_connect_is_sent_once_on_connect() {
+        let mut state = WebSocketSubscriptions::new();
+
+        assert!(state.subscribe(candle("UNI")).is_empty());
+
+        let connected = state.connected(vec![account_state()]);
+
+        assert_eq!(
+            subscriptions(&connected),
+            vec![(HyperliquidMethod::Subscribe, account_state()), (HyperliquidMethod::Subscribe, candle("UNI")),]
+        );
+    }
+
+    #[test]
+    fn test_subscribe_while_connected_is_sent_immediately_and_not_repeated() {
+        let mut state = WebSocketSubscriptions::new();
+        state.connected(vec![]);
+
+        assert_eq!(subscriptions(&state.subscribe(candle("UNI"))), vec![(HyperliquidMethod::Subscribe, candle("UNI"))]);
+        assert!(state.subscribe(candle("UNI")).is_empty());
+    }
+
+    #[test]
+    fn test_reconnect_resends_everything_once() {
+        let mut state = WebSocketSubscriptions::new();
+        state.connected(vec![account_state()]);
+        state.subscribe(candle("UNI"));
+
+        state.disconnected();
+        let reconnected = state.connected(vec![account_state()]);
+
+        assert_eq!(
+            subscriptions(&reconnected),
+            vec![(HyperliquidMethod::Subscribe, account_state()), (HyperliquidMethod::Subscribe, candle("UNI")),]
+        );
+    }
+
+    #[test]
+    fn test_unsubscribe_while_disconnected_drops_it_from_the_next_connect() {
+        let mut state = WebSocketSubscriptions::new();
+        state.connected(vec![]);
+        state.subscribe(candle("UNI"));
+
+        state.disconnected();
+        assert!(state.unsubscribe(&candle("UNI")).is_empty());
+
+        assert!(state.connected(vec![]).is_empty());
+    }
+
+    #[test]
+    fn test_unsubscribe_is_sent_once() {
+        let mut state = WebSocketSubscriptions::new();
+        state.connected(vec![]);
+        state.subscribe(candle("UNI"));
+
+        assert_eq!(subscriptions(&state.unsubscribe(&candle("UNI"))), vec![(HyperliquidMethod::Unsubscribe, candle("UNI"))]);
+        assert!(state.unsubscribe(&candle("UNI")).is_empty());
+    }
+
+    #[test]
+    fn test_connected_without_disconnect_resends_for_the_new_connection() {
+        let mut state = WebSocketSubscriptions::new();
+        state.subscribe(candle("UNI"));
+        state.connected(vec![account_state()]);
+
+        let reconnected = state.connected(vec![account_state()]);
+
+        assert_eq!(
+            subscriptions(&reconnected),
+            vec![(HyperliquidMethod::Subscribe, account_state()), (HyperliquidMethod::Subscribe, candle("UNI"))]
+        );
+    }
+
+    #[test]
+    fn test_account_subscriptions_are_not_kept_across_reconnect() {
+        let mut state = WebSocketSubscriptions::new();
+        state.connected(vec![account_state()]);
+
+        state.disconnected();
+
+        assert!(state.connected(vec![]).is_empty());
+    }
+}

--- a/core/gemstone/src/models/perpetual.rs
+++ b/core/gemstone/src/models/perpetual.rs
@@ -162,12 +162,6 @@ pub struct GemHyperliquidOpenOrder {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Enum)]
-pub enum GemSubscriptionMethod {
-    Subscribe,
-    Unsubscribe,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, uniffi::Enum)]
 pub enum GemPerpetualSubscription {
     AccountState { address: String },
     SpotState { address: String },
@@ -202,6 +196,9 @@ pub enum GemHyperliquidSocketMessage {
     },
     SubscriptionResponse {
         subscription_type: String,
+    },
+    Error {
+        message: String,
     },
     Unknown,
 }

--- a/core/gemstone/src/perpetual.rs
+++ b/core/gemstone/src/perpetual.rs
@@ -1,11 +1,16 @@
+use std::sync::{Mutex, MutexGuard};
+
 use gem_hypercore::{
-    models::websocket::{HyperliquidMethod, HyperliquidRequest, HyperliquidSubscription},
+    models::websocket::{HyperliquidRequest, HyperliquidSubscription},
     perpetual_formatter::PerpetualFormatter,
-    provider::websocket_mapper::{account_subscriptions, diff_clearinghouse_positions, diff_open_orders_positions, parse_websocket_data},
+    provider::{
+        websocket_mapper::{account_subscriptions, diff_clearinghouse_positions, diff_open_orders_positions, parse_websocket_data},
+        websocket_subscriptions::WebSocketSubscriptions,
+    },
 };
 use primitives::{AutocloseValidation, AutocloseValidator as Validator, PerpetualAccountMode, PerpetualDirection, PerpetualPosition, PerpetualProvider, TpslType};
 
-use crate::models::perpetual::{GemHyperliquidOpenOrder, GemHyperliquidSocketMessage, GemPerpetualSubscription, GemPositionsDiff, GemSubscriptionMethod};
+use crate::models::perpetual::{GemHyperliquidOpenOrder, GemHyperliquidSocketMessage, GemPerpetualSubscription, GemPositionsDiff};
 
 #[derive(Debug, uniffi::Object)]
 pub struct Perpetual {
@@ -54,19 +59,8 @@ impl Hyperliquid {
         Self {}
     }
 
-    pub fn account_subscriptions(&self, address: String, mode: PerpetualAccountMode) -> Vec<GemPerpetualSubscription> {
-        account_subscriptions(address, mode).into_iter().map(GemPerpetualSubscription::from).collect()
-    }
-
     pub fn parse_websocket_data(&self, data: Vec<u8>, mode: PerpetualAccountMode) -> Result<GemHyperliquidSocketMessage, crate::GemstoneError> {
         Ok(parse_websocket_data(&data, mode)?)
-    }
-
-    pub fn websocket_request(&self, method: GemSubscriptionMethod, subscription: GemPerpetualSubscription) -> Result<String, crate::GemstoneError> {
-        Ok(serde_json::to_string(&HyperliquidRequest {
-            method: method.map(),
-            subscription: subscription.map(),
-        })?)
     }
 
     pub fn diff_clearinghouse_positions(&self, new_positions: Vec<PerpetualPosition>, existing_positions: Vec<PerpetualPosition>) -> GemPositionsDiff {
@@ -111,13 +105,48 @@ impl AutocloseValidator {
     }
 }
 
-impl GemSubscriptionMethod {
-    fn map(self) -> HyperliquidMethod {
-        match self {
-            Self::Subscribe => HyperliquidMethod::Subscribe,
-            Self::Unsubscribe => HyperliquidMethod::Unsubscribe,
+#[derive(Debug, Default, uniffi::Object)]
+pub struct HyperliquidSubscriptions {
+    state: Mutex<WebSocketSubscriptions>,
+}
+
+#[uniffi::export]
+impl HyperliquidSubscriptions {
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(WebSocketSubscriptions::new()),
         }
     }
+
+    pub fn subscribe(&self, subscription: GemPerpetualSubscription) -> Result<Vec<String>, crate::GemstoneError> {
+        encode(self.state().subscribe(subscription.map()))
+    }
+
+    pub fn unsubscribe(&self, subscription: GemPerpetualSubscription) -> Result<Vec<String>, crate::GemstoneError> {
+        encode(self.state().unsubscribe(&subscription.map()))
+    }
+
+    pub fn connected(&self, address: String, mode: PerpetualAccountMode) -> Result<Vec<String>, crate::GemstoneError> {
+        encode(self.state().connected(account_subscriptions(address, mode)))
+    }
+
+    pub fn disconnected(&self) {
+        self.state().disconnected();
+    }
+}
+
+impl HyperliquidSubscriptions {
+    fn state(&self) -> MutexGuard<'_, WebSocketSubscriptions> {
+        match self.state.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
+fn encode(requests: Vec<HyperliquidRequest>) -> Result<Vec<String>, crate::GemstoneError> {
+    Ok(requests.iter().map(serde_json::to_string).collect::<Result<Vec<_>, _>>()?)
 }
 
 impl From<HyperliquidSubscription> for GemPerpetualSubscription {
@@ -153,35 +182,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_account_subscriptions() {
-        let hyperliquid = Hyperliquid::new();
+    fn test_connected_subscribes_account_subscriptions() {
+        let subscriptions = HyperliquidSubscriptions::new();
+
+        let requests = subscriptions.connected("0x123".to_string(), PerpetualAccountMode::Unified).unwrap();
 
         assert_eq!(
-            hyperliquid.account_subscriptions("0x123".to_string(), PerpetualAccountMode::Standard),
+            requests,
             vec![
-                GemPerpetualSubscription::AccountState { address: "0x123".to_string() },
-                GemPerpetualSubscription::OpenOrders { address: "0x123".to_string() },
-            ]
-        );
-        assert_eq!(
-            hyperliquid.account_subscriptions("0x123".to_string(), PerpetualAccountMode::Unified),
-            vec![
-                GemPerpetualSubscription::AccountState { address: "0x123".to_string() },
-                GemPerpetualSubscription::OpenOrders { address: "0x123".to_string() },
-                GemPerpetualSubscription::SpotState { address: "0x123".to_string() },
+                r#"{"method":"subscribe","subscription":{"type":"clearinghouseState","user":"0x123"}}"#,
+                r#"{"method":"subscribe","subscription":{"type":"openOrders","user":"0x123"}}"#,
+                r#"{"method":"subscribe","subscription":{"type":"spotState","user":"0x123"}}"#,
             ]
         );
     }
 
     #[test]
-    fn test_websocket_request_maps_generic_subscription() {
-        let request = HyperliquidRequest {
-            method: GemSubscriptionMethod::Subscribe.map(),
-            subscription: GemPerpetualSubscription::AccountState { address: "0x123".to_string() }.map(),
-        };
+    fn test_subscriptions_encode_generic_subscription() {
+        let subscriptions = HyperliquidSubscriptions::new();
+        subscriptions.connected("0x456".to_string(), PerpetualAccountMode::Standard).unwrap();
+
+        let requests = subscriptions.subscribe(GemPerpetualSubscription::AccountState { address: "0x123".to_string() }).unwrap();
 
         assert_eq!(
-            serde_json::to_value(request).unwrap(),
+            serde_json::from_str::<serde_json::Value>(&requests[0]).unwrap(),
             json!({
                 "method": "subscribe",
                 "subscription": {

--- a/ios/GemTests/unit_frameworks.xctestplan
+++ b/ios/GemTests/unit_frameworks.xctestplan
@@ -361,6 +361,13 @@
         "identifier" : "TransactionsServiceTests",
         "name" : "TransactionsServiceTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/FeatureServices",
+        "identifier" : "PerpetualServiceTests",
+        "name" : "PerpetualServiceTests"
+      }
     }
   ],
   "version" : 1

--- a/ios/Packages/FeatureServices/Package.swift
+++ b/ios/Packages/FeatureServices/Package.swift
@@ -105,6 +105,15 @@ let package = Package(
             ],
             path: "PerpetualService/TestKit",
         ),
+        .testTarget(
+            name: "PerpetualServiceTests",
+            dependencies: [
+                "PerpetualService",
+                "Primitives",
+                .product(name: "WebSocketClientTestKit", package: "SwiftHTTPClient"),
+            ],
+            path: "PerpetualService/Tests",
+        ),
         .target(
             name: "BalanceService",
             dependencies: [

--- a/ios/Packages/FeatureServices/PerpetualService/HyperliquidEventHandler.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/HyperliquidEventHandler.swift
@@ -37,6 +37,8 @@ public actor HyperliquidEventHandler {
                 try perpetualService.updatePrices(prices)
             case let .subscriptionResponse(subscriptionType):
                 debugLog("HyperliquidEventHandler: subscription response - \(subscriptionType)")
+            case let .error(message):
+                debugLog("HyperliquidEventHandler: error message: \(message)")
             case .unknown:
                 debugLog("HyperliquidEventHandler: unknown message: \(String(data: data, encoding: .utf8) ?? "nil")")
             }

--- a/ios/Packages/FeatureServices/PerpetualService/HyperliquidObserverService.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/HyperliquidObserverService.swift
@@ -47,6 +47,7 @@ public actor HyperliquidObserverService: PerpetualObservable {
         observeTask = nil
         currentWallet = nil
 
+        await subscriptionService.disconnected()
         await webSocket.disconnect()
     }
 
@@ -95,7 +96,7 @@ public actor HyperliquidObserverService: PerpetualObservable {
             case let .message(data):
                 await eventHandler.handle(data, walletId: walletId, mode: mode)
             case .disconnected:
-                break
+                await subscriptionService.disconnected()
             }
         }
     }

--- a/ios/Packages/FeatureServices/PerpetualService/HyperliquidSubscriptionService.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/HyperliquidSubscriptionService.swift
@@ -2,55 +2,39 @@
 
 import Foundation
 import enum Gemstone.GemPerpetualSubscription
-import enum Gemstone.GemSubscriptionMethod
-import class Gemstone.Hyperliquid
+import class Gemstone.HyperliquidSubscriptions
 import Primitives
 import WebSocketClient
 
 public actor HyperliquidSubscriptionService {
     private let webSocket: any WebSocketConnectable
-    private let hyperliquid = Hyperliquid()
-
-    private var activeSubscriptions: Set<GemPerpetualSubscription> = []
+    private let subscriptions = HyperliquidSubscriptions()
 
     public init(webSocket: any WebSocketConnectable) {
         self.webSocket = webSocket
     }
 
     public func subscribe(_ subscription: GemPerpetualSubscription) async throws {
-        activeSubscriptions.insert(subscription)
-        try await send(method: .subscribe, subscription: subscription)
+        try await send(subscriptions.subscribe(subscription: subscription))
     }
 
     public func unsubscribe(_ subscription: GemPerpetualSubscription) async throws {
-        activeSubscriptions.remove(subscription)
-        try await send(method: .unsubscribe, subscription: subscription)
+        try await send(subscriptions.unsubscribe(subscription: subscription))
     }
 
     public func connected(address: String, mode: PerpetualAccountMode) async throws {
-        let subscriptions = (hyperliquid.accountSubscriptions(address: address, mode: mode.map()) + activeSubscriptions.asArray()).distinct()
-        try await subscribe(subscriptions)
+        try await send(subscriptions.connected(address: address, mode: mode.map()))
+    }
+
+    public func disconnected() {
+        subscriptions.disconnected()
     }
 
     // MARK: - Private
 
-    private func subscribe(_ subscriptions: [GemPerpetualSubscription]) async throws {
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            for subscription in subscriptions {
-                group.addTask {
-                    try await self.send(method: .subscribe, subscription: subscription)
-                }
-            }
-            try await group.waitForAll()
+    private func send(_ requests: [String]) async throws {
+        for request in requests {
+            try await webSocket.send(request)
         }
-    }
-
-    private func send(method: GemSubscriptionMethod, subscription: GemPerpetualSubscription) async throws {
-        try await webSocket.send(
-            hyperliquid.websocketRequest(
-                method: method,
-                subscription: subscription,
-            ),
-        )
     }
 }

--- a/ios/Packages/FeatureServices/PerpetualService/Tests/HyperliquidSubscriptionServiceTests.swift
+++ b/ios/Packages/FeatureServices/PerpetualService/Tests/HyperliquidSubscriptionServiceTests.swift
@@ -1,0 +1,40 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+@testable import PerpetualService
+import Primitives
+import Testing
+import WebSocketClientTestKit
+
+struct HyperliquidSubscriptionServiceTests {
+    @Test
+    func sendsExactFramesThroughTheSocket() async throws {
+        let webSocket = WebSocketConnectionMock()
+        let service = HyperliquidSubscriptionService(webSocket: webSocket)
+
+        try await service.subscribe(.marketPrices)
+        #expect(await webSocket.getSentData().isEmpty)
+
+        await webSocket.simulateConnected()
+        try await service.connected(address: "0xabc", mode: .standard)
+
+        let sent = await sentFrames(webSocket)
+        #expect(sent.count == 3)
+        #expect(Set(sent) == [
+            #"{"method":"subscribe","subscription":{"type":"clearinghouseState","user":"0xabc"}}"#,
+            #"{"method":"subscribe","subscription":{"type":"openOrders","user":"0xabc"}}"#,
+            #"{"method":"subscribe","subscription":{"type":"allMids"}}"#,
+        ])
+
+        try await service.unsubscribe(.marketPrices)
+        #expect(await sentFrames(webSocket).last == #"{"method":"unsubscribe","subscription":{"type":"allMids"}}"#)
+
+        await service.disconnected()
+        try await service.subscribe(.marketPrices)
+        #expect(await webSocket.getSentData().count == 4)
+    }
+
+    private func sentFrames(_ webSocket: WebSocketConnectionMock) async -> [String] {
+        await webSocket.getSentData().compactMap { String(data: $0, encoding: .utf8) }
+    }
+}


### PR DESCRIPTION
Moves Hyperliquid websocket subscription tracking into core: both apps now ask a shared subscriptions object what to send, so a subscription can never be sent twice or lost around connects and reconnects. Hyperliquid error messages are now parsed and logged instead of failing to decode.

Closes #462