### PR TITLE
Drop unused wallets argument from switchPushEnabled

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/AppViewModel.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/AppViewModel.kt
@@ -126,10 +126,7 @@ class AppViewModel @Inject constructor(
     fun onNotificationsEnable() {
         viewModelScope.launch(Dispatchers.IO) {
             userConfig.stopAskNotifications()
-            switchPushEnabled.switchPushEnabled(
-                true,
-                walletsRepository.getAll().firstOrNull() ?: emptyList()
-            )
+            switchPushEnabled.switchPushEnabled(true)
         }
     }
 

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/EnableDevicePushImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/device/EnableDevicePushImpl.kt
@@ -2,15 +2,12 @@ package com.gemwallet.android.data.coordinators.device
 
 import com.gemwallet.android.application.device.coordinators.EnableDevicePush
 import com.gemwallet.android.cases.device.SwitchPushEnabled
-import com.gemwallet.android.data.repositories.wallets.WalletsRepository
-import kotlinx.coroutines.flow.firstOrNull
 
 class EnableDevicePushImpl(
     private val switchPushEnabled: SwitchPushEnabled,
-    private val walletsRepository: WalletsRepository,
 ) : EnableDevicePush {
 
     override suspend fun invoke() {
-        switchPushEnabled.switchPushEnabled(true, walletsRepository.getAll().firstOrNull() ?: emptyList())
+        switchPushEnabled.switchPushEnabled(true)
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/DeviceModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/DeviceModule.kt
@@ -6,7 +6,6 @@ import com.gemwallet.android.application.device.coordinators.GetDeviceId
 import com.gemwallet.android.cases.device.SwitchPushEnabled
 import com.gemwallet.android.data.coordinators.device.EnableDevicePushImpl
 import com.gemwallet.android.data.coordinators.device.GetDeviceIdImpl
-import com.gemwallet.android.data.repositories.wallets.WalletsRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,6 +23,5 @@ object DeviceModule {
     @Singleton
     fun provideEnableDevicePush(
         switchPushEnabled: SwitchPushEnabled,
-        walletsRepository: WalletsRepository,
-    ): EnableDevicePush = EnableDevicePushImpl(switchPushEnabled, walletsRepository)
+    ): EnableDevicePush = EnableDevicePushImpl(switchPushEnabled)
 }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/device/EnableDevicePushImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/device/EnableDevicePushImplTest.kt
@@ -1,43 +1,22 @@
 package com.gemwallet.android.data.coordinators.device
 
 import com.gemwallet.android.cases.device.SwitchPushEnabled
-import com.gemwallet.android.data.repositories.wallets.WalletsRepository
-import com.wallet.core.primitives.Wallet
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 class EnableDevicePushImplTest {
 
     @Test
-    fun invoke_switchesPushEnabledWithCurrentWallets() = runBlocking {
-        val wallets = listOf(mockk<Wallet>())
-        val walletsRepository = mockk<WalletsRepository> {
-            coEvery { getAll() } returns flowOf(wallets)
-        }
+    fun invoke_switchesPushEnabled() = runBlocking {
         val switchPushEnabled = mockk<SwitchPushEnabled> {
-            coEvery { switchPushEnabled(any(), any()) } returns Unit
+            coEvery { switchPushEnabled(any()) } returns Unit
         }
 
-        EnableDevicePushImpl(switchPushEnabled, walletsRepository).invoke()
+        EnableDevicePushImpl(switchPushEnabled).invoke()
 
-        coVerify(exactly = 1) { switchPushEnabled.switchPushEnabled(true, wallets) }
-    }
-
-    @Test
-    fun invoke_withNoWallets_switchesPushEnabledWithEmptyList() = runBlocking {
-        val walletsRepository = mockk<WalletsRepository> {
-            coEvery { getAll() } returns flowOf(emptyList())
-        }
-        val switchPushEnabled = mockk<SwitchPushEnabled> {
-            coEvery { switchPushEnabled(any(), any()) } returns Unit
-        }
-
-        EnableDevicePushImpl(switchPushEnabled, walletsRepository).invoke()
-
-        coVerify(exactly = 1) { switchPushEnabled.switchPushEnabled(true, emptyList()) }
+        coVerify(exactly = 1) { switchPushEnabled.switchPushEnabled(true) }
     }
 }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/device/DeviceRepository.kt
@@ -76,7 +76,7 @@ class DeviceRepository(
         }
     }
 
-    override suspend fun switchPushEnabled(enabled: Boolean, wallets: List<Wallet>) {
+    override suspend fun switchPushEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[Key.PushEnabled] = enabled && notificationsAvailable
         }

--- a/android/features/settings/settings/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/settings/viewmodels/SettingsViewModel.kt
+++ b/android/features/settings/settings/viewmodels/src/main/kotlin/com/gemwallet/android/features/settings/settings/viewmodels/SettingsViewModel.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -117,20 +116,14 @@ class SettingsViewModel @Inject constructor(
     fun enableNotifications() {
         viewModelScope.launch(Dispatchers.IO) {
             userConfig.stopAskNotifications()
-            switchPushEnabled.switchPushEnabled(
-                true,
-                wallets.firstOrNull() ?: emptyList()
-            )
+            switchPushEnabled.switchPushEnabled(true)
         }
     }
 
     fun disableNotifications() {
         viewModelScope.launch(Dispatchers.IO) {
             userConfig.stopAskNotifications()
-            switchPushEnabled.switchPushEnabled(
-                false,
-                wallets.firstOrNull() ?: emptyList()
-            )
+            switchPushEnabled.switchPushEnabled(false)
         }
     }
 

--- a/android/features/settings/settings/viewmodels/src/test/kotlin/com/gemwallet/android/features/settings/settings/viewmodels/SettingsViewModelTest.kt
+++ b/android/features/settings/settings/viewmodels/src/test/kotlin/com/gemwallet/android/features/settings/settings/viewmodels/SettingsViewModelTest.kt
@@ -66,7 +66,7 @@ class SettingsViewModelTest {
         advanceUntilIdle()
 
         coVerify(exactly = 1) { userConfig.stopAskNotifications() }
-        coVerify(exactly = 1) { switchPushEnabled.switchPushEnabled(false, emptyList()) }
+        coVerify(exactly = 1) { switchPushEnabled.switchPushEnabled(false) }
     }
 
     @Test

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SwitchPushEnabled.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/cases/device/SwitchPushEnabled.kt
@@ -1,7 +1,5 @@
 package com.gemwallet.android.cases.device
 
-import com.wallet.core.primitives.Wallet
-
 interface SwitchPushEnabled {
-    suspend fun switchPushEnabled(enabled: Boolean, wallets: List<Wallet>)
+    suspend fun switchPushEnabled(enabled: Boolean)
 }


### PR DESCRIPTION
Enabling or disabling push notifications took a list of wallets that was never used.

It stopped being used when device subscription sync moved inside the device repository, which loads wallets on its own. Since then every caller was fetching wallets just to pass them along, and one of them kept a whole wallets repository dependency only for that.

Behavior is unchanged.