### PR TITLE
Fix perpetual position shown from another wallet

### DIFF
--- a/android/data/coordinators/src/androidTest/kotlin/com/gemwallet/android/data/repositories/perpetual/FakePerpetualRepository.kt
+++ b/android/data/coordinators/src/androidTest/kotlin/com/gemwallet/android/data/repositories/perpetual/FakePerpetualRepository.kt
@@ -117,15 +117,9 @@ class FakePerpetualRepository @Inject constructor() : PerpetualRepository {
         return positionsFlow.map { it[walletId.id] ?: emptyList() }
     }
 
-    override fun getPositionByPositionId(id: String): Flow<PerpetualPositionData?> {
+    override fun getPositionByPerpetualId(walletId: WalletId, id: PerpetualId): Flow<PerpetualPositionData?> {
         return positionsFlow.map { positionsMap ->
-            positionsMap.values.flatten().firstOrNull { it.position.id == id }
-        }
-    }
-
-    override fun getPositionByPerpetualId(id: PerpetualId): Flow<PerpetualPositionData?> {
-        return positionsFlow.map { positionsMap ->
-            positionsMap.values.flatten().firstOrNull { it.perpetual.id == id }
+            positionsMap[walletId.id].orEmpty().firstOrNull { it.perpetual.id == id }
         }
     }
 

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/BuildPerpetualParamsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/BuildPerpetualParamsImpl.kt
@@ -89,8 +89,10 @@ class BuildPerpetualParamsImpl(
     private suspend fun getPerpetual(perpetualId: PerpetualId): PerpetualData? =
         perpetualRepository.getPerpetual(perpetualId).firstOrNull()
 
-    private suspend fun getPosition(perpetualId: PerpetualId): PerpetualPosition? =
-        perpetualRepository.getPositionByPerpetualId(perpetualId).firstOrNull()?.position
+    private suspend fun getPosition(perpetualId: PerpetualId): PerpetualPosition? {
+        val walletId = sessionRepository.session().value?.wallet?.id ?: return null
+        return perpetualRepository.getPositionByPerpetualId(walletId, perpetualId).firstOrNull()?.position
+    }
 
     private fun createTransferData(
         data: PerpetualData,

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualPositionImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/perpetuals/GetPerpetualPositionImpl.kt
@@ -13,6 +13,7 @@ import com.wallet.core.primitives.Currency
 import com.wallet.core.primitives.PerpetualId
 import com.wallet.core.primitives.PerpetualMarginType
 import com.wallet.core.primitives.PerpetualPositionData
+import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -20,8 +21,8 @@ import javax.inject.Inject
 class GetPerpetualPositionImpl @Inject constructor(
     private val perpetualRepository: PerpetualRepository
 ) : GetPerpetualPosition {
-    override fun getPositionByPerpetual(id: PerpetualId): Flow<PerpetualPositionDetailsDataAggregate?> {
-        return perpetualRepository.getPositionByPerpetualId(id).map { PerpetualPositionDetailsDataAggregateImpl(it ?: return@map null) }
+    override fun getPositionByPerpetual(walletId: WalletId, id: PerpetualId): Flow<PerpetualPositionDetailsDataAggregate?> {
+        return perpetualRepository.getPositionByPerpetualId(walletId, id).map { PerpetualPositionDetailsDataAggregateImpl(it ?: return@map null) }
     }
 }
 

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/perpetuals/BuildPerpetualParamsImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/perpetuals/BuildPerpetualParamsImplTest.kt
@@ -1,0 +1,80 @@
+package com.gemwallet.android.data.coordinators.perpetuals
+
+import com.gemwallet.android.data.repositories.perpetual.PerpetualRepository
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.domains.perpetual.PerpetualPositionAction
+import com.gemwallet.android.testkit.mockAsset
+import com.gemwallet.android.testkit.mockPerpetualData
+import com.gemwallet.android.testkit.mockPerpetualPosition
+import com.gemwallet.android.testkit.mockPerpetualPositionData
+import com.gemwallet.android.testkit.mockSession
+import com.gemwallet.android.testkit.mockWallet
+import com.gemwallet.android.testkit.mockWalletId
+import com.wallet.core.primitives.PerpetualDirection
+import com.wallet.core.primitives.WalletId
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BuildPerpetualParamsImplTest {
+
+    private val asset = mockAsset()
+    private val perpetualData = mockPerpetualData(asset = asset)
+    private val ownWalletId = mockWalletId("wallet-own")
+    private val otherWalletId = mockWalletId("wallet-other")
+
+    private val ownPosition = mockPerpetualPositionData(
+        perpetual = perpetualData.perpetual,
+        asset = asset,
+        position = mockPerpetualPosition(
+            id = "own",
+            perpetualId = perpetualData.perpetual.id,
+            assetId = asset.id,
+            direction = PerpetualDirection.Long,
+            marginAmount = 12.0,
+        ),
+    )
+    private val otherWalletPosition = mockPerpetualPositionData(
+        perpetual = perpetualData.perpetual,
+        asset = asset,
+        position = mockPerpetualPosition(
+            id = "other",
+            perpetualId = perpetualData.perpetual.id,
+            assetId = asset.id,
+            direction = PerpetualDirection.Short,
+            marginAmount = 9_999.0,
+        ),
+    )
+
+    private val perpetualRepository = mockk<PerpetualRepository> {
+        every { getPerpetual(perpetualData.perpetual.id) } returns flowOf(perpetualData)
+        every { getPositionByPerpetualId(ownWalletId, perpetualData.perpetual.id) } returns flowOf(ownPosition)
+        every { getPositionByPerpetualId(otherWalletId, perpetualData.perpetual.id) } returns flowOf(otherWalletPosition)
+    }
+
+    @Test
+    fun `reduce builds params from the session wallet position, not from any wallet on this market`() = runTest {
+        val own = reduceFor(ownWalletId)
+        val other = reduceFor(otherWalletId)
+
+        assertEquals(PerpetualDirection.Long, own.positionDirection)
+        assertEquals(PerpetualDirection.Short, other.positionDirection)
+        assertEquals(true, own.available < other.available)
+    }
+
+    private suspend fun reduceFor(walletId: WalletId): PerpetualPositionAction.Reduce {
+        val sessionRepository = mockk<SessionRepository> {
+            every { session() } returns MutableStateFlow(mockSession(wallet = mockWallet(id = walletId.id)))
+        }
+        val subject = BuildPerpetualParamsImpl(
+            perpetualRepository = perpetualRepository,
+            sessionRepository = sessionRepository,
+        )
+        val params = requireNotNull(subject.reduce(perpetualData.perpetual.id))
+        return params.positionAction as PerpetualPositionAction.Reduce
+    }
+}

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/PerpetualRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/PerpetualRepository.kt
@@ -33,9 +33,7 @@ interface PerpetualRepository {
 
     fun getPositions(walletId: WalletId): Flow<List<PerpetualPositionData>>
 
-    fun getPositionByPositionId(id: String): Flow<PerpetualPositionData?>
-
-    fun getPositionByPerpetualId(id: PerpetualId): Flow<PerpetualPositionData?>
+    fun getPositionByPerpetualId(walletId: WalletId, id: PerpetualId): Flow<PerpetualPositionData?>
 
     suspend fun putAsset(asset: Asset)
 

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/PerpetualRepositoryImpl.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/perpetual/PerpetualRepositoryImpl.kt
@@ -109,12 +109,8 @@ class PerpetualRepositoryImpl(
         return perpetualPositionDao.getPositionsData(walletId.id).map { items -> items.mapNotNull { it.toDTO() } }
     }
 
-    override fun getPositionByPositionId(id: String): Flow<PerpetualPositionData?> {
-        return perpetualPositionDao.getPositionData(id).map { it?.toDTO() }
-    }
-
-    override fun getPositionByPerpetualId(id: PerpetualId): Flow<PerpetualPositionData?> {
-        return perpetualPositionDao.getPositionDataByPerpetual(id.toIdentifier()).map { it?.toDTO() }
+    override fun getPositionByPerpetualId(walletId: WalletId, id: PerpetualId): Flow<PerpetualPositionData?> {
+        return perpetualPositionDao.getPositionDataByPerpetual(walletId.id, id.toIdentifier()).map { it?.toDTO() }
     }
 
     override suspend fun putAsset(asset: Asset) {

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/PerpetualPositionDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/PerpetualPositionDao.kt
@@ -55,10 +55,6 @@ interface PerpetualPositionDao {
     fun getPositionsData(walletId: String): Flow<List<DbPerpetualPositionData>>
 
     @Transaction
-    @Query("SELECT * FROM perpetuals_positions WHERE id = :positionId")
-    fun getPositionData(positionId: String): Flow<DbPerpetualPositionData?>
-
-    @Transaction
-    @Query("SELECT * FROM perpetuals_positions WHERE perpetualId = :perpetualId LIMIT 1")
-    fun getPositionDataByPerpetual(perpetualId: String): Flow<DbPerpetualPositionData?>
+    @Query("SELECT * FROM perpetuals_positions WHERE walletId = :walletId AND perpetualId = :perpetualId LIMIT 1")
+    fun getPositionDataByPerpetual(walletId: String, perpetualId: String): Flow<DbPerpetualPositionData?>
 }

--- a/android/features/perpetual/viewmodels/src/main/kotlin/com/gemwallet/android/features/perpetual/viewmodels/AutocloseViewModel.kt
+++ b/android/features/perpetual/viewmodels/src/main/kotlin/com/gemwallet/android/features/perpetual/viewmodels/AutocloseViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gemwallet.android.application.perpetual.coordinators.BuildPerpetualParams
+import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.data.repositories.perpetual.PerpetualRepository
 import com.gemwallet.android.domains.perpetual.autoclose.AutocloseEstimator
 import com.gemwallet.android.domains.perpetual.autoclose.AutocloseField
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
@@ -43,6 +45,7 @@ import javax.inject.Inject
 class AutocloseViewModel @Inject constructor(
     private val perpetualRepository: PerpetualRepository,
     private val buildPerpetualParams: BuildPerpetualParams,
+    getSession: GetSession,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -50,10 +53,12 @@ class AutocloseViewModel @Inject constructor(
 
     private val numericFormatter = NumericFormatter()
 
-    val position: StateFlow<PerpetualPositionData?> = perpetualRepository.getPerpetualByAssetId(assetId)
-        .distinctUntilChanged()
-        .flatMapLatest { data ->
-            data?.let { perpetualRepository.getPositionByPerpetualId(it.perpetual.id) } ?: flowOf(null)
+    val position: StateFlow<PerpetualPositionData?> = combine(
+        perpetualRepository.getPerpetualByAssetId(assetId).distinctUntilChanged(),
+        getSession().filterNotNull(),
+    ) { data, session -> data to session.wallet.id }
+        .flatMapLatest { (data, walletId) ->
+            data?.let { perpetualRepository.getPositionByPerpetualId(walletId, it.perpetual.id) } ?: flowOf(null)
         }
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)

--- a/android/features/perpetual/viewmodels/src/main/kotlin/com/gemwallet/android/features/perpetual/viewmodels/PerpetualDetailsViewModel.kt
+++ b/android/features/perpetual/viewmodels/src/main/kotlin/com/gemwallet/android/features/perpetual/viewmodels/PerpetualDetailsViewModel.kt
@@ -12,6 +12,7 @@ import com.gemwallet.android.application.perpetual.coordinators.PerpetualObserve
 
 import com.gemwallet.android.application.perpetual.coordinators.SetPerpetualChartPeriod
 import com.gemwallet.android.application.perpetual.coordinators.SyncPerpetualPositions
+import com.gemwallet.android.application.session.coordinators.GetSession
 import com.gemwallet.android.application.transactions.coordinators.GetTransactions
 import com.gemwallet.android.application.transactions.coordinators.SyncAssetTransactions
 import com.gemwallet.android.application.transactions.coordinators.TransactionsRequestFilter
@@ -37,6 +38,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -60,6 +62,7 @@ class PerpetualDetailsViewModel @Inject constructor(
     private val syncPerpetualPositions: SyncPerpetualPositions,
     private val buildPerpetualParams: BuildPerpetualParams,
     private val perpetualObserver: PerpetualObserver,
+    getSession: GetSession,
     getPerpetualChartPeriod: GetPerpetualChartPeriod,
     private val setPerpetualChartPeriod: SetPerpetualChartPeriod,
     savedStateHandle: SavedStateHandle
@@ -92,9 +95,12 @@ class PerpetualDetailsViewModel @Inject constructor(
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    val position = perpetual
-        .flatMapLatest { perpetual ->
-            perpetual?.let { getPerpetualPosition.getPositionByPerpetual(it.id) } ?: flowOf(null)
+    val position = combine(
+        perpetual,
+        getSession().filterNotNull(),
+    ) { perpetual, session -> perpetual to session.wallet.id }
+        .flatMapLatest { (perpetual, walletId) ->
+            perpetual?.let { getPerpetualPosition.getPositionByPerpetual(walletId, it.id) } ?: flowOf(null)
         }
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/perpetual/coordinators/GetPerpetualPosition.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/perpetual/coordinators/GetPerpetualPosition.kt
@@ -2,8 +2,9 @@ package com.gemwallet.android.application.perpetual.coordinators
 
 import com.gemwallet.android.domains.perpetual.aggregates.PerpetualPositionDetailsDataAggregate
 import com.wallet.core.primitives.PerpetualId
+import com.wallet.core.primitives.WalletId
 import kotlinx.coroutines.flow.Flow
 
 interface GetPerpetualPosition {
-    fun getPositionByPerpetual(id: PerpetualId): Flow<PerpetualPositionDetailsDataAggregate?>
+    fun getPositionByPerpetual(walletId: WalletId, id: PerpetualId): Flow<PerpetualPositionDetailsDataAggregate?>
 }


### PR DESCRIPTION
Opening a perpetual market showed a position that belongs to a different wallet, even when the current wallet had no positions of its own. The position is now looked up within the current wallet only.