### PR TITLE
Fix failing core tests

### DIFF
--- a/core/crates/gem_solana/src/provider/node_status.rs
+++ b/core/crates/gem_solana/src/provider/node_status.rs
@@ -93,16 +93,19 @@ mod tests {
     use gem_jsonrpc::testkit::mock_jsonrpc_client;
     use primitives::{NodeCheckRequest, NodeCheckStatus, NodeSyncStatus};
     use serde_json::json;
+    use std::sync::{Arc, Mutex};
 
     use super::*;
     use crate::rpc::SolanaClient;
 
     #[tokio::test]
     async fn test_parser_profile_checks_recent_block() {
-        let client = mock_jsonrpc_client(|method, params| match method {
+        let requested_slots = Arc::new(Mutex::new(Vec::new()));
+        let recorded_slots = requested_slots.clone();
+        let client = mock_jsonrpc_client(move |method, params| match method {
             method::GET_GENESIS_HASH => Ok(json!("5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d")),
             method::GET_BLOCK => {
-                assert_eq!(params[0], 990);
+                recorded_slots.lock().unwrap().push(params[0].as_u64().unwrap());
                 Ok(json!({ "blockTime": 1_700_000_000, "transactions": [] }))
             }
             _ => panic!("unexpected method: {method}"),
@@ -111,7 +114,9 @@ mod tests {
 
         let report = ChainTraits::check_node(&provider, &NodeCheckRequest::Parser, &NodeSyncStatus::synced(1_000), Duration::ZERO).await;
 
-        assert_eq!(report.checks.len(), 3);
+        assert_eq!(*requested_slots.lock().unwrap(), vec![1_000, 990]);
+        assert_eq!(report.checks.len(), 4);
+        assert_eq!(report.get("block_transactions_latest").unwrap().status, NodeCheckStatus::Passed { result: "0".to_string() });
         assert_eq!(report.get("block_transactions").unwrap().status, NodeCheckStatus::Passed { result: "0".to_string() });
         assert_eq!(
             report.get(method::GET_GENESIS_HASH).unwrap().status,

--- a/core/gemstone/src/gateway/mod.rs
+++ b/core/gemstone/src/gateway/mod.rs
@@ -204,7 +204,7 @@ mod tests {
     fn test_get_node_status_http_404_error() {
         let provider: Arc<dyn AlienProvider> = Arc::new(TestAlienProvider::with_status(404));
         let preferences: Arc<dyn GemPreferences> = Arc::new(EmptyPreferences {});
-        let gateway = GemGateway::new(provider, preferences.clone(), preferences.clone(), "https://example.invalid".to_string());
+        let gateway = GemGateway::new(provider, preferences.clone(), preferences.clone());
 
         let result = futures::executor::block_on(gateway.get_node_status(Chain::Bitcoin, "https://httpbin.org/status/404"));
 


### PR DESCRIPTION
Two tests on main were left behind by recent changes and fail CI.

The gateway test still passed an argument to the constructor that no longer exists.

The Solana node check test still expected a single block, but the check now looks at two.