### PR TITLE
Deactivate staking validators missing from the chain response

### DIFF
--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/gemstone/StakeStore.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/gemstone/StakeStore.kt
@@ -38,6 +38,14 @@ class GemstoneStakeStore(
     override suspend fun saveValidators(validators: List<String>) =
         stakeDao.upsertValidators(validators.map { it.decodeJson<DelegationValidator>() }.toRecord())
 
+    override suspend fun deactivateValidators(assetId: String, validatorIds: List<String>) {
+        if (validatorIds.isEmpty()) {
+            return
+        }
+        val id = assetId.toAssetId() ?: return
+        stakeDao.deactivateValidators(id, validatorIds)
+    }
+
     override suspend fun getDelegationIds(walletId: String, assetId: String, providerType: String): List<String> {
         val id = assetId.toAssetId() ?: return emptyList()
         return stakeDao.getDelegationIds(WalletId(walletId), id)

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/StakeDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/StakeDao.kt
@@ -17,6 +17,9 @@ interface StakeDao {
     @Upsert
     suspend fun upsertValidators(validators: List<DbDelegationValidator>)
 
+    @Query("UPDATE stake_validators SET isActive=0, apr=0 WHERE assetId=:assetId AND validatorId IN (:validatorIds)")
+    suspend fun deactivateValidators(assetId: AssetId, validatorIds: List<String>)
+
     @Upsert
     suspend fun upsertDelegations(delegations: List<DbDelegationBase>)
 

--- a/core/gemstone/src/services/stake/mod.rs
+++ b/core/gemstone/src/services/stake/mod.rs
@@ -64,7 +64,12 @@ impl GemStakeService {
         );
         let validators = rules::merge_validators(validators?, delegation_validators?, &names);
         if !validators.is_empty() {
+            let asset_id = AssetId::from_chain(chain);
+            let stale_ids = rules::stale_validator_ids(self.store.get_validators(asset_id.clone(), StakeProviderType::Stake).await?, &validators);
             self.store.save_validators(validators.clone()).await?;
+            if !stale_ids.is_empty() {
+                self.store.deactivate_validators(asset_id, stale_ids).await?;
+            }
             self.store.save_address_names(rules::validator_address_names(&validators)).await?;
         }
         Ok(names)
@@ -142,6 +147,16 @@ mod tests {
         assert_eq!(missing[0].id, "gone");
         assert_eq!(missing[0].name, "Gone");
         assert!(!missing[0].is_active);
+    }
+
+    #[test]
+    fn test_stale_validator_ids_returns_only_ids_missing_from_the_response() {
+        let existing = vec![validator("kept", true), validator("gone", true)];
+        let incoming = vec![validator("kept", true), validator("fresh", true)];
+
+        assert_eq!(stale_validator_ids(existing, &incoming), vec!["gone".to_string()]);
+        assert!(stale_validator_ids(vec![validator("kept", true)], &[validator("kept", true)]).is_empty());
+        assert!(stale_validator_ids(vec![validator("gone", false)], &[validator("kept", true)]).is_empty());
     }
 
     #[test]

--- a/core/gemstone/src/services/stake/rules.rs
+++ b/core/gemstone/src/services/stake/rules.rs
@@ -67,6 +67,15 @@ pub fn stale_delegation_ids(existing_ids: Vec<String>, incoming: &[DelegationBas
     existing_ids.into_iter().filter(|id| !incoming_ids.contains(id)).collect()
 }
 
+pub fn stale_validator_ids(existing: Vec<DelegationValidator>, incoming: &[DelegationValidator]) -> Vec<String> {
+    let incoming_ids: HashSet<&str> = incoming.iter().map(|validator| validator.id.as_str()).collect();
+    existing
+        .into_iter()
+        .filter(|validator| validator.is_active && !incoming_ids.contains(validator.id.as_str()))
+        .map(|validator| validator.id)
+        .collect()
+}
+
 pub fn validator_address_names(validators: &[DelegationValidator]) -> Vec<AddressName> {
     validators
         .iter()

--- a/core/gemstone/src/services/stake/store.rs
+++ b/core/gemstone/src/services/stake/store.rs
@@ -8,6 +8,7 @@ pub trait GemStakeStore: Send + Sync {
     async fn get_apr(&self, asset_id: AssetId, provider_type: StakeProviderType) -> Result<Option<f64>, GemServiceError>;
     async fn get_validators(&self, asset_id: AssetId, provider_type: StakeProviderType) -> Result<Vec<DelegationValidator>, GemServiceError>;
     async fn save_validators(&self, validators: Vec<DelegationValidator>) -> Result<(), GemServiceError>;
+    async fn deactivate_validators(&self, asset_id: AssetId, validator_ids: Vec<String>) -> Result<(), GemServiceError>;
     async fn get_delegation_ids(&self, wallet_id: WalletId, asset_id: AssetId, provider_type: StakeProviderType) -> Result<Vec<String>, GemServiceError>;
     async fn update_delegations(&self, wallet_id: WalletId, delegations: Vec<DelegationBase>, delete_ids: Vec<String>) -> Result<(), GemServiceError>;
     async fn save_address_names(&self, names: Vec<AddressName>) -> Result<(), GemServiceError>;

--- a/ios/Packages/GemstoneServices/Sources/Stores/StakeStore.swift
+++ b/ios/Packages/GemstoneServices/Sources/Stores/StakeStore.swift
@@ -36,6 +36,10 @@ public final class GemstoneStakeStore: GemStakeStore, @unchecked Sendable {
         try store.updateValidators(validators.map { try Primitives.DelegationValidator($0) })
     }
 
+    public func deactivateValidators(assetId: Gemstone.AssetId, validatorIds: [String]) async throws {
+        try store.deactivateValidators(assetId: Primitives.AssetId(id: assetId), validatorIds: validatorIds)
+    }
+
     public func getDelegationIds(walletId: String, assetId: Gemstone.AssetId, providerType: Gemstone.StakeProviderType) async throws -> [String] {
         try store.getDelegations(walletId: WalletId.from(id: walletId), assetId: Primitives.AssetId(id: assetId), providerType: Primitives.StakeProviderType(providerType)).map(\.id)
     }

--- a/ios/Packages/Store/Sources/Stores/StakeStore.swift
+++ b/ios/Packages/Store/Sources/Stores/StakeStore.swift
@@ -85,6 +85,20 @@ public struct StakeStore: Sendable {
         }
     }
 
+    @discardableResult
+    public func deactivateValidators(assetId: AssetId, validatorIds: [String]) throws -> Int {
+        try db.write { db in
+            try StakeValidatorRecord
+                .filter(StakeValidatorRecord.Columns.assetId == assetId.identifier)
+                .filter(validatorIds.contains(StakeValidatorRecord.Columns.validatorId))
+                .updateAll(
+                    db,
+                    StakeValidatorRecord.Columns.isActive.set(to: false),
+                    StakeValidatorRecord.Columns.apr.set(to: 0),
+                )
+        }
+    }
+
     public func getDelegations(walletId: WalletId, assetId: AssetId, providerType: StakeProviderType) throws -> [Delegation] {
         try db.read { db in
             try DelegationsRequest(walletId: walletId, assetId: assetId, providerType: providerType).fetch(db)

--- a/ios/Packages/Store/Tests/StoreTests/StakeStoreTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/StakeStoreTests.swift
@@ -1,0 +1,45 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Primitives
+import PrimitivesTestKit
+import Store
+import StoreTestKit
+import Testing
+
+struct StakeStoreTests {
+    @Test
+    func deactivateValidatorsKeepsRow() throws {
+        let store = StakeStore(db: .mockWithChains([.cosmos]))
+        let elected = DelegationValidator.mock(.cosmos, id: "elected")
+        let dropped = DelegationValidator.mock(.cosmos, id: "dropped")
+        try store.updateValidators([elected, dropped])
+
+        try store.deactivateValidators(assetId: Chain.cosmos.assetId, validatorIds: [dropped.id])
+
+        let active = try store.getValidatorsActive(assetId: Chain.cosmos.assetId, providerType: .stake)
+        #expect(active.map(\.id) == [elected.id])
+
+        let stored = try store.getValidators(assetId: Chain.cosmos.assetId, providerType: .stake)
+        #expect(stored.count == 2)
+        #expect(stored.first { $0.id == dropped.id }?.apr == 0)
+        #expect(stored.first { $0.id == elected.id }?.apr == elected.apr)
+    }
+
+    @Test
+    func deactivateValidatorsKeepsOtherChain() throws {
+        let store = StakeStore(db: .mockWithChains([.cosmos, .celestia]))
+        let sharedId = "valoper1shared"
+        try store.updateValidators([
+            DelegationValidator.mock(.cosmos, id: sharedId),
+            DelegationValidator.mock(.celestia, id: sharedId),
+        ])
+
+        try store.deactivateValidators(assetId: Chain.cosmos.assetId, validatorIds: [sharedId])
+
+        let cosmos = try store.getValidatorsActive(assetId: Chain.cosmos.assetId, providerType: .stake)
+        #expect(cosmos.isEmpty)
+
+        let celestia = try store.getValidatorsActive(assetId: Chain.celestia.assetId, providerType: .stake)
+        #expect(celestia.map(\.id) == [sharedId])
+    }
+}


### PR DESCRIPTION
Validators that disappear from the chain are no longer shown as active.

Before this, the app only added validators to its local list and never removed them. A validator that stopped being active kept showing up in the validator picker with its old rate, and could still be picked for a new stake.

Now such validators are marked inactive so they drop out of the picker. They are not deleted, because deleting a validator would also delete the stake that points at it. A failed or empty response from the network never deactivates anything.