### PR TITLE
Retry the activities sync after a failed attempt

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/SyncTransactionsImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/transaction/SyncTransactionsImpl.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.data.coordinators.transaction
 import com.gemwallet.android.application.transactions.coordinators.SyncAssetTransactions
 import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
 import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.ext.runCatchingCancellable
 import com.gemwallet.android.ext.toIdentifier
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.Wallet
@@ -16,9 +17,8 @@ class SyncTransactionsImpl @Inject constructor(
     private val sessionRepository: SessionRepository,
 ) : SyncTransactions, SyncAssetTransactions {
 
-    override suspend fun syncTransactions(wallet: Wallet) {
-        runCatching { transactionsService.sync(wallet.id.id, null) }
-    }
+    override suspend fun syncTransactions(wallet: Wallet): Boolean =
+        runCatchingCancellable { transactionsService.sync(wallet.id.id, null) }.isSuccess
 
     override suspend fun syncAssetTransactions(assetId: AssetId) {
         val wallet = sessionRepository.getCurrentWallet() ?: return

--- a/android/features/activities/viewmodels/build.gradle.kts
+++ b/android/features/activities/viewmodels/build.gradle.kts
@@ -59,6 +59,9 @@ dependencies {
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk.android)
+    testImplementation(testFixtures(project(":gemcore")))
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModel.kt
+++ b/android/features/activities/viewmodels/src/main/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModel.kt
@@ -12,6 +12,7 @@ import com.wallet.core.primitives.WalletId
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -49,7 +50,7 @@ class TransactionsViewModel @Inject constructor(
         .map { it?.wallet?.id }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    private var lastSyncedWalletId: WalletId? = null
+    private var syncedWalletId: WalletId? = null
 
     val transactions = combine(
         chainsFilter,
@@ -82,13 +83,16 @@ class TransactionsViewModel @Inject constructor(
         }
     }
 
-    fun syncIfNeeded() {
-        val current = walletId.value ?: return
-        if (current == lastSyncedWalletId) return
-        lastSyncedWalletId = current
-        viewModelScope.launch(Dispatchers.IO) {
-            val wallet = session.firstOrNull()?.wallet ?: return@launch
-            syncTransactions.syncTransactions(wallet)
+    fun syncIfNeeded(): Job? {
+        val current = walletId.value ?: return null
+        if (current == syncedWalletId) return null
+        syncedWalletId = current
+        return viewModelScope.launch(Dispatchers.IO) {
+            val wallet = session.firstOrNull()?.wallet
+            val synced = wallet != null && syncTransactions.syncTransactions(wallet)
+            if (!synced && syncedWalletId == current) {
+                syncedWalletId = null
+            }
         }
     }
 

--- a/android/features/activities/viewmodels/src/test/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModelSyncTest.kt
+++ b/android/features/activities/viewmodels/src/test/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModelSyncTest.kt
@@ -1,0 +1,83 @@
+package com.gemwallet.android.features.activities.viewmodels
+
+import com.gemwallet.android.application.transactions.coordinators.GetTransactions
+import com.gemwallet.android.application.transactions.coordinators.SyncTransactions
+import com.gemwallet.android.data.repositories.session.SessionRepository
+import com.gemwallet.android.domains.transaction.aggregates.TransactionDataAggregate
+import com.gemwallet.android.model.Session
+import com.gemwallet.android.testkit.mockSession
+import com.gemwallet.android.testkit.mockWallet
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TransactionsViewModelSyncTest {
+
+    private val session = MutableStateFlow<Session?>(mockSession(wallet = mockWallet()))
+    private val syncTransactions = mockk<SyncTransactions>()
+    private val getTransactions = mockk<GetTransactions> {
+        every { getTransactions(any()) } returns MutableStateFlow(emptyList<TransactionDataAggregate>())
+        every { transactions() } returns MutableStateFlow(emptyList())
+    }
+    private val sessionRepository = mockk<SessionRepository>(relaxed = true) {
+        every { session() } returns session
+    }
+
+    @Before
+    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `failed sync is retried on the next screen entry`() = runBlocking {
+        coEvery { syncTransactions.syncTransactions(any()) } returns false
+        val viewModel = createViewModel()
+
+        viewModel.syncIfNeeded()?.join()
+        viewModel.syncIfNeeded()?.join()
+
+        coVerify(exactly = 2) { syncTransactions.syncTransactions(any()) }
+    }
+
+    @Test
+    fun `successful sync is not repeated for the same wallet`() = runBlocking {
+        coEvery { syncTransactions.syncTransactions(any()) } returns true
+        val viewModel = createViewModel()
+
+        viewModel.syncIfNeeded()?.join()
+        viewModel.syncIfNeeded()?.join()
+
+        coVerify(exactly = 1) { syncTransactions.syncTransactions(any()) }
+    }
+
+    @Test
+    fun `wallet switch syncs the new wallet`() = runBlocking {
+        coEvery { syncTransactions.syncTransactions(any()) } returns true
+        val viewModel = createViewModel()
+
+        viewModel.syncIfNeeded()?.join()
+        session.value = mockSession(wallet = mockWallet(id = "wallet-2"))
+        viewModel.syncIfNeeded()?.join()
+
+        coVerify { syncTransactions.syncTransactions(match { it.id.id == "wallet-2" }) }
+    }
+
+    private fun createViewModel() = TransactionsViewModel(
+        sessionRepository = sessionRepository,
+        getTransactions = getTransactions,
+        syncTransactions = syncTransactions,
+    )
+}

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/transactions/coordinators/SyncTransactions.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/transactions/coordinators/SyncTransactions.kt
@@ -3,5 +3,5 @@ package com.gemwallet.android.application.transactions.coordinators
 import com.wallet.core.primitives.Wallet
 
 interface SyncTransactions {
-    suspend fun syncTransactions(wallet: Wallet)
+    suspend fun syncTransactions(wallet: Wallet): Boolean
 }


### PR DESCRIPTION
The Activity tab syncs once per wallet when you open it. If that sync failed — say the app started without a connection — it was marked as done anyway and never tried again, so the list stayed stale until you pulled to refresh.

Now a failed sync is not counted as done, and the next visit to the tab tries again.