### PR TITLE
Fix WalletConnect signing on iOS

### DIFF
--- a/ios/Packages/GemstoneServices/Tests/ConnectionStoreTests.swift
+++ b/ios/Packages/GemstoneServices/Tests/ConnectionStoreTests.swift
@@ -27,6 +27,7 @@ struct ConnectionStoreTests {
         let connectionB = try #require(try await store.getConnection(sessionId: "b").map { try WalletConnection($0) })
         #expect(connectionA.wallet.id == walletA.id)
         #expect(connectionB.wallet.id == walletB.id)
+        #expect(connectionA.wallet.accounts.map(\.chain) == [.ethereum])
         #expect(try await store.getConnection(sessionId: "missing") == nil)
     }
 

--- a/ios/Packages/Store/Sources/Requests/BannerRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/BannerRequest.swift
@@ -27,7 +27,7 @@ public struct BannersRequest: DatabaseQueryable {
         var query = BannerRecord
             .including(optional: BannerRecord.asset)
             .including(optional: BannerRecord.chain)
-            .including(optional: BannerRecord.wallet)
+            .including(optional: BannerRecord.wallet.including(all: WalletRecord.accounts))
             .filter(events.map(\.rawValue).contains(BannerRecord.Columns.event))
             .filter(BannerRecord.Columns.state != BannerState.cancelled.rawValue)
             .asRequest(of: BannerInfo.self)

--- a/ios/Packages/Store/Sources/Stores/ConnectionsStore.swift
+++ b/ios/Packages/Store/Sources/Stores/ConnectionsStore.swift
@@ -23,6 +23,7 @@ public struct ConnectionsStore: Sendable {
         try db.read { db in
             try WalletRecord
                 .including(required: WalletRecord.connection)
+                .including(all: WalletRecord.accounts)
                 .asRequest(of: WalletConnectionInfo.self)
                 .filter(
                     TableAlias(name: WalletConnectionRecord.databaseTableName)[WalletConnectionRecord.Columns.sessionId] == sessionId,

--- a/ios/Packages/Store/Sources/Stores/WalletStore.swift
+++ b/ios/Packages/Store/Sources/Stores/WalletStore.swift
@@ -107,22 +107,6 @@ public struct WalletStore: Sendable {
     }
 }
 
-extension WalletRecord {
-    func mapToWallet() -> Wallet {
-        Wallet(
-            id: id,
-            externalId: externalId,
-            name: name,
-            index: index.asInt32,
-            type: type,
-            accounts: [],
-            isPinned: isPinned,
-            imageUrl: imageUrl,
-            source: source,
-        )
-    }
-}
-
 extension Wallet {
     var record: WalletRecord {
         WalletRecord(

--- a/ios/Packages/Store/Sources/Types/BannerInfo.swift
+++ b/ios/Packages/Store/Sources/Types/BannerInfo.swift
@@ -8,7 +8,7 @@ struct BannerInfo: Codable, FetchableRecord {
     let banner: BannerRecord
     let asset: AssetRecord?
     let chain: AssetRecord?
-    let wallet: WalletRecord?
+    let wallet: WalletRecordInfo?
 
     init(row: Row) throws {
         banner = try BannerRecord(row: row)

--- a/ios/Packages/Store/Sources/Types/TransactionWalletInfo.swift
+++ b/ios/Packages/Store/Sources/Types/TransactionWalletInfo.swift
@@ -6,13 +6,12 @@ import Primitives
 
 struct WalletTransactionInfo: FetchableRecord, Decodable {
     var transaction: TransactionRecord
-    var wallet: WalletRecord
-    var accounts: [AccountRecord]
+    var wallet: WalletRecordInfo
 
     var transactionWallet: TransactionWallet {
         TransactionWallet(
             transaction: transaction.mapToTransaction(),
-            wallet: WalletRecordInfo(wallet: wallet, accounts: accounts).mapToWallet(),
+            wallet: wallet.mapToWallet(),
         )
     }
 }

--- a/ios/Packages/Store/Sources/Types/WalletRecordInfo.swift
+++ b/ios/Packages/Store/Sources/Types/WalletRecordInfo.swift
@@ -26,7 +26,7 @@ extension WalletRecordInfo {
 }
 
 struct WalletConnectionInfo: FetchableRecord, Codable {
-    var wallet: WalletRecord
+    var wallet: WalletRecordInfo
     var connection: WalletConnectionRecord
 }
 


### PR DESCRIPTION
Signing anything through WalletConnect on iOS was failing — sign message, sign transaction and send transaction, on every chain.

The wallet handed to the signing code came without its accounts, so it could not tell which account to sign with.

Now the accounts are always loaded together with the wallet, and the shortcut that allowed building a wallet without them is gone.