### PR TITLE
Simplify banner scope to asset and wallet id

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetShowWelcomeBannerImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetShowWelcomeBannerImpl.kt
@@ -59,5 +59,5 @@ class GetShowWelcomeBannerImpl(
 }
 
 internal fun onboardingBannerId(wallet: Wallet): String = bannerIdentifier(
-    GemBannerKey(walletId = wallet.id.id, assetId = null, chain = null, event = BannerEvent.Onboarding.toJson())
+    GemBannerKey(walletId = wallet.id.id, assetId = null, event = BannerEvent.Onboarding.toJson())
 )

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetShowWelcomeBannerImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/GetShowWelcomeBannerImpl.kt
@@ -53,8 +53,6 @@ class GetShowWelcomeBannerImpl(
         assetRankScore = null,
         hasPerpetualsSupport = false,
         isWalletEmpty = isWalletEmpty,
-        notificationsAvailable = false,
-        launchCount = 0u,
     )
 }
 

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/HideWelcomeBannerImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/HideWelcomeBannerImpl.kt
@@ -16,7 +16,7 @@ class HideWelcomeBannerImpl(
     override suspend fun invoke() {
         val wallet = sessionRepository.session().value?.wallet ?: return
         applyBannerAction(
-            Banner(wallet = wallet, asset = null, chain = null, event = BannerEvent.Onboarding, state = BannerState.Active),
+            Banner(walletId = wallet.id, asset = null, event = BannerEvent.Onboarding, state = BannerState.Active),
             BannerAction.Close,
         )
     }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/banners/BannersRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/banners/BannersRepository.kt
@@ -38,26 +38,12 @@ import java.math.BigInteger
 class BannersRepository(
     private val assetRepository: AssetsRepository,
     private val bannersDao: BannersDao,
-    private val userConfig: UserConfig,
-    private val notificationsAvailable: NotificationsAvailable,
     private val bannerService: GemBannerService,
 ) : GetBannersCase, BannerActionCase, HasMultiSign {
 
     override suspend fun getActiveBanners(wallet: Wallet?, asset: Asset?, isGlobal: Boolean): List<Banner> = withContext(Dispatchers.IO) {
         val assetInfo = asset?.id?.let { assetRepository.getAssetInfo(it).firstOrNull() }
         val sceneWallet = wallet.takeUnless { isGlobal }
-        val generated = bannerService.activeEvents(
-            walletId = sceneWallet?.id?.id,
-            assetId = asset?.id?.toIdentifier(),
-            context = bannerContext(sceneWallet, assetInfo),
-        ).map { event ->
-            Banner(
-                walletId = sceneWallet?.id,
-                asset = assetInfo?.asset,
-                state = BannerState.Active,
-                event = event.decodeJson(),
-            )
-        }
         val stored = when {
             asset != null -> bannersDao.getAssetBanners(
                 walletId = wallet?.id?.id,
@@ -66,13 +52,12 @@ class BannersRepository(
             wallet != null -> bannersDao.getWalletBanners(wallet.id.id, listOf(BannerEvent.AccountBlockedMultiSignature))
             else -> emptyList()
         }.map { it.toDTO(asset) }
-        val banners = stored + generated
         bannerService.visibleBanners(
-            stored = banners.map { GemBannerItem(event = it.event.toJson(), state = it.state.toJson()) },
+            stored = stored.map { GemBannerItem(event = it.event.toJson(), state = it.state.toJson()) },
             context = bannerContext(wallet, assetInfo),
         ).map { item ->
             val event = item.event.decodeJson<BannerEvent>()
-            banners.firstOrNull { it.event == event }
+            stored.firstOrNull { it.event == event }
                 ?: Banner(walletId = sceneWallet?.id, asset = assetInfo?.asset, state = item.state.decodeJson(), event = event)
         }
     }
@@ -95,8 +80,6 @@ class BannersRepository(
         assetRankScore = assetInfo?.metadata?.rankScore,
         hasPerpetualsSupport = wallet?.hasPerpetualsSupport == true,
         isWalletEmpty = false,
-        notificationsAvailable = notificationsAvailable,
-        launchCount = userConfig.getLaunchNumber().toUInt(),
     )
 }
 

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/banners/BannersRepository.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/banners/BannersRepository.kt
@@ -52,9 +52,8 @@ class BannersRepository(
             context = bannerContext(sceneWallet, assetInfo),
         ).map { event ->
             Banner(
-                wallet = sceneWallet,
+                walletId = sceneWallet?.id,
                 asset = assetInfo?.asset,
-                chain = null,
                 state = BannerState.Active,
                 event = event.decodeJson(),
             )
@@ -63,11 +62,10 @@ class BannersRepository(
             asset != null -> bannersDao.getAssetBanners(
                 walletId = wallet?.id?.id,
                 assetId = asset.id.toIdentifier(),
-                chain = asset.id.chain,
             )
             wallet != null -> bannersDao.getWalletBanners(wallet.id.id, listOf(BannerEvent.AccountBlockedMultiSignature))
             else -> emptyList()
-        }.map { it.toDTO(wallet, asset) }
+        }.map { it.toDTO(asset) }
         val banners = stored + generated
         bannerService.visibleBanners(
             stored = banners.map { GemBannerItem(event = it.event.toJson(), state = it.state.toJson()) },
@@ -75,7 +73,7 @@ class BannersRepository(
         ).map { item ->
             val event = item.event.decodeJson<BannerEvent>()
             banners.firstOrNull { it.event == event }
-                ?: Banner(wallet = sceneWallet, asset = assetInfo?.asset, chain = null, state = item.state.decodeJson(), event = event)
+                ?: Banner(walletId = sceneWallet?.id, asset = assetInfo?.asset, state = item.state.decodeJson(), event = event)
         }
     }
 
@@ -103,9 +101,8 @@ class BannersRepository(
 }
 
 private fun Banner.toGemKey() = GemBannerKey(
-    walletId = wallet?.id?.id,
+    walletId = walletId?.id,
     assetId = asset?.id?.toIdentifier(),
-    chain = chain?.string,
     event = event.toJson(),
 )
 

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/BannersModule.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/di/BannersModule.kt
@@ -35,23 +35,19 @@ object BannersModule {
 
     @Provides
     @Singleton
-    fun provideGemBannerService(store: GemBannerStore, permissions: GemNotificationPermissions): GemBannerService =
-        GemBannerService(store, permissions)
+    fun provideGemBannerService(store: GemBannerStore): GemBannerService =
+        GemBannerService(store)
 
     @Provides
     @Singleton
     fun provideBannersRepository(
         assetsRepository: AssetsRepository,
         bannersDao: BannersDao,
-        configRepository: UserConfig,
-        notificationsAvailable: NotificationsAvailable,
         bannerService: GemBannerService,
     ): BannersRepository {
         return BannersRepository(
             assetsRepository,
             bannersDao,
-            configRepository,
-            notificationsAvailable,
             bannerService,
         )
     }

--- a/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/gemstone/BannerStore.kt
+++ b/android/data/repositories/src/main/kotlin/com/gemwallet/android/data/repositories/gemstone/BannerStore.kt
@@ -33,7 +33,6 @@ class GemstoneBannerStore(
         id = bannerIdentifier(this),
         walletId = walletId,
         assetId = assetId,
-        chain = chain?.requireChain(),
         event = event.decodeJson<BannerEvent>(),
         state = state.decodeJson(),
     )

--- a/android/data/services/store/schemas/com.gemwallet.android.data.service.store.database.GemDatabase/89.json
+++ b/android/data/services/store/schemas/com.gemwallet.android.data.service.store.database.GemDatabase/89.json
@@ -1,0 +1,2727 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 89,
+    "identityHash": "2774bbbc5c5263a7d39dc70f98432f07",
+    "entities": [
+      {
+        "tableName": "wallets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `domain_name` TEXT, `type` TEXT NOT NULL, `position` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `index` INTEGER NOT NULL, `source` TEXT NOT NULL DEFAULT 'Import', `imageUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainName",
+            "columnName": "domain_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Import'"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "accounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`wallet_id` TEXT NOT NULL, `derivation_path` TEXT NOT NULL, `address` TEXT NOT NULL, `chain` TEXT NOT NULL, `extendedPublicKey` TEXT, PRIMARY KEY(`wallet_id`, `chain`), FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "derivationPath",
+            "columnName": "derivation_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extendedPublicKey",
+            "columnName": "extendedPublicKey",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "wallet_id",
+            "chain"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_accounts_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_accounts_chain` ON `${TABLE_NAME}` (`chain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "addresses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chain` TEXT NOT NULL, `address` TEXT NOT NULL, `walletId` TEXT, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `status` TEXT NOT NULL, `imageUrl` TEXT, PRIMARY KEY(`chain`, `address`), FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`walletId`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "walletId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chain",
+            "address"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_addresses_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_addresses_chain` ON `${TABLE_NAME}` (`chain`)"
+          },
+          {
+            "name": "index_addresses_walletId",
+            "unique": false,
+            "columnNames": [
+              "walletId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_addresses_walletId` ON `${TABLE_NAME}` (`walletId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "walletId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "contacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `imageUrl` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "contacts_addresses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `contactId` TEXT NOT NULL, `address` TEXT NOT NULL, `chain` TEXT NOT NULL, `memo` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`contactId`) REFERENCES `contacts`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contactId",
+            "columnName": "contactId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memo",
+            "columnName": "memo",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_contacts_addresses_contactId",
+            "unique": false,
+            "columnNames": [
+              "contactId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contacts_addresses_contactId` ON `${TABLE_NAME}` (`contactId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "contacts",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "contactId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "asset",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `symbol` TEXT NOT NULL, `decimals` INTEGER NOT NULL, `type` TEXT NOT NULL, `chain` TEXT NOT NULL, `is_enabled` INTEGER NOT NULL, `is_buy_enabled` INTEGER NOT NULL, `is_sell_enabled` INTEGER NOT NULL, `is_swap_enabled` INTEGER NOT NULL, `is_stake_enabled` INTEGER NOT NULL, `staking_apr` REAL, `is_earn_enabled` INTEGER NOT NULL DEFAULT 0, `earn_apr` REAL, `rank` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, `associations` TEXT NOT NULL DEFAULT '[]', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decimals",
+            "columnName": "decimals",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "is_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBuyEnabled",
+            "columnName": "is_buy_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSellEnabled",
+            "columnName": "is_sell_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSwapEnabled",
+            "columnName": "is_swap_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStakeEnabled",
+            "columnName": "is_stake_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stakingApr",
+            "columnName": "staking_apr",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "isEarnEnabled",
+            "columnName": "is_earn_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "earnApr",
+            "columnName": "earn_apr",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "associations",
+            "columnName": "associations",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "balances",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `wallet_id` TEXT NOT NULL, `available` TEXT NOT NULL, `available_amount` REAL NOT NULL, `frozen` TEXT NOT NULL, `frozen_amount` REAL NOT NULL, `locked` TEXT NOT NULL, `locked_amount` REAL NOT NULL, `staked` TEXT NOT NULL, `staked_amount` REAL NOT NULL, `pending` TEXT NOT NULL, `pending_amount` REAL NOT NULL, `rewards` TEXT NOT NULL, `rewards_amount` REAL NOT NULL, `reserved` TEXT NOT NULL, `reserved_amount` REAL NOT NULL, `withdrawable` TEXT NOT NULL, `withdrawableAmount` REAL NOT NULL, `pending_unconfirmed` TEXT NOT NULL DEFAULT '0', `pending_unconfirmed_amount` REAL NOT NULL DEFAULT 0.0, `earn` TEXT NOT NULL DEFAULT '0', `earn_amount` REAL NOT NULL DEFAULT 0.0, `total_amount` REAL NOT NULL, `is_active` INTEGER NOT NULL, `is_pinned` INTEGER NOT NULL, `is_visible` INTEGER NOT NULL, `list_position` INTEGER NOT NULL, `votes` INTEGER NOT NULL DEFAULT 0, `energy_available` INTEGER NOT NULL DEFAULT 0, `energy_total` INTEGER NOT NULL DEFAULT 0, `bandwidth_available` INTEGER NOT NULL DEFAULT 0, `bandwidth_total` INTEGER NOT NULL DEFAULT 0, `updated_at` INTEGER, PRIMARY KEY(`asset_id`, `wallet_id`), FOREIGN KEY(`asset_id`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "available",
+            "columnName": "available",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "availableAmount",
+            "columnName": "available_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frozen",
+            "columnName": "frozen",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frozenAmount",
+            "columnName": "frozen_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lockedAmount",
+            "columnName": "locked_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staked",
+            "columnName": "staked",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stakedAmount",
+            "columnName": "staked_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pending",
+            "columnName": "pending",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingAmount",
+            "columnName": "pending_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rewards",
+            "columnName": "rewards",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rewardsAmount",
+            "columnName": "rewards_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reserved",
+            "columnName": "reserved",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reservedAmount",
+            "columnName": "reserved_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "withdrawable",
+            "columnName": "withdrawable",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "withdrawableAmount",
+            "columnName": "withdrawableAmount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingUnconfirmed",
+            "columnName": "pending_unconfirmed",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "pendingUnconfirmedAmount",
+            "columnName": "pending_unconfirmed_amount",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "earn",
+            "columnName": "earn",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "earnAmount",
+            "columnName": "earn_amount",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "totalAmount",
+            "columnName": "total_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "is_pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isVisible",
+            "columnName": "is_visible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listPosition",
+            "columnName": "list_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "votes",
+            "columnName": "votes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "energyAvailable",
+            "columnName": "energy_available",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "energyTotal",
+            "columnName": "energy_total",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bandwidthAvailable",
+            "columnName": "bandwidth_available",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bandwidthTotal",
+            "columnName": "bandwidth_total",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id",
+            "wallet_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_balances_wallet_id",
+            "unique": false,
+            "columnNames": [
+              "wallet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_balances_wallet_id` ON `${TABLE_NAME}` (`wallet_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "prices",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `value` REAL, `usd_value` REAL, `day_changed` REAL, `currency` TEXT NOT NULL, `updatedAt` INTEGER, PRIMARY KEY(`asset_id`))",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "usdValue",
+            "columnName": "usd_value",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "dayChanged",
+            "columnName": "day_changed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id"
+          ]
+        }
+      },
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `walletId` TEXT NOT NULL, `hash` TEXT NOT NULL, `assetId` TEXT NOT NULL, `feeAssetId` TEXT NOT NULL, `owner` TEXT NOT NULL, `recipient` TEXT NOT NULL, `contract` TEXT, `metadata` TEXT, `state` TEXT NOT NULL, `type` TEXT NOT NULL, `blockNumber` TEXT NOT NULL, `sequence` TEXT NOT NULL, `fee` TEXT NOT NULL, `value` TEXT NOT NULL, `payload` TEXT, `direction` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `estimatedConfirmationInSeconds` INTEGER, PRIMARY KEY(`id`, `walletId`), FOREIGN KEY(`walletId`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "walletId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feeAssetId",
+            "columnName": "feeAssetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipient",
+            "columnName": "recipient",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contract",
+            "columnName": "contract",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockNumber",
+            "columnName": "blockNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fee",
+            "columnName": "fee",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmationEtaSeconds",
+            "columnName": "estimatedConfirmationInSeconds",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "walletId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_walletId",
+            "unique": false,
+            "columnNames": [
+              "walletId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transactions_walletId` ON `${TABLE_NAME}` (`walletId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "walletId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tx_swap_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tx_id` TEXT NOT NULL, `from_asset_id` TEXT NOT NULL, `to_asset_id` TEXT NOT NULL, `from_amount` TEXT NOT NULL, `to_amount` TEXT NOT NULL, PRIMARY KEY(`tx_id`))",
+        "fields": [
+          {
+            "fieldPath": "txId",
+            "columnName": "tx_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromAssetId",
+            "columnName": "from_asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toAssetId",
+            "columnName": "to_asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromAmount",
+            "columnName": "from_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toAmount",
+            "columnName": "to_amount",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tx_id"
+          ]
+        }
+      },
+      {
+        "tableName": "wallets_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `wallet_id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `state` TEXT NOT NULL, `chains` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `expire_at` INTEGER NOT NULL, `app_name` TEXT NOT NULL, `app_description` TEXT NOT NULL, `app_url` TEXT NOT NULL, `app_icon` TEXT NOT NULL, `redirect_native` TEXT, `redirect_universal` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chains",
+            "columnName": "chains",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expireAt",
+            "columnName": "expire_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "app_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appDescription",
+            "columnName": "app_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appUrl",
+            "columnName": "app_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appIcon",
+            "columnName": "app_icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "redirectNative",
+            "columnName": "redirect_native",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "redirectUniversal",
+            "columnName": "redirect_universal",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_wallets_connections_wallet_id",
+            "unique": false,
+            "columnNames": [
+              "wallet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_wallets_connections_wallet_id` ON `${TABLE_NAME}` (`wallet_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stake_validators",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `assetId` TEXT NOT NULL, `validatorId` TEXT NOT NULL, `name` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `commission` REAL NOT NULL, `apr` REAL NOT NULL, `providerType` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "validatorId",
+            "columnName": "validatorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commission",
+            "columnName": "commission",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apr",
+            "columnName": "apr",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stake_validators_assetId",
+            "unique": false,
+            "columnNames": [
+              "assetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stake_validators_assetId` ON `${TABLE_NAME}` (`assetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stake_delegations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `walletId` TEXT NOT NULL, `assetId` TEXT NOT NULL, `validatorId` TEXT NOT NULL, `state` TEXT NOT NULL, `delegationId` TEXT NOT NULL, `balance` TEXT NOT NULL, `shares` TEXT NOT NULL, `rewards` TEXT NOT NULL, `completionDate` INTEGER, PRIMARY KEY(`walletId`, `id`), FOREIGN KEY(`walletId`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`validatorId`) REFERENCES `stake_validators`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "walletId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "validatorId",
+            "columnName": "validatorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "delegationId",
+            "columnName": "delegationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shares",
+            "columnName": "shares",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rewards",
+            "columnName": "rewards",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completionDate",
+            "columnName": "completionDate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "walletId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stake_delegations_assetId",
+            "unique": false,
+            "columnNames": [
+              "assetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stake_delegations_assetId` ON `${TABLE_NAME}` (`assetId`)"
+          },
+          {
+            "name": "index_stake_delegations_validatorId",
+            "unique": false,
+            "columnNames": [
+              "validatorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stake_delegations_validatorId` ON `${TABLE_NAME}` (`validatorId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "walletId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "stake_validators",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "validatorId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `status` TEXT NOT NULL, `priority` INTEGER NOT NULL, `chain` TEXT NOT NULL, PRIMARY KEY(`url`), FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nodes_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_chain` ON `${TABLE_NAME}` (`chain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `wallet_id` TEXT NOT NULL, `currency` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "banners",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `wallet_id` TEXT, `asset_id` TEXT, `state` TEXT NOT NULL, `event` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "event",
+            "columnName": "event",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_banners_event",
+            "unique": false,
+            "columnNames": [
+              "event"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_banners_event` ON `${TABLE_NAME}` (`event`)"
+          },
+          {
+            "name": "index_banners_wallet_id",
+            "unique": false,
+            "columnNames": [
+              "wallet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_banners_wallet_id` ON `${TABLE_NAME}` (`wallet_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "price_alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `assetId` TEXT NOT NULL, `currency` TEXT NOT NULL, `price` REAL, `pricePercentChange` REAL, `priceDirection` TEXT, `lastNotifiedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "pricePercentChange",
+            "columnName": "pricePercentChange",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "priceDirection",
+            "columnName": "priceDirection",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastNotifiedAt",
+            "columnName": "lastNotifiedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "nft_collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `chain` TEXT NOT NULL, `contractAddress` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `previewImageUrl` TEXT NOT NULL, `originalSourceUrl` TEXT NOT NULL, `status` TEXT, `links` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contractAddress",
+            "columnName": "contractAddress",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "previewImageUrl",
+            "columnName": "previewImageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalSourceUrl",
+            "columnName": "originalSourceUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "links",
+            "columnName": "links",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nft_collections_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nft_collections_chain` ON `${TABLE_NAME}` (`chain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nft_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `collection_id` TEXT NOT NULL, `token_id` TEXT NOT NULL, `token_type` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `chain` TEXT NOT NULL, `contract_address` TEXT, `image_url` TEXT NOT NULL, `preview_image_url` TEXT NOT NULL, `original_image_url` TEXT NOT NULL, `attributes` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`collection_id`) REFERENCES `nft_collections`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`chain`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collection_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenId",
+            "columnName": "token_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenType",
+            "columnName": "token_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chain",
+            "columnName": "chain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contractAddress",
+            "columnName": "contract_address",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "previewImageUrl",
+            "columnName": "preview_image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalSourceUrl",
+            "columnName": "original_image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributes",
+            "columnName": "attributes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nft_assets_collection_id",
+            "unique": false,
+            "columnNames": [
+              "collection_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nft_assets_collection_id` ON `${TABLE_NAME}` (`collection_id`)"
+          },
+          {
+            "name": "index_nft_assets_chain",
+            "unique": false,
+            "columnNames": [
+              "chain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nft_assets_chain` ON `${TABLE_NAME}` (`chain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "nft_collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "collection_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chain"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nft_assets_associations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`wallet_id` TEXT NOT NULL, `asset_id` TEXT NOT NULL, PRIMARY KEY(`wallet_id`, `asset_id`), FOREIGN KEY(`asset_id`) REFERENCES `nft_assets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "wallet_id",
+            "asset_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nft_assets_associations_asset_id",
+            "unique": false,
+            "columnNames": [
+              "asset_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nft_assets_associations_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "nft_assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "asset_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL, PRIMARY KEY(`asset_id`, `name`), FOREIGN KEY(`asset_id`) REFERENCES `asset`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id",
+            "name"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "asset_market",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `marketCap` REAL, `marketCapFdv` REAL, `marketCapRank` INTEGER, `totalVolume` REAL, `circulatingSupply` REAL, `totalSupply` REAL, `maxSupply` REAL, `allTimeHigh` REAL, `allTimeHighDate` INTEGER, `allTimeHighChangePercentage` REAL, `allTimeLow` REAL, `allTimeLowDate` INTEGER, `allTimeLowChangePercentage` REAL, PRIMARY KEY(`asset_id`), FOREIGN KEY(`asset_id`) REFERENCES `asset`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "marketCap",
+            "columnName": "marketCap",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "marketCapFdv",
+            "columnName": "marketCapFdv",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "marketCapRank",
+            "columnName": "marketCapRank",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalVolume",
+            "columnName": "totalVolume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "circulatingSupply",
+            "columnName": "circulatingSupply",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "totalSupply",
+            "columnName": "totalSupply",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "maxSupply",
+            "columnName": "maxSupply",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "allTimeHigh",
+            "columnName": "allTimeHigh",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "allTimeHighDate",
+            "columnName": "allTimeHighDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "allTimeHighChangePercentage",
+            "columnName": "allTimeHighChangePercentage",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "allTimeLow",
+            "columnName": "allTimeLow",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "allTimeLowDate",
+            "columnName": "allTimeLowDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "allTimeLowChangePercentage",
+            "columnName": "allTimeLowChangePercentage",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "asset_lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `assetId` TEXT, `perpetualId` TEXT, `listId` TEXT, `priority` INTEGER NOT NULL, FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`perpetualId`) REFERENCES `perpetuals`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`listId`) REFERENCES `asset_lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "perpetualId",
+            "columnName": "perpetualId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_query",
+            "unique": false,
+            "columnNames": [
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_query` ON `${TABLE_NAME}` (`query`)"
+          },
+          {
+            "name": "index_search_assetId_query",
+            "unique": true,
+            "columnNames": [
+              "assetId",
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_assetId_query` ON `${TABLE_NAME}` (`assetId`, `query`)"
+          },
+          {
+            "name": "index_search_perpetualId_query",
+            "unique": true,
+            "columnNames": [
+              "perpetualId",
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_perpetualId_query` ON `${TABLE_NAME}` (`perpetualId`, `query`)"
+          },
+          {
+            "name": "index_search_listId_query",
+            "unique": true,
+            "columnNames": [
+              "listId",
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_listId_query` ON `${TABLE_NAME}` (`listId`, `query`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "perpetuals",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "perpetualId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "asset_lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "currency_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`currency` TEXT NOT NULL, `rate` REAL NOT NULL, PRIMARY KEY(`currency`))",
+        "fields": [
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "currency"
+          ]
+        }
+      },
+      {
+        "tableName": "fiat_transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `walletId` TEXT NOT NULL, `assetId` TEXT NOT NULL, `transactionType` TEXT NOT NULL, `provider` TEXT NOT NULL, `status` TEXT NOT NULL, `fiatAmount` REAL NOT NULL, `fiatCurrency` TEXT NOT NULL, `value` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `detailsUrl` TEXT, PRIMARY KEY(`id`, `walletId`), FOREIGN KEY(`walletId`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "walletId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionType",
+            "columnName": "transactionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fiatAmount",
+            "columnName": "fiatAmount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fiatCurrency",
+            "columnName": "fiatCurrency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detailsUrl",
+            "columnName": "detailsUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "walletId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_fiat_transactions_walletId",
+            "unique": false,
+            "columnNames": [
+              "walletId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiat_transactions_walletId` ON `${TABLE_NAME}` (`walletId`)"
+          },
+          {
+            "name": "index_fiat_transactions_assetId",
+            "unique": false,
+            "columnNames": [
+              "assetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_fiat_transactions_assetId` ON `${TABLE_NAME}` (`assetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "walletId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recent_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `wallet_id` TEXT NOT NULL, `to_asset_id` TEXT, `type` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`asset_id`, `wallet_id`, `type`), FOREIGN KEY(`asset_id`) REFERENCES `asset`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toAssetId",
+            "columnName": "to_asset_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "asset_id",
+            "wallet_id",
+            "type"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recent_assets_wallet_id",
+            "unique": false,
+            "columnNames": [
+              "wallet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recent_assets_wallet_id` ON `${TABLE_NAME}` (`wallet_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "perpetuals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `provider` TEXT NOT NULL, `assetId` TEXT NOT NULL, `identifier` TEXT NOT NULL, `price` REAL NOT NULL, `pricePercentChange24h` REAL NOT NULL, `openInterest` REAL NOT NULL, `volume24h` REAL NOT NULL, `funding` REAL NOT NULL, `maxLeverage` INTEGER NOT NULL, `isIsolatedOnly` INTEGER NOT NULL, `isPinned` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identifier",
+            "columnName": "identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pricePercentChange24h",
+            "columnName": "pricePercentChange24h",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openInterest",
+            "columnName": "openInterest",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volume24h",
+            "columnName": "volume24h",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "funding",
+            "columnName": "funding",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxLeverage",
+            "columnName": "maxLeverage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIsolatedOnly",
+            "columnName": "isIsolatedOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "perpetuals_asset_id_idx",
+            "unique": false,
+            "columnNames": [
+              "assetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `perpetuals_asset_id_idx` ON `${TABLE_NAME}` (`assetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "perpetuals_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `walletId` TEXT NOT NULL, `perpetualId` TEXT NOT NULL, `assetId` TEXT NOT NULL, `size` REAL NOT NULL, `sizeValue` REAL NOT NULL, `leverage` INTEGER NOT NULL, `entryPrice` REAL, `liquidationPrice` REAL, `marginType` TEXT NOT NULL, `direction` TEXT NOT NULL, `marginAmount` REAL NOT NULL, `takeProfitPrice` REAL, `takeProfitType` TEXT, `takeProfitOrderId` TEXT, `stopLossPrice` REAL, `stopLossType` TEXT, `stopLossOrderId` TEXT, `pnl` REAL NOT NULL, `funding` REAL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`, `walletId`), FOREIGN KEY(`walletId`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`perpetualId`) REFERENCES `perpetuals`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`assetId`) REFERENCES `asset`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "walletId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perpetualId",
+            "columnName": "perpetualId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "assetId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeValue",
+            "columnName": "sizeValue",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "leverage",
+            "columnName": "leverage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryPrice",
+            "columnName": "entryPrice",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "liquidationPrice",
+            "columnName": "liquidationPrice",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "marginType",
+            "columnName": "marginType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "marginAmount",
+            "columnName": "marginAmount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "takeProfitPrice",
+            "columnName": "takeProfitPrice",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "takeProfitType",
+            "columnName": "takeProfitType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "takeProfitOrderId",
+            "columnName": "takeProfitOrderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stopLossPrice",
+            "columnName": "stopLossPrice",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "stopLossType",
+            "columnName": "stopLossType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stopLossOrderId",
+            "columnName": "stopLossOrderId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pnl",
+            "columnName": "pnl",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "funding",
+            "columnName": "funding",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "walletId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "perpetuals_positions_wallet_id_idx",
+            "unique": false,
+            "columnNames": [
+              "walletId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `perpetuals_positions_wallet_id_idx` ON `${TABLE_NAME}` (`walletId`)"
+          },
+          {
+            "name": "perpetuals_positions_perpetual_id_idx",
+            "unique": false,
+            "columnNames": [
+              "perpetualId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `perpetuals_positions_perpetual_id_idx` ON `${TABLE_NAME}` (`perpetualId`)"
+          },
+          {
+            "name": "perpetuals_positions_asset_id_idx",
+            "unique": false,
+            "columnNames": [
+              "assetId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `perpetuals_positions_asset_id_idx` ON `${TABLE_NAME}` (`assetId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "walletId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "perpetuals",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "perpetualId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "asset",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "assetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "in_app_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `wallet_id` TEXT NOT NULL, `read_at` INTEGER, `created_at` INTEGER NOT NULL, `item` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`wallet_id`) REFERENCES `wallets`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readAt",
+            "columnName": "read_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "item",
+            "columnName": "item",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_in_app_notifications_wallet_id",
+            "unique": false,
+            "columnNames": [
+              "wallet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_in_app_notifications_wallet_id` ON `${TABLE_NAME}` (`wallet_id`)"
+          },
+          {
+            "name": "index_in_app_notifications_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_in_app_notifications_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "wallets",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "wallet_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "support_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `content` TEXT NOT NULL, `sender` TEXT NOT NULL, `status` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `images` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "images",
+            "columnName": "images",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_support_messages_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_support_messages_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2774bbbc5c5263a7d39dc70f98432f07')"
+    ]
+  }
+}

--- a/android/data/services/store/src/androidTest/kotlin/com/gemwallet/android/service/store/Migration_88_89Test.kt
+++ b/android/data/services/store/src/androidTest/kotlin/com/gemwallet/android/service/store/Migration_88_89Test.kt
@@ -1,0 +1,41 @@
+package com.gemwallet.android.service.store
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.gemwallet.android.data.service.store.database.GemDatabase
+import com.gemwallet.android.data.service.store.database.di.Migration_88_89
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class Migration_88_89Test {
+
+    private val testDb = "migration-88-89-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        GemDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Before
+    fun setUp() {
+        InstrumentationRegistry.getInstrumentation().targetContext.deleteDatabase(testDb)
+    }
+
+    @Test
+    fun migrate88To89_recreatesBannersWithoutChain() {
+        helper.createDatabase(testDb, 88).apply {
+            execSQL("INSERT INTO banners (id, wallet_id, asset_id, chain, state, event) VALUES ('stale', 'wallet-1', NULL, 'ethereum', 'AlwaysActive', 'AccountBlockedMultiSignature')")
+            close()
+        }
+
+        helper.runMigrationsAndValidate(testDb, 89, true, Migration_88_89).close()
+    }
+}

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/BannersDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/BannersDao.kt
@@ -23,13 +23,12 @@ interface BannersDao {
             banners
         WHERE
             (wallet_id IS NULL OR wallet_id = :walletId)
-            AND (asset_id = :assetId OR chain = :chain)
+            AND asset_id = :assetId
             AND state IN (:states)
     """)
     suspend fun getAssetBanners(
         walletId: String?,
         assetId: String,
-        chain: Chain,
         states: List<BannerState> = listOf(BannerState.Active, BannerState.AlwaysActive),
     ): List<DbBanner>
 

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/GemDatabase.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/GemDatabase.kt
@@ -36,7 +36,7 @@ import com.gemwallet.android.data.service.store.database.entities.DbTxSwapMetada
 import com.gemwallet.android.data.service.store.database.entities.DbWallet
 
 @Database(
-    version = 88,
+    version = 89,
     entities = [
         DbWallet::class,
         DbAccount::class,

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/di/DatabaseModule.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/di/DatabaseModule.kt
@@ -92,6 +92,7 @@ object DatabaseModule {
         .addMigrations(Migration_85_86)
         .addMigrations(Migration_86_87)
         .addMigrations(Migration_87_88)
+        .addMigrations(Migration_88_89)
         .build()
 
     @Singleton

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/di/Migration_88_89.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/di/Migration_88_89.kt
@@ -1,0 +1,24 @@
+package com.gemwallet.android.data.service.store.database.di
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+object Migration_88_89 : Migration(88, 89) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("DROP TABLE banners")
+        db.execSQL(
+            """
+            CREATE TABLE banners (
+                id TEXT NOT NULL,
+                wallet_id TEXT,
+                asset_id TEXT,
+                state TEXT NOT NULL,
+                event TEXT NOT NULL,
+                PRIMARY KEY(id)
+            )
+            """
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_banners_event ON banners(event)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_banners_wallet_id ON banners(wallet_id)")
+    }
+}

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbBanner.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbBanner.kt
@@ -10,30 +10,24 @@ import com.wallet.core.primitives.Asset
 import com.wallet.core.primitives.Banner
 import com.wallet.core.primitives.BannerEvent
 import com.wallet.core.primitives.BannerState
-import com.wallet.core.primitives.Chain
-import com.wallet.core.primitives.Wallet
+import com.wallet.core.primitives.WalletId
 
 @Entity(
     tableName = "banners",
-    indices = [Index("event"), Index("wallet_id"), Index("chain")],
-    foreignKeys = [
-        ForeignKey(DbAsset::class, ["id"], ["chain"], onDelete = ForeignKey.CASCADE, onUpdate = ForeignKey.CASCADE),
-    ],
+    indices = [Index("event"), Index("wallet_id")],
 )
 data class DbBanner(
     @PrimaryKey val id: String,
     @ColumnInfo("wallet_id") val walletId: String?,
     @ColumnInfo("asset_id") val assetId: String?,
-    val chain: Chain?,
     val state: BannerState,
     val event: BannerEvent,
 )
 
-fun DbBanner.toDTO(wallet: Wallet?, asset: Asset?): Banner {
+fun DbBanner.toDTO(asset: Asset?): Banner {
     return Banner(
-        wallet = wallet?.takeIf { it.id.id == walletId },
+        walletId = walletId?.let { WalletId(it) },
         asset = asset?.takeIf { it.id.toIdentifier() == assetId },
-        chain = chain,
         state = state,
         event = event,
     )

--- a/android/features/banner/presents/src/main/kotlin/com/gemwallet/android/features/banner/views/BannerItemUIModel.kt
+++ b/android/features/banner/presents/src/main/kotlin/com/gemwallet/android/features/banner/views/BannerItemUIModel.kt
@@ -47,10 +47,6 @@ internal fun bannerItemUIModel(
                 getActivationFee(asset),
             ),
         )
-        BannerEvent.EnableNotifications -> Pair(
-            stringResource(R.string.banner_enable_notifications_title, assetName),
-            stringResource(R.string.banner_enable_notifications_description),
-        )
         BannerEvent.AccountBlockedMultiSignature -> Pair(
             stringResource(R.string.common_warning),
             stringResource(R.string.warnings_multi_signature_blocked, asset?.chain ?: ""),

--- a/android/gemcore/src/main/kotlin/com/wallet/core/primitives/generated/Banner.kt
+++ b/android/gemcore/src/main/kotlin/com/wallet/core/primitives/generated/Banner.kt
@@ -39,9 +39,8 @@ enum class BannerState(val string: String) {
 
 @Serializable
 data class Banner (
-	val wallet: Wallet? = null,
+	val walletId: WalletId? = null,
 	val asset: Asset? = null,
-	val chain: Chain? = null,
 	val event: BannerEvent,
 	val state: BannerState
 )

--- a/android/gemcore/src/main/kotlin/com/wallet/core/primitives/generated/Banner.kt
+++ b/android/gemcore/src/main/kotlin/com/wallet/core/primitives/generated/Banner.kt
@@ -13,8 +13,6 @@ enum class BannerEvent(val string: String) {
 	Stake("stake"),
 	@SerialName("accountActivation")
 	AccountActivation("accountActivation"),
-	@SerialName("enableNotifications")
-	EnableNotifications("enableNotifications"),
 	@SerialName("accountBlockedMultiSignature")
 	AccountBlockedMultiSignature("accountBlockedMultiSignature"),
 	@SerialName("activateAsset")

--- a/core/crates/primitives/src/banner.rs
+++ b/core/crates/primitives/src/banner.rs
@@ -21,7 +21,6 @@ pub struct Banner {
 pub enum BannerEvent {
     Stake,
     AccountActivation,
-    EnableNotifications,
     AccountBlockedMultiSignature,
     ActivateAsset,
     SuspiciousAsset,

--- a/core/crates/primitives/src/banner.rs
+++ b/core/crates/primitives/src/banner.rs
@@ -2,15 +2,14 @@ use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, EnumString};
 use typeshare::typeshare;
 
-use crate::{Asset, Chain, Wallet};
+use crate::{Asset, WalletId};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[typeshare(swift = "Equatable, Sendable")]
 #[serde(rename_all = "camelCase")]
 pub struct Banner {
-    pub wallet: Option<Wallet>,
+    pub wallet_id: Option<WalletId>,
     pub asset: Option<Asset>,
-    pub chain: Option<Chain>,
     pub event: BannerEvent,
     pub state: BannerState,
 }

--- a/core/gemstone/src/services/banner/mod.rs
+++ b/core/gemstone/src/services/banner/mod.rs
@@ -6,7 +6,7 @@ pub mod store;
 use crate::services::error::GemServiceError;
 use std::sync::Arc;
 
-use primitives::{AssetId, BannerEvent, BannerState, Wallet, WalletId};
+use primitives::{BannerState, Wallet};
 
 pub use model::{GemBannerAction, GemBannerContext, GemBannerItem, GemBannerKey};
 pub use permissions::GemNotificationPermissions;
@@ -15,14 +15,13 @@ pub use store::GemBannerStore;
 #[derive(uniffi::Object)]
 pub struct GemBannerService {
     store: Arc<dyn GemBannerStore>,
-    permissions: Arc<dyn GemNotificationPermissions>,
 }
 
 #[uniffi::export]
 impl GemBannerService {
     #[uniffi::constructor]
-    pub fn new(store: Arc<dyn GemBannerStore>, permissions: Arc<dyn GemNotificationPermissions>) -> Self {
-        Self { store, permissions }
+    pub fn new(store: Arc<dyn GemBannerStore>) -> Self {
+        Self { store }
     }
 
     pub async fn setup(&self) -> Result<(), GemServiceError> {
@@ -34,27 +33,10 @@ impl GemBannerService {
     }
 
     pub async fn apply_action(&self, key: GemBannerKey, action: GemBannerAction) -> Result<(), GemServiceError> {
-        let closes = match rules::close_decision(&action) {
-            rules::BannerClose::Close => true,
-            rules::BannerClose::Keep => false,
-            rules::BannerClose::AfterPermission => self.permissions.request_permissions_or_open_settings().await?,
-        };
-        if closes {
-            self.close(key).await?;
+        match action {
+            GemBannerAction::Close => self.close(key).await,
+            GemBannerAction::Event { .. } | GemBannerAction::Button => Ok(()),
         }
-        Ok(())
-    }
-
-    pub async fn active_events(&self, wallet_id: Option<WalletId>, asset_id: Option<AssetId>, context: GemBannerContext) -> Result<Vec<BannerEvent>, GemServiceError> {
-        let mut active = Vec::new();
-        for event in rules::suggested_events(&context) {
-            let key = rules::event_key(wallet_id.clone(), asset_id.clone(), event);
-            let state = self.store.get_state(key).await?.unwrap_or_else(|| rules::default_state(event));
-            if rules::is_visible(state) {
-                active.push(event);
-            }
-        }
-        Ok(active)
     }
 
     pub async fn close(&self, key: GemBannerKey) -> Result<(), GemServiceError> {

--- a/core/gemstone/src/services/banner/model.rs
+++ b/core/gemstone/src/services/banner/model.rs
@@ -1,4 +1,4 @@
-use primitives::{AssetId, BannerEvent, BannerState, Chain, WalletId};
+use primitives::{AssetId, BannerEvent, BannerState, WalletId};
 
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct GemBannerContext {
@@ -25,7 +25,6 @@ pub struct GemBannerItem {
 pub struct GemBannerKey {
     pub wallet_id: Option<WalletId>,
     pub asset_id: Option<AssetId>,
-    pub chain: Option<Chain>,
     pub event: BannerEvent,
 }
 
@@ -41,7 +40,6 @@ pub fn banner_identifier(key: GemBannerKey) -> String {
     [
         key.wallet_id.map(|wallet_id| wallet_id.id()),
         key.asset_id.map(|asset_id| asset_id.to_string()),
-        key.chain.map(|chain| chain.as_ref().to_string()),
         Some(key.event.as_ref().to_string()),
     ]
     .into_iter()
@@ -57,24 +55,20 @@ mod tests {
 
     #[test]
     fn test_banner_identifier() {
-        let key = |wallet_id: Option<&str>, asset_id: Option<AssetId>, chain: Option<Chain>, event: BannerEvent| GemBannerKey {
+        let key = |wallet_id: Option<&str>, asset_id: Option<AssetId>, event: BannerEvent| GemBannerKey {
             wallet_id: wallet_id.map(|id| WalletId::Multicoin(id.to_string())),
             asset_id,
-            chain,
             event,
         };
 
         assert_eq!(
-            banner_identifier(key(Some("wallet-1"), Some(AssetId::from_chain(Chain::Bitcoin)), Some(Chain::Bitcoin), BannerEvent::Stake)),
-            "multicoin_wallet-1_bitcoin_bitcoin_stake"
+            banner_identifier(key(Some("wallet-1"), Some(AssetId::from_chain(Chain::Bitcoin)), BannerEvent::Stake)),
+            "multicoin_wallet-1_bitcoin_stake"
         );
-        assert_eq!(banner_identifier(key(None, None, None, BannerEvent::EnableNotifications)), "enableNotifications");
+        assert_eq!(banner_identifier(key(None, None, BannerEvent::EnableNotifications)), "enableNotifications");
+        assert_eq!(banner_identifier(key(Some("wallet-1"), None, BannerEvent::Onboarding)), "multicoin_wallet-1_onboarding");
         assert_eq!(
-            banner_identifier(key(Some("wallet-1"), None, None, BannerEvent::Onboarding)),
-            "multicoin_wallet-1_onboarding"
-        );
-        assert_eq!(
-            banner_identifier(key(None, Some(AssetId::from_chain(Chain::Ethereum)), None, BannerEvent::ActivateAsset)),
+            banner_identifier(key(None, Some(AssetId::from_chain(Chain::Ethereum)), BannerEvent::ActivateAsset)),
             "ethereum_activateAsset"
         );
     }

--- a/core/gemstone/src/services/banner/model.rs
+++ b/core/gemstone/src/services/banner/model.rs
@@ -11,8 +11,6 @@ pub struct GemBannerContext {
     pub asset_rank_score: Option<i32>,
     pub has_perpetuals_support: bool,
     pub is_wallet_empty: bool,
-    pub notifications_available: bool,
-    pub launch_count: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, uniffi::Record)]
@@ -65,7 +63,7 @@ mod tests {
             banner_identifier(key(Some("wallet-1"), Some(AssetId::from_chain(Chain::Bitcoin)), BannerEvent::Stake)),
             "multicoin_wallet-1_bitcoin_stake"
         );
-        assert_eq!(banner_identifier(key(None, None, BannerEvent::EnableNotifications)), "enableNotifications");
+        assert_eq!(banner_identifier(key(None, None, BannerEvent::SuspiciousAsset)), "suspiciousAsset");
         assert_eq!(banner_identifier(key(Some("wallet-1"), None, BannerEvent::Onboarding)), "multicoin_wallet-1_onboarding");
         assert_eq!(
             banner_identifier(key(None, Some(AssetId::from_chain(Chain::Ethereum)), BannerEvent::ActivateAsset)),

--- a/core/gemstone/src/services/banner/rules.rs
+++ b/core/gemstone/src/services/banner/rules.rs
@@ -1,41 +1,11 @@
-use primitives::{AssetId, BannerEvent, BannerState, Chain, Wallet, WalletId, WalletSource};
+use primitives::{AssetId, BannerEvent, BannerState, Chain, Wallet, WalletSource};
 
-use super::model::{GemBannerAction, GemBannerContext, GemBannerItem, GemBannerKey};
+use super::model::{GemBannerContext, GemBannerItem, GemBannerKey};
 
 const ACCOUNT_ACTIVATION_CHAINS: [Chain; 3] = [Chain::Xrp, Chain::Stellar, Chain::Algorand];
 const TRADE_PERPETUALS_CHAINS: [Chain; 2] = [Chain::HyperCore, Chain::Hyperliquid];
 
 const SUSPICIOUS_RANK_SCORE: i32 = 5;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BannerClose {
-    Close,
-    Keep,
-    AfterPermission,
-}
-
-pub fn close_decision(action: &GemBannerAction) -> BannerClose {
-    match action {
-        GemBannerAction::Close => BannerClose::Close,
-        GemBannerAction::Button => BannerClose::Keep,
-        GemBannerAction::Event { event } => {
-            if closes_on_action(*event) {
-                BannerClose::AfterPermission
-            } else {
-                BannerClose::Keep
-            }
-        }
-    }
-}
-
-pub fn event_key(wallet_id: Option<WalletId>, asset_id: Option<AssetId>, event: BannerEvent) -> GemBannerKey {
-    GemBannerKey {
-        wallet_id,
-        asset_id,
-        chain: None,
-        event,
-    }
-}
 
 pub fn is_visible(state: BannerState) -> bool {
     match state {

--- a/core/gemstone/src/services/banner/rules.rs
+++ b/core/gemstone/src/services/banner/rules.rs
@@ -5,7 +5,6 @@ use super::model::{GemBannerAction, GemBannerContext, GemBannerItem, GemBannerKe
 const ACCOUNT_ACTIVATION_CHAINS: [Chain; 3] = [Chain::Xrp, Chain::Stellar, Chain::Algorand];
 const TRADE_PERPETUALS_CHAINS: [Chain; 2] = [Chain::HyperCore, Chain::Hyperliquid];
 
-const ENABLE_NOTIFICATIONS_MINIMUM_LAUNCHES: u32 = 3;
 const SUSPICIOUS_RANK_SCORE: i32 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,23 +49,9 @@ pub fn default_state(event: BannerEvent) -> BannerState {
         BannerEvent::ActivateAsset | BannerEvent::AccountBlockedMultiSignature => BannerState::AlwaysActive,
         BannerEvent::Stake
         | BannerEvent::AccountActivation
-        | BannerEvent::EnableNotifications
         | BannerEvent::SuspiciousAsset
         | BannerEvent::Onboarding
         | BannerEvent::TradePerpetuals => BannerState::Active,
-    }
-}
-
-pub fn closes_on_action(event: BannerEvent) -> bool {
-    match event {
-        BannerEvent::EnableNotifications => true,
-        BannerEvent::Stake
-        | BannerEvent::AccountActivation
-        | BannerEvent::AccountBlockedMultiSignature
-        | BannerEvent::ActivateAsset
-        | BannerEvent::SuspiciousAsset
-        | BannerEvent::Onboarding
-        | BannerEvent::TradePerpetuals => false,
     }
 }
 
@@ -103,16 +88,9 @@ pub fn wallet_setup_keys(wallet: &Wallet) -> Vec<GemBannerKey> {
         .collect()
 }
 
-pub fn is_available(event: BannerEvent, context: &GemBannerContext) -> bool {
-    match event {
-        BannerEvent::EnableNotifications => context.notifications_available && context.launch_count >= ENABLE_NOTIFICATIONS_MINIMUM_LAUNCHES,
-        _ => true,
-    }
-}
-
 pub fn is_visible_event(event: BannerEvent, context: &GemBannerContext) -> bool {
     match event {
-        BannerEvent::EnableNotifications | BannerEvent::AccountBlockedMultiSignature => true,
+        BannerEvent::AccountBlockedMultiSignature => true,
         BannerEvent::AccountActivation => !context.has_asset || !context.has_available_balance,
         BannerEvent::Stake => context.has_asset && !context.has_stake_balance,
         BannerEvent::ActivateAsset => context.has_asset && !context.is_asset_activated,
@@ -165,27 +143,11 @@ fn event_priority(event: BannerEvent) -> u8 {
         BannerEvent::ActivateAsset => 2,
         BannerEvent::SuspiciousAsset => 3,
         BannerEvent::Onboarding => 4,
-        BannerEvent::EnableNotifications => 5,
-        BannerEvent::Stake => 6,
-        BannerEvent::TradePerpetuals => 7,
+        BannerEvent::Stake => 5,
+        BannerEvent::TradePerpetuals => 6,
     }
 }
 
-pub fn suggested_events(context: &GemBannerContext) -> Vec<BannerEvent> {
-    let mut events = Vec::new();
-    if !context.has_wallet && !context.has_asset {
-        events.push(BannerEvent::EnableNotifications);
-    }
-    if context.has_asset {
-        if context.is_stakeable && !context.has_stake_balance {
-            events.push(BannerEvent::Stake);
-        }
-        if !context.is_asset_activated {
-            events.push(BannerEvent::ActivateAsset);
-        }
-    }
-    events.into_iter().filter(|event| is_available(*event, context)).collect()
-}
 
 #[cfg(test)]
 mod tests {
@@ -245,8 +207,6 @@ mod tests {
             asset_rank_score: Some(50),
             has_perpetuals_support: true,
             is_wallet_empty: false,
-            notifications_available: true,
-            launch_count: 3,
         }
     }
 
@@ -302,7 +262,6 @@ mod tests {
     fn test_visible_banners_order_and_wallet_rules() {
         let stored = vec![
             item(BannerEvent::Stake, BannerState::Active),
-            item(BannerEvent::EnableNotifications, BannerState::Cancelled),
             item(BannerEvent::AccountActivation, BannerState::AlwaysActive),
         ];
         let suspicious = GemBannerContext {
@@ -314,16 +273,13 @@ mod tests {
         assert_eq!(banners[0].state, BannerState::AlwaysActive);
         assert_eq!(banners[2].state, BannerState::Active);
 
-        let wallet = vec![
-            item(BannerEvent::Onboarding, BannerState::AlwaysActive),
-            item(BannerEvent::EnableNotifications, BannerState::Active),
-        ];
-        assert_eq!(events(&visible_banners(wallet.clone(), &context(false))), vec![BannerEvent::EnableNotifications]);
+        let wallet = vec![item(BannerEvent::Onboarding, BannerState::AlwaysActive)];
+        assert!(visible_banners(wallet.clone(), &context(false)).is_empty());
         let empty = GemBannerContext {
             is_wallet_empty: true,
             ..context(false)
         };
-        assert_eq!(events(&visible_banners(wallet, &empty)), vec![BannerEvent::Onboarding, BannerEvent::EnableNotifications]);
+        assert_eq!(events(&visible_banners(wallet, &empty)), vec![BannerEvent::Onboarding]);
     }
 
     #[test]
@@ -333,55 +289,6 @@ mod tests {
         assert!(!is_visible(BannerState::Cancelled));
         assert_eq!(default_state(BannerEvent::ActivateAsset), BannerState::AlwaysActive);
         assert_eq!(default_state(BannerEvent::Stake), BannerState::Active);
-        assert!(closes_on_action(BannerEvent::EnableNotifications));
-        assert!(!closes_on_action(BannerEvent::Stake));
     }
 
-    #[test]
-    fn test_notifications_banner_waits_for_launches() {
-        let mut no_asset = context(false);
-        no_asset.has_wallet = false;
-        assert!(is_available(BannerEvent::EnableNotifications, &no_asset));
-        assert_eq!(suggested_events(&no_asset), vec![BannerEvent::EnableNotifications]);
-
-        no_asset.launch_count = ENABLE_NOTIFICATIONS_MINIMUM_LAUNCHES - 1;
-        assert!(!is_available(BannerEvent::EnableNotifications, &no_asset));
-        assert!(suggested_events(&no_asset).is_empty());
-        assert!(is_available(BannerEvent::Stake, &no_asset));
-
-        let mut asset = context(true);
-        asset.is_asset_activated = false;
-        assert_eq!(suggested_events(&asset), vec![BannerEvent::Stake, BannerEvent::ActivateAsset]);
-    }
-
-    #[test]
-    fn test_close_decision_asks_for_permission_only_on_closing_events() {
-        assert_eq!(close_decision(&GemBannerAction::Close), BannerClose::Close);
-        assert_eq!(close_decision(&GemBannerAction::Button), BannerClose::Keep);
-        assert_eq!(
-            close_decision(&GemBannerAction::Event {
-                event: BannerEvent::EnableNotifications
-            }),
-            BannerClose::AfterPermission
-        );
-        assert_eq!(
-            close_decision(&GemBannerAction::Event {
-                event: BannerEvent::AccountActivation
-            }),
-            BannerClose::Keep
-        );
-    }
-
-    #[test]
-    fn test_event_key_targets_the_wallet_and_asset_without_a_chain() {
-        let wallet_id = WalletId::Multicoin("wallet".into());
-        let asset_id = AssetId::from_chain(Chain::Ethereum);
-
-        let key = event_key(Some(wallet_id.clone()), Some(asset_id.clone()), BannerEvent::AccountActivation);
-
-        assert_eq!(key.wallet_id, Some(wallet_id));
-        assert_eq!(key.asset_id, Some(asset_id));
-        assert_eq!(key.chain, None);
-        assert_eq!(key.event, BannerEvent::AccountActivation);
-    }
 }

--- a/core/gemstone/src/services/banner/rules.rs
+++ b/core/gemstone/src/services/banner/rules.rs
@@ -74,7 +74,6 @@ fn asset_key(chain: Chain, event: BannerEvent) -> GemBannerKey {
     GemBannerKey {
         wallet_id: None,
         asset_id: Some(AssetId::from_chain(chain)),
-        chain: None,
         event,
     }
 }
@@ -93,7 +92,6 @@ pub fn wallet_setup_keys(wallet: &Wallet) -> Vec<GemBannerKey> {
         WalletSource::Create => Some(GemBannerKey {
             wallet_id: Some(wallet.id.clone()),
             asset_id: None,
-            chain: None,
             event: BannerEvent::Onboarding,
         }),
         WalletSource::Import => None,
@@ -197,7 +195,7 @@ mod tests {
     #[test]
     fn test_setup_keys() {
         let keys = setup_keys();
-        assert!(keys.iter().all(|key| key.wallet_id.is_none() && key.chain.is_none()));
+        assert!(keys.iter().all(|key| key.wallet_id.is_none()));
         assert!(
             keys.iter()
                 .any(|key| key.event == BannerEvent::Stake && key.asset_id == Some(AssetId::from_chain(Chain::Cosmos)))

--- a/core/gemstone/src/services/wallet_configuration/rules.rs
+++ b/core/gemstone/src/services/wallet_configuration/rules.rs
@@ -1,4 +1,4 @@
-use primitives::{BannerEvent, WalletConfiguration, WalletId};
+use primitives::{AssetId, BannerEvent, WalletConfiguration, WalletId};
 
 use crate::services::banner::GemBannerKey;
 
@@ -8,8 +8,7 @@ pub fn multi_signature_banners(wallet_id: &WalletId, configuration: &WalletConfi
         .iter()
         .map(|account| GemBannerKey {
             wallet_id: Some(wallet_id.clone()),
-            asset_id: None,
-            chain: Some(account.chain),
+            asset_id: Some(AssetId::from_chain(account.chain)),
             event: BannerEvent::AccountBlockedMultiSignature,
         })
         .collect()
@@ -35,7 +34,10 @@ mod tests {
                 .iter()
                 .all(|key| key.wallet_id == Some(wallet_id.clone()) && key.event == BannerEvent::AccountBlockedMultiSignature)
         );
-        assert_eq!(banners.iter().map(|key| key.chain).collect::<Vec<_>>(), vec![Some(Chain::Tron), Some(Chain::Ethereum)]);
+        assert_eq!(
+            banners.iter().map(|key| key.asset_id.clone()).collect::<Vec<_>>(),
+            vec![Some(AssetId::from_chain(Chain::Tron)), Some(AssetId::from_chain(Chain::Ethereum))]
+        );
         assert!(multi_signature_banners(&wallet_id, &WalletConfiguration { multi_signature_accounts: vec![] }).is_empty());
     }
 }

--- a/ios/Features/Assets/Sources/Types/AssetSceneInput.swift
+++ b/ios/Features/Assets/Sources/Types/AssetSceneInput.swift
@@ -29,7 +29,6 @@ public struct AssetSceneInput: Sendable {
         bannersRequest = BannersRequest(
             walletId: wallet.id,
             assetId: asset.id,
-            chain: asset.id.chain,
             events: BannerEvent.allCases,
         )
     }

--- a/ios/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/ios/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -232,7 +232,7 @@ public final class AssetSceneViewModel: Sendable {
     }
 
     var visibleBanners: [Banner] {
-        (try? bannerService.visibleBanners(banners, wallet: wallet, asset: assetData.asset, context: bannerContext)) ?? []
+        (try? bannerService.visibleBanners(banners, walletId: wallet.id, asset: assetData.asset, context: bannerContext)) ?? []
     }
 
     private var bannerContext: GemBannerContext {

--- a/ios/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/ios/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -246,8 +246,6 @@ public final class AssetSceneViewModel: Sendable {
             assetRankScore: assetData.metadata.rankScore,
             hasPerpetualsSupport: wallet.hasPerpetualsSupport,
             isWalletEmpty: false,
-            notificationsAvailable: false,
-            launchCount: 0,
         )
     }
 
@@ -400,8 +398,7 @@ public extension AssetSceneViewModel {
                         value: 0,
                     ),
                 )
-            case .enableNotifications,
-                 .accountActivation,
+            case .accountActivation,
                  .accountBlockedMultiSignature,
                  .onboarding:
                 Task {

--- a/ios/Features/Settings/Sources/Settings/ViewModels/NotificationsViewModel.swift
+++ b/ios/Features/Settings/Sources/Settings/ViewModels/NotificationsViewModel.swift
@@ -56,7 +56,7 @@ extension NotificationsViewModel {
         case true:
             self.isEnabled = try await requestPermissionsOrOpenSettings()
             if isEnabled {
-                try await bannerService.close(key: GemBannerKey(walletId: nil, assetId: nil, chain: nil, event: BannerEvent.enableNotifications.json()))
+                try await bannerService.close(key: GemBannerKey(walletId: nil, assetId: nil, event: BannerEvent.enableNotifications.json()))
             }
         case false:
             try preferencesService.setPushNotificationsEnabled(enabled: isEnabled)

--- a/ios/Features/Settings/Sources/Settings/ViewModels/NotificationsViewModel.swift
+++ b/ios/Features/Settings/Sources/Settings/ViewModels/NotificationsViewModel.swift
@@ -55,9 +55,6 @@ extension NotificationsViewModel {
         switch isEnabled {
         case true:
             self.isEnabled = try await requestPermissionsOrOpenSettings()
-            if isEnabled {
-                try await bannerService.close(key: GemBannerKey(walletId: nil, assetId: nil, event: BannerEvent.enableNotifications.json()))
-            }
         case false:
             try preferencesService.setPushNotificationsEnabled(enabled: isEnabled)
         }

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -85,7 +85,7 @@ public final class WalletSceneViewModel: Sendable, AssetActions {
             initialValue: [],
         )
         assetsQuery = ObservableQuery(AssetsRequest(walletId: wallet.id, filters: [.enabledBalance]), initialValue: [])
-        bannersQuery = ObservableQuery(BannersRequest(walletId: wallet.id, assetId: .none, chain: .none, events: [.accountBlockedMultiSignature, .onboarding]), initialValue: [])
+        bannersQuery = ObservableQuery(BannersRequest(walletId: wallet.id, assetId: .none, events: [.accountBlockedMultiSignature, .onboarding]), initialValue: [])
         self.isPresentingSelectedAssetInput = isPresentingSelectedAssetInput
         self.isPresentingWallets = isPresentingWallets
     }
@@ -172,7 +172,7 @@ public final class WalletSceneViewModel: Sendable, AssetActions {
     }
 
     var visibleBanners: [Banner] {
-        (try? bannerService.visibleBanners(banners, wallet: wallet, asset: .none, context: bannerContext)) ?? []
+        (try? bannerService.visibleBanners(banners, walletId: wallet.id, asset: .none, context: bannerContext)) ?? []
     }
 
     private var bannerContext: GemBannerContext {

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -186,8 +186,6 @@ public final class WalletSceneViewModel: Sendable, AssetActions {
             assetRankScore: .none,
             hasPerpetualsSupport: wallet.hasPerpetualsSupport,
             isWalletEmpty: totalFiatValue.value.isZero,
-            notificationsAvailable: false,
-            launchCount: 0,
         )
     }
 }

--- a/ios/Gem/Services/ServicesFactory.swift
+++ b/ios/Gem/Services/ServicesFactory.swift
@@ -156,10 +156,7 @@ struct ServicesFactory {
         let transactionStateTracker = TransactionStateTracker(service: gemTransactionStateService)
 
         let pushNotificationEnablerService = PushNotificationEnablerService(preferencesService: preferencesService)
-        let bannerService = Gemstone.GemBannerService(
-            store: gemBannerStore,
-            permissions: GemstoneNotificationPermissions(service: pushNotificationEnablerService),
-        )
+        let bannerService = Gemstone.GemBannerService(store: gemBannerStore)
         let navigationPresenter = NavigationPresenter()
         let portfolioService = Gemstone.GemPortfolioService(api: gemDeviceApiClient, store: GemstonePortfolioStore(assetStore: storeManager.assetStore), price: gemPriceService)
         let gemPerpetualStore = GemstonePerpetualStore(store: storeManager.perpetualStore, assetStore: storeManager.assetStore, balanceStore: storeManager.balanceStore)

--- a/ios/Packages/GemstonePrimitives/Sources/Extensions/Banner+GemstonePrimitives.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/Extensions/Banner+GemstonePrimitives.swift
@@ -12,9 +12,8 @@ public extension Primitives.Banner {
     var gemKey: GemBannerKey {
         get throws {
             try GemBannerKey(
-                walletId: wallet?.id.id,
+                walletId: walletId?.id,
                 assetId: asset?.id.identifier,
-                chain: chain?.rawValue,
                 event: event.json(),
             )
         }
@@ -34,14 +33,13 @@ public extension Primitives.BannerActionType {
 }
 
 public extension GemBannerServiceProtocol {
-    func visibleBanners(_ banners: [Banner], wallet: Wallet?, asset: Asset?, context: GemBannerContext) throws -> [Banner] {
+    func visibleBanners(_ banners: [Banner], walletId: WalletId?, asset: Asset?, context: GemBannerContext) throws -> [Banner] {
         let stored = try banners.map { try GemBannerItem(event: $0.event.json(), state: $0.state.json()) }
         return try visibleBanners(stored: stored, context: context).map { item in
             let event = try Primitives.BannerEvent(item.event)
             return try banners.first { $0.event == event } ?? Banner(
-                wallet: wallet,
+                walletId: walletId,
                 asset: asset,
-                chain: .none,
                 event: event,
                 state: Primitives.BannerState(item.state),
             )

--- a/ios/Packages/GemstonePrimitives/TestKit/GemServiceMocks.swift
+++ b/ios/Packages/GemstonePrimitives/TestKit/GemServiceMocks.swift
@@ -519,16 +519,8 @@ public final class GemBannerServiceMock: GemBannerServiceProtocol, @unchecked Se
         stored
     }
 
-    public func activeEvents(walletId _: Gemstone.WalletId?, assetId _: Gemstone.AssetId?, context _: GemBannerContext) async throws -> [Gemstone.BannerEvent] {
-        []
-    }
-
     public func close(key: GemBannerKey) async throws {
         closedKeys.append(key)
-    }
-
-    public func closesOnAction(event _: Gemstone.BannerEvent) -> Bool {
-        false
     }
 
     public func applyAction(key _: GemBannerKey, action: GemBannerAction) async throws {

--- a/ios/Packages/GemstoneServices/Sources/Stores/BannerStore.swift
+++ b/ios/Packages/GemstoneServices/Sources/Stores/BannerStore.swift
@@ -36,7 +36,6 @@ public final class GemstoneBannerStore: GemBannerStore, @unchecked Sendable {
         try NewBanner(
             walletId: key.walletId,
             assetId: key.assetId.map { try Primitives.AssetId(id: $0) },
-            chain: key.chain.flatMap { Primitives.Chain(rawValue: $0) },
             event: Primitives.BannerEvent(key.event),
             state: state,
         )

--- a/ios/Packages/GemstoneServices/Tests/GemBannerServiceTests.swift
+++ b/ios/Packages/GemstoneServices/Tests/GemBannerServiceTests.swift
@@ -14,7 +14,7 @@ import Testing
 struct GemBannerServiceTests {
     @Test
     func closeActionCancelsBanner() async throws {
-        let (store, banner, service, _) = try makeService()
+        let (store, banner, service) = try makeService()
 
         try await service.applyAction(key: banner.gemKey, action: .close)
 
@@ -22,23 +22,10 @@ struct GemBannerServiceTests {
     }
 
     @Test
-    func enableNotificationsClosesOnlyWhenPermissionsGranted() async throws {
-        for granted in [true, false] {
-            let banner = Banner(walletId: nil, asset: nil, event: .enableNotifications, state: .active)
-            let (store, _, service, permissions) = try makeService(banner: banner, granted: granted)
-
-            try await service.applyAction(key: banner.gemKey, action: .event(event: BannerEvent.enableNotifications.json()))
-
-            #expect(permissions.requestCount == 1)
-            #expect(try store.getBanner(id: banner.id)?.state == (granted ? .cancelled : .active))
-        }
-    }
-
-    @Test
     func setupWalletSeedsOnboardingForCreatedWalletsOnly() async throws {
         let created = Wallet.mock(id: .multicoin(address: "0xcreated"), source: .create)
         let imported = Wallet.mock(id: .multicoin(address: "0ximported"), source: .import)
-        let (store, _, service, _) = try makeService(chains: [.xrp, .stellar, .algorand], wallets: [created, imported])
+        let (store, _, service) = try makeService(chains: [.xrp, .stellar, .algorand], wallets: [created, imported])
 
         try await service.setupWallet(wallet: created.json())
         try await service.setupWallet(wallet: imported.json())
@@ -50,10 +37,9 @@ struct GemBannerServiceTests {
 
     private func makeService(
         banner: Banner = Banner(walletId: nil, asset: nil, event: .stake, state: .active),
-        granted: Bool = true,
         chains: [Chain] = [],
         wallets: [Wallet] = [],
-    ) throws -> (BannerStore, Banner, GemBannerService, NotificationPermissionsMock) {
+    ) throws -> (BannerStore, Banner, GemBannerService) {
         let db = DB.mockWithChains(chains)
         let walletStore = WalletStore.mock(db: db)
         for wallet in wallets {
@@ -61,8 +47,7 @@ struct GemBannerServiceTests {
         }
         let store = BannerStore.mock(db: db)
         try store.addBanners([NewBanner(walletId: banner.walletId?.id, assetId: banner.asset?.id, event: banner.event, state: banner.state)])
-        let permissions = NotificationPermissionsMock(granted: granted)
-        let service = GemBannerService(store: GemstoneBannerStore(store: store), permissions: permissions)
-        return (store, banner, service, permissions)
+        let service = GemBannerService(store: GemstoneBannerStore(store: store))
+        return (store, banner, service)
     }
 }

--- a/ios/Packages/GemstoneServices/Tests/GemBannerServiceTests.swift
+++ b/ios/Packages/GemstoneServices/Tests/GemBannerServiceTests.swift
@@ -24,7 +24,7 @@ struct GemBannerServiceTests {
     @Test
     func enableNotificationsClosesOnlyWhenPermissionsGranted() async throws {
         for granted in [true, false] {
-            let banner = Banner(wallet: nil, asset: nil, chain: nil, event: .enableNotifications, state: .active)
+            let banner = Banner(walletId: nil, asset: nil, event: .enableNotifications, state: .active)
             let (store, _, service, permissions) = try makeService(banner: banner, granted: granted)
 
             try await service.applyAction(key: banner.gemKey, action: .event(event: BannerEvent.enableNotifications.json()))
@@ -49,7 +49,7 @@ struct GemBannerServiceTests {
     }
 
     private func makeService(
-        banner: Banner = Banner(wallet: nil, asset: nil, chain: nil, event: .stake, state: .active),
+        banner: Banner = Banner(walletId: nil, asset: nil, event: .stake, state: .active),
         granted: Bool = true,
         chains: [Chain] = [],
         wallets: [Wallet] = [],
@@ -60,7 +60,7 @@ struct GemBannerServiceTests {
             try walletStore.addWallet(wallet)
         }
         let store = BannerStore.mock(db: db)
-        try store.addBanners([NewBanner(walletId: banner.wallet?.id.id, assetId: banner.asset?.id, chain: banner.chain, event: banner.event, state: banner.state)])
+        try store.addBanners([NewBanner(walletId: banner.walletId?.id, assetId: banner.asset?.id, event: banner.event, state: banner.state)])
         let permissions = NotificationPermissionsMock(granted: granted)
         let service = GemBannerService(store: GemstoneBannerStore(store: store), permissions: permissions)
         return (store, banner, service, permissions)

--- a/ios/Packages/Primitives/Sources/Extensions/Banner+Primitives.swift
+++ b/ios/Packages/Primitives/Sources/Extensions/Banner+Primitives.swift
@@ -4,6 +4,6 @@ import Foundation
 
 extension Banner: Identifiable {
     public var id: String {
-        [wallet?.id.id, asset?.id.identifier, chain?.id, event.rawValue].compactMap(\.self).joined(separator: "_")
+        [walletId?.id, asset?.id.identifier, event.rawValue].compactMap(\.self).joined(separator: "_")
     }
 }

--- a/ios/Packages/Primitives/Sources/Generated/Banner.swift
+++ b/ios/Packages/Primitives/Sources/Generated/Banner.swift
@@ -7,7 +7,6 @@ import Foundation
 public enum BannerEvent: String, Codable, CaseIterable, Equatable, Sendable {
 	case stake
 	case accountActivation
-	case enableNotifications
 	case accountBlockedMultiSignature
 	case activateAsset
 	case suspiciousAsset

--- a/ios/Packages/Primitives/Sources/Generated/Banner.swift
+++ b/ios/Packages/Primitives/Sources/Generated/Banner.swift
@@ -22,16 +22,14 @@ public enum BannerState: String, Codable, CaseIterable, Equatable, Sendable {
 }
 
 public struct Banner: Codable, Equatable, Sendable {
-	public let wallet: Wallet?
+	public let walletId: WalletId?
 	public let asset: Asset?
-	public let chain: Chain?
 	public let event: BannerEvent
 	public let state: BannerState
 
-	public init(wallet: Wallet?, asset: Asset?, chain: Chain?, event: BannerEvent, state: BannerState) {
-		self.wallet = wallet
+	public init(walletId: WalletId?, asset: Asset?, event: BannerEvent, state: BannerState) {
+		self.walletId = walletId
 		self.asset = asset
-		self.chain = chain
 		self.event = event
 		self.state = state
 	}

--- a/ios/Packages/Primitives/TestKit/Banner+PrimitivesTestKit.swift
+++ b/ios/Packages/Primitives/TestKit/Banner+PrimitivesTestKit.swift
@@ -5,16 +5,14 @@ import Primitives
 
 public extension Banner {
     static func mock(
-        wallet: Wallet? = .mock(),
+        walletId: WalletId? = .mock(),
         asset: Asset? = .mock(),
-        chain: Chain? = .bitcoin,
         event: BannerEvent = .stake,
         state: BannerState = .active,
     ) -> Banner {
         Banner(
-            wallet: wallet,
+            walletId: walletId,
             asset: asset,
-            chain: chain,
             event: event,
             state: state,
         )

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/BannerViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/BannerViewModel.swift
@@ -188,10 +188,7 @@ struct BannerViewModel {
     }
 
     private var asset: Asset? {
-        if let asset = banner.asset {
-            return asset
-        }
-        return banner.chain?.asset
+        banner.asset
     }
 }
 

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/BannerViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/BannerViewModel.swift
@@ -30,8 +30,6 @@ struct BannerViewModel {
                 return .none
             }
             return AssetImage.image(ChainImage(chain: asset.chain).placeholder)
-        case .enableNotifications:
-            return AssetImage.image(Images.System.bell)
         case .accountBlockedMultiSignature:
             return AssetImage.image(Images.System.exclamationmarkTriangle)
         case .suspiciousAsset:
@@ -52,8 +50,6 @@ struct BannerViewModel {
             return Localized.Banner.Stake.title(asset.name)
         case .accountActivation:
             return Localized.Banner.AccountActivation.title
-        case .enableNotifications:
-            return Localized.Banner.EnableNotifications.title
         case .accountBlockedMultiSignature:
             return Localized.Common.warning
         case .activateAsset:
@@ -79,8 +75,6 @@ struct BannerViewModel {
             let amount = ValueFormatter(style: .auto)
                 .string(fee.asInt.asBigInt, decimals: asset.decimals.asInt, currency: asset.symbol)
             return Localized.Banner.AccountActivation.description(asset.name, amount)
-        case .enableNotifications:
-            return Localized.Banner.EnableNotifications.description
         case .accountBlockedMultiSignature:
             return Localized.Warnings.multiSignatureBlocked(asset?.name ?? "")
         case .activateAsset:
@@ -103,7 +97,6 @@ struct BannerViewModel {
         switch banner.event {
         case .stake,
              .accountActivation,
-             .enableNotifications,
              .accountBlockedMultiSignature,
              .activateAsset,
              .suspiciousAsset,
@@ -119,8 +112,7 @@ struct BannerViewModel {
              .activateAsset,
              .suspiciousAsset,
              .tradePerpetuals: 14
-        case .enableNotifications,
-             .accountBlockedMultiSignature,
+        case .accountBlockedMultiSignature,
              .onboarding: 0
         }
     }
@@ -136,7 +128,6 @@ struct BannerViewModel {
     var url: URL? {
         switch banner.event {
         case .stake,
-             .enableNotifications,
              .activateAsset,
              .onboarding,
              .tradePerpetuals:
@@ -162,7 +153,6 @@ struct BannerViewModel {
         switch banner.event {
         case .stake,
              .accountActivation,
-             .enableNotifications,
              .accountBlockedMultiSignature,
              .activateAsset,
              .suspiciousAsset,
@@ -175,7 +165,6 @@ struct BannerViewModel {
         switch banner.event {
         case .stake,
              .accountActivation,
-             .enableNotifications,
              .accountBlockedMultiSignature,
              .activateAsset,
              .suspiciousAsset,

--- a/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/HeaderBannerEventViewModelTests.swift
+++ b/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/HeaderBannerEventViewModelTests.swift
@@ -6,7 +6,6 @@ import Testing
 struct HeaderBannerEventViewModelTests {
     @Test func isEnabled() {
         #expect(HeaderBannerEventViewModel(events: [.stake]).isButtonsEnabled == true)
-        #expect(HeaderBannerEventViewModel(events: [.enableNotifications]).isButtonsEnabled == true)
         #expect(HeaderBannerEventViewModel(events: [.accountActivation]).isButtonsEnabled == true)
         #expect(HeaderBannerEventViewModel(events: [.accountActivation, .activateAsset]).isButtonsEnabled == false)
         #expect(HeaderBannerEventViewModel(events: [.stake, .activateAsset]).isButtonsEnabled == false)

--- a/ios/Packages/Store/Sources/Migrations.swift
+++ b/ios/Packages/Store/Sources/Migrations.swift
@@ -525,6 +525,11 @@ struct Migrations {
             }
         }
 
+        migrator.registerMigration("Recreate \(BannerRecord.databaseTableName) without chain") { db in
+            try? db.drop(table: BannerRecord.databaseTableName)
+            try? BannerRecord.create(db: db)
+        }
+
         try migrator.migrate(dbQueue)
     }
 }

--- a/ios/Packages/Store/Sources/Models/BannerRecord.swift
+++ b/ios/Packages/Store/Sources/Models/BannerRecord.swift
@@ -12,20 +12,16 @@ public struct BannerRecord: Codable, FetchableRecord, PersistableRecord {
         static let state = Column("state")
         static let event = Column("event")
         static let assetId = Column("assetId")
-        static let chain = Column("chain")
         static let walletId = Column("walletId")
     }
 
     public var id: String
     public var walletId: String?
     public var assetId: AssetId?
-    public var chain: String?
     public var event: BannerEvent
     public var state: BannerState
 
     static let asset = belongsTo(AssetRecord.self, key: "asset", using: ForeignKey(["assetId"], to: ["id"]))
-    static let chain = belongsTo(AssetRecord.self, key: "chain", using: ForeignKey(["chain"], to: ["id"]))
-    static let wallet = belongsTo(WalletRecord.self).forKey("wallet")
 }
 
 extension BannerRecord: CreateTable {
@@ -39,8 +35,6 @@ extension BannerRecord: CreateTable {
                 .references(WalletRecord.databaseTableName, onDelete: .cascade, onUpdate: .cascade)
             $0.column(Columns.assetId.name, .text)
                 .references(AssetRecord.databaseTableName, onDelete: .cascade, onUpdate: .cascade)
-            $0.column(Columns.chain.name, .text)
-                .references(AssetRecord.databaseTableName, onDelete: .cascade, onUpdate: .cascade)
             $0.column(Columns.event.name, .text)
                 .notNull()
             $0.column(Columns.state.name, .text)
@@ -49,7 +43,6 @@ extension BannerRecord: CreateTable {
                 [
                     Columns.walletId.name,
                     Columns.assetId.name,
-                    Columns.chain.name,
                     Columns.event.name,
                 ],
             )
@@ -61,9 +54,8 @@ extension Banner {
     var record: BannerRecord {
         BannerRecord(
             id: id,
-            walletId: wallet?.id.id,
+            walletId: walletId?.id,
             assetId: asset?.id,
-            chain: chain?.id,
             event: event,
             state: state,
         )
@@ -72,46 +64,30 @@ extension Banner {
 
 extension NewBanner {
     var record: BannerRecord {
-        let wallet: Wallet? = {
-            if let walletId, let id = try? WalletId.from(id: walletId) {
-                return Wallet(id: id, externalId: nil, name: "", index: 0, type: .multicoin, accounts: [], isPinned: false, imageUrl: nil, source: .create)
-            }
-            return .none
-        }()
-        let asset: Asset? = {
-            if let assetId {
-                return Asset(id: assetId, name: "", symbol: "", decimals: 0, type: .native)
-            }
-            return .none
-        }()
-
-        return Banner(
-            wallet: wallet,
-            asset: asset,
-            chain: chain,
+        BannerRecord(
+            id: [walletId, assetId?.identifier, event.rawValue].compactMap(\.self).joined(separator: "_"),
+            walletId: walletId,
+            assetId: assetId,
             event: event,
             state: state,
-        ).record
+        )
     }
 }
 
 public struct NewBanner {
     let walletId: String?
     let assetId: AssetId?
-    var chain: Chain?
     let event: BannerEvent
     let state: BannerState
 
     public init(
         walletId: String? = .none,
         assetId: AssetId? = .none,
-        chain: Chain? = .none,
         event: BannerEvent,
         state: BannerState,
     ) {
         self.walletId = walletId
         self.assetId = assetId
-        self.chain = chain
         self.event = event
         self.state = state
     }

--- a/ios/Packages/Store/Sources/Requests/BannerRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/BannerRequest.swift
@@ -8,26 +8,21 @@ public struct BannersRequest: DatabaseQueryable {
     public var walletId: WalletId?
 
     private let assetId: AssetId?
-    private let chain: Chain?
     private let events: [BannerEvent]
 
     public init(
         walletId: WalletId?,
         assetId: AssetId?,
-        chain: Chain?,
         events: [BannerEvent],
     ) {
         self.walletId = walletId
         self.assetId = assetId
-        self.chain = chain
         self.events = events
     }
 
     public func fetch(_ db: Database) throws -> [Banner] {
         var query = BannerRecord
             .including(optional: BannerRecord.asset)
-            .including(optional: BannerRecord.chain)
-            .including(optional: BannerRecord.wallet.including(all: WalletRecord.accounts))
             .filter(events.map(\.rawValue).contains(BannerRecord.Columns.event))
             .filter(BannerRecord.Columns.state != BannerState.cancelled.rawValue)
             .asRequest(of: BannerInfo.self)
@@ -35,12 +30,8 @@ public struct BannersRequest: DatabaseQueryable {
         if let walletId {
             query = query.filter(BannerRecord.Columns.walletId == walletId.id || BannerRecord.Columns.walletId == nil)
         }
-        if let assetId, let chain {
-            query = query.filter(BannerRecord.Columns.assetId == assetId.identifier || BannerRecord.Columns.chain == chain.rawValue)
-        } else if let assetId {
+        if let assetId {
             query = query.filter(BannerRecord.Columns.assetId == assetId.identifier)
-        } else if let chain {
-            query = query.filter(BannerRecord.Columns.chain == chain.rawValue)
         }
 
         return try query

--- a/ios/Packages/Store/Sources/Types/BannerInfo.swift
+++ b/ios/Packages/Store/Sources/Types/BannerInfo.swift
@@ -7,23 +7,13 @@ import Primitives
 struct BannerInfo: Codable, FetchableRecord {
     let banner: BannerRecord
     let asset: AssetRecord?
-    let chain: AssetRecord?
-    let wallet: WalletRecordInfo?
-
-    init(row: Row) throws {
-        banner = try BannerRecord(row: row)
-        asset = row["asset"]
-        chain = row["chain"]
-        wallet = row["wallet"]
-    }
 }
 
 extension BannerInfo {
     func mapToBanner() -> Banner {
         Banner(
-            wallet: wallet?.mapToWallet(),
+            walletId: banner.walletId.flatMap { try? WalletId.from(id: $0) },
             asset: asset?.mapToAsset(),
-            chain: chain?.chain,
             event: banner.event,
             state: banner.state,
         )


### PR DESCRIPTION
A banner was carrying both an asset and a chain, and a whole wallet where only its id was ever used.

The chain is already part of the asset, so banners scoped to a network now use that network's own asset. This also fixes the multi-signature warning on Android, which showed an empty network name.

The wallet is now just a wallet id. Together this removes a database column, both joins from the banner query, and a hand-written decoder that only existed to work around a name clash.