### PR TITLE
Fix wallet connections not showed 

### DIFF
--- a/ios/Packages/Store/Sources/Requests/ConnectionsRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/ConnectionsRequest.swift
@@ -10,6 +10,7 @@ public struct ConnectionsRequest: DatabaseQueryable {
     public func fetch(_ db: Database) throws -> [WalletConnection] {
         try WalletRecord
             .including(required: WalletRecord.connection)
+            .including(all: WalletRecord.accounts)
             .asRequest(of: WalletConnectionInfo.self)
             .fetchAll(db)
             .map { $0.mapToWalletConnection() }

--- a/ios/Packages/Store/Tests/StoreTests/Requests/ConnectionsRequestTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/Requests/ConnectionsRequestTests.swift
@@ -1,0 +1,27 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Primitives
+import PrimitivesTestKit
+import Store
+import StoreTestKit
+import Testing
+
+struct ConnectionsRequestTests {
+    @Test
+    func fetchReturnsConnectionsWithWalletAccounts() throws {
+        let db = DB.mockWithChains([.ethereum])
+        let walletStore = WalletStore(db: db)
+        let connectionsStore = ConnectionsStore(db: db)
+
+        let wallet = Wallet.mock(id: .multicoin(address: "0xa"), accounts: [.mock(chain: .ethereum)])
+        try walletStore.addWallet(wallet)
+        try connectionsStore.addConnection(.mock(session: .mock(sessionId: "session-a"), wallet: wallet))
+
+        try db.dbQueue.read { db in
+            let connections = try ConnectionsRequest().fetch(db)
+
+            #expect(connections.map(\.session.sessionId) == ["session-a"])
+            #expect(connections.first?.wallet.accounts.map(\.chain) == [.ethereum])
+        }
+    }
+}

--- a/ios/Packages/Store/Tests/StoreTests/Requests/ConnectionsRequestTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/Requests/ConnectionsRequestTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 struct ConnectionsRequestTests {
     @Test
-    func fetchReturnsConnectionsWithWalletAccounts() throws {
+    func returnsConnectionsWithWalletAccounts() throws {
         let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
         let connectionsStore = ConnectionsStore(db: db)


### PR DESCRIPTION
WalletConnectionInfo requires the accounts association since wallets carry their accounts, but ConnectionsRequest never included it, so the connections screen decoded nothing and showed no active connections.