### PR TITLE
Drive the add token lookup with a debounced fetch trigger

### DIFF
--- a/ios/Features/Assets/Sources/Scenes/AddAssetScene.swift
+++ b/ios/Features/Assets/Sources/Scenes/AddAssetScene.swift
@@ -39,7 +39,12 @@ public struct AddAssetScene: View {
             .onAppear {
                 focusedField = .address
             }
-            .onChange(of: model.input.address, onAddressClean)
+            .onChange(of: model.input.address) {
+                model.onChangeAddress()
+            }
+            .debouncedTask(id: model.fetchTrigger) {
+                await model.fetch()
+            }
             .listSectionSpacing(.compact)
             .navigationTitle(model.title)
             .navigationDestination(for: Scenes.NetworksSelector.self) { _ in
@@ -82,7 +87,7 @@ extension AddAssetScene {
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
                 .submitLabel(.search)
-                .onSubmit(fetch)
+                .onSubmit(model.onSubmitAddress)
             }
 
             switch model.state {
@@ -132,7 +137,7 @@ extension AddAssetScene {
 extension AddAssetScene {
     private func onFinishChainSelection(chains: [Chain]) {
         model.input.chain = chains.first
-        onAddressClean(nil, nil)
+        model.input.address = nil
     }
 
     private func onSelectImportToken() {
@@ -146,30 +151,12 @@ extension AddAssetScene {
 
     private func onSelectPaste() {
         guard let address = UIPasteboard.general.string else { return }
-        model.input.address = address
+        model.setInput(address)
         focusedField = nil
-        fetch()
     }
 
     private func onHandleScan(_ result: String) {
-        model.input.address = result
+        model.setInput(result)
         focusedField = nil
-        fetch()
-    }
-
-    private func onAddressClean(_: String?, _ newValue: String?) {
-        guard newValue == nil else { return }
-        model.input.address = newValue
-        fetch()
-    }
-}
-
-// MARK: - Effects
-
-extension AddAssetScene {
-    private func fetch() {
-        Task {
-            await model.fetch()
-        }
     }
 }

--- a/ios/Features/Assets/Sources/Types/AddAssetFetchTrigger.swift
+++ b/ios/Features/Assets/Sources/Types/AddAssetFetchTrigger.swift
@@ -1,0 +1,10 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Components
+import Primitives
+
+struct AddAssetFetchTrigger: DebouncableTrigger {
+    let chain: Chain
+    let address: String
+    let isImmediate: Bool
+}

--- a/ios/Features/Assets/Sources/ViewModels/AddAssetSceneViewModel.swift
+++ b/ios/Features/Assets/Sources/ViewModels/AddAssetSceneViewModel.swift
@@ -21,6 +21,7 @@ public final class AddAssetSceneViewModel {
     var input: AddAssetInput
 
     var isPresentingScanner = false
+    var fetchTrigger: AddAssetFetchTrigger?
 
     public init(wallet: Wallet, gatewayService: GatewayService, explorerService: any GemExplorerServiceProtocol) {
         self.gatewayService = gatewayService
@@ -96,19 +97,39 @@ public final class AddAssetSceneViewModel {
 // MARK: - Business Logic
 
 extension AddAssetSceneViewModel {
+    func setInput(_ address: String) {
+        input.address = address
+        setFetchTrigger(isImmediate: true)
+    }
+
+    func onChangeAddress() {
+        guard fetchTrigger?.address != input.address else { return }
+        setFetchTrigger(isImmediate: false)
+    }
+
+    func onSubmitAddress() {
+        setFetchTrigger(isImmediate: true)
+    }
+
     func fetch() async {
-        guard let chain = input.chain, let address = input.address, !address.isEmpty else {
-            state = .noData
-            return
-        }
+        guard let trigger = fetchTrigger else { return }
 
         state = .loading
 
         do {
-            let asset = try await gatewayService.tokenData(chain: chain, tokenId: address)
+            let asset = try await gatewayService.tokenData(chain: trigger.chain, tokenId: trigger.address)
             state = .data(AddAssetViewModel(asset: asset, explorerService: explorerService))
         } catch {
             state.setError(error)
         }
+    }
+
+    private func setFetchTrigger(isImmediate: Bool) {
+        guard let chain = input.chain, let address = input.address, !address.isEmpty else {
+            state = .noData
+            fetchTrigger = nil
+            return
+        }
+        fetchTrigger = AddAssetFetchTrigger(chain: chain, address: address, isImmediate: isImmediate)
     }
 }

--- a/ios/Features/Assets/Tests/AssetsTests/AddAssetSceneViewModelTests.swift
+++ b/ios/Features/Assets/Tests/AssetsTests/AddAssetSceneViewModelTests.swift
@@ -1,0 +1,48 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+@testable import Assets
+import GemstonePrimitivesTestKit
+import GemstoneServicesTestKit
+import Primitives
+import PrimitivesTestKit
+import Testing
+
+@MainActor
+struct AddAssetSceneViewModelTests {
+    @Test
+    func fetchTrigger() {
+        let model = AddAssetSceneViewModel.mock()
+
+        model.input.address = "0x1"
+        model.onChangeAddress()
+        #expect(model.fetchTrigger == AddAssetFetchTrigger(chain: .ethereum, address: "0x1", isImmediate: false))
+
+        model.onSubmitAddress()
+        #expect(model.fetchTrigger == AddAssetFetchTrigger(chain: .ethereum, address: "0x1", isImmediate: true))
+
+        model.setInput("0x2")
+        #expect(model.input.address == "0x2")
+        #expect(model.fetchTrigger == AddAssetFetchTrigger(chain: .ethereum, address: "0x2", isImmediate: true))
+
+        model.onChangeAddress()
+        #expect(model.fetchTrigger == AddAssetFetchTrigger(chain: .ethereum, address: "0x2", isImmediate: true))
+
+        model.state = .loading
+        model.input.address = nil
+        model.onChangeAddress()
+        #expect(model.fetchTrigger == nil)
+        #expect(model.state.isNoData)
+    }
+}
+
+// MARK: - Mock Extensions
+
+extension AddAssetSceneViewModel {
+    static func mock() -> AddAssetSceneViewModel {
+        AddAssetSceneViewModel(
+            wallet: .mock(accounts: [.mock(chain: .ethereum)]),
+            gatewayService: .mock(),
+            explorerService: GemExplorerServiceMock(),
+        )
+    }
+}


### PR DESCRIPTION
Pasting or scanning a contract address fetches token details immediately, typing fetches after a short pause, and an outdated lookup can no longer replace the details on screen or be imported. Editing the address clears the shown token until the new lookup finishes.