### PR TITLE
Encode bitcoin varints over u64 internally

### DIFF
--- a/core/crates/gem_bitcoin/src/signer/encoding.rs
+++ b/core/crates/gem_bitcoin/src/signer/encoding.rs
@@ -1,14 +1,17 @@
-pub fn encode_varint(n: usize) -> Vec<u8> {
-    if n < 0xfd {
-        vec![n as u8]
-    } else if n <= 0xffff {
-        let b = (n as u16).to_le_bytes();
+const _: () = assert!(size_of::<usize>() <= size_of::<u64>());
+
+pub fn encode_varint(value: usize) -> Vec<u8> {
+    let value = value as u64;
+    if value < 0xfd {
+        vec![value as u8]
+    } else if value <= 0xffff {
+        let b = (value as u16).to_le_bytes();
         vec![0xfd, b[0], b[1]]
-    } else if n <= 0xffffffff {
-        let b = (n as u32).to_le_bytes();
+    } else if value <= 0xffffffff {
+        let b = (value as u32).to_le_bytes();
         vec![0xfe, b[0], b[1], b[2], b[3]]
     } else {
-        let b = (n as u64).to_le_bytes();
+        let b = value.to_le_bytes();
         vec![0xff, b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]
     }
 }
@@ -33,6 +36,8 @@ mod tests {
         assert_eq!(encode_varint(253), vec![0xfd, 253, 0]);
         assert_eq!(encode_varint(0xffff), vec![0xfd, 0xff, 0xff]);
         assert_eq!(encode_varint(0x10000), vec![0xfe, 0, 0, 1, 0]);
+        assert_eq!(encode_varint(0x1_0000_0000), vec![0xff, 0, 0, 0, 0, 1, 0, 0, 0]);
+        assert_eq!(encode_varint(usize::MAX), vec![0xff; 9]);
         assert_eq!(varint_len(0), 1);
         assert_eq!(varint_len(0xfc), 1);
         assert_eq!(varint_len(0xfd), 3);


### PR DESCRIPTION
For better cross platform compatibility (e.g. wasm32), plus a compile-time guard for the value as u64 cast