### PR TITLE
Await the debounced lookup in the name record test

### DIFF
--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/NameRecordViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/NameRecordViewModel.swift
@@ -9,7 +9,7 @@ import Primitives
 @MainActor
 public final class NameRecordViewModel {
     private let nameService: any GemNameServiceProtocol
-    private var nameRecordTask: Task<Void, Never>?
+    private(set) var nameRecordTask: Task<Void, Never>?
 
     public var state: NameRecordState = .none
 

--- a/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/NameRecordViewModelTests.swift
+++ b/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/NameRecordViewModelTests.swift
@@ -9,7 +9,7 @@ import Testing
 @MainActor
 struct NameRecordViewModelTests {
     @Test
-    func acceptsOnlyCompleteRecords() async throws {
+    func acceptsOnlyCompleteRecords() async {
         let record = NameRecord.mock()
         let nameService = GemNameServiceMock(nameRecord: record)
         let valid = NameRecordViewModel(nameService: nameService)
@@ -19,7 +19,9 @@ struct NameRecordViewModelTests {
         valid.getNameRecord(name: record.name, chain: record.chain)
         emptyAddress.getNameRecord(name: record.name, chain: record.chain)
         emptyName.getNameRecord(name: record.name, chain: record.chain)
-        try await Task.sleep(for: .milliseconds(500))
+        await valid.nameRecordTask?.value
+        await emptyAddress.nameRecordTask?.value
+        await emptyName.nameRecordTask?.value
 
         #expect(valid.state == .complete(record))
         #expect(emptyAddress.state == .error)


### PR DESCRIPTION
Fixes the iOS CI failure on main: the test raced a fixed 500ms sleep against three 250ms-debounced lookups and lost on a loaded runner. The test now awaits the view model's in-flight task, so it is deterministic under any load.