### PR TITLE
Apply contact renames to the addresses row

### DIFF
--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AddressesDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AddressesDao.kt
@@ -28,7 +28,7 @@ interface AddressesDao {
 
     @Query(
         "UPDATE addresses SET name = :name, type = :type, status = :status, imageUrl = :imageUrl " +
-            "WHERE chain = :chain AND address = :address AND type NOT IN (:localTypes)"
+            "WHERE chain = :chain AND address = :address AND type NOT IN (:reservedTypes)"
     )
     suspend fun updateAddressName(
         chain: Chain,
@@ -37,7 +37,7 @@ interface AddressesDao {
         type: AddressType,
         status: VerificationStatus,
         imageUrl: String?,
-        localTypes: List<AddressType> = AddressType.entries.filter { it.isLocal },
+        reservedTypes: List<AddressType> = AddressType.entries.filter { it.isLocal && it != type },
     )
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)

--- a/ios/Packages/GemstoneServices/Tests/ContactServiceTests.swift
+++ b/ios/Packages/GemstoneServices/Tests/ContactServiceTests.swift
@@ -1,0 +1,56 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import class Gemstone.GemContactService
+import GemstonePrimitives
+@testable import GemstoneServices
+import Primitives
+import Store
+import StoreTestKit
+import Testing
+
+struct ContactServiceTests {
+    @Test
+    func renamingAContactRenamesItsAddressName() async throws {
+        let db = DB.mockWithChains([.ethereum])
+        let addressStore = AddressStore(db: db)
+        let service = GemContactService(
+            store: GemstoneContactStore(store: ContactStore(db: db)),
+            addressStore: GemstoneAddressStore(store: addressStore),
+            files: GemstoneFileStore(),
+        )
+        let contactId = UUID().uuidString
+        let address = "0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326"
+        let addresses = try service.addAddress(
+            [],
+            contactId: contactId,
+            chain: .ethereum,
+            address: address,
+            memo: nil,
+            replacingId: nil,
+        )
+
+        let created = try await service.saveContact(
+            id: contactId,
+            existing: nil,
+            name: "Alice",
+            description: "",
+            avatar: .empty,
+            addresses: addresses,
+        )
+        #expect(try addressStore.getAddressName(chain: .ethereum, address: address)?.name == "Alice")
+
+        _ = try await service.saveContact(
+            id: contactId,
+            existing: created,
+            name: "Bob",
+            description: "",
+            avatar: .empty,
+            addresses: addresses,
+        )
+
+        let renamed = try #require(try addressStore.getAddressName(chain: .ethereum, address: address))
+        #expect(renamed.name == "Bob")
+        #expect(renamed.type == .contact)
+    }
+}

--- a/ios/Packages/Store/Sources/Stores/AddressStore.swift
+++ b/ios/Packages/Store/Sources/Stores/AddressStore.swift
@@ -23,13 +23,15 @@ public struct AddressStore: Sendable {
         if addressNames.isEmpty {
             return
         }
-        let localTypes = AddressType.allCases.filter(\.isLocal).map(\.rawValue)
         try db.write { db in
             for addressName in addressNames {
+                let reservedTypes = AddressType.allCases
+                    .filter { $0.isLocal && $0 != addressName.type }
+                    .map(\.rawValue)
                 try AddressRecord
                     .filter(AddressRecord.Columns.chain == addressName.chain.rawValue)
                     .filter(AddressRecord.Columns.address == addressName.address)
-                    .filter(!localTypes.contains(AddressRecord.Columns.type))
+                    .filter(!reservedTypes.contains(AddressRecord.Columns.type))
                     .updateAll(db, [
                         AddressRecord.Columns.name.set(to: addressName.name),
                         AddressRecord.Columns.type.set(to: addressName.type.rawValue),

--- a/ios/Packages/Store/Tests/StoreTests/ContactStoreTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/ContactStoreTests.swift
@@ -31,6 +31,48 @@ struct ContactStoreTests {
     }
 
     @Test
+    func updateAddressNamesRenamesContactName() throws {
+        let test = try setupTest(
+            chain: .bitcoin,
+            address: "bc1qml9s2f9k8wc0882x63lyplzp97srzg2c39fyaw",
+            addressType: .contact,
+        )
+        let renamed = AddressName.mock(chain: test.chain, address: test.address, name: "Bob", type: .contact)
+
+        try test.addressStore.updateAddressNames([renamed])
+
+        #expect(try test.addressStore.getAddressName(chain: test.chain, address: test.address) == renamed)
+    }
+
+    @Test
+    func updateAddressNamesKeepsRemoteNamesFromRenamingContacts() throws {
+        let test = try setupTest(
+            chain: .bitcoin,
+            address: "bc1qml9s2f9k8wc0882x63lyplzp97srzg2c39fyaw",
+            addressType: .contact,
+        )
+        let remote = AddressName.mock(chain: test.chain, address: test.address, name: "Binance", type: .address)
+
+        try test.addressStore.updateAddressNames([remote])
+
+        #expect(try test.addressStore.getAddressName(chain: test.chain, address: test.address) == test.addressName)
+    }
+
+    @Test
+    func updateAddressNamesKeepsNamesReservedByAnotherLocalType() throws {
+        let test = try setupTest(
+            chain: .bitcoin,
+            address: "bc1qml9s2f9k8wc0882x63lyplzp97srzg2c39fyaw",
+            addressType: .internalWallet,
+        )
+        let contact = AddressName.mock(chain: test.chain, address: test.address, name: "Bob", type: .contact)
+
+        try test.addressStore.updateAddressNames([contact])
+
+        #expect(try test.addressStore.getAddressName(chain: test.chain, address: test.address) == test.addressName)
+    }
+
+    @Test
     func updateContactDropsRemovedAddresses() throws {
         let test = try setupTest(
             chain: .bitcoin,


### PR DESCRIPTION
Renaming a contact kept the old name on the transfer confirmation screen and in transaction details, because the rename never reached the stored address name. Now the new name shows up everywhere right after saving, on both iOS and Android.