### PR TITLE
Keep the recipient address when adding a new contact from the contacts list

### DIFF
--- a/ios/Features/Contacts/Sources/Scenes/ContactsNavigationView.swift
+++ b/ios/Features/Contacts/Sources/Scenes/ContactsNavigationView.swift
@@ -27,7 +27,7 @@ public struct ContactsNavigationView: View {
             }
             .sheet(isPresented: $model.isPresentingAddContact) {
                 NavigationStack {
-                    manageContact(for: .add())
+                    manageContact(for: model.addContactMode)
                         .toolbarDismissItem(type: .close, placement: .cancellationAction)
                 }
             }

--- a/ios/Features/Contacts/Sources/ViewModels/ContactsViewModel.swift
+++ b/ios/Features/Contacts/Sources/ViewModels/ContactsViewModel.swift
@@ -45,6 +45,13 @@ public final class ContactsViewModel {
         Localized.Contacts.title
     }
 
+    var addContactMode: ManageContactViewModel.Mode {
+        switch mode {
+        case .list: .add()
+        case let .addAddress(recipient): .add(recipient)
+        }
+    }
+
     func add(to contact: ContactData) {
         guard case let .addAddress(recipient) = mode else { return }
         Task {


### PR DESCRIPTION
Tapping + on the contacts list after choosing "Add to Contact" on a recipient opened an empty contact form, dropping the address you came to save. The form is now prefilled with that address.