### PR TITLE
Count the owner reserve in the XRP available balance

### DIFF
--- a/core/crates/gem_xrp/src/provider/balances.rs
+++ b/core/crates/gem_xrp/src/provider/balances.rs
@@ -25,9 +25,10 @@ fn default_if_account_not_found<T: Default>(result: Result<T, Box<dyn Error + Se
 impl<C: Client + Clone> ChainBalances for XrpClient<C> {
     async fn get_balance_coin(&self, address: String) -> Result<AssetBalance, Box<dyn Error + Sync + Send>> {
         let account = default_if_account_not_found(self.get_account_info(&address).await)?;
-        let reserved_amount = self.get_chain().account_activation_fee().unwrap_or(0) as u64;
+        let base_reserve = self.get_chain().account_activation_fee().unwrap_or(0) as u64;
+        let owner_reserve = self.get_chain().token_activation_fee().unwrap_or(0) as u64;
 
-        map_balance_coin(account, self.get_chain().as_asset_id(), reserved_amount)
+        map_balance_coin(account, self.get_chain().as_asset_id(), base_reserve, owner_reserve)
     }
 
     async fn get_balance_tokens(&self, address: String, token_ids: Vec<String>) -> Result<Vec<AssetBalance>, Box<dyn Error + Sync + Send>> {

--- a/core/crates/gem_xrp/src/provider/balances_mapper.rs
+++ b/core/crates/gem_xrp/src/provider/balances_mapper.rs
@@ -74,33 +74,22 @@ mod tests {
     use crate::models::rpc::AccountInfo;
     use primitives::{AssetId, Chain};
 
-    fn account_info(balance: u64, owner_count: u32) -> AccountInfo {
-        AccountInfo {
-            balance,
-            sequence: 100,
-            owner_count,
-            account: None,
-            flags: None,
-            ledger_entry_type: None,
-        }
-    }
-
     #[test]
     fn test_map_balance_coin() {
         let asset_id = AssetId::from_chain(Chain::Xrp);
         let base_reserve = 1_000_000;
         let owner_reserve = 200_000;
 
-        let with_owned_objects = map_balance_coin(Some(account_info(35_892_065, 2)), asset_id.clone(), base_reserve, owner_reserve).unwrap();
+        let with_owned_objects = map_balance_coin(Some(AccountInfo::mock_with_balance(35_892_065, 2)), asset_id.clone(), base_reserve, owner_reserve).unwrap();
         assert_eq!(with_owned_objects.asset_id, asset_id);
         assert_eq!(with_owned_objects.balance.available, BigUint::from(34_492_065_u64));
         assert_eq!(with_owned_objects.balance.reserved, BigUint::from(1_400_000_u64));
 
-        let without_owned_objects = map_balance_coin(Some(account_info(10_000_000, 0)), asset_id.clone(), base_reserve, owner_reserve).unwrap();
+        let without_owned_objects = map_balance_coin(Some(AccountInfo::mock_with_balance(10_000_000, 0)), asset_id.clone(), base_reserve, owner_reserve).unwrap();
         assert_eq!(without_owned_objects.balance.available, BigUint::from(9_000_000_u64));
         assert_eq!(without_owned_objects.balance.reserved, BigUint::from(1_000_000_u64));
 
-        let balance_below_reserve = map_balance_coin(Some(account_info(500_000, 2)), asset_id.clone(), base_reserve, owner_reserve).unwrap();
+        let balance_below_reserve = map_balance_coin(Some(AccountInfo::mock_with_balance(500_000, 2)), asset_id.clone(), base_reserve, owner_reserve).unwrap();
         assert_eq!(balance_below_reserve.balance.available, BigUint::ZERO);
         assert_eq!(balance_below_reserve.balance.reserved, BigUint::from(1_400_000_u64));
     }

--- a/core/crates/gem_xrp/src/provider/balances_mapper.rs
+++ b/core/crates/gem_xrp/src/provider/balances_mapper.rs
@@ -7,9 +7,12 @@ use number_formatter::BigNumberFormatter;
 use primitives::{AssetBalance, AssetId, Balance, Chain};
 use std::{collections::HashMap, error::Error};
 
-pub fn map_balance_coin(account: Option<AccountInfo>, asset_id: AssetId, reserved_amount: u64) -> Result<AssetBalance, Box<dyn Error + Sync + Send>> {
+pub fn map_balance_coin(account: Option<AccountInfo>, asset_id: AssetId, base_reserve: u64, owner_reserve: u64) -> Result<AssetBalance, Box<dyn Error + Sync + Send>> {
     let (available, reserved) = account
-        .map(|account| (account.balance.saturating_sub(reserved_amount), reserved_amount))
+        .map(|account| {
+            let reserved = base_reserve + u64::from(account.owner_count) * owner_reserve;
+            (account.balance.saturating_sub(reserved), reserved)
+        })
         .unwrap_or_default();
 
     Ok(AssetBalance::new_balance(
@@ -71,46 +74,35 @@ mod tests {
     use crate::models::rpc::AccountInfo;
     use primitives::{AssetId, Chain};
 
-    #[test]
-    fn test_map_native_balance() {
-        let account = AccountInfo {
-            balance: 10000000, // 10 XRP
+    fn account_info(balance: u64, owner_count: u32) -> AccountInfo {
+        AccountInfo {
+            balance,
             sequence: 100,
-            owner_count: 2,
+            owner_count,
             account: None,
             flags: None,
             ledger_entry_type: None,
-        };
-
-        let asset_id = AssetId::from_chain(Chain::Xrp);
-        let reserved_amount = 1000000; // 1 XRP reserve
-
-        let result = map_balance_coin(Some(account), asset_id.clone(), reserved_amount).unwrap();
-
-        assert_eq!(result.asset_id, asset_id);
-        assert_eq!(result.balance.available, BigUint::from(9000000_u64)); // 10 - 1 = 9 XRP
-        assert_eq!(result.balance.reserved, BigUint::from(1000000_u64));
+        }
     }
 
     #[test]
-    fn test_map_native_balance_insufficient() {
-        let account = AccountInfo {
-            balance: 500000, // 0.5 XRP
-            sequence: 100,
-            owner_count: 2,
-            account: None,
-            flags: None,
-            ledger_entry_type: None,
-        };
-
+    fn test_map_balance_coin() {
         let asset_id = AssetId::from_chain(Chain::Xrp);
-        let reserved_amount = 1000000; // 1 XRP reserve
+        let base_reserve = 1_000_000;
+        let owner_reserve = 200_000;
 
-        let result = map_balance_coin(Some(account), asset_id.clone(), reserved_amount).unwrap();
+        let with_owned_objects = map_balance_coin(Some(account_info(35_892_065, 2)), asset_id.clone(), base_reserve, owner_reserve).unwrap();
+        assert_eq!(with_owned_objects.asset_id, asset_id);
+        assert_eq!(with_owned_objects.balance.available, BigUint::from(34_492_065_u64));
+        assert_eq!(with_owned_objects.balance.reserved, BigUint::from(1_400_000_u64));
 
-        assert_eq!(result.asset_id, asset_id);
-        assert_eq!(result.balance.available, BigUint::from(0u32)); // Insufficient balance
-        assert_eq!(result.balance.reserved, BigUint::from(1000000_u64));
+        let without_owned_objects = map_balance_coin(Some(account_info(10_000_000, 0)), asset_id.clone(), base_reserve, owner_reserve).unwrap();
+        assert_eq!(without_owned_objects.balance.available, BigUint::from(9_000_000_u64));
+        assert_eq!(without_owned_objects.balance.reserved, BigUint::from(1_000_000_u64));
+
+        let balance_below_reserve = map_balance_coin(Some(account_info(500_000, 2)), asset_id.clone(), base_reserve, owner_reserve).unwrap();
+        assert_eq!(balance_below_reserve.balance.available, BigUint::ZERO);
+        assert_eq!(balance_below_reserve.balance.reserved, BigUint::from(1_400_000_u64));
     }
 
     #[test]

--- a/core/crates/gem_xrp/src/provider/testkit.rs
+++ b/core/crates/gem_xrp/src/provider/testkit.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use crate::models::rpc::AccountInfo;
 #[cfg(all(test, feature = "chain_integration_tests"))]
 use crate::rpc::XrpClient;
 #[cfg(all(test, feature = "chain_integration_tests"))]
@@ -21,4 +23,18 @@ pub fn create_xrp_test_client() -> XrpClient<ReqwestClient> {
     let reqwest_client = ReqwestClient::new(settings.chains.xrp.url, gem_client::reqwest_client());
     let rpc_client = JsonRpcClient::new(reqwest_client);
     XrpClient::new(rpc_client)
+}
+
+#[cfg(test)]
+impl AccountInfo {
+    pub fn mock_with_balance(balance: u64, owner_count: u32) -> Self {
+        Self {
+            balance,
+            sequence: 100,
+            owner_count,
+            account: None,
+            flags: None,
+            ledger_entry_type: None,
+        }
+    }
 }


### PR DESCRIPTION
XRP accounts with trustlines or other ledger objects showed a higher available balance than the network actually allows to send, so Max transfers failed with an insufficient reserve error. The reserve now includes the per-object part, matching what the ledger enforces.