### PR TITLE
Show the activate asset banner on Android for Algorand and Stellar

### DIFF
--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbAssetInfo.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbAssetInfo.kt
@@ -129,10 +129,7 @@ fun DbAssetInfo.toDTO(): AssetInfo? {
                 bandwidthTotal = entity.bandwidthTotal?.toUInt() ?: 0U,
             )
         } else null,
-        isActive = when (assetId.chain) {
-            Chain.Xrp -> assetIsActive != false
-            else -> true
-        },
+        isActive = assetIsActive != false,
     )
 
     val account = if (entity.address.isNullOrEmpty()) null else Account(

--- a/android/data/services/store/src/test/kotlin/com/gemwallet/android/data/service/store/database/entities/DbAssetInfoTest.kt
+++ b/android/data/services/store/src/test/kotlin/com/gemwallet/android/data/service/store/database/entities/DbAssetInfoTest.kt
@@ -52,6 +52,17 @@ class DbAssetInfoTest {
     }
 
     @Test
+    fun toDTO_usesStoredBalanceActiveFlag() {
+        val inactive = mockDbAssetInfo(chain = Chain.Algorand, assetIsActive = false).toDTO()
+        val active = mockDbAssetInfo(chain = Chain.Stellar, assetIsActive = true).toDTO()
+        val unknown = mockDbAssetInfo(chain = Chain.Ethereum, assetIsActive = null).toDTO()
+
+        assertEquals(false, inactive?.balance?.isActive)
+        assertEquals(true, active?.balance?.isActive)
+        assertEquals(true, unknown?.balance?.isActive)
+    }
+
+    @Test
     fun toDTO_includesAssociations() {
         val associations = listOf(AssetAssociation(AssetId(Chain.Ethereum), AssetAssociationType.Official))
         val assetInfo = mockDbAssetInfo(associations = associations).toDTO()


### PR DESCRIPTION
Android reads the stored asset activation state for every chain now, so the Activate Asset banner appears for Algorand assets without an opt-in and Stellar assets without a trustline, matching iOS.