### PR TITLE
Let the custom token lookup call Core directly

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/add_asset/SearchCustomTokenImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/add_asset/SearchCustomTokenImpl.kt
@@ -1,17 +1,22 @@
 package com.gemwallet.android.data.coordinators.add_asset
 
+import android.util.Log
 import com.gemwallet.android.application.add_asset.cases.SearchCustomToken
-import com.gemwallet.android.application.tokens.cases.SearchTokens
-import com.gemwallet.android.application.session.cases.GetCurrentCurrency
+import com.gemwallet.android.ext.runCatchingCancellable
+import com.gemwallet.android.ext.toIdentifier
 import com.wallet.core.primitives.AssetId
+import uniffi.gemstone.GemAssetsService
 
 class SearchCustomTokenImpl(
-    private val getCurrentCurrency: GetCurrentCurrency,
-    private val searchTokensCase: SearchTokens,
+    private val assetsService: GemAssetsService,
 ) : SearchCustomToken {
 
-    override suspend fun invoke(assetId: AssetId): Boolean {
-        val currency = getCurrentCurrency.getCurrentCurrency()
-        return searchTokensCase.search(assetId, currency)
+    override suspend fun invoke(assetId: AssetId): Boolean =
+        runCatchingCancellable { assetsService.ensureTokenAsset(assetId.toIdentifier()) }
+            .onFailure { Log.e(TAG, "token asset lookup failed", it) }
+            .isSuccess
+
+    private companion object {
+        const val TAG = "SearchCustomToken"
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AddAssetModule.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/di/AddAssetModule.kt
@@ -9,7 +9,6 @@ import com.gemwallet.android.data.coordinators.add_asset.AddCustomTokenImpl
 import com.gemwallet.android.data.coordinators.add_asset.GetAvailableTokenChainsImpl
 import com.gemwallet.android.data.coordinators.add_asset.ObserveTokenImpl
 import com.gemwallet.android.data.coordinators.add_asset.SearchCustomTokenImpl
-import com.gemwallet.android.application.tokens.cases.SearchTokens
 import com.gemwallet.android.application.session.cases.GetSession
 import dagger.Module
 import dagger.Provides
@@ -18,7 +17,7 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 import com.gemwallet.android.data.services.gemstone.stores.GemstoneAssetStore
 import com.gemwallet.android.application.session.cases.GetCurrentWalletId
-import com.gemwallet.android.application.session.cases.GetCurrentCurrency
+import uniffi.gemstone.GemAssetsService
 
 @InstallIn(SingletonComponent::class)
 @Module
@@ -35,9 +34,8 @@ object AddAssetModule {
     @Provides
     @Singleton
     fun provideSearchCustomToken(
-        getCurrentCurrency: GetCurrentCurrency,
-        searchTokensCase: SearchTokens,
-    ): SearchCustomToken = SearchCustomTokenImpl(getCurrentCurrency, searchTokensCase)
+        assetsService: GemAssetsService,
+    ): SearchCustomToken = SearchCustomTokenImpl(assetsService)
 
     @Provides
     @Singleton

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/tokens/SearchTokensImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/tokens/SearchTokensImpl.kt
@@ -35,11 +35,6 @@ class SearchTokensImpl(
             .onFailure { Log.e(TAG, "assets sync failed", it) }
             .isSuccess
 
-    override suspend fun search(assetId: AssetId, currency: Currency): Boolean =
-        runCatchingCancellable { assetsService.ensureTokenAsset(assetId.toIdentifier()) }
-            .onFailure { Log.e(TAG, "token asset lookup failed", it) }
-            .isSuccess
-
     private companion object {
         const val TAG = "SearchTokens"
     }

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/application/tokens/cases/SearchTokens.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/application/tokens/cases/SearchTokens.kt
@@ -7,7 +7,5 @@ import com.wallet.core.primitives.Currency
 interface SearchTokens {
     suspend fun search(query: String, currency: Currency, chains: List<Chain> = emptyList()): Boolean
 
-    suspend fun search(assetId: AssetId, currency: Currency): Boolean
-
     suspend fun search(assetIds: List<AssetId>, currency: Currency): Boolean
 }


### PR DESCRIPTION
The Add Token lookup on Android fetched the current currency only to hand it to a search overload that never used it. That overload existed for this one caller and made the token search interface look like it covered a lookup it did not really own.

The custom token lookup now asks Core for the token directly, and the unused overload and currency dependency are removed. Behavior of the Add Token screen is unchanged.