### PR TITLE
Keep an enabled asset enabled when its refresh fails

### DIFF
--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/EnableAssetImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/EnableAssetImpl.kt
@@ -1,6 +1,8 @@
 package com.gemwallet.android.data.coordinators.asset
 
+import android.util.Log
 import com.gemwallet.android.application.assets.cases.EnableAsset
+import com.gemwallet.android.ext.runCatchingCancellable
 import com.gemwallet.android.ext.toIdentifier
 import com.wallet.core.primitives.AssetId
 import com.wallet.core.primitives.WalletId
@@ -14,7 +16,15 @@ class EnableAssetImpl(
 
     override suspend fun invoke(walletId: WalletId, assetId: AssetId, enabled: Boolean) = invoke(walletId, listOf(assetId), enabled)
 
-    override suspend fun invoke(walletId: WalletId, assetIds: List<AssetId>, enabled: Boolean) = withContext(Dispatchers.IO) {
-        balanceService.setAssetsEnabled(walletId.id, assetIds.map { it.toIdentifier() }, enabled)
+    override suspend fun invoke(walletId: WalletId, assetIds: List<AssetId>, enabled: Boolean) {
+        val identifiers = assetIds.map { it.toIdentifier() }
+        withContext(Dispatchers.IO) {
+            runCatchingCancellable { balanceService.setAssetsEnabled(walletId.id, identifiers, enabled) }
+                .onFailure { Log.e(TAG, "setting assets enabled=$enabled failed for $identifiers", it) }
+        }
+    }
+
+    private companion object {
+        const val TAG = "EnableAsset"
     }
 }

--- a/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/SetAssetPinnedImpl.kt
+++ b/android/data/coordinators/src/main/kotlin/com/gemwallet/android/data/coordinators/asset/SetAssetPinnedImpl.kt
@@ -1,7 +1,9 @@
 package com.gemwallet.android.data.coordinators.asset
 
+import android.util.Log
 import com.gemwallet.android.application.assets.cases.SetAssetPinned
 import com.gemwallet.android.application.session.cases.GetSession
+import com.gemwallet.android.ext.runCatchingCancellable
 import com.gemwallet.android.ext.toIdentifier
 import com.wallet.core.primitives.AssetId
 import uniffi.gemstone.GemBalanceService
@@ -16,11 +18,17 @@ class SetAssetPinnedImpl(
     override suspend fun invoke(assetId: AssetId, pinned: Boolean) {
         val session = getSession().value ?: return
         withContext(Dispatchers.IO) {
-            balanceService.setAssetPinned(
-                walletId = session.wallet.id.id,
-                assetId = assetId.toIdentifier(),
-                pinned = pinned,
-            )
+            runCatchingCancellable {
+                balanceService.setAssetPinned(
+                    walletId = session.wallet.id.id,
+                    assetId = assetId.toIdentifier(),
+                    pinned = pinned,
+                )
+            }.onFailure { Log.e(TAG, "setting pinned=$pinned failed for ${assetId.toIdentifier()}", it) }
         }
+    }
+
+    private companion object {
+        const val TAG = "SetAssetPinned"
     }
 }

--- a/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/EnableAssetImplTest.kt
+++ b/android/data/coordinators/src/test/kotlin/com/gemwallet/android/data/coordinators/asset/EnableAssetImplTest.kt
@@ -26,4 +26,11 @@ class EnableAssetImplTest {
 
         coVerify { balanceService.setAssetsEnabled(walletId.id, listOf(asset.id.toIdentifier()), true) }
     }
+
+    @Test
+    fun coreFailureDoesNotPropagate() = runTest {
+        coEvery { balanceService.setAssetsEnabled(any(), any(), any()) } throws IllegalStateException("offline")
+
+        subject(mockWalletId(), mockAsset().id)
+    }
 }

--- a/core/gemstone/src/services/balance/mod.rs
+++ b/core/gemstone/src/services/balance/mod.rs
@@ -71,18 +71,10 @@ impl GemBalanceService {
         let enabled_ids = self.store.get_enabled_asset_ids(wallet_id.clone(), asset_ids.clone()).await?;
         self.assets.add_missing_balances(wallet_id.clone(), asset_ids.clone()).await?;
         self.store.set_assets_enabled(wallet_id.clone(), asset_ids.clone(), enabled).await?;
-        if !enabled {
-            return Ok(());
+        if enabled {
+            self.refresh_enabled_assets(wallet_id, rules::newly_enabled_asset_ids(&asset_ids, &enabled_ids)).await;
         }
-        let new_asset_ids = rules::newly_enabled_asset_ids(&asset_ids, &enabled_ids);
-        if new_asset_ids.is_empty() {
-            return Ok(());
-        }
-        let currency = self.preferences.get_currency();
-        let prices = self.price.get_prices(Some(currency.clone()), new_asset_ids.clone()).await?;
-        self.price.update_prices(prices, currency).await?;
-        self.stream.add_prices(new_asset_ids.clone()).await?;
-        self.update(wallet_id, new_asset_ids).await
+        Ok(())
     }
 
     pub async fn set_asset_pinned(&self, wallet_id: WalletId, asset_id: AssetId, pinned: bool) -> Result<(), GemServiceError> {
@@ -122,6 +114,18 @@ impl GemBalanceService {
 }
 
 impl GemBalanceService {
+    async fn refresh_enabled_assets(&self, wallet_id: WalletId, asset_ids: Vec<AssetId>) {
+        if asset_ids.is_empty() {
+            return;
+        }
+        let currency = self.preferences.get_currency();
+        if let Ok(prices) = self.price.get_prices(Some(currency.clone()), asset_ids.clone()).await {
+            let _ = self.price.update_prices(prices, currency).await;
+        }
+        let _ = self.stream.add_prices(asset_ids.clone()).await;
+        let _ = self.update(wallet_id, asset_ids).await;
+    }
+
     pub async fn update_balances(&self, wallet_id: WalletId, updates: Vec<GemBalanceUpdate>) -> Result<(), GemServiceError> {
         let asset_ids = updates.iter().map(|update| update.asset_id.clone()).collect();
         self.assets.add_missing_balances(wallet_id.clone(), asset_ids).await?;


### PR DESCRIPTION
Adding or pinning an asset while offline crashed the Android app, and on iOS it silently skipped the success toast. The asset was already enabled locally, but the follow-up price refresh failed and that failure was treated as if the enable itself had failed. A pin was lost the same way.

Enabling an asset now succeeds once it is saved, and the price, stream and balance refresh runs on a best-effort basis; the regular sync fills in anything that failed. The Android enable and pin coordinators log core errors instead of letting them escape.