### PR TITLE
Refresh fiat quotes on the timer instead of skipping them

### DIFF
--- a/ios/Features/FiatConnect/Sources/Scenes/FiatScene.swift
+++ b/ios/Features/FiatConnect/Sources/Scenes/FiatScene.swift
@@ -37,7 +37,7 @@ public struct FiatScene: View {
         .debouncedTask(id: model.loadTrigger, interval: model.quoteDebounce) {
             await model.load()
         }
-        .onTimer(every: model.quoteRefreshInterval) {
+        .onTimer(every: model.quoteRefreshInterval, id: model.loadTrigger) {
             await model.load()
         }
         .alertSheet($model.isPresentingAlertMessage)

--- a/ios/Features/FiatConnect/Sources/ViewModels/FiatOperationViewModel.swift
+++ b/ios/Features/FiatConnect/Sources/ViewModels/FiatOperationViewModel.swift
@@ -103,16 +103,7 @@ final class FiatOperationViewModel {
     }
 
     func shouldSkipFetch(for amount: Double) -> Bool {
-        if loadingAmount == amount {
-            return true
-        }
-
-        switch quotesState {
-        case let .data(fiatQuotes):
-            return fiatQuotes.amount == amount
-        case .loading, .noData, .error:
-            return false
-        }
+        loadingAmount == amount
     }
 
     func updateValidators() {

--- a/ios/Features/FiatConnect/Sources/ViewModels/FiatOperationViewModel.swift
+++ b/ios/Features/FiatConnect/Sources/ViewModels/FiatOperationViewModel.swift
@@ -18,7 +18,10 @@ final class FiatOperationViewModel {
     private let currencyFormatter: CurrencyFormatter
 
     var quotesState: StateViewType<FiatQuotes> = .loading
-    var selectedQuote: FiatQuote?
+    var selectedQuote: FiatQuote? {
+        didSet { updateValidators() }
+    }
+
     var loadTask: Task<Void, Never>?
     var amount: String
     var loadingAmount: Double?
@@ -88,7 +91,6 @@ final class FiatOperationViewModel {
                 if quotes.isNotEmpty {
                     selectedQuote = quotes.first
                     quotesState = .data(FiatQuotes(amount: amount, quotes: quotes))
-                    updateValidators()
                 } else {
                     quotesState = .noData
                 }

--- a/ios/Features/FiatConnect/Tests/FiatOperationViewModelTests.swift
+++ b/ios/Features/FiatConnect/Tests/FiatOperationViewModelTests.swift
@@ -47,35 +47,9 @@ final class FiatOperationViewModelTests {
     }
 
     @Test
-    func shouldSkipFetchWhenDataExists() {
+    func shouldNotSkipFetchWhenQuotesAlreadyLoadedForSameAmount() {
         let model = FiatOperationViewModelTests.mock()
-        let quotes = FiatQuotes(amount: 100.0, quotes: [.mock()])
-        model.quotesState = .data(quotes)
-
-        #expect(model.shouldSkipFetch(for: 100.0) == true)
-        #expect(model.shouldSkipFetch(for: 50.0) == false)
-    }
-
-    @Test
-    func shouldNotSkipFetchForErrorState() {
-        let model = FiatOperationViewModelTests.mock()
-        model.quotesState = .error(NSError(domain: "test", code: 1))
-
-        #expect(model.shouldSkipFetch(for: 100.0) == false)
-    }
-
-    @Test
-    func shouldNotSkipFetchForLoadingState() {
-        let model = FiatOperationViewModelTests.mock()
-        model.quotesState = .loading
-
-        #expect(model.shouldSkipFetch(for: 100.0) == false)
-    }
-
-    @Test
-    func shouldNotSkipFetchForNoDataState() {
-        let model = FiatOperationViewModelTests.mock()
-        model.quotesState = .noData
+        model.quotesState = .data(FiatQuotes(amount: 100.0, quotes: [.mock()]))
 
         #expect(model.shouldSkipFetch(for: 100.0) == false)
     }

--- a/ios/Features/FiatConnect/Tests/FiatSceneViewModelTests.swift
+++ b/ios/Features/FiatConnect/Tests/FiatSceneViewModelTests.swift
@@ -173,7 +173,6 @@ final class FiatSceneViewModelTests {
         )
         let quote = FiatQuote.mock(fiatAmount: 100, cryptoAmount: 104.97, type: .sell)
         model.sellViewModel.selectedQuote = quote
-        model.sellViewModel.updateValidators()
         model.inputValidationModel.text = "100"
 
         #expect(model.inputValidationModel.update() == false)
@@ -186,6 +185,33 @@ final class FiatSceneViewModelTests {
         #expect(model.buyViewModel.availableBalance == BigInt(415_650_000))
         #expect(model.sellViewModel.availableBalance == BigInt(415_650_000))
         #expect(model.inputValidationModel.update() == true)
+    }
+
+    @Test
+    func selectingProviderRevalidatesSellBalance() {
+        let asset = Asset.mockEthereumUSDT()
+        let formatter = CurrencyFormatter(locale: .US, currencyCode: Currency.usd.rawValue)
+        let affordable = FiatQuote.mock(fiatAmount: 100, cryptoAmount: 100, type: .sell)
+        let unaffordable = FiatQuote.mock(fiatAmount: 100, cryptoAmount: 300, type: .sell)
+        let model = FiatSceneViewModelTests.mock(
+            assetAddress: .mock(asset: asset),
+            type: .sell,
+        )
+
+        model.onAssetDataChange(
+            .mock(asset: asset),
+            .mock(asset: asset, balance: .mock(available: BigInt(200_000_000))),
+        )
+        model.inputValidationModel.text = "100"
+        model.sellViewModel.quotesState = .data(FiatQuotes(amount: 100, quotes: [affordable, unaffordable]))
+        model.sellViewModel.selectedQuote = affordable
+
+        #expect(model.actionButtonState.value != nil)
+
+        model.onSelectQuotes([FiatQuoteViewModel(asset: asset, quote: unaffordable, formatter: formatter)])
+
+        #expect(model.inputValidationModel.isInvalid)
+        #expect(model.actionButtonState.value == nil)
     }
 
     @Test

--- a/ios/Features/FiatConnect/Tests/FiatSceneViewModelTests.swift
+++ b/ios/Features/FiatConnect/Tests/FiatSceneViewModelTests.swift
@@ -337,15 +337,6 @@ final class FiatSceneViewModelTests {
     }
 
     @Test
-    func secondFetchSkippedWhenDataExistsForSameAmount() {
-        let model = FiatSceneViewModelTests.mock()
-
-        model.buyViewModel.quotesState = .data(FiatQuotes(amount: 100.0, quotes: []))
-
-        #expect(model.buyViewModel.shouldSkipFetch(for: 100.0) == true)
-    }
-
-    @Test
     func fetchAllowedForDifferentAmount() {
         let model = FiatSceneViewModelTests.mock()
 


### PR DESCRIPTION
Buy and sell quotes were fetched once and then stayed on screen unchanged for as long as the user kept the screen open, so the rate they saw could be minutes old and tapping Continue could hand off a quote the provider had already expired.

The five-minute refresh was being skipped every time because the app treated an unchanged amount as nothing to fetch, even though refreshing the same amount is the whole point. The check that blocked it is removed, the guard against duplicate in-flight requests stays, and the refresh interval now restarts on user input the same way the swap screen already works.