### PR TITLE
Show a person placeholder while a contact has no name

### DIFF
--- a/android/features/settings/contacts/presents/src/main/kotlin/com/gemwallet/android/features/settings/contacts/presents/ContactAvatar.kt
+++ b/android/features/settings/contacts/presents/src/main/kotlin/com/gemwallet/android/features/settings/contacts/presents/ContactAvatar.kt
@@ -14,6 +14,7 @@ import com.gemwallet.android.ui.components.image.EmojiView
 import com.gemwallet.android.ui.components.image.InitialsAvatar
 import com.gemwallet.android.ui.components.image.RemoveBadge
 import com.gemwallet.android.ui.components.image.walletImageModel
+import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.theme.listItemIconSize
 
 @Composable
@@ -24,10 +25,14 @@ internal fun ContactAvatar(
     size: Dp = listItemIconSize,
     onRemove: (() -> Unit)? = null,
 ) {
-    val initials = name.take(2).uppercase()
+    val initials = name.trim().take(2).uppercase()
     Box(modifier = modifier) {
         when (avatar) {
-            ContactAvatarState.Empty -> InitialsAvatar(text = initials, size = size)
+            ContactAvatarState.Empty -> InitialsAvatar(
+                text = initials,
+                size = size,
+                placeholder = AppIcons.Person,
+            )
             is ContactAvatarState.Image -> AsyncImage(
                 model = walletImageModel(LocalContext.current, avatar.imageUrl),
                 size = size,

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/image/InitialsAvatar.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/image/InitialsAvatar.kt
@@ -4,12 +4,14 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import com.gemwallet.android.ui.theme.secondaryFaded
@@ -19,6 +21,7 @@ fun InitialsAvatar(
     text: String,
     size: Dp,
     modifier: Modifier = Modifier,
+    placeholder: ImageVector? = null,
 ) {
     Box(
         modifier = modifier
@@ -27,11 +30,20 @@ fun InitialsAvatar(
             .background(MaterialTheme.colorScheme.secondaryFaded),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.titleMedium,
-            fontSize = with(LocalDensity.current) { (size * AvatarScale.INITIALS).toSp() },
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+        if (text.isEmpty() && placeholder != null) {
+            Icon(
+                imageVector = placeholder,
+                contentDescription = null,
+                modifier = Modifier.size(size * AvatarScale.EMOJI),
+                tint = MaterialTheme.colorScheme.outline,
+            )
+        } else {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.titleMedium,
+                fontSize = with(LocalDensity.current) { (size * AvatarScale.INITIALS).toSp() },
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
     }
 }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/icons/AppIcons.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/icons/AppIcons.kt
@@ -45,6 +45,7 @@ object AppIcons {
     val MoreVert: ImageVector @Composable get() = ImageVector.vectorResource(R.drawable.ic_more_vert)
     val Notifications: ImageVector @Composable get() = ImageVector.vectorResource(R.drawable.ic_notifications)
     val NotificationsOutlined: ImageVector @Composable get() = ImageVector.vectorResource(R.drawable.ic_notifications_outlined)
+    val Person: ImageVector @Composable get() = ImageVector.vectorResource(R.drawable.ic_person)
     val PushPin: ImageVector @Composable get() = ImageVector.vectorResource(R.drawable.ic_push_pin)
     val QrCodeScanner: ImageVector @Composable get() = ImageVector.vectorResource(R.drawable.ic_qr_code_scanner)
     val Refresh: ImageVector @Composable get() = ImageVector.vectorResource(R.drawable.ic_refresh)

--- a/android/ui/src/main/res/drawable/ic_person.xml
+++ b/android/ui/src/main/res/drawable/ic_person.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,20c3.683,0 6.667,-2.983 6.667,-6.667S23.683,6.667 20,6.667 13.333,9.65 13.333,13.333 16.317,20 20,20z"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,23.333c-4.45,0 -13.333,2.234 -13.333,6.667v3.333h26.667v-3.333c0,-4.433 -8.883,-6.667 -13.333,-6.667z"/>
+</vector>

--- a/ios/Features/Contacts/Sources/Scenes/ManageContactScene.swift
+++ b/ios/Features/Contacts/Sources/Scenes/ManageContactScene.swift
@@ -79,6 +79,7 @@ extension ManageContactScene {
                 size: .image.extraLarge,
                 action: onSelectAvatar,
                 removeAction: model.onClearAvatar,
+                style: model.avatarStyle,
             )
             .frame(maxWidth: .infinity, alignment: .center)
             .listRowBackground(Color.clear)

--- a/ios/Features/Contacts/Sources/ViewModels/ManageContactViewModel.swift
+++ b/ios/Features/Contacts/Sources/ViewModels/ManageContactViewModel.swift
@@ -138,9 +138,16 @@ public final class ManageContactViewModel {
 
     var avatarImage: AssetImage {
         switch avatar {
-        case .empty: AssetImage(type: .text(initials))
+        case .empty: initials.isEmpty ? .image(Images.System.personCircleFill) : AssetImage(type: .text(initials))
         case let .image(imageUrl): AssetImage(type: .text(initials), imageURL: ImageSource(imageUrl).url)
         case let .emoji(value): AssetImage(type: .emoji(value.emoji))
+        }
+    }
+
+    var avatarStyle: AssetImageView.Style? {
+        switch avatar {
+        case .empty: initials.isEmpty ? AssetImageView.Style(foregroundColor: Colors.grayLight) : nil
+        case .image, .emoji: nil
         }
     }
 

--- a/ios/Features/Contacts/Sources/ViewModels/ManageContactViewModel.swift
+++ b/ios/Features/Contacts/Sources/ViewModels/ManageContactViewModel.swift
@@ -146,7 +146,7 @@ public final class ManageContactViewModel {
 
     var avatarStyle: AssetImageView.Style? {
         switch avatar {
-        case .empty: initials.isEmpty ? AssetImageView.Style(foregroundColor: Colors.grayLight) : nil
+        case .empty: initials.isEmpty ? AssetImageView.Style(foregroundColor: Colors.grayLightFaded) : nil
         case .image, .emoji: nil
         }
     }

--- a/ios/Packages/PrimitivesComponents/Sources/Views/AvatarView.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Views/AvatarView.swift
@@ -10,17 +10,20 @@ public struct AvatarView: View {
     private let size: CGFloat
     private let action: VoidAction
     private let removeAction: VoidAction
+    private let style: AssetImageView.Style?
 
     public init(
         avatarImage: AssetImage,
         size: CGFloat,
         action: VoidAction = nil,
         removeAction: VoidAction = nil,
+        style: AssetImageView.Style? = nil,
     ) {
         self.avatarImage = avatarImage
         self.size = size
         self.action = action
         self.removeAction = removeAction
+        self.style = style
     }
 
     public var body: some View {
@@ -52,6 +55,7 @@ public struct AvatarView: View {
         AssetImageView(
             assetImage: avatarImage,
             size: size,
+            style: style,
         )
     }
 

--- a/ios/Packages/Style/Sources/Extentions/Images+SystemImage.swift
+++ b/ios/Packages/Style/Sources/Extentions/Images+SystemImage.swift
@@ -51,6 +51,7 @@ public extension Images {
         public static let arrowTriangleUp = Image(systemName: SystemImage.arrowTriangleUp)
         public static let arrowTriangleDown = Image(systemName: SystemImage.arrowTriangleDown)
         public static let person = Image(systemName: SystemImage.person)
+        public static let personCircleFill = Image(systemName: SystemImage.personCircleFill)
         public static let personBadgePlus = Image(systemName: SystemImage.personBadgePlus)
         public static let checkmarkSealFill = Image(systemName: SystemImage.checkmarkSealFill)
     }


### PR DESCRIPTION
Creating a contact showed an empty grey circle until a name was typed. It now shows a person placeholder, and switches to the initials as soon as the name is entered. Same on iOS and Android.

<img width="320" alt="contact-placeholder-android" src="https://github.com/user-attachments/assets/3bdb96a0-0c91-4664-b428-bf2cfa6f8a3a" />
<img width="320" alt="contact-placeholder-ios" src="https://github.com/user-attachments/assets/45157caa-192b-449e-b3f3-03acb1b1a906" />
