### PR TITLE
Open assets off the main thread on Android

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/NotificationNavigation.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/NotificationNavigation.kt
@@ -26,7 +26,9 @@ import com.wallet.core.primitives.AssetType
 import com.wallet.core.primitives.Transaction
 import com.wallet.core.primitives.Wallet
 import com.wallet.core.primitives.WalletId
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
 import uniffi.gemstone.GemAssetsService
 import uniffi.gemstone.GemPushNotification
 import uniffi.gemstone.GemPushNotificationService
@@ -84,7 +86,9 @@ class NotificationNavigation @Inject constructor(
         if (assetId == null) {
             return emptyList()
         }
-        val asset = assetsService.openAsset(assetId.toIdentifier())?.toPrimitives() ?: return emptyList()
+        val asset = withContext(Dispatchers.IO) {
+            assetsService.openAsset(assetId.toIdentifier())
+        }?.toPrimitives() ?: return emptyList()
         return listOf(AssetRoute(asset.id))
     }
 

--- a/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/RootRoute.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/ui/navigation/RootRoute.kt
@@ -6,7 +6,9 @@ import com.gemwallet.android.ui.LocalTransferService
 import uniffi.gemstone.GemAssetsServiceInterface
 import uniffi.gemstone.GemTransferService
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
@@ -151,11 +153,12 @@ class WalletNavigator(
         return backStack.add(route)
     }
 
-    private fun openAssetRoute(route: AssetRoute) {
-        scope.launch {
-            if (assetsService.openAsset(route.assetId.toIdentifier()) != null) {
-                push(route)
-            }
+    private fun openAssetRoute(route: AssetRoute) = scope.launch {
+        val asset = withContext(Dispatchers.IO) {
+            assetsService.openAsset(route.assetId.toIdentifier())
+        }
+        if (asset != null) {
+            push(route)
         }
     }
 

--- a/android/app/src/test/kotlin/com/gemwallet/android/NotificationNavigationTest.kt
+++ b/android/app/src/test/kotlin/com/gemwallet/android/NotificationNavigationTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import uniffi.gemstone.GemAssetsService
@@ -203,12 +204,21 @@ class NotificationNavigationTest {
     @Test
     fun assetNotification_opensAssetThroughCore() = runBlocking {
         val asset = mockAsset(chain = Chain.Solana)
-        coEvery { assetsService.openAsset(asset.id.toIdentifier()) } returns asset.toGem()
+        val callingThreads = mutableListOf<String>()
+        coEvery { assetsService.openAsset(asset.id.toIdentifier()) } answers {
+            callingThreads += Thread.currentThread().name
+            asset.toGem()
+        }
 
         val route = subject.prepareNavigation(GemPushNotification.Asset(asset.id.toIdentifier()))
 
         assertEquals(listOf(AssetRoute(asset.id)), route)
         coVerify(exactly = 0) { setCurrentWallet.setCurrentWallet(any()) }
+        assertTrue(
+            "openAsset reads the current wallet through a synchronous store callback that blocks on Room; " +
+                "the notification routes are built on the main scope. Got $callingThreads",
+            callingThreads.single().startsWith("DefaultDispatcher-worker"),
+        )
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/gemwallet/android/ui/navigation/WalletNavigatorTest.kt
+++ b/android/app/src/test/kotlin/com/gemwallet/android/ui/navigation/WalletNavigatorTest.kt
@@ -5,6 +5,7 @@ import uniffi.gemstone.GemDeeplinkService
 import uniffi.gemstone.GemTransferService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
 import androidx.compose.runtime.mutableStateOf
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
@@ -63,19 +64,31 @@ import org.junit.Test
 class WalletNavigatorTest {
 
     @Test
-    fun openAsset_pushesOnlyAssetsCoreOpens() {
+    fun openAsset_pushesOnlyAssetsCoreOpens() = runTest {
         val blocked = mockAssetId(Chain.Tempo)
         val opened = mockAssetId(Chain.Tron)
+        val callingThreads = mutableListOf<String>()
         val assetsService = mockk<GemAssetsServiceInterface> {
-            coEvery { openAsset(blocked.toIdentifier()) } returns null
-            coEvery { openAsset(opened.toIdentifier()) } returns mockAsset(chain = Chain.Tron).toGem()
+            coEvery { openAsset(blocked.toIdentifier()) } answers {
+                callingThreads += Thread.currentThread().name
+                null
+            }
+            coEvery { openAsset(opened.toIdentifier()) } answers {
+                callingThreads += Thread.currentThread().name
+                mockAsset(chain = Chain.Tron).toGem()
+            }
         }
-        val navigator = navigatorWith(WalletRootRoute, assetsService = assetsService)
+        val navigator = navigatorWith(WalletRootRoute, assetsService = assetsService, scope = this)
 
-        navigator.openAsset(blocked)
-        navigator.openAsset(opened)
+        navigator.openAsset(blocked).join()
+        navigator.openAsset(opened).join()
 
         assertEquals(listOf(WalletRootRoute, AssetRoute(opened)), navigator.backStack.toList())
+        assertTrue(
+            "openAsset reads the current wallet through a synchronous store callback that blocks on Room; " +
+                "calling it on the navigator scope lands on main. Got $callingThreads",
+            callingThreads.size == 2 && callingThreads.all { it.startsWith("DefaultDispatcher-worker") },
+        )
     }
 
     @Test
@@ -531,6 +544,7 @@ class WalletNavigatorTest {
     private fun navigatorWith(
         vararg routes: NavKey,
         assetsService: GemAssetsServiceInterface = mockk(),
+        scope: CoroutineScope = CoroutineScope(Dispatchers.Unconfined),
     ): WalletNavigator {
         return WalletNavigator(
             backStack = NavBackStack(*routes),
@@ -538,7 +552,7 @@ class WalletNavigatorTest {
             transferService = GemTransferService(),
             deeplinkService = GemDeeplinkService(),
             assetsService = assetsService,
-            scope = CoroutineScope(Dispatchers.Unconfined),
+            scope = scope,
         )
     }
 }


### PR DESCRIPTION
Tapping an asset in wallet search crashed the app. Opening an asset from a
push notification crashed the same way.

Assets now open without blocking the main thread, so both paths work again.

Closes #1073