### PR TITLE
Select a node by its url instead of its host

### DIFF
--- a/ios/Features/Settings/Package.swift
+++ b/ios/Features/Settings/Package.swift
@@ -55,5 +55,13 @@ let package = Package(
                 .product(name: "GemstoneServicesTestKit", package: "GemstoneServices"),
             ],
         ),
+        .testTarget(
+            name: "ChainSettingsTests",
+            dependencies: [
+                "Settings",
+                "Primitives",
+                .product(name: "GemstonePrimitivesTestKit", package: "GemstonePrimitives"),
+            ],
+        ),
     ],
 )

--- a/ios/Features/Settings/Sources/ChainSettings/Scenes/ChainSettingsScene.swift
+++ b/ios/Features/Settings/Sources/ChainSettings/Scenes/ChainSettingsScene.swift
@@ -26,11 +26,10 @@ public struct ChainSettingsScene: View {
                         titleTagStyle: nodeModel.titleTagStyle,
                         subtitle: .none,
                         subtitleExtra: .none,
-                        value: nodeModel.chainNode.host,
-                        selection: model.selectedNode.host,
-                    ) { _ in
-                        model.onSelectNode(nodeModel.chainNode)
-                    }
+                        value: nodeModel.chainNode,
+                        selection: model.selectedNode,
+                        action: model.onSelectNode,
+                    )
                     .contextMenu(
                         .copy(value: nodeModel.chainNode.node.url),
                     )

--- a/ios/Features/Settings/Tests/ChainSettingsTests/ChainSettingsSceneViewModelTests.swift
+++ b/ios/Features/Settings/Tests/ChainSettingsTests/ChainSettingsSceneViewModelTests.swift
@@ -1,0 +1,44 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import GemstonePrimitivesTestKit
+import Primitives
+@testable import Settings
+import Testing
+
+@MainActor
+struct ChainSettingsSceneViewModelTests {
+    @Test
+    func loadsSelectedNodeByUrl() async throws {
+        let model = ChainSettingsSceneViewModel.mock()
+
+        await model.load()
+
+        let first = try #require(model.nodesModels.first)
+        #expect(model.nodesModels.allSatisfy { $0.chainNode.host == first.chainNode.host })
+        #expect(model.selectedNode.node.url == first.chainNode.node.url)
+        #expect(model.nodesModels.count(where: { $0.chainNode == model.selectedNode }) == 1)
+    }
+
+    @Test
+    func selectsSameHostNode() async throws {
+        let model = ChainSettingsSceneViewModel.mock()
+        await model.load()
+        let last = try #require(model.nodesModels.last)
+
+        model.onSelectNode(last.chainNode)
+
+        #expect(model.selectedNode.node.url == last.chainNode.node.url)
+        #expect(model.nodesModels.count(where: { $0.chainNode == model.selectedNode }) == 1)
+    }
+}
+
+// MARK: - Mock
+
+extension ChainSettingsSceneViewModel {
+    static func mock() -> ChainSettingsSceneViewModel {
+        ChainSettingsSceneViewModel(
+            chain: .ethereum,
+            service: GemChainSettingsServiceMock(nodeUrls: ["https://rpc.example.com/one", "https://rpc.example.com/two"]),
+        )
+    }
+}

--- a/ios/GemTests/unit_frameworks.xctestplan
+++ b/ios/GemTests/unit_frameworks.xctestplan
@@ -191,6 +191,13 @@
     },
     {
       "target": {
+        "containerPath": "container:Features\/Settings",
+        "identifier": "ChainSettingsTests",
+        "name": "ChainSettingsTests"
+      }
+    },
+    {
+      "target": {
         "containerPath": "container:Packages\/Preferences",
         "identifier": "PreferencesTest",
         "name": "PreferencesTest"

--- a/ios/Packages/GemstonePrimitives/TestKit/GemServiceMocks.swift
+++ b/ios/Packages/GemstonePrimitives/TestKit/GemServiceMocks.swift
@@ -794,6 +794,68 @@ public final class GemCurrencyServiceMock: GemCurrencyServiceProtocol, @unchecke
     }
 }
 
+public final class GemChainSettingsServiceMock: GemChainSettingsServiceProtocol, @unchecked Sendable {
+    private let nodeUrls: [String]
+    private var selectedUrl: String
+
+    public init(nodeUrls: [String]) {
+        self.nodeUrls = nodeUrls
+        selectedUrl = nodeUrls.first ?? ""
+    }
+
+    public func nodes(chain _: Gemstone.Chain) async throws -> [Gemstone.Node] {
+        nodeUrls.map(node(url:))
+    }
+
+    public func selectedNode(chain _: Gemstone.Chain) -> Gemstone.Node {
+        node(url: selectedUrl)
+    }
+
+    public func selectNode(chain _: Gemstone.Chain, url: String) async throws {
+        selectedUrl = url
+    }
+
+    public func nodeStatus(chain _: Gemstone.Chain, url _: String) async -> GemNodeStatusState {
+        .loading
+    }
+
+    public func canDeleteNode(chain _: Gemstone.Chain, url _: String) -> Bool {
+        true
+    }
+
+    public func nodeFlag(url _: String) -> String? {
+        nil
+    }
+
+    public func chains(query _: String) -> [Gemstone.Chain] {
+        []
+    }
+
+    public func explorers(chain _: Gemstone.Chain) -> [String] {
+        []
+    }
+
+    public func explorerName(chain _: Gemstone.Chain) -> String {
+        ""
+    }
+
+    public func nodeCheckDebounceMilliseconds() -> UInt64 {
+        0
+    }
+
+    public func checkNode(chain _: Gemstone.Chain, url _: String) async throws -> GemNodeCheck {
+        throw AnyError("not stubbed")
+    }
+
+    public func addNode(chain _: Gemstone.Chain, url _: String) async throws {}
+    public func deleteNode(chain _: Gemstone.Chain, url _: String) async throws {}
+    public func setExplorerName(chain _: Gemstone.Chain, name _: String) throws {}
+
+    private func node(url: String) -> Gemstone.Node {
+        Primitives.Node(url: url, status: .active, priority: 0).json()
+    }
+}
+
 public final class GemBannerServiceMock: GemBannerServiceProtocol, @unchecked Sendable {
     public private(set) var closedKeys: [GemBannerKey] = []
     public private(set) var handledActions: [GemBannerAction] = []


### PR DESCRIPTION
On iOS the networks screen decided which node was selected by comparing hosts, so two nodes on the same host with different paths both showed a checkmark while only one was really in use. The selection now compares the whole node, so the checkmark stands on the node that is actually selected.