### PR TITLE
Promote recurring review lessons into the agent guides

### DIFF
--- a/android/skills/code-style.md
+++ b/android/skills/code-style.md
@@ -6,6 +6,7 @@ Use for any Kotlin or Compose change.
 - Kotlin conventions and existing project patterns; Jetpack Compose for UI; Hilt for dependency injection; repository-based data access
 - Do not add unnecessary comments; clean imports after every modification
 - In suspend or flow code, a `catch (e: Throwable)` must rethrow `CancellationException` before mapping to an error state; otherwise a cancelled collection surfaces as a failure (see `InAppUpdateServiceImpl.kt`)
+- No blocking store, Room, or gemstone call on the main thread. A synchronous getter reached from a view model constructor, a Hilt provider, or composition throws and kills the process; expose it as a suspend function or flow and collect it. `allowMainThreadQueries()` belongs to migration tests only
 - Prefer the smallest change that satisfies the requirement
 
 ## Security and Hygiene
@@ -22,7 +23,7 @@ Use for any Kotlin or Compose change.
 ## Room Schema
 
 - Table names are plural `snake_case` (`nft_collections`, `nft_assets`, `nft_assets_associations`)
-- Entity fields are Kotlin `camelCase` stored as SQLite `snake_case` columns via `@ColumnInfo(name = "asset_id")`
+- Entity fields are Kotlin `camelCase` and the column keeps the property name. `@ColumnInfo` maps only the older entities that already own `snake_case` columns; a new entity does not add it. Reference: `data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/entities/DbContact.kt`
 - When an equivalent iOS store model exists, mirror its schema naming instead of inventing Android-only variants; keep one naming scheme within a table
 
 Shared clean-code principles live in `../../skills/engineering-principles.md`.

--- a/skills/engineering-principles.md
+++ b/skills/engineering-principles.md
@@ -41,7 +41,7 @@ The most important rule in this file. Before changing anything, ask why the fail
 ## Tests
 
 - Tests verify intent, not just behavior. If the test still passes after the business rule flips, it is a tautology: break the rule, watch the test fail, then fix the assertion or the function under test. A test that mocks the layer where the defect lives proves nothing about that defect
-- For a high-impact bug, add the smallest test that materially reduces regression risk; skip trivial, framework, formatting-only, and purely visual coverage unless asked or already cheap
+- For a high-impact bug with a deterministic seam, add the smallest test that materially reduces regression risk and write it before the fix; skip trivial, framework, formatting-only, and purely visual coverage unless asked or already cheap
 - "Tests pass" is not a green light if any were skipped, marked expected-failure, or gated behind features you did not run. Report what you executed
 - Unit tests never spin up ad hoc HTTP/TCP servers. Use the platform testkit fixtures, pure mappers and parsers, or injected clients; when network behavior matters, use the gated integration tests
 

--- a/skills/engineering-principles.md
+++ b/skills/engineering-principles.md
@@ -20,7 +20,9 @@ The most important rule in this file. Before changing anything, ask why the fail
 - No code comments. Convey intent through names and structure; if code seems to need a comment, rename or restructure it. Only compiler- or tooling-required comments (attributes, lint directives, license headers) are exceptions
 - Full domain terms in names (`transaction`, not `tx`) except when preserving external protocol fields, database columns, or URLs verbatim
 - Intent-specific names that state the domain action and result (`parse_destination_tag`, `build_transfer_message`, `map_balance_assets`). Generic verbs such as `process`, `handle`, `manage`, `perform`, `execute`, and `resolve` hide the contract; keep them only when a framework or protocol owns the signature
+- Search for the existing component, domain type, mapper, or testkit fixture before adding a new one; a new view, property, or helper next to one that already does the job is a finding
 - Understand a nearby pattern before copying it; copying patterns you cannot explain is how dead conventions spread
+- Model variants with a type, not a boolean flag or a bare string. An enum or sealed hierarchy the compiler checks exhaustively replaces paired booleans, optional-plus-flag pairs, and default branches that hide a missing state
 - Small API surface: public only when it must be
 - Immutable bindings (`let`, `val`, non-`mut`); mutation only where ownership requires it, in the narrowest scope
 - When two patterns contradict (iOS vs. Android on a shared flow, two error-mapping styles in `core/`, parallel providers), do not blend them. Pick the more recent or better tested one, say why, and flag the other for follow-up
@@ -38,7 +40,7 @@ The most important rule in this file. Before changing anything, ask why the fail
 
 ## Tests
 
-- Tests verify intent, not just behavior. If the test still passes after the business rule flips, it is a tautology: fix the assertion or the function under test
+- Tests verify intent, not just behavior. If the test still passes after the business rule flips, it is a tautology: break the rule, watch the test fail, then fix the assertion or the function under test. A test that mocks the layer where the defect lives proves nothing about that defect
 - For a high-impact bug, add the smallest test that materially reduces regression risk; skip trivial, framework, formatting-only, and purely visual coverage unless asked or already cheap
 - "Tests pass" is not a green light if any were skipped, marked expected-failure, or gated behind features you did not run. Report what you executed
 - Unit tests never spin up ad hoc HTTP/TCP servers. Use the platform testkit fixtures, pure mappers and parsers, or injected clients; when network behavior matters, use the gated integration tests


### PR DESCRIPTION
Ran the new guidance-refresh skill over the session history and memory this machine accumulated for the repo. Five corrections kept coming back in reviews and were not stated in the guides.

Shared guides get three rules: reuse the component, type or fixture that already exists before adding a new one, model variants with a type instead of a boolean flag, and prove a test by breaking the rule it guards.

Android gets the rule that store and Room calls stay off the main thread, and a correction to the Room column rule, which described a convention new entities no longer follow.