### PR TITLE
Perpetual autoclose returns a value and its sheet carries the position

### DIFF
--- a/ios/Features/Perpetuals/Sources/Scenes/AutocloseScene.swift
+++ b/ios/Features/Perpetuals/Sources/Scenes/AutocloseScene.swift
@@ -63,6 +63,8 @@ public struct AutocloseScene: View {
             )
         }
         .navigationTitle(model.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar { ToolbarDismissItem(type: .close, placement: .topBarLeading) }
         .onChange(of: focusedField, model.onChangeFocusField)
     }
 

--- a/ios/Features/Perpetuals/Sources/Types/AutocloseInput.swift
+++ b/ios/Features/Perpetuals/Sources/Types/AutocloseInput.swift
@@ -26,6 +26,13 @@ struct AutocloseInput {
         stopLossText.map { stopLoss.text = $0 }
     }
 
+    var selection: AutocloseSelection {
+        AutocloseSelection(
+            takeProfit: takeProfit.text.isEmpty ? nil : takeProfit.text,
+            stopLoss: stopLoss.text.isEmpty ? nil : stopLoss.text,
+        )
+    }
+
     var focused: InputValidationViewModel? {
         switch focusField {
         case .takeProfit: takeProfit

--- a/ios/Features/Perpetuals/Sources/Types/AutocloseSelection.swift
+++ b/ios/Features/Perpetuals/Sources/Types/AutocloseSelection.swift
@@ -1,0 +1,13 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public struct AutocloseSelection: Sendable {
+    public let takeProfit: String?
+    public let stopLoss: String?
+
+    public init(takeProfit: String?, stopLoss: String?) {
+        self.takeProfit = takeProfit
+        self.stopLoss = stopLoss
+    }
+}

--- a/ios/Features/Perpetuals/Sources/Types/AutocloseType.swift
+++ b/ios/Features/Perpetuals/Sources/Types/AutocloseType.swift
@@ -3,9 +3,8 @@
 import Foundation
 import GemstonePrimitives
 import Primitives
-import PrimitivesComponents
 
-public typealias AutocloseCompletion = (_ takeProfit: InputValidationViewModel, _ stopLoss: InputValidationViewModel) -> Void
+public typealias AutocloseCompletion = (AutocloseSelection) -> Void
 
 public enum AutocloseType {
     case modify(PerpetualPositionData, onTransferAction: TransferDataAction)

--- a/ios/Features/Perpetuals/Sources/ViewModels/AutocloseSceneViewModel.swift
+++ b/ios/Features/Perpetuals/Sources/ViewModels/AutocloseSceneViewModel.swift
@@ -114,7 +114,7 @@ public extension AutocloseSceneViewModel {
             onTransferAction?(modify.transfer(provider: position.perpetual.provider.map(), asset: position.asset.map()))
 
         case let .open(_, onComplete):
-            onComplete(input.takeProfit, input.stopLoss)
+            onComplete(input.selection)
         }
     }
 

--- a/ios/Features/Perpetuals/Sources/ViewModels/PerpetualSceneViewModel.swift
+++ b/ios/Features/Perpetuals/Sources/ViewModels/PerpetualSceneViewModel.swift
@@ -54,7 +54,7 @@ public final class PerpetualSceneViewModel {
 
     public var isPresentingInfoSheet: InfoSheetType?
     public var isPresentingModifyAlert: Bool?
-    public var isPresentingAutoclose: Bool = false
+    public var isPresentingAutoclose: PerpetualPositionData?
 
     public init(
         wallet: Wallet,
@@ -227,7 +227,7 @@ public extension PerpetualSceneViewModel {
     }
 
     func onSelectAutoclose() {
-        isPresentingAutoclose = true
+        isPresentingAutoclose = positions.first
     }
 
     func onSelectAutocloseInfo() {
@@ -265,7 +265,7 @@ public extension PerpetualSceneViewModel {
     }
 
     func onAutocloseComplete() {
-        isPresentingAutoclose = false
+        isPresentingAutoclose = nil
     }
 }
 

--- a/ios/Features/Perpetuals/Sources/Views/AutocloseSheet.swift
+++ b/ios/Features/Perpetuals/Sources/Views/AutocloseSheet.swift
@@ -1,8 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
-import Components
 import Primitives
-import PrimitivesComponents
 import SwiftUI
 
 public struct AutocloseSheet: View {
@@ -15,8 +13,6 @@ public struct AutocloseSheet: View {
     public var body: some View {
         NavigationStack {
             AutocloseScene(model: model)
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar { ToolbarDismissItem(type: .close, placement: .topBarLeading) }
         }
     }
 }

--- a/ios/Features/Perpetuals/TestKit/AutocloseType+TestKit.swift
+++ b/ios/Features/Perpetuals/TestKit/AutocloseType+TestKit.swift
@@ -15,6 +15,6 @@ extension AutocloseType {
     static func mockOpen(
         data: AutocloseOpenData = .mock(),
     ) -> AutocloseType {
-        .open(data, onComplete: { _, _ in })
+        .open(data, onComplete: { _ in })
     }
 }

--- a/ios/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/ios/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -187,12 +187,9 @@ extension AmountSceneViewModel {
         isPresentingSheet = .autoclose(perpetual.makeAutocloseData(size: amount))
     }
 
-    public func onAutocloseComplete(takeProfit: InputValidationViewModel, stopLoss: InputValidationViewModel) {
+    public func onAutocloseComplete(_ selection: AutocloseSelection) {
         if case let .perpetual(perpetual) = provider {
-            perpetual.updateAutoclose(
-                takeProfit: takeProfit.text.isEmpty ? nil : takeProfit.text,
-                stopLoss: stopLoss.text.isEmpty ? nil : stopLoss.text,
-            )
+            perpetual.updateAutoclose(takeProfit: selection.takeProfit, stopLoss: selection.stopLoss)
         }
         isPresentingSheet = nil
     }

--- a/ios/Gem/Navigation/Perpetuals/AutocloseNavigationStack.swift
+++ b/ios/Gem/Navigation/Perpetuals/AutocloseNavigationStack.swift
@@ -4,7 +4,6 @@ import Components
 import Perpetuals
 import GemstonePrimitives
 import Primitives
-import PrimitivesComponents
 import Store
 import SwiftUI
 import Transfer
@@ -26,8 +25,6 @@ struct AutocloseNavigationStack: View {
                     type: .modify(position, onTransferAction: { navigationPath.append($0) }),
                 ),
             )
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar { ToolbarDismissItem(type: .close, placement: .topBarLeading) }
             .navigationDestination(for: GemTransferData.self) {
                 ConfirmTransferNavigationView(
                     model: viewModelFactory.confirmTransferScene(

--- a/ios/Gem/Navigation/Perpetuals/PerpetualNavigationView.swift
+++ b/ios/Gem/Navigation/Perpetuals/PerpetualNavigationView.swift
@@ -19,14 +19,12 @@ public struct PerpetualNavigationView: View {
 
     public var body: some View {
         PerpetualScene(model: model)
-            .sheet(isPresented: $model.isPresentingAutoclose) {
-                if let position = model.positions.first {
-                    AutocloseNavigationStack(
-                        position: position,
-                        wallet: model.wallet,
-                        onComplete: model.onAutocloseComplete,
-                    )
-                }
+            .sheet(item: $model.isPresentingAutoclose) { position in
+                AutocloseNavigationStack(
+                    position: position,
+                    wallet: model.wallet,
+                    onComplete: model.onAutocloseComplete,
+                )
             }
             .bindQuery(model.positionsQuery, model.perpetualQuery, model.transactionsQuery, model.perpetualFiatValuesQuery)
             .onChange(of: isPresentingSheet) { oldValue, newValue in


### PR DESCRIPTION
Editing take profit and stop loss for a perpetual position goes through one shared screen, but the screen handed its result back as live input fields, and the position screen did not say which position the sheet was about — the view had to guess it.

Now the editor returns plain values, the sheet carries the position it edits, and the screen keeps its own title and close button instead of every caller repeating them.