### PR TITLE
Resolve the home refresh asset set in Core

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/di/GatewayModule.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/di/GatewayModule.kt
@@ -200,7 +200,6 @@ object GatewayModule {
         apiClient: GemstoneDeviceApiClient,
         authService: GemAuthService,
         balanceService: GemBalanceService,
-        sessionService: GemWalletSessionService,
     ): GemRewardsServiceInterface = GemRewardsService(apiClient, authService, balanceService)
 
 

--- a/android/data/services/gemstone/src/main/kotlin/com/gemwallet/android/data/services/gemstone/di/AssetsModule.kt
+++ b/android/data/services/gemstone/src/main/kotlin/com/gemwallet/android/data/services/gemstone/di/AssetsModule.kt
@@ -28,6 +28,7 @@ import uniffi.gemstone.GemBannerService
 import com.gemwallet.android.data.services.gemstone.stores.GemstoneBalanceStore
 import com.gemwallet.android.data.services.gemstone.stores.GemstoneWalletStore
 import uniffi.gemstone.GemBalanceService
+import uniffi.gemstone.GemBalanceStore
 import com.gemwallet.android.data.services.gemstone.stores.GemstonePriceStore
 import com.gemwallet.android.data.service.store.database.PricesDao
 import uniffi.gemstone.GemPreferencesService
@@ -67,22 +68,28 @@ object AssetsModule {
 
     @Provides
     @Singleton
+    fun provideGemBalanceStore(
+        assetsDao: AssetsDao,
+        balancesDao: BalancesDao,
+        transactionRunner: StoreTransactionRunner,
+    ): GemBalanceStore = GemstoneBalanceStore(balancesDao, assetsDao, transactionRunner)
+
+    @Provides
+    @Singleton
     fun provideGemBalanceService(
         gateway: GemGateway,
         walletStore: GemstoneWalletStore,
         assetStore: GemAssetStore,
-        assetsDao: AssetsDao,
-        balancesDao: BalancesDao,
+        balanceStore: GemBalanceStore,
         assetsService: GemAssetsService,
         priceService: GemPriceService,
         streamSubscriptionService: GemStreamSubscriptionService,
         preferencesService: GemPreferencesService,
-        transactionRunner: StoreTransactionRunner,
     ): GemBalanceService = GemBalanceService(
         gateway,
         walletStore,
         assetStore,
-        GemstoneBalanceStore(balancesDao, assetsDao, transactionRunner),
+        balanceStore,
         assetsService,
         priceService,
         streamSubscriptionService,
@@ -140,11 +147,11 @@ object AssetsModule {
     @Provides
     @Singleton
     fun provideStreamSubscriptionService(
-        priceService: GemPriceService,
+        balanceStore: GemBalanceStore,
         priceAlertStore: GemPriceAlertStore,
         connection: WebSocketConnectable,
     ): GemStreamSubscriptionService = GemStreamSubscriptionService(
-        price = priceService,
+        balances = balanceStore,
         alerts = priceAlertStore,
         connection = GemstoneStreamConnection(connection),
     )

--- a/android/data/services/gemstone/src/main/kotlin/com/gemwallet/android/data/services/gemstone/stores/BalanceStore.kt
+++ b/android/data/services/gemstone/src/main/kotlin/com/gemwallet/android/data/services/gemstone/stores/BalanceStore.kt
@@ -22,8 +22,7 @@ class GemstoneBalanceStore(
         assetIds.mapNotNull { balancesDao.getByAsset(walletId, it)?.toGemAssetBalance() }
     }
 
-    override suspend fun getEnabledAssetIds(walletId: String, assetIds: List<String>): List<String> =
-        balancesDao.getVisibleAssetIds(walletId, assetIds)
+    override suspend fun getEnabledAssetIds(walletId: String): List<String> = balancesDao.getEnabledAssetIds(walletId)
 
     override suspend fun setAssetsEnabled(walletId: String, assetIds: List<String>, enabled: Boolean) =
         assetsDao.setWalletAssetsVisibility(walletId, assetIds, enabled)

--- a/android/data/services/gemstone/src/main/kotlin/com/gemwallet/android/data/services/gemstone/stores/PriceStore.kt
+++ b/android/data/services/gemstone/src/main/kotlin/com/gemwallet/android/data/services/gemstone/stores/PriceStore.kt
@@ -28,8 +28,6 @@ class GemstonePriceStore(
     override suspend fun getPrices(assetIds: List<String>): List<GemAssetPrice> =
         pricesDao.getByAssets(assetIds).map { it.toGemAssetPrice() }
 
-    override suspend fun getEnabledPriceAssetIds(walletId: String): List<String> = assetsDao.getAssetsPriceUpdate(walletId)
-
     override suspend fun getRate(currency: String): String? =
         pricesDao.getRates(currency.toCurrency()).firstOrNull()?.toDTO()?.toJson()
 

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
@@ -243,14 +243,6 @@ interface AssetsDao {
     fun getAssetsInfoByAllWallets(walletId: String, ids: List<String>): Flow<List<DbAssetInfo>>
 
     @Query("""
-        SELECT asset.id FROM asset
-        JOIN balances ON balances.asset_id = asset.id
-        WHERE balances.is_visible = 1
-        AND balances.wallet_id = :walletId
-    """)
-    suspend fun getAssetsPriceUpdate(walletId: String): List<String>
-
-    @Query("""
         SELECT asset_info.*
         FROM $ASSET_INFO WHERE
             asset_info.id NOT IN (:exclude)

--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/BalancesDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/BalancesDao.kt
@@ -28,8 +28,8 @@ interface BalancesDao {
     @Query("SELECT * FROM balances WHERE wallet_id = :walletId AND asset_id = :assetId")
     fun getByAsset(walletId: String, assetId: String): DbBalance?
 
-    @Query("SELECT asset_id FROM balances WHERE wallet_id = :walletId AND asset_id IN (:assetIds) AND is_visible != 0")
-    suspend fun getVisibleAssetIds(walletId: String, assetIds: List<String>): List<String>
+    @Query("SELECT asset_id FROM balances WHERE wallet_id = :walletId AND is_visible != 0")
+    suspend fun getEnabledAssetIds(walletId: String): List<String>
 
     @Query("""
         UPDATE balances SET

--- a/android/features/activities/viewmodels/src/test/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModelSyncTest.kt
+++ b/android/features/activities/viewmodels/src/test/kotlin/com/gemwallet/android/features/activities/viewmodels/TransactionsViewModelSyncTest.kt
@@ -31,7 +31,7 @@ class TransactionsViewModelSyncTest {
 
     private val session = MutableStateFlow<Session?>(mockSession(wallet = mockWallet()))
     private val service = mockk<GemTransactionsService> {
-        every { filterChains() } returns emptyList()
+        every { filterChains(any()) } returns emptyList()
     }
     private val getTransactions = mockk<GetTransactions> {
         every { getTransactions(any()) } returns MutableStateFlow(emptyList<TransactionDataAggregate>())

--- a/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsViewModel.kt
+++ b/android/features/assets/viewmodels/src/main/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsViewModel.kt
@@ -106,8 +106,7 @@ class AssetsViewModel @Inject constructor(
     }
 
     private suspend fun refresh() {
-        val assetIds = assetGroups.value.let { it.pinned + it.unpinned }.map { it.id.toIdentifier() }
-        runCatchingCancellable { service.refresh(assetIds) }
+        runCatchingCancellable { service.refresh() }
             .onFailure { Log.e(TAG, "assets refresh failed", it) }
     }
 

--- a/android/features/assets/viewmodels/src/test/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsViewModelTest.kt
+++ b/android/features/assets/viewmodels/src/test/kotlin/com/gemwallet/android/features/assets/viewmodels/AssetsViewModelTest.kt
@@ -86,7 +86,7 @@ class AssetsViewModelTest {
         val refreshStarted = CompletableDeferred<Unit>()
         val refreshGate = CompletableDeferred<Unit>()
         every { service.showsInitialLoading() } returns true
-        coEvery { service.refresh(any()) } coAnswers {
+        coEvery { service.refresh() } coAnswers {
             refreshStarted.complete(Unit)
             refreshGate.await()
         }
@@ -99,7 +99,7 @@ class AssetsViewModelTest {
         assertTrue(viewModel.isLoadingAssets.value)
         refreshGate.complete(Unit)
         assertFalse(viewModel.isLoadingAssets.first { !it })
-        coVerify(exactly = 1) { service.refresh(any()) }
+        coVerify(exactly = 1) { service.refresh() }
     }
 
     @Test
@@ -107,7 +107,7 @@ class AssetsViewModelTest {
         val refreshStarted = CompletableDeferred<Unit>()
         val refreshGate = CompletableDeferred<Unit>()
         every { service.showsInitialLoading() } returns false
-        coEvery { service.refresh(any()) } coAnswers {
+        coEvery { service.refresh() } coAnswers {
             refreshStarted.complete(Unit)
             refreshGate.await()
         }

--- a/android/features/swap/viewmodels/src/test/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapSelectViewModelTest.kt
+++ b/android/features/swap/viewmodels/src/test/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapSelectViewModelTest.kt
@@ -43,7 +43,7 @@ class SwapSelectViewModelTest {
         every { getRecentAssets(any()) } returns flowOf(emptyList())
         every { searchSwapAssets(any(), any(), any(), any()) } returns flowOf(emptyList())
         coEvery { service.searchAssets(any()) } returns emptyList()
-        every { service.supportsTokens() } returns false
+        every { service.supportsTokens(any()) } returns false
     }
 
     @After

--- a/core/gemstone/src/services/balance/mod.rs
+++ b/core/gemstone/src/services/balance/mod.rs
@@ -14,7 +14,6 @@ pub use model::{GemAssetBalance, GemBalanceRequirement, GemBalanceRow, GemBalanc
 pub use store::GemBalanceStore;
 
 use crate::gateway::GemGateway;
-use crate::services::assets::rules::default_balances;
 use crate::services::assets::{GemAssetStore, GemAssetsService};
 use crate::services::preferences::GemPreferencesService;
 use crate::services::price::GemPriceService;
@@ -71,7 +70,7 @@ impl GemBalanceService {
         if enabled {
             self.assets.sync_missing_assets(asset_ids.clone()).await?;
         }
-        let enabled_ids = self.store.get_enabled_asset_ids(wallet_id.clone(), asset_ids.clone()).await?;
+        let enabled_ids = self.store.get_enabled_asset_ids(wallet_id.clone()).await?;
         self.assets.add_missing_balances(wallet_id.clone(), asset_ids.clone()).await?;
         self.store.set_assets_enabled(wallet_id.clone(), asset_ids.clone(), enabled).await?;
         if enabled {
@@ -119,9 +118,13 @@ impl GemBalanceService {
 }
 
 impl GemBalanceService {
+    pub async fn update_enabled_balances(&self, wallet_id: WalletId) -> Result<(), GemServiceError> {
+        let asset_ids = self.store.get_enabled_asset_ids(wallet_id.clone()).await?;
+        self.update(wallet_id, asset_ids).await
+    }
+
     pub async fn setup_wallet(&self, wallet: Wallet) -> Result<(), GemServiceError> {
-        let (defaults, _) = default_balances(&wallet);
-        let stored = self.store.get_enabled_asset_ids(wallet.id.clone(), defaults).await?;
+        let stored = self.store.get_enabled_asset_ids(wallet.id.clone()).await?;
         let enabled = self.assets.setup_wallet(wallet.clone()).await?;
         self.refresh_enabled_assets(wallet.id, rules::newly_enabled_asset_ids(&enabled, &stored)).await;
         Ok(())

--- a/core/gemstone/src/services/balance/store.rs
+++ b/core/gemstone/src/services/balance/store.rs
@@ -9,7 +9,7 @@ use super::model::{GemAssetBalance, GemBalanceUpdate};
 pub trait GemBalanceStore: Send + Sync {
     async fn get_available_balances(&self, wallet_id: WalletId, asset_ids: Vec<AssetId>) -> Result<Vec<GemAssetBalance>, GemServiceError>;
     async fn update_balances(&self, wallet_id: WalletId, updates: Vec<GemBalanceUpdate>) -> Result<(), GemServiceError>;
-    async fn get_enabled_asset_ids(&self, wallet_id: WalletId, asset_ids: Vec<AssetId>) -> Result<Vec<AssetId>, GemServiceError>;
+    async fn get_enabled_asset_ids(&self, wallet_id: WalletId) -> Result<Vec<AssetId>, GemServiceError>;
     async fn set_assets_enabled(&self, wallet_id: WalletId, asset_ids: Vec<AssetId>, enabled: bool) -> Result<(), GemServiceError>;
     async fn set_asset_pinned(&self, wallet_id: WalletId, asset_id: AssetId, pinned: bool) -> Result<(), GemServiceError>;
 }

--- a/core/gemstone/src/services/price/mod.rs
+++ b/core/gemstone/src/services/price/mod.rs
@@ -8,9 +8,7 @@ use crate::services::error::GemServiceError;
 use std::sync::Arc;
 
 use primitives::currency::Currency;
-use primitives::{AssetId, AssetMarket, AssetPrice, FiatRate, WalletId};
-
-use crate::models::asset::asset_ids_enabled_by_default;
+use primitives::{AssetId, AssetMarket, AssetPrice, FiatRate};
 
 pub use model::{GemAssetPrice, GemPriceUpdate};
 pub use store::GemPriceStore;
@@ -63,23 +61,11 @@ impl GemPriceService {
         };
         self.store.convert_prices(currency, rate.rate).await
     }
-}
 
-impl GemPriceService {
     pub async fn update_asset_price(&self, asset_id: AssetId, price: Option<AssetPrice>, currency: Currency) -> Result<(), GemServiceError> {
         update_prices(self.store.as_ref(), vec![price.unwrap_or_else(|| AssetPrice::empty(asset_id))], currency).await
     }
 
-    pub async fn observable_asset_ids(&self, wallet_id: WalletId, alert_asset_ids: Vec<AssetId>) -> Result<Vec<AssetId>, GemServiceError> {
-        Ok(rules::observable_asset_ids(
-            self.store.get_enabled_price_asset_ids(wallet_id).await?,
-            alert_asset_ids,
-            asset_ids_enabled_by_default(),
-        ))
-    }
-}
-
-impl GemPriceService {
     pub async fn rate(&self, currency: Currency) -> Result<Option<FiatRate>, GemServiceError> {
         Ok(rules::rate_or_base(currency.clone(), self.store.get_rate(currency).await?))
     }

--- a/core/gemstone/src/services/price/store.rs
+++ b/core/gemstone/src/services/price/store.rs
@@ -1,7 +1,7 @@
 use crate::services::error::GemServiceError;
 use async_trait::async_trait;
 use primitives::currency::Currency;
-use primitives::{AssetId, AssetMarket, FiatRate, WalletId};
+use primitives::{AssetId, AssetMarket, FiatRate};
 
 use super::model::{GemAssetPrice, GemPriceUpdate};
 
@@ -10,7 +10,6 @@ use super::model::{GemAssetPrice, GemPriceUpdate};
 pub trait GemPriceStore: Send + Sync {
     async fn get_prices(&self, asset_ids: Vec<AssetId>) -> Result<Vec<GemAssetPrice>, GemServiceError>;
     async fn get_rate(&self, currency: Currency) -> Result<Option<FiatRate>, GemServiceError>;
-    async fn get_enabled_price_asset_ids(&self, wallet_id: WalletId) -> Result<Vec<AssetId>, GemServiceError>;
     async fn save_rates(&self, rates: Vec<FiatRate>) -> Result<(), GemServiceError>;
     async fn save_prices(&self, currency: Currency, prices: Vec<GemPriceUpdate>) -> Result<(), GemServiceError>;
     async fn convert_prices(&self, currency: Currency, rate: f64) -> Result<(), GemServiceError>;

--- a/core/gemstone/src/services/price/testkit.rs
+++ b/core/gemstone/src/services/price/testkit.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 
 use primitives::currency::Currency;
-use primitives::{AssetId, AssetMarket, FiatRate, WalletId};
+use primitives::{AssetId, AssetMarket, FiatRate};
 
 use super::{GemAssetPrice, GemPriceStore, GemPriceUpdate};
 use crate::services::error::GemServiceError;
@@ -18,10 +18,6 @@ impl GemPriceStore for MemoryPriceStore {
     async fn get_prices(&self, _asset_ids: Vec<AssetId>) -> Result<Vec<GemAssetPrice>, GemServiceError> {
         Ok(vec![])
     }
-    async fn get_enabled_price_asset_ids(&self, _wallet_id: WalletId) -> Result<Vec<AssetId>, GemServiceError> {
-        Ok(vec![])
-    }
-
     async fn get_rate(&self, currency: Currency) -> Result<Option<FiatRate>, GemServiceError> {
         Ok(self.rates.lock().unwrap().iter().find(|rate| rate.symbol == currency).cloned())
     }

--- a/core/gemstone/src/services/stream/subscription.rs
+++ b/core/gemstone/src/services/stream/subscription.rs
@@ -7,8 +7,10 @@ use primitives::{AssetId, StreamMessage, StreamMessagePrices, WalletId};
 
 use super::connection::GemStreamConnection;
 use super::rules;
+use crate::models::asset::asset_ids_enabled_by_default;
+use crate::services::balance::GemBalanceStore;
 use crate::services::error::GemServiceError;
-use crate::services::price::GemPriceService;
+use crate::services::price::rules as price_rules;
 use crate::services::price_alert::GemPriceAlertStore;
 
 #[derive(Default)]
@@ -19,7 +21,7 @@ struct SubscriptionState {
 
 #[derive(uniffi::Object)]
 pub struct GemStreamSubscriptionService {
-    price: Arc<GemPriceService>,
+    balances: Arc<dyn GemBalanceStore>,
     alerts: Arc<dyn GemPriceAlertStore>,
     connection: Arc<dyn GemStreamConnection>,
     state: Mutex<SubscriptionState>,
@@ -28,9 +30,9 @@ pub struct GemStreamSubscriptionService {
 #[uniffi::export]
 impl GemStreamSubscriptionService {
     #[uniffi::constructor]
-    pub fn new(price: Arc<GemPriceService>, alerts: Arc<dyn GemPriceAlertStore>, connection: Arc<dyn GemStreamConnection>) -> Self {
+    pub fn new(balances: Arc<dyn GemBalanceStore>, alerts: Arc<dyn GemPriceAlertStore>, connection: Arc<dyn GemStreamConnection>) -> Self {
         Self {
-            price,
+            balances,
             alerts,
             connection,
             state: Mutex::new(SubscriptionState::default()),
@@ -54,7 +56,8 @@ impl GemStreamSubscriptionService {
             return Ok(());
         }
         let alert_asset_ids = self.alerts.get_price_alerts(None).await?.into_iter().map(|alert| alert.asset_id).collect();
-        let asset_ids = self.price.observable_asset_ids(wallet_id, alert_asset_ids).await?;
+        let enabled_asset_ids = self.balances.get_enabled_asset_ids(wallet_id).await?;
+        let asset_ids = price_rules::observable_asset_ids(enabled_asset_ids, alert_asset_ids, asset_ids_enabled_by_default());
         let target: HashSet<AssetId> = asset_ids.iter().cloned().collect();
         if subscribed == target {
             return Ok(());
@@ -84,52 +87,29 @@ impl GemStreamSubscriptionService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::alien::{AlienError, AlienProvider, AlienResponse, AlienTarget};
-    use crate::api::GemApiClient;
-    use crate::services::price::GemAssetPrice;
-    use crate::services::price::{GemPriceStore, GemPriceUpdate};
+    use crate::services::balance::{GemAssetBalance, GemBalanceUpdate};
     use async_trait::async_trait;
     use primitives::currency::Currency;
-    use primitives::{AssetMarket, Chain, FiatRate, PriceAlert};
+    use primitives::{Chain, PriceAlert};
     use std::sync::atomic::{AtomicBool, Ordering};
-
-    #[derive(Debug)]
-    struct NoopProvider;
-
-    #[async_trait]
-    impl AlienProvider for NoopProvider {
-        async fn request(&self, _target: AlienTarget) -> Result<Arc<AlienResponse>, AlienError> {
-            Err(AlienError::ResponseError { msg: "unused".into() })
-        }
-
-        fn get_endpoint(&self, _chain: Chain) -> Result<String, AlienError> {
-            Ok("https://example.com".into())
-        }
-    }
 
     struct EnabledStore(Vec<AssetId>);
 
     #[async_trait]
-    impl GemPriceStore for EnabledStore {
-        async fn get_prices(&self, _asset_ids: Vec<AssetId>) -> Result<Vec<GemAssetPrice>, GemServiceError> {
+    impl GemBalanceStore for EnabledStore {
+        async fn get_available_balances(&self, _wallet_id: WalletId, _asset_ids: Vec<AssetId>) -> Result<Vec<GemAssetBalance>, GemServiceError> {
             Ok(vec![])
         }
-        async fn get_rate(&self, _currency: Currency) -> Result<Option<FiatRate>, GemServiceError> {
-            Ok(None)
+        async fn update_balances(&self, _wallet_id: WalletId, _updates: Vec<GemBalanceUpdate>) -> Result<(), GemServiceError> {
+            Ok(())
         }
-        async fn get_enabled_price_asset_ids(&self, _wallet_id: WalletId) -> Result<Vec<AssetId>, GemServiceError> {
+        async fn get_enabled_asset_ids(&self, _wallet_id: WalletId) -> Result<Vec<AssetId>, GemServiceError> {
             Ok(self.0.clone())
         }
-        async fn save_rates(&self, _rates: Vec<FiatRate>) -> Result<(), GemServiceError> {
+        async fn set_assets_enabled(&self, _wallet_id: WalletId, _asset_ids: Vec<AssetId>, _enabled: bool) -> Result<(), GemServiceError> {
             Ok(())
         }
-        async fn save_prices(&self, _currency: Currency, _prices: Vec<GemPriceUpdate>) -> Result<(), GemServiceError> {
-            Ok(())
-        }
-        async fn convert_prices(&self, _currency: Currency, _rate: f64) -> Result<(), GemServiceError> {
-            Ok(())
-        }
-        async fn save_market(&self, _asset_id: AssetId, _market: AssetMarket) -> Result<(), GemServiceError> {
+        async fn set_asset_pinned(&self, _wallet_id: WalletId, _asset_id: AssetId, _pinned: bool) -> Result<(), GemServiceError> {
             Ok(())
         }
     }
@@ -175,12 +155,8 @@ mod tests {
         }
     }
 
-    fn service(connection: Arc<Connection>) -> GemStreamSubscriptionService {
-        let price = GemPriceService::new(
-            Arc::new(GemApiClient::new(Arc::new(NoopProvider))),
-            Arc::new(EnabledStore(vec![AssetId::from_chain(Chain::Bitcoin)])),
-        );
-        GemStreamSubscriptionService::new(Arc::new(price), Arc::new(AlertStore(vec![AssetId::from_chain(Chain::Bitcoin)])), connection)
+    fn service(connection: Arc<Connection>, enabled: Vec<AssetId>, alerts: Vec<AssetId>) -> GemStreamSubscriptionService {
+        GemStreamSubscriptionService::new(Arc::new(EnabledStore(enabled)), Arc::new(AlertStore(alerts)), connection)
     }
 
     fn subscribed(connection: &Connection) -> Vec<Vec<AssetId>> {
@@ -200,7 +176,7 @@ mod tests {
     fn test_subscribes_once_when_connected_and_after_reset() {
         futures::executor::block_on(async {
             let connection = Arc::new(Connection::default());
-            let service = service(connection.clone());
+            let service = service(connection.clone(), vec![AssetId::from_chain(Chain::Bitcoin)], vec![AssetId::from_chain(Chain::Bitcoin)]);
             let wallet_id = WalletId::Multicoin("0x1".into());
 
             service.setup_assets(wallet_id.clone()).await.unwrap();
@@ -221,6 +197,19 @@ mod tests {
             service.reset().await;
             service.resubscribe().await.unwrap();
             assert_eq!(subscribed(&connection).len(), 2);
+        });
+    }
+
+    #[test]
+    fn test_subscribes_to_alerted_assets_the_wallet_has_not_enabled() {
+        futures::executor::block_on(async {
+            let connection = Arc::new(Connection::default());
+            let service = service(connection.clone(), vec![AssetId::from_chain(Chain::Bitcoin)], vec![AssetId::from_chain(Chain::Ethereum)]);
+            connection.connected.store(true, Ordering::SeqCst);
+
+            service.setup_assets(WalletId::Multicoin("0x1".into())).await.unwrap();
+
+            assert_eq!(subscribed(&connection)[0], vec![AssetId::from_chain(Chain::Bitcoin), AssetId::from_chain(Chain::Ethereum)]);
         });
     }
 }

--- a/core/gemstone/src/services/wallet_home/mod.rs
+++ b/core/gemstone/src/services/wallet_home/mod.rs
@@ -74,9 +74,9 @@ impl GemWalletHomeService {
         Ok(rules::shows_initial_loading(completed, self.wallet_preferences.get_assets_timestamp(wallet_id)))
     }
 
-    pub async fn refresh(&self, asset_ids: Vec<AssetId>) -> Result<(), GemServiceError> {
+    pub async fn refresh(&self) -> Result<(), GemServiceError> {
         let wallet_id = self.session.current_wallet_id()?;
-        let (balances, discovery) = futures::join!(self.balances.update(wallet_id.clone(), asset_ids), self.discovery.discover(wallet_id));
+        let (balances, discovery) = futures::join!(self.balances.update_enabled_balances(wallet_id.clone()), self.discovery.discover(wallet_id));
         balances?;
         discovery
     }

--- a/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/ios/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -179,7 +179,7 @@ public final class WalletSceneViewModel: Sendable, AssetActions {
 
 public extension WalletSceneViewModel {
     internal func load() async {
-        await updateWallet(for: wallet)
+        await updateWallet()
     }
 
     internal func loadOnce() async {
@@ -256,28 +256,28 @@ public extension WalletSceneViewModel {
 
 extension WalletSceneViewModel {
     private func loadOnce(wallet: Wallet) async {
-        let shouldShowLoadingAssets = shouldShowInitialLoadingAssets(for: wallet)
+        let shouldShowLoadingAssets = shouldShowInitialLoadingAssets
 
         if shouldShowLoadingAssets {
             isLoadingAssets = true
         }
 
-        await updateWallet(for: wallet)
+        await updateWallet()
 
         if shouldShowLoadingAssets, self.wallet.id == wallet.id {
             isLoadingAssets = false
         }
     }
 
-    private func updateWallet(for wallet: Wallet) async {
+    private func updateWallet() async {
         do {
-            try await service.refresh(assetIds: assets.map(\.asset.id))
+            try await service.refresh()
         } catch {
             debugLog("WalletSceneViewModel refresh error: \(error)")
         }
     }
 
-    private func shouldShowInitialLoadingAssets(for wallet: Wallet) -> Bool {
+    private var shouldShowInitialLoadingAssets: Bool {
         (try? service.showsInitialLoading()) ?? false
     }
 

--- a/ios/Gem/Services/ServicesFactory.swift
+++ b/ios/Gem/Services/ServicesFactory.swift
@@ -107,15 +107,16 @@ struct ServicesFactory {
         let avatarService = Gemstone.GemAvatarService(wallets: gemstoneWalletStore, files: gemstoneFileStore, provider: nativeProvider)
         let webSocket = Self.makeWebSocket(deviceKeyService: deviceKeyService, reconnection: connectionService)
         let gemstonePriceAlertStore = GemstonePriceAlertStore(store: storeManager.priceAlertStore)
+        let gemstoneBalanceStore = GemstoneBalanceStore(store: storeManager.balanceStore)
         let streamSubscriptionService = Gemstone.GemStreamSubscriptionService(
-            price: priceService,
+            balances: gemstoneBalanceStore,
             alerts: gemstonePriceAlertStore,
             connection: GemstoneStreamConnection(webSocket: webSocket),
         )
         let balanceService = gatewayService.balanceService(
             walletStore: gemstoneWalletStore,
             assetStore: gemstoneAssetStore,
-            store: GemstoneBalanceStore(store: storeManager.balanceStore),
+            store: gemstoneBalanceStore,
             assets: assetsService,
             price: priceService,
             stream: streamSubscriptionService,

--- a/ios/Packages/GemstonePrimitives/Sources/Services/GemWalletHomeService.swift
+++ b/ios/Packages/GemstonePrimitives/Sources/Services/GemWalletHomeService.swift
@@ -6,10 +6,6 @@ import protocol Gemstone.GemWalletHomeServiceProtocol
 import Primitives
 
 public extension GemWalletHomeServiceProtocol {
-    func refresh(assetIds: [AssetId]) async throws {
-        try await refresh(assetIds: assetIds.ids)
-    }
-
     func updateBalances(assetIds: [AssetId]) async throws {
         try await updateBalances(assetIds: assetIds.ids)
     }

--- a/ios/Packages/GemstonePrimitives/TestKit/GemServiceMocks.swift
+++ b/ios/Packages/GemstonePrimitives/TestKit/GemServiceMocks.swift
@@ -767,7 +767,7 @@ public final class GemWalletHomeServiceMock: GemWalletHomeServiceProtocol, @unch
         showsLoading
     }
 
-    public func refresh(assetIds _: [Gemstone.AssetId]) async throws {}
+    public func refresh() async throws {}
 
     public func setAssetPinned(assetId: Gemstone.AssetId, pinned isPinned: Bool) async throws {
         pinned.append((assetId, isPinned))

--- a/ios/Packages/GemstoneServices/Sources/Stores/BalanceStore.swift
+++ b/ios/Packages/GemstoneServices/Sources/Stores/BalanceStore.swift
@@ -39,12 +39,8 @@ public final class GemstoneBalanceStore: GemBalanceStore, @unchecked Sendable {
         try store.updateBalances(balances, for: walletId)
     }
 
-    public func getEnabledAssetIds(walletId: String, assetIds: [Gemstone.AssetId]) async throws -> [Gemstone.AssetId] {
-        try store.getBalanceAssetIds(
-            walletId: WalletId.from(id: walletId),
-            assetIds: assetIds.map { try Primitives.AssetId(id: $0) },
-            filters: [.enabled],
-        ).map(\Primitives.AssetId.identifier)
+    public func getEnabledAssetIds(walletId: String) async throws -> [Gemstone.AssetId] {
+        try store.getEnabledAssetIds(walletId: WalletId.from(id: walletId)).map(\Primitives.AssetId.identifier)
     }
 
     public func setAssetsEnabled(walletId: String, assetIds: [Gemstone.AssetId], enabled: Bool) async throws {

--- a/ios/Packages/GemstoneServices/Sources/Stores/PriceStore.swift
+++ b/ios/Packages/GemstoneServices/Sources/Stores/PriceStore.swift
@@ -1,6 +1,5 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
-import typealias Gemstone.WalletId
 import Foundation
 import typealias Gemstone.AssetId
 import typealias Gemstone.AssetMarket
@@ -24,10 +23,6 @@ public final class GemstonePriceStore: GemPriceStore, @unchecked Sendable {
 
     public func getPrices(assetIds: [Gemstone.AssetId]) throws -> [GemAssetPrice] {
         try priceStore.getPrices(for: assetIds).map(\.gem)
-    }
-
-    public func getEnabledPriceAssetIds(walletId: Gemstone.WalletId) async throws -> [Gemstone.AssetId] {
-        try priceStore.enabledPriceAssets(walletId: Primitives.WalletId.from(id: walletId)).map(\.identifier)
     }
 
     public func getRate(currency: Gemstone.Currency) async throws -> Gemstone.FiatRate? {

--- a/ios/Packages/Store/Sources/Stores/BalanceStore.swift
+++ b/ios/Packages/Store/Sources/Stores/BalanceStore.swift
@@ -129,38 +129,15 @@ public struct BalanceStore: Sendable {
         }
     }
 
-    @discardableResult
-    func getBalances(
-        walletId: WalletId,
-        assetIds: [AssetId],
-        filters: [BalanceRequestFilter] = []
-    ) throws -> [BalanceRecord] {
+    public func getEnabledAssetIds(walletId: WalletId) throws -> [AssetId] {
         try db.read { db in
-            var request = BalanceRecord
+            try BalanceRecord
                 .filter(BalanceRecord.Columns.walletId == walletId.id)
-                .filter(assetIds.map(\.identifier).contains(BalanceRecord.Columns.assetId))
-
-            for filter in filters {
-                switch filter {
-                case .enabled:
-                    request = request.filter(BalanceRecord.Columns.isEnabled == true)
-                }
-            }
-
-            return try request
+                .filter(BalanceRecord.Columns.isEnabled == true)
                 .distinct()
                 .fetchAll(db)
+                .map(\.assetId)
         }
-    }
-
-    @discardableResult
-    public func getBalanceAssetIds(
-        walletId: WalletId,
-        assetIds: [AssetId],
-        filters: [BalanceRequestFilter] = []
-    ) throws -> [AssetId] {
-        try getBalances(walletId: walletId, assetIds: assetIds, filters: filters)
-            .map(\.assetId)
     }
 
     @discardableResult

--- a/ios/Packages/Store/Sources/Stores/PriceStore.swift
+++ b/ios/Packages/Store/Sources/Stores/PriceStore.swift
@@ -80,16 +80,6 @@ public struct PriceStore: Sendable {
         }
     }
 
-    public func enabledPriceAssets(walletId: WalletId) throws -> [AssetId] {
-        try db.read { db in
-            try BalanceRecord
-                .filter(BalanceRecord.Columns.walletId == walletId.id)
-                .filter(BalanceRecord.Columns.isEnabled == true)
-                .fetchAll(db)
-                .compactMap(\.assetId)
-        }
-    }
-
     @discardableResult
     public func convertPrices(rate: Double) throws -> Int {
         try db.write { db in

--- a/ios/Packages/Store/Sources/Types/BalanceRequestFilter.swift
+++ b/ios/Packages/Store/Sources/Types/BalanceRequestFilter.swift
@@ -1,7 +1,0 @@
-// Copyright (c). Gem Wallet. All rights reserved.
-
-import Foundation
-
-public enum BalanceRequestFilter: Hashable, Sendable {
-    case enabled
-}

--- a/ios/Packages/Store/Tests/StoreTests/WalletIdMigrationTests.swift
+++ b/ios/Packages/Store/Tests/StoreTests/WalletIdMigrationTests.swift
@@ -233,7 +233,6 @@ struct WalletIdMigrationTests {
         let userDefaults = UserDefaults.mock()
         let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
-        let balanceStore = BalanceStore(db: db)
         let assetStore = AssetStore(db: db)
 
         let oldId = "uuid-with-balances"
@@ -258,8 +257,13 @@ struct WalletIdMigrationTests {
         }
 
         let newWalletId = try WalletId.from(id: "multicoin_\(ethAddress)")
-        let balances = try balanceStore.getBalances(walletId: newWalletId, assetIds: [asset.asset.id])
-        #expect(balances.count == 1)
+        let balanceCount = try db.dbQueue.read { db in
+            try BalanceRecord
+                .filter(BalanceRecord.Columns.walletId == newWalletId.id)
+                .filter(BalanceRecord.Columns.assetId == asset.asset.id.identifier)
+                .fetchCount(db)
+        }
+        #expect(balanceCount == 1)
     }
 
     @Test


### PR DESCRIPTION
The home screen used to tell Core which assets to refresh, taking the list from what was currently on screen. After switching wallets that list still belonged to the previous wallet, so the balances of the newly selected wallet were not fetched until a manual pull to refresh. Core now resolves the current wallet's assets itself, which fixes the same problem on both apps.