### PR TITLE
Quiet the copy button in the receive asset list

### DIFF
--- a/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/SelectReceiveScreen.kt
+++ b/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/SelectReceiveScreen.kt
@@ -1,8 +1,11 @@
 package com.gemwallet.android.features.asset_select.presents.views
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -10,6 +13,8 @@ import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.clipboard.setPlainText
 import com.gemwallet.android.features.asset_select.viewmodels.AssetSelectViewModel
 import com.gemwallet.android.ui.icons.AppIcons
+import com.gemwallet.android.ui.theme.compactIconSize
+import com.gemwallet.android.ui.theme.iconSize
 import com.wallet.core.primitives.AssetId
 import com.gemwallet.android.ui.components.clipboard.clipboardManager
 import uniffi.gemstone.GemAssetAction
@@ -38,9 +43,15 @@ fun SelectReceiveScreen(
                 onClick = {
                     viewModel.onChangeVisibility(it.asset.id, true)
                     clipboardManager.setPlainText(context, it.accountAddress)
-                }
+                },
+                modifier = Modifier.size(iconSize),
             ) {
-                Icon(imageVector = AppIcons.ContentCopy, contentDescription = "")
+                Icon(
+                    imageVector = AppIcons.ContentCopyOutlined,
+                    contentDescription = "",
+                    modifier = Modifier.size(compactIconSize),
+                    tint = MaterialTheme.colorScheme.secondary,
+                )
             }
         },
         onCancel = onCancel,


### PR DESCRIPTION
The copy button in each row of the receive asset list was a full size button with a filled icon, which pulled attention away from the asset. It now uses the lighter outlined copy icon at a smaller size, matching the quieter copy controls elsewhere in the app.

Closes #1126

<img width="320" alt="after" src="https://github.com/user-attachments/assets/98a37ef0-b5ed-46c0-b0f0-fd1de8ba48bf" />
