### PR TITLE
Read Core off the main thread on the swap and rewards screens

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/NotificationNavigation.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/NotificationNavigation.kt
@@ -54,26 +54,26 @@ class NotificationNavigation @Inject constructor(
         return prepareNavigation(notification)
     }
 
-    internal suspend fun prepareNavigation(notification: GemPushNotification): List<NavKey> {
-        return when (notification) {
+    internal suspend fun prepareNavigation(notification: GemPushNotification): List<NavKey> = withContext(Dispatchers.IO) {
+        when (notification) {
             is GemPushNotification.Asset -> prepareAssetRoute(notification.assetId.toAssetId())
             is GemPushNotification.PriceAlert -> prepareAssetRoute(notification.assetId.toAssetId())
             is GemPushNotification.BuyAsset -> {
-                val assetId = notification.assetId.toAssetId() ?: return emptyList()
+                val assetId = notification.assetId.toAssetId() ?: return@withContext emptyList()
                 prepareAssets(assetId)
                 listOf(FiatInputRoute(assetId))
             }
             is GemPushNotification.FiatTransaction -> prepareWalletAssetRoutes(WalletId(notification.walletId), notification.assetId.toAssetId())
             is GemPushNotification.Stake -> prepareWalletAssetRoutes(WalletId(notification.walletId), notification.assetId.toAssetId())
             is GemPushNotification.SwapAsset -> {
-                val fromAssetId = notification.fromAssetId.toAssetId() ?: return emptyList()
-                val toAssetId = notification.toAssetId.toAssetId() ?: return emptyList()
+                val fromAssetId = notification.fromAssetId.toAssetId() ?: return@withContext emptyList()
+                val toAssetId = notification.toAssetId.toAssetId() ?: return@withContext emptyList()
                 prepareAssets(fromAssetId, toAssetId)
                 listOf(SwapPairRoute(fromAssetId, toAssetId))
             }
             is GemPushNotification.Transaction -> prepareTransactionRoutes(
                 walletId = WalletId(notification.walletId),
-                assetId = notification.assetId.toAssetId() ?: return emptyList(),
+                assetId = notification.assetId.toAssetId() ?: return@withContext emptyList(),
                 transaction = notification.transaction.decodeJson(),
             )
             GemPushNotification.Rewards -> listOf(ReferralRoute())
@@ -86,9 +86,7 @@ class NotificationNavigation @Inject constructor(
         if (assetId == null) {
             return emptyList()
         }
-        val asset = withContext(Dispatchers.IO) {
-            assetsService.openAsset(assetId.toIdentifier())
-        }?.toPrimitives() ?: return emptyList()
+        val asset = assetsService.openAsset(assetId.toIdentifier())?.toPrimitives() ?: return emptyList()
         return listOf(AssetRoute(asset.id))
     }
 

--- a/android/app/src/test/kotlin/com/gemwallet/android/NotificationNavigationTest.kt
+++ b/android/app/src/test/kotlin/com/gemwallet/android/NotificationNavigationTest.kt
@@ -19,6 +19,7 @@ import com.gemwallet.android.ui.navigation.routes.PerpetualPositionRoute
 import com.gemwallet.android.ui.navigation.routes.PerpetualRoute
 import com.gemwallet.android.ui.navigation.routes.ReferralRoute
 import com.gemwallet.android.ui.navigation.routes.SupportRoute
+import com.gemwallet.android.ui.navigation.routes.SwapPairRoute
 import com.gemwallet.android.ui.navigation.routes.TransactionDetailsRoute
 import com.wallet.core.primitives.AssetType
 import com.wallet.core.primitives.Chain
@@ -217,6 +218,31 @@ class NotificationNavigationTest {
         assertTrue(
             "openAsset reads the current wallet through a synchronous store callback that blocks on Room; " +
                 "the notification routes are built on the main scope. Got $callingThreads",
+            callingThreads.single().startsWith("DefaultDispatcher-worker"),
+        )
+    }
+
+    @Test
+    fun swapNotification_syncsAssetsThroughCore() = runBlocking {
+        val fromAssetId = mockAssetId(Chain.SmartChain, tokenId = "0xcake")
+        val toAssetId = mockAssetId(Chain.SmartChain)
+        val callingThreads = mutableListOf<String>()
+        coEvery { assetsService.syncMissingAssets(any()) } answers {
+            callingThreads += Thread.currentThread().name
+            emptyList()
+        }
+
+        val route = subject.prepareNavigation(
+            GemPushNotification.SwapAsset(
+                fromAssetId = fromAssetId.toIdentifier(),
+                toAssetId = toAssetId.toIdentifier(),
+            )
+        )
+
+        assertEquals(listOf(SwapPairRoute(fromAssetId, toAssetId)), route)
+        assertTrue(
+            "every notification branch reaches Core, which reads the store through synchronous " +
+                "callbacks that block on Room; routes must not be built on the main scope. Got $callingThreads",
             callingThreads.single().startsWith("DefaultDispatcher-worker"),
         )
     }

--- a/android/features/referral/viewmodels/src/main/kotlin/com/gemwallet/android/features/referral/viewmodels/ReferralViewModel.kt
+++ b/android/features/referral/viewmodels/src/main/kotlin/com/gemwallet/android/features/referral/viewmodels/ReferralViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
@@ -51,11 +52,13 @@ class ReferralViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     val availableWallets = getWallets().mapLatest { service.wallets().map { it.decodeJson<Wallet>() } }
+        .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val session = getSession()
         .filterNotNull()
         .combine(availableWallets) { _, _ -> service.selectedWallet()?.decodeJson<Wallet>() }
+        .flowOn(Dispatchers.IO)
         .onEach { wallet ->
             currentWallet.update {
                 if (it?.id == null || it.id == wallet?.id) {

--- a/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModel.kt
+++ b/android/features/swap/viewmodels/src/main/kotlin/com/gemwallet/android/features/swap/viewmodels/SwapViewModel.kt
@@ -234,13 +234,13 @@ class SwapViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Eagerly, SwapUiState())
 
     init {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             selectedSlippageBps.value = swapQuoteService.slippageBps()
         }
         matchedQuoteResults
             .onEach(::onQuoteResults)
             .launchIn(viewModelScope)
-        viewModelScope.launch { suggestPair() }
+        viewModelScope.launch(Dispatchers.IO) { suggestPair() }
     }
 
     private suspend fun suggestPair() {


### PR DESCRIPTION
The swap screen left the receive asset empty, the Rewards screen crashed, and tapping the push notification of a finished swap crashed the app. All three read Core from the main thread, where the database refuses to work, so one failed silently and the other two died on opening. The reads now happen in the background: the swap suggests a pair again, Rewards opens, and the notification opens the transaction.

Closes #1128
Closes #1122
Closes #1121