### PR TITLE
Fix UniFFI ProGuard rules for release builds

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -6,6 +6,11 @@
 -optimizations !code/allocation/variable
 -optimizations !class/unboxing/enum
 
+-keep class com.sun.jna.** { *; }
+-keep class * extends com.sun.jna.Structure { *; }
+-keep class uniffi.** { *; }
+-keepattributes RuntimeVisibleAnnotations
+
 -keepnames @dagger.hilt.android.lifecycle.HiltViewModel class * extends androidx.lifecycle.ViewModel
 
 # Reproducible builds: prevent R8 non-deterministic inlining of appcompat methods


### PR DESCRIPTION
## Summary

- keep JNA classes and Structure subclasses in the app release shrinker
- keep every UniFFI namespace instead of only the Gemstone bindings
- preserve runtime-visible annotations used by the native binding layer

## Root cause

WalletConnect Pay brings in Yttrium bindings under uniffi.yttrium_wcpay. Those generated bindings use public fields on com.sun.jna.Structure subclasses such as UniffiRustCallStatus and RustBuffer to describe their native memory layout.

The broad JNA and UniFFI rules existed in library-module proguard-rules.pro files. Those files configure shrinking of the library module itself; they are not exported to the consuming app R8 run. Gemstone exports narrower consumer rules, but they only cover uniffi.gemstone, and the Yttrium AAR does not export equivalent consumer rules.

As a result, the Google release R8 pass removed the public fields from the Yttrium Structure subclasses. JNA then reflected on fieldless classes, calculated an unknown or zero native size, and WalletConnect Pay initialization failed. Debug and F-Droid builds did not expose the same combination of release shrinking and Pay dependencies.

Putting the rules in android/app/proguard-rules.pro makes the application that owns the final R8 invocation preserve every UniFFI/JNA boundary, including transitive SDK bindings.

## Verification

- clean Google release AAB build passed for arm64-v8a and armeabi-v7a
- targeted Google release R8 minification passed
- final minified dex inspection confirmed capacity, data, and len remain on RustBuffer
- final minified dex inspection confirmed code and error_buf remain on UniffiRustCallStatus
- locally signed minified release APK installed and launched on a Seeker without an immediate runtime crash
- git diff --check passed

Closes #1123