### PR TITLE
Drop the empty transaction placeholder on iOS

### DIFF
--- a/ios/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
+++ b/ios/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
@@ -21,8 +21,9 @@ public final class TransactionSceneViewModel {
     private let onAddContact: ((AddContactType) -> Void)?
 
     public let query: ObservableQuery<TransactionRequest>
+    private let initialTransaction: TransactionExtended
     var transactionExtended: TransactionExtended {
-        query.value
+        query.value ?? initialTransaction
     }
 
     var isPresentingTransactionSheet: TransactionSheetType?
@@ -38,6 +39,7 @@ public final class TransactionSceneViewModel {
         self.service = service
         self.onHeaderAction = onHeaderAction
         self.onAddContact = onAddContact
+        initialTransaction = transaction
         query = ObservableQuery(TransactionRequest(walletId: walletId, transactionId: transaction.transaction.id), initialValue: transaction)
     }
 

--- a/ios/Gem/Navigation/NavigationHandler.swift
+++ b/ios/Gem/Navigation/NavigationHandler.swift
@@ -288,7 +288,9 @@ extension NavigationHandler {
             return
         }
         trackNotificationTransaction(walletId: walletId, transaction: transaction)
-        let transaction = try transactionStore.getTransaction(walletId: walletId, transactionId: transaction.id)
+        guard let transaction = try transactionStore.getTransaction(walletId: walletId, transactionId: transaction.id) else {
+            return
+        }
 
         await selectWalletIfNeeded(walletId)
         switch asset.type {

--- a/ios/Packages/Store/Sources/Requests/TransactionRequest.swift
+++ b/ios/Packages/Store/Sources/Requests/TransactionRequest.swift
@@ -18,58 +18,14 @@ public struct TransactionRequest: DatabaseQueryable {
         self.transactionId = transactionId
     }
 
-    public func fetch(_ db: Database) throws -> TransactionExtended {
+    public func fetch(_ db: Database) throws -> TransactionExtended? {
         try TransactionsRequest.fetch(
             db,
             type: .transaction(id: transactionId.identifier),
             filters: filters,
             walletId: walletId,
-        ).first ?? .empty
+        ).first
     }
 }
 
 extension TransactionRequest: Equatable {}
-
-public extension TransactionExtended {
-    static let empty: TransactionExtended = {
-        let asset = Asset(
-            id: AssetId(chain: .bitcoin, tokenId: nil),
-            name: "",
-            symbol: "",
-            decimals: 0,
-            type: .native,
-        )
-
-        return TransactionExtended(
-            transaction: Transaction(
-                id: TransactionId(chain: .ethereum, hash: ""),
-                assetId: AssetId(chain: .bitcoin, tokenId: nil),
-                from: "",
-                to: "",
-                contract: nil,
-                type: .transfer,
-                state: .pending,
-                blockNumber: "",
-                sequence: "",
-                fee: "",
-                feeAssetId: AssetId(chain: .bitcoin, tokenId: nil),
-                value: "",
-                memo: nil,
-                direction: .selfTransfer,
-                utxoInputs: [],
-                utxoOutputs: [],
-                metadata: nil,
-                createdAt: .now,
-            ),
-            asset: asset,
-            feeAsset: asset,
-            price: nil,
-            feePrice: nil,
-            assets: [],
-            prices: [],
-            fromAddress: nil,
-            toAddress: nil,
-            confirmationEtaSeconds: nil,
-        )
-    }()
-}

--- a/ios/Packages/Store/Sources/Stores/TransactionStore.swift
+++ b/ios/Packages/Store/Sources/Stores/TransactionStore.swift
@@ -56,7 +56,7 @@ public struct TransactionStore: Sendable {
         }
     }
 
-    public func getTransaction(walletId: WalletId, transactionId: TransactionId) throws -> TransactionExtended {
+    public func getTransaction(walletId: WalletId, transactionId: TransactionId) throws -> TransactionExtended? {
         try db.read { db in
             try TransactionRequest(walletId: walletId, transactionId: transactionId).fetch(db)
         }


### PR DESCRIPTION
Fixes #1135

`TransactionRequest.fetch` returned a fabricated `TransactionExtended.empty` with empty `fee` and `value` when the observed row was gone. Since primitives cross the FFI as JSON, `GemTransactionSummary` panics on the empty integer and the UniFFI `try!` crashes the app. The row disappears whenever Core renames or merges the pending transaction on `HashChange`.

1. `TransactionRequest.fetch` returns `TransactionExtended?` and the placeholder is removed
2. `TransactionSceneViewModel` keeps the last known transaction when the observed row is renamed or merged
3. Push notification navigation bails out when the transaction cannot be loaded from the store

Verification from `ios/`:

- `just build-package Store` PASS
- `just build-package Transactions` PASS
- `just build` PASS
- `just test TransactionsTests` PASS (40 tests, 7 suites)
