### PR TITLE
Declare the content type on every request that carries a body

### DIFF
--- a/core/crates/gem_algorand/src/rpc/client.rs
+++ b/core/crates/gem_algorand/src/rpc/client.rs
@@ -58,7 +58,7 @@ mod tests {
     async fn test_broadcast_transaction() {
         let client = AlgorandClient::new(MockClient::new().with_post_with_headers(|path, body, headers| {
             assert_eq!(path, "/v2/transactions");
-            assert_eq!(body, br#""deadbeef""#);
+            assert_eq!(body, [0xde, 0xad, 0xbe, 0xef]);
             assert_eq!(headers.get(CONTENT_TYPE).map(String::as_str), Some(ContentType::ApplicationXBinary.as_str()));
             Ok(br#"{"txId":"TXID"}"#.to_vec())
         }));

--- a/core/crates/gem_algorand/src/rpc/target.rs
+++ b/core/crates/gem_algorand/src/rpc/target.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use gem_client::{CONTENT_TYPE, ContentType, Target};
+use gem_client::{ContentType, Target};
 
 #[derive(Clone, Debug)]
 pub enum AlgorandTarget {
@@ -22,10 +20,10 @@ impl Target for AlgorandTarget {
         }
     }
 
-    fn headers(&self) -> HashMap<String, String> {
+    fn content_type(&self) -> ContentType {
         match self {
-            Self::SendTransaction => HashMap::from([(CONTENT_TYPE.to_string(), ContentType::ApplicationXBinary.as_str().to_string())]),
-            _ => HashMap::new(),
+            Self::SendTransaction => ContentType::ApplicationXBinary,
+            _ => ContentType::ApplicationJson,
         }
     }
 }

--- a/core/crates/gem_aptos/src/rpc/client.rs
+++ b/core/crates/gem_aptos/src/rpc/client.rs
@@ -228,7 +228,7 @@ mod tests {
     async fn test_submit_transaction() {
         let client = AptosClient::new(MockClient::new().with_post_with_headers(|path, body, headers| {
             assert_eq!(path, "/v1/transactions");
-            assert_eq!(body, b"[1,2,3]");
+            assert_eq!(body, [1, 2, 3]);
             assert_eq!(headers.get(CONTENT_TYPE).map(String::as_str), Some(ContentType::ApplicationAptosBcs.as_str()));
             Ok(br#"{"hash":"0xhash"}"#.to_vec())
         }));

--- a/core/crates/gem_aptos/src/rpc/target.rs
+++ b/core/crates/gem_aptos/src/rpc/target.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use gem_client::{CONTENT_TYPE, ContentType, Target, build_path_with_query};
+use gem_client::{ContentType, Target, build_path_with_query};
 
 use crate::models::SimulateTransactionQuery;
 
@@ -36,10 +34,10 @@ impl Target for AptosTarget {
         }
     }
 
-    fn headers(&self) -> HashMap<String, String> {
+    fn content_type(&self) -> ContentType {
         match self {
-            Self::SubmitTransaction => HashMap::from([(CONTENT_TYPE.to_string(), ContentType::ApplicationAptosBcs.as_str().to_string())]),
-            _ => HashMap::new(),
+            Self::SubmitTransaction => ContentType::ApplicationAptosBcs,
+            _ => ContentType::ApplicationJson,
         }
     }
 }

--- a/core/crates/gem_bitcoin/src/rpc/client.rs
+++ b/core/crates/gem_bitcoin/src/rpc/client.rs
@@ -93,7 +93,7 @@ mod tests {
         let client = BitcoinClient::new(
             MockClient::new().with_post_with_headers(|path, body, headers| {
                 assert_eq!(path, "/api/v2/sendtx/");
-                assert_eq!(body, br#""0100beef""#);
+                assert_eq!(body, b"0100beef");
                 assert_eq!(headers.get(CONTENT_TYPE).map(String::as_str), Some(ContentType::TextPlain.as_str()));
                 Ok(br#"{"result":"txid"}"#.to_vec())
             }),

--- a/core/crates/gem_bitcoin/src/rpc/target.rs
+++ b/core/crates/gem_bitcoin/src/rpc/target.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use gem_client::{CONTENT_TYPE, ContentType, Target};
+use gem_client::{ContentType, Target};
 
 #[derive(Clone, Debug)]
 pub enum BlockbookTarget {
@@ -28,10 +26,10 @@ impl Target for BlockbookTarget {
         }
     }
 
-    fn headers(&self) -> HashMap<String, String> {
+    fn content_type(&self) -> ContentType {
         match self {
-            Self::SendTransaction => HashMap::from([(CONTENT_TYPE.to_string(), ContentType::TextPlain.as_str().to_string())]),
-            _ => HashMap::new(),
+            Self::SendTransaction => ContentType::TextPlain,
+            _ => ContentType::ApplicationJson,
         }
     }
 }

--- a/core/crates/gem_client/Cargo.toml
+++ b/core/crates/gem_client/Cargo.toml
@@ -16,3 +16,6 @@ serde_urlencoded = { workspace = true }
 reqwest = { workspace = true, optional = true }
 hex = { workspace = true }
 tokio = { workspace = true, features = ["time"], optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/core/crates/gem_client/src/lib.rs
+++ b/core/crates/gem_client/src/lib.rs
@@ -10,7 +10,7 @@ mod request;
 mod target;
 mod types;
 
-#[cfg(feature = "testkit")]
+#[cfg(any(test, feature = "testkit"))]
 pub mod testkit;
 
 #[cfg(feature = "reqwest")]
@@ -31,7 +31,8 @@ pub use query::{build_path_with_query, build_request_url};
 use request::BodyMethod;
 pub use request::{GetRequest, PostRequest};
 pub use target::Target;
-pub use types::{ClientError, Response, decode_json_byte_array, deserialize_response, encode_request};
+use target::body_headers;
+pub use types::{ClientError, Response, decode_json_byte_array, deserialize_response, encode_request_body};
 
 #[cfg(feature = "reqwest")]
 pub use reqwest_client::{ReqwestClient, json_response};
@@ -76,14 +77,14 @@ pub trait ClientExt: Client {
     where
         T: Serialize + Send + Sync,
     {
-        PostRequest::new(self, BodyMethod::Post, target.path(), target.headers(), body)
+        PostRequest::new(self, BodyMethod::Post, target.path(), body_headers(&target), body)
     }
 
     fn patch<'a, T, R>(&'a self, target: impl Target, body: &'a T) -> PostRequest<'a, Self, T, R>
     where
         T: Serialize + Send + Sync,
     {
-        PostRequest::new(self, BodyMethod::Patch, target.path(), target.headers(), body)
+        PostRequest::new(self, BodyMethod::Patch, target.path(), body_headers(&target), body)
     }
 
     async fn get_or_error<R, E>(&self, target: impl Target + Send) -> Result<R, ClientError<Option<E>>>

--- a/core/crates/gem_client/src/lib.rs
+++ b/core/crates/gem_client/src/lib.rs
@@ -31,7 +31,7 @@ pub use query::{build_path_with_query, build_request_url};
 use request::BodyMethod;
 pub use request::{GetRequest, PostRequest};
 pub use target::Target;
-pub use types::{ClientError, Response, decode_json_byte_array, deserialize_response, encode_request_body};
+pub use types::{ClientError, Response, decode_json_byte_array, deserialize_response, encode_request};
 
 #[cfg(feature = "reqwest")]
 pub use reqwest_client::{ReqwestClient, json_response};

--- a/core/crates/gem_client/src/reqwest_client.rs
+++ b/core/crates/gem_client/src/reqwest_client.rs
@@ -5,7 +5,7 @@ use reqwest::header::USER_AGENT;
 use reqwest::{Method, RequestBuilder};
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::{CONTENT_TYPE, Client, ClientError, ContentType, Response, build_request_url, deserialize_response, encode_request_body, retry_policy};
+use crate::{Client, ClientError, Response, build_request_url, deserialize_response, encode_request, retry_policy};
 
 #[derive(Debug, Clone)]
 pub struct ReqwestClient {
@@ -136,12 +136,7 @@ impl ReqwestClient {
         R: DeserializeOwned,
     {
         let url = build_request_url(&self.base_url, path);
-        let headers = if headers.is_empty() {
-            HashMap::from([(CONTENT_TYPE.to_string(), ContentType::ApplicationJson.as_str().to_string())])
-        } else {
-            headers
-        };
-        let request_body = encode_request_body(&headers, body)?;
+        let (headers, request_body) = encode_request(headers, body)?;
         let request = self.build_request(self.client.request(method, &url).body(request_body), headers);
         let response = request.send().await.map_err(Self::map_reqwest_error)?;
 

--- a/core/crates/gem_client/src/reqwest_client.rs
+++ b/core/crates/gem_client/src/reqwest_client.rs
@@ -5,7 +5,7 @@ use reqwest::header::USER_AGENT;
 use reqwest::{Method, RequestBuilder};
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::{Client, ClientError, Response, build_request_url, deserialize_response, encode_request, retry_policy};
+use crate::{Client, ClientError, Response, build_request_url, deserialize_response, encode_request_body, retry_policy};
 
 #[derive(Debug, Clone)]
 pub struct ReqwestClient {
@@ -136,7 +136,7 @@ impl ReqwestClient {
         R: DeserializeOwned,
     {
         let url = build_request_url(&self.base_url, path);
-        let (headers, request_body) = encode_request(headers, body)?;
+        let request_body = encode_request_body(&headers, body)?;
         let request = self.build_request(self.client.request(method, &url).body(request_body), headers);
         let response = request.send().await.map_err(Self::map_reqwest_error)?;
 

--- a/core/crates/gem_client/src/target.rs
+++ b/core/crates/gem_client/src/target.rs
@@ -1,10 +1,16 @@
 use std::collections::HashMap;
 
+use crate::{CONTENT_TYPE, ContentType};
+
 pub trait Target {
     fn path(&self) -> String;
 
     fn headers(&self) -> HashMap<String, String> {
         HashMap::new()
+    }
+
+    fn content_type(&self) -> ContentType {
+        ContentType::ApplicationJson
     }
 }
 
@@ -17,5 +23,35 @@ impl Target for &str {
 impl Target for &String {
     fn path(&self) -> String {
         self.to_string()
+    }
+}
+
+pub(crate) fn body_headers(target: &impl Target) -> HashMap<String, String> {
+    let mut headers = target.headers();
+    headers.entry(CONTENT_TYPE.to_string()).or_insert_with(|| target.content_type().as_str().to_string());
+    headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ClientExt, testkit::MockClient};
+    use serde_json::Value;
+
+    #[tokio::test]
+    async fn test_post_declares_json_next_to_call_site_headers() {
+        let client = MockClient::new().with_post_with_headers(|path, body, headers| {
+            assert_eq!(path, "/messages");
+            assert_eq!(body, br#"{"content":"hello"}"#);
+            assert_eq!(headers.get(CONTENT_TYPE).map(String::as_str), Some(ContentType::ApplicationJson.as_str()));
+            assert_eq!(headers.get("x-auth-token").map(String::as_str), Some("token"));
+            Ok(b"{}".to_vec())
+        });
+
+        let _: Value = client
+            .post("/messages", &serde_json::json!({"content": "hello"}))
+            .headers(HashMap::from([("x-auth-token".to_string(), "token".to_string())]))
+            .await
+            .unwrap();
     }
 }

--- a/core/crates/gem_client/src/testkit.rs
+++ b/core/crates/gem_client/src/testkit.rs
@@ -1,4 +1,4 @@
-use crate::{Client, ClientError, Response, deserialize_response};
+use crate::{Client, ClientError, Response, deserialize_response, encode_request};
 use async_trait::async_trait;
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
@@ -84,7 +84,7 @@ impl Client for MockClient {
         R: DeserializeOwned,
     {
         let handler = self.post_handler.as_ref().ok_or(ClientError::Http { status: 404, body: vec![] })?;
-        let body_bytes = serde_json::to_vec(body).map_err(|e| ClientError::Serialization(e.to_string()))?;
+        let (headers, body_bytes) = encode_request(headers, body)?;
         let data = handler(path, &body_bytes, &headers)?;
         deserialize_response(&Response { status: Some(200), data })
     }

--- a/core/crates/gem_client/src/testkit.rs
+++ b/core/crates/gem_client/src/testkit.rs
@@ -1,4 +1,4 @@
-use crate::{Client, ClientError, Response, deserialize_response, encode_request};
+use crate::{Client, ClientError, Response, deserialize_response, encode_request_body};
 use async_trait::async_trait;
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
@@ -84,7 +84,7 @@ impl Client for MockClient {
         R: DeserializeOwned,
     {
         let handler = self.post_handler.as_ref().ok_or(ClientError::Http { status: 404, body: vec![] })?;
-        let (headers, body_bytes) = encode_request(headers, body)?;
+        let body_bytes = encode_request_body(&headers, body)?;
         let data = handler(path, &body_bytes, &headers)?;
         deserialize_response(&Response { status: Some(200), data })
     }

--- a/core/crates/gem_client/src/types.rs
+++ b/core/crates/gem_client/src/types.rs
@@ -81,7 +81,13 @@ impl From<serde_json::Error> for ClientError {
     }
 }
 
-pub fn encode_request_body<T: Serialize>(headers: &HashMap<String, String>, body: &T) -> Result<Vec<u8>, ClientError> {
+pub fn encode_request<T: Serialize>(mut headers: HashMap<String, String>, body: &T) -> Result<(HashMap<String, String>, Vec<u8>), ClientError> {
+    headers.entry(CONTENT_TYPE.to_string()).or_insert_with(|| ContentType::ApplicationJson.as_str().to_string());
+    let data = encode_request_body(&headers, body)?;
+    Ok((headers, data))
+}
+
+fn encode_request_body<T: Serialize>(headers: &HashMap<String, String>, body: &T) -> Result<Vec<u8>, ClientError> {
     let content_type = headers.get(CONTENT_TYPE).map(String::as_str);
     let is_multipart = content_type.is_some_and(|value| value.starts_with(MULTIPART_FORM_DATA));
     match content_type.and_then(|value| ContentType::from_str(value).ok()) {
@@ -127,4 +133,29 @@ fn validate_http_status(response: &Response) -> Result<(), ClientError> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_request_declares_json_next_to_custom_headers() {
+        let headers = HashMap::from([("x-auth-token".to_string(), "token".to_string())]);
+
+        let (headers, body) = encode_request(headers, &serde_json::json!({"content": "hello"})).unwrap();
+
+        assert_eq!(headers.get(CONTENT_TYPE).map(String::as_str), Some(ContentType::ApplicationJson.as_str()));
+        assert_eq!(body, br#"{"content":"hello"}"#.to_vec());
+    }
+
+    #[test]
+    fn test_encode_request_keeps_explicit_content_type() {
+        let headers = HashMap::from([(CONTENT_TYPE.to_string(), ContentType::TextPlain.as_str().to_string())]);
+
+        let (headers, body) = encode_request(headers, &"raw".to_string()).unwrap();
+
+        assert_eq!(headers.get(CONTENT_TYPE).map(String::as_str), Some(ContentType::TextPlain.as_str()));
+        assert_eq!(body, b"raw".to_vec());
+    }
 }

--- a/core/crates/gem_client/src/types.rs
+++ b/core/crates/gem_client/src/types.rs
@@ -81,13 +81,7 @@ impl From<serde_json::Error> for ClientError {
     }
 }
 
-pub fn encode_request<T: Serialize>(mut headers: HashMap<String, String>, body: &T) -> Result<(HashMap<String, String>, Vec<u8>), ClientError> {
-    headers.entry(CONTENT_TYPE.to_string()).or_insert_with(|| ContentType::ApplicationJson.as_str().to_string());
-    let data = encode_request_body(&headers, body)?;
-    Ok((headers, data))
-}
-
-fn encode_request_body<T: Serialize>(headers: &HashMap<String, String>, body: &T) -> Result<Vec<u8>, ClientError> {
+pub fn encode_request_body<T: Serialize>(headers: &HashMap<String, String>, body: &T) -> Result<Vec<u8>, ClientError> {
     let content_type = headers.get(CONTENT_TYPE).map(String::as_str);
     let is_multipart = content_type.is_some_and(|value| value.starts_with(MULTIPART_FORM_DATA));
     match content_type.and_then(|value| ContentType::from_str(value).ok()) {
@@ -133,29 +127,4 @@ fn validate_http_status(response: &Response) -> Result<(), ClientError> {
         }
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_encode_request_declares_json_next_to_custom_headers() {
-        let headers = HashMap::from([("x-auth-token".to_string(), "token".to_string())]);
-
-        let (headers, body) = encode_request(headers, &serde_json::json!({"content": "hello"})).unwrap();
-
-        assert_eq!(headers.get(CONTENT_TYPE).map(String::as_str), Some(ContentType::ApplicationJson.as_str()));
-        assert_eq!(body, br#"{"content":"hello"}"#.to_vec());
-    }
-
-    #[test]
-    fn test_encode_request_keeps_explicit_content_type() {
-        let headers = HashMap::from([(CONTENT_TYPE.to_string(), ContentType::TextPlain.as_str().to_string())]);
-
-        let (headers, body) = encode_request(headers, &"raw".to_string()).unwrap();
-
-        assert_eq!(headers.get(CONTENT_TYPE).map(String::as_str), Some(ContentType::TextPlain.as_str()));
-        assert_eq!(body, b"raw".to_vec());
-    }
 }

--- a/core/crates/gem_hypercore/src/rpc/client.rs
+++ b/core/crates/gem_hypercore/src/rpc/client.rs
@@ -234,7 +234,8 @@ impl<C: Client> chain_traits::ChainProvider for HyperCoreClient<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gem_client::Target;
+    use crate::rpc::target::INFO_CACHE_TTL_SECS;
+    use gem_client::X_CACHE_TTL;
     use gem_client::testkit::MockClient;
     use serde_json::json;
     use std::sync::Mutex;
@@ -263,13 +264,8 @@ mod tests {
 
         assert_eq!(mode, UserAbstractionMode::Default);
         assert_eq!(
-            recorded_headers,
-            vec![
-                HyperCoreTarget::Info {
-                    request: InfoRequest::UserAbstraction { user: "0x123".to_string() }
-                }
-                .headers()
-            ]
+            recorded_headers.iter().map(|headers| headers.get(X_CACHE_TTL).cloned()).collect::<Vec<_>>(),
+            vec![Some(INFO_CACHE_TTL_SECS.to_string())]
         );
     }
 }

--- a/core/crates/gem_hypercore/src/rpc/target.rs
+++ b/core/crates/gem_hypercore/src/rpc/target.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use gem_client::{CONTENT_TYPE, ContentType, Target, X_CACHE_TTL};
+use gem_client::{Target, X_CACHE_TTL};
 
 use crate::models::info::InfoRequest;
 
-const INFO_CACHE_TTL_SECS: u64 = 3600;
+pub(crate) const INFO_CACHE_TTL_SECS: u64 = 3600;
 
 #[derive(Clone, Debug)]
 pub enum HyperCoreTarget {
@@ -24,10 +24,7 @@ impl Target for HyperCoreTarget {
         match self {
             Self::Info {
                 request: InfoRequest::SpotMeta | InfoRequest::UserAbstraction { .. },
-            } => HashMap::from([
-                (CONTENT_TYPE.to_string(), ContentType::ApplicationJson.as_str().to_string()),
-                (X_CACHE_TTL.to_string(), INFO_CACHE_TTL_SECS.to_string()),
-            ]),
+            } => HashMap::from([(X_CACHE_TTL.to_string(), INFO_CACHE_TTL_SECS.to_string())]),
             _ => HashMap::new(),
         }
     }

--- a/core/crates/gem_jsonrpc/src/rpc.rs
+++ b/core/crates/gem_jsonrpc/src/rpc.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use gem_client::{Client, ClientError, Response, build_request_url, deserialize_response, encode_request};
+use gem_client::{Client, ClientError, Response, build_request_url, deserialize_response, encode_request_body};
 use primitives::Chain;
 use serde::{Serialize, de::DeserializeOwned};
 
@@ -137,12 +137,12 @@ where
         R: DeserializeOwned,
     {
         let url = build_request_url(&self.base_url, path);
-        let (request_headers, data) = encode_request(headers, body)?;
+        let data = encode_request_body(&headers, body)?;
 
         let target = Target {
             url,
             method,
-            headers: Some(request_headers),
+            headers: Some(headers),
             body: Some(data),
         };
 

--- a/core/crates/gem_jsonrpc/src/rpc.rs
+++ b/core/crates/gem_jsonrpc/src/rpc.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use gem_client::{CONTENT_TYPE, Client, ClientError, ContentType, Response, build_request_url, deserialize_response, encode_request_body};
+use gem_client::{Client, ClientError, Response, build_request_url, deserialize_response, encode_request};
 use primitives::Chain;
 use serde::{Serialize, de::DeserializeOwned};
 
@@ -137,9 +137,7 @@ where
         R: DeserializeOwned,
     {
         let url = build_request_url(&self.base_url, path);
-        let mut request_headers = HashMap::from([(CONTENT_TYPE.to_string(), ContentType::ApplicationJson.as_str().to_string())]);
-        request_headers.extend(headers);
-        let data = encode_request_body(&request_headers, body)?;
+        let (request_headers, data) = encode_request(headers, body)?;
 
         let target = Target {
             url,

--- a/core/crates/gem_stellar/src/rpc/client.rs
+++ b/core/crates/gem_stellar/src/rpc/client.rs
@@ -152,7 +152,7 @@ mod tests {
     async fn test_broadcast_transaction() {
         let client = StellarClient::new(MockClient::new().with_post_with_headers(|path, body, headers| {
             assert_eq!(path, "/transactions_async");
-            assert_eq!(body, br#""tx=AAAA%2B%2F%3D%3D""#);
+            assert_eq!(body, b"tx=AAAA%2B%2F%3D%3D");
             assert_eq!(headers.get(CONTENT_TYPE).map(String::as_str), Some(ContentType::ApplicationFormUrlEncoded.as_str()));
             Ok(br#"{"hash":"abc","tx_status":"PENDING"}"#.to_vec())
         }));

--- a/core/crates/gem_stellar/src/rpc/target.rs
+++ b/core/crates/gem_stellar/src/rpc/target.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use gem_client::{CONTENT_TYPE, ContentType, Target, build_path_with_query};
+use gem_client::{ContentType, Target, build_path_with_query};
 
 use crate::models::transaction::PaymentsQuery;
 
@@ -32,10 +30,10 @@ impl Target for HorizonTarget {
         }
     }
 
-    fn headers(&self) -> HashMap<String, String> {
+    fn content_type(&self) -> ContentType {
         match self {
-            Self::SubmitTransaction => HashMap::from([(CONTENT_TYPE.to_string(), ContentType::ApplicationFormUrlEncoded.as_str().to_string())]),
-            _ => HashMap::new(),
+            Self::SubmitTransaction => ContentType::ApplicationFormUrlEncoded,
+            _ => ContentType::ApplicationJson,
         }
     }
 }

--- a/core/crates/security_provider/src/providers/hashdit/target.rs
+++ b/core/crates/security_provider/src/providers/hashdit/target.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use gem_client::{CONTENT_TYPE, Target};
+use gem_client::Target;
 
 #[derive(Clone, Debug)]
 pub enum HashDitTarget {
@@ -14,9 +12,5 @@ impl Target for HashDitTarget {
             Self::AddressSecurity => "/v2/hashdit/address-security-v2".to_string(),
             Self::TokenSecurity => "/v2/hashdit/token-security".to_string(),
         }
-    }
-
-    fn headers(&self) -> HashMap<String, String> {
-        HashMap::from([(CONTENT_TYPE.to_string(), "application/json".to_string())])
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -547,6 +547,31 @@ struct that implements six traits. Cross-cutting doubles (`TestAlienProvider`) l
 `gemstone/src/testkit.rs`. A double that exists to probe one behavior of one test (a store that
 counts writes or delays a read) stays inline with that test.
 
+**A test never hand-rolls a double a testkit already ships.** A `struct` in a test module that
+implements `Client`, `Target` or a store trait is a stand-in nobody else uses: it drifts the moment
+the real trait grows a method, and it asserts the stand-in rather than the path the app takes. Take
+the double from the owning crate's `testkit` — enabled through that crate's `testkit` feature under
+`[dev-dependencies]`, never copied — and drive the real request through it:
+
+```rust
+let client = AlgorandClient::new(MockClient::new().with_post_with_headers(|path, body, headers| {
+    assert_eq!(path, "/v2/transactions");
+    assert_eq!(body, [0xde, 0xad, 0xbe, 0xef]);
+    assert_eq!(headers.get(CONTENT_TYPE).map(String::as_str), Some(ContentType::ApplicationXBinary.as_str()));
+    Ok(br#"{"txId":"TXID"}"#.to_vec())
+}));
+```
+
+`MockClient` encodes the body exactly as `ReqwestClient` and `RpcClient` do, so a handler that
+asserts bytes and headers is asserting the wire. References:
+[`gem_client::testkit`](../core/crates/gem_client/src/testkit.rs) and `mock_jsonrpc_client` for HTTP,
+[`gem_hypercore/src/testkit.rs`](../core/crates/gem_hypercore/src/testkit.rs) for a chain client,
+[`primitives/src/testkit/asset_mock.rs`](../core/crates/primitives/src/testkit/asset_mock.rs) and
+[`storage/src/testkit/scan_address_mock.rs`](../core/crates/storage/src/testkit/scan_address_mock.rs)
+for fixtures; call sites in
+[`gem_algorand/src/rpc/client.rs`](../core/crates/gem_algorand/src/rpc/client.rs) and
+[`gem_stellar/src/rpc/client.rs`](../core/crates/gem_stellar/src/rpc/client.rs).
+
 ### Do not test the same rule twice through a thicker stack
 
 An app test that stands up a real Core service over a real store and then asserts *Core's decision* is a second copy of a Core test, paid for in database setup and simulator time. It fails for the same reasons the Core test does, and it goes stale in a different file.
@@ -636,7 +661,8 @@ impl<C: Client> TronGridClient<C> {
 ```
 
 Variant fields are named: `GetAccount(String)` does not say what the string is. The target implements
-`gem_client::Target` (`path()`, and `headers()` when a request carries one); the client owns the
+`gem_client::Target` (`path()`, `headers()` when a request carries one, and `content_type()` when a
+body is not JSON); the client owns the
 transport, the credentials, the clock, the signature, the envelope and the pagination loop. A
 method is `self.client.get(target).await` or `self.client.post(target, &body).await`. A private helper exists only for shared work: credentials
 (`TronGridClient::send`), a 404 that is a value (`StellarClient::get_or_not_found`), an envelope
@@ -649,7 +675,7 @@ method is `self.client.get(target).await` or `self.client.post(target, &body).aw
 | Query string | Part of `path()`; a transport only ever sees a path. One or two fixed parameters are a `format!`; more, or any optional one, is a flat `Serialize` struct rendered by `build_path_with_query` (`None` omitted, values encoded, a slice of pairs for a repeated key). A client without a target yet calls `client.get(path).query(&query)`, which renders the same way | `GemApiTarget`, `CoinMarketsQuery`, `mayan::quote_path` |
 | Optional parameter | An `Option` field of the query struct, omitted when `None`, never a second variant | `TransactionsQuery { limit, fingerprint: Option<String> }`, `PaymentsQuery { cursor, .. }` |
 | Method and body | The method calls `post(target, &body)` with the body it has; a POST variant carries nothing the path does not need. `Client` speaks GET and POST; the device client builds `gem_jsonrpc::Target` with a `method()` for PUT and DELETE. A host that multiplexes on the body (HyperCore `/info`, Cardano GraphQL) has a constant path and a variant per query | `AptosClient::submit_transaction`, `GemDeviceApiTarget` |
-| Raw body | `String` for `text/plain` and form-urlencoded, `Vec<u8>` for binary; the content type in the target's `headers()`, always from `ContentType` | Bitcoin `sendtx`, Stellar, Algorand, Aptos BCS, `SendSupportImage` |
+| Raw body | `String` for `text/plain` and form-urlencoded, `Vec<u8>` for binary; the content type from the target's `content_type()`, always a `ContentType` variant, never a `Content-Type` string in `headers()`. A body-carrying request declares `application/json` by default, so only a non-JSON body overrides it | Bitcoin `sendtx`, Stellar, Algorand, Aptos BCS, `SendSupportImage` |
 | Credentials | `fn headers(&self)` on the client, empty when the key is blank (`Option<String>` decided once at construction), passed as `.headers(self.headers())`; a key the host wants in the query is appended by `send` the same way. Transport default headers are backend-only: `RpcClient` has none | `JupiterClient`, `NearIntentsClient`, Blockscout `apikey` |
 | Request header | On the target: cache TTL (`X_CACHE_TTL`), API version, idempotency key | `HyperCoreClient`, TON emulate, Flashnet |
 | Signature | A pure `fn` in `auth.rs` over method, path, body, timestamp and nonce; the client reads the clock and merges the result last. A refreshed token sits behind an injected port | `okx::auth::sign`, `GoPlusProvider::sign`, `build_device_auth_header` |


### PR DESCRIPTION
A message typed in the support chat was never delivered. Our API passes the message on to the support desk, and that request went out without saying what format its body was in, so the desk refused it and the app only showed a failed message with a retry button.

The place that packs a request body now also labels it, so a request can no longer lose that label just because it carries an extra header such as an auth token. Both network layers go through the same code, and the test double behaves like the real one, which uncovered a few tests that were checking a made-up request body.

The error is still not explained to the user in the chat — that part is not covered here.

Close #1127