### PR TITLE
Keep the failed message icon next to its bubble

### DIFF
--- a/ios/Features/Support/Sources/Views/SupportMessageBubble.swift
+++ b/ios/Features/Support/Sources/Views/SupportMessageBubble.swift
@@ -18,6 +18,16 @@ struct SupportMessageBubble: View {
     }
 
     var body: some View {
+        HStack(alignment: .center, spacing: .small) {
+            if model.isFailed {
+                failedIndicator
+            }
+            messageView
+        }
+        .frame(maxWidth: Constants.maxWidth, alignment: model.alignment)
+    }
+
+    private var messageView: some View {
         VStack(alignment: model.alignment.horizontal, spacing: .tiny) {
             if model.hasImages {
                 imagesView
@@ -26,7 +36,12 @@ struct SupportMessageBubble: View {
                 textBubble
             }
         }
-        .frame(maxWidth: Constants.maxWidth, alignment: model.alignment)
+    }
+
+    private var failedIndicator: some View {
+        Image(systemName: SystemImage.errorOccurred)
+            .font(.body)
+            .foregroundStyle(Colors.red)
     }
 
     private var textBubble: some View {

--- a/ios/Features/Support/Sources/Views/SupportUserMessageGroup.swift
+++ b/ios/Features/Support/Sources/Views/SupportUserMessageGroup.swift
@@ -9,13 +9,8 @@ struct SupportUserMessageGroup: View {
     var body: some View {
         VStack(alignment: .trailing, spacing: .tiny) {
             ForEach(messages) { message in
-                HStack(alignment: .center, spacing: .small) {
+                HStack(spacing: .zero) {
                     Spacer(minLength: .space32)
-                    if message.isFailed {
-                        Image(systemName: SystemImage.errorOccurred)
-                            .font(.body)
-                            .foregroundStyle(Colors.red)
-                    }
                     SupportMessageBubble(model: message)
                 }
             }


### PR DESCRIPTION
In the support chat, the warning icon on a message that failed to send was drawn far away from the message, pushed to the opposite side of the screen.

The icon now sits right beside the bubble, the way it does on Android.

<img width="320" alt="supportfailedicon" src="https://github.com/user-attachments/assets/7bb39c25-fcca-4102-b4e3-e327a6bf2444" />
