### PR TITLE
Fix Android crash when unstaking Sui delegation

### DIFF
--- a/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/viewmodels/DelegationViewModel.kt
+++ b/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/viewmodels/DelegationViewModel.kt
@@ -127,7 +127,14 @@ class DelegationViewModel @Inject constructor(
             buildUndelegate()?.let { amountCall(it) }
             return
         }
-        confirmCall(stakeService.stakeTransferData(assetInfo.asset.toGem(), StakeType.Unstake(delegation).toJson(), BigInteger(delegation.base.balance), false))
+        confirmCall(
+            stakeService.stakeTransferData(
+                asset = assetInfo.asset.toGem(),
+                stakeType = StakeType.Unstake(delegation).toJson<StakeType>(),
+                value = BigInteger(delegation.base.balance),
+                useMaxAmount = false,
+            )
+        )
     }
 
     fun onRedelegate(call: AmountTransactionAction) {
@@ -137,7 +144,14 @@ class DelegationViewModel @Inject constructor(
     fun onWithdraw(call: ConfirmTransactionAction) {
         val assetInfo = assetInfo.value ?: return
         val delegation = delegation.value ?: return
-        call(stakeService.stakeTransferData(assetInfo.asset.toGem(), StakeType.Withdraw(delegation).toJson(), BigInteger(delegation.base.balance), false))
+        call(
+            stakeService.stakeTransferData(
+                asset = assetInfo.asset.toGem(),
+                stakeType = StakeType.Withdraw(delegation).toJson<StakeType>(),
+                value = BigInteger(delegation.base.balance),
+                useMaxAmount = false,
+            )
+        )
     }
 
     fun onClaimRewards(call: ConfirmTransactionAction) {
@@ -145,10 +159,10 @@ class DelegationViewModel @Inject constructor(
         val delegation = delegation.value ?: return
         call(
             stakeService.stakeTransferData(
-                assetInfo.asset.toGem(),
-                StakeType.Rewards(listOf(delegation.validator)).toJson(),
-                delegation.rewardsBalance(),
-                false,
+                asset = assetInfo.asset.toGem(),
+                stakeType = StakeType.Rewards(listOf(delegation.validator)).toJson<StakeType>(),
+                value = delegation.rewardsBalance(),
+                useMaxAmount = false,
             )
         )
     }

--- a/android/features/earn/stake/viewmodels/src/main/kotlin/com/gemwallet/android/features/stake/viewmodels/StakeViewModel.kt
+++ b/android/features/earn/stake/viewmodels/src/main/kotlin/com/gemwallet/android/features/stake/viewmodels/StakeViewModel.kt
@@ -146,7 +146,14 @@ class StakeViewModel @Inject constructor(
             return
         }
         val assetInfo = assetInfo.value ?: return
-        onConfirm(stakeService.stakeTransferData(assetInfo.asset.toGem(), StakeType.Withdraw(delegation).toJson(), BigInteger(delegation.base.balance), false))
+        onConfirm(
+            stakeService.stakeTransferData(
+                asset = assetInfo.asset.toGem(),
+                stakeType = StakeType.Withdraw(delegation).toJson<StakeType>(),
+                value = BigInteger(delegation.base.balance),
+                useMaxAmount = false,
+            )
+        )
     }
 
     fun onRewards(onAmount: AmountTransactionAction, onConfirm: ConfirmTransactionAction) {

--- a/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/stake/StakeTypeSerializationTest.kt
+++ b/android/gemcore/src/test/kotlin/com/gemwallet/android/domains/stake/StakeTypeSerializationTest.kt
@@ -1,0 +1,29 @@
+package com.gemwallet.android.domains.stake
+
+import com.gemwallet.android.serializer.decodeJson
+import com.gemwallet.android.serializer.toJson
+import com.gemwallet.android.testkit.mockDelegation
+import com.wallet.core.primitives.StakeType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StakeTypeSerializationTest {
+
+    @Test
+    fun `concrete stake variants serialize as the base type`() {
+        val delegation = mockDelegation()
+        val unstake = StakeType.Unstake(delegation)
+        val withdraw = StakeType.Withdraw(delegation)
+        val rewards = StakeType.Rewards(listOf(delegation.validator))
+        val stakeTypes: List<StakeType> = listOf(unstake, withdraw, rewards)
+        val encodedStakeTypes = listOf(
+            unstake.toJson<StakeType>(),
+            withdraw.toJson<StakeType>(),
+            rewards.toJson<StakeType>(),
+        )
+
+        assertTrue(encodedStakeTypes.all { "\"type\"" in it })
+        assertEquals(stakeTypes, encodedStakeTypes.map { it.decodeJson<StakeType>() })
+    }
+}


### PR DESCRIPTION
## Summary
- serialize direct Unstake, Withdraw, and Rewards variants through the base `StakeType` serializer
- preserve the tagged-enum discriminator expected by the Gemstone JSON bridge
- add a regression test covering discriminator presence and round-trip decoding

## Root cause
The reproduced 2.114.12 device crash was an `uniffi.gemstone.InternalException` from `GemStakeService.stakeTransferData`: Core could not lift the `stake_type` JSON because the payload was missing the `type` field.

Android called the generic `toJson()` extension directly on `StakeType.Unstake`. Kotlin therefore inferred the concrete subtype serializer, which encoded only the variant content. Core deserializes this payload as the Rust tagged `StakeType` enum and requires a discriminator such as `"type":"Unstake"`, so it rejected the payload before transaction construction.

The same inference bug existed in the direct Withdraw and Rewards paths. The amount-screen path was already safe because it first widened the value to `StakeType`. The fix makes that base type explicit at each direct JSON boundary with `toJson<StakeType>()`.

This is independent of ProGuard/R8 and of the original missing-delegation hypothesis in the issue.

## Verification
- `./gradlew :gemcore:testDebugUnitTest --tests com.gemwallet.android.domains.stake.StakeTypeSerializationTest :features:earn:delegation:viewmodels:testDebugUnitTest`
- `SKIP_SIGN=true BUILD_MODE=release GEMSTONE_ANDROID_ABIS=arm64-v8a ./gradlew -Pchannel=google :app:assembleGoogleRelease --no-configuration-cache --no-daemon`

Fixes #1129