### PR TITLE
Sort Android fiat totals as zero when the asset has no price

### DIFF
--- a/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
+++ b/android/data/services/store/src/main/kotlin/com/gemwallet/android/data/service/store/database/AssetsDao.kt
@@ -68,7 +68,7 @@ private const val ASSET_INFO_COLUMNS = """
     COALESCE(balances.earn, '0') AS balanceEarn,
     balances.earn_amount AS balanceEarnAmount,
     balances.total_amount AS balanceTotalAmount,
-    (balances.total_amount * prices.value) AS balanceFiatTotalAmount,
+    (balances.total_amount * COALESCE(prices.value, 0)) AS balanceFiatTotalAmount,
     balances.is_active AS assetIsActive,
     balances.votes AS votes,
     balances.energy_available AS energyAvailable,


### PR DESCRIPTION
Android wallet search showed a different order than iOS for the same query. Assets that had no price were pushed to the end of the list, so the server order was lost. Android now treats a missing price as zero, the same way iOS does, and both apps show the same list.

Verified on a Pixel 8 Pro by searching "Cats" and comparing with iOS. This cannot be covered by a unit test: the change lives in a Room SQL query, and the store module has no JVM database test setup.