### PR TITLE
Name the known swap contracts by provider and role

### DIFF
--- a/core/apps/daemon/src/setup/scan_addresses.rs
+++ b/core/apps/daemon/src/setup/scan_addresses.rs
@@ -11,15 +11,24 @@ use gem_evm::{
 };
 use gem_tracing::info_with_fields;
 use primitives::{Chain, ScanAddress, SwapProvider};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::error::Error;
 use storage::{Database, ScanAddressesRepository};
+use swapper::{chainflip, mayan, near_intents, squid, thorchain::THORChainNetwork};
 
 pub fn setup_scan_addresses(database: &Database) -> Result<(), Box<dyn Error + Send + Sync>> {
-    let mut values = HashMap::new();
+    let values = known_contracts();
+    let count = values.len();
+    let upserted = database.scan_addresses()?.upsert_scan_addresses(values)?;
+
+    info_with_fields!("setup", step = "scan addresses", count = count, upserted = upserted);
+    Ok(())
+}
+
+fn known_contracts() -> Vec<ScanAddress> {
+    let mut contracts = Vec::new();
 
     for chain in Chain::all() {
-        let uniswap_permit2 = get_uniswap_permit2_by_chain(&chain);
         let uniswap_v3 = get_uniswap_router_deployment_by_chain(&chain);
         let uniswap_v4 = get_uniswap_deployment_by_chain(&chain);
         let pancakeswap = get_pancakeswap_router_deployment_by_chain(&chain);
@@ -27,10 +36,8 @@ pub fn setup_scan_addresses(database: &Database) -> Result<(), Box<dyn Error + S
         let wagmi = get_wagmi_router_deployment_by_chain(&chain);
         let aerodrome = get_aerodrome_router_deployment_by_chain(&chain);
 
-        if let Some(address) = uniswap_permit2 {
-            values
-                .entry((chain, address.to_string()))
-                .or_insert_with(|| ScanAddress::contract(chain, address, SwapProvider::UniswapV3.name()));
+        if let Some(address) = get_uniswap_permit2_by_chain(&chain) {
+            contracts.push(ScanAddress::contract(chain, address, format!("{} Permit2", SwapProvider::UniswapV3.name())));
         }
 
         for (provider, address) in [
@@ -42,9 +49,7 @@ pub fn setup_scan_addresses(database: &Database) -> Result<(), Box<dyn Error + S
             (SwapProvider::Aerodrome, aerodrome.as_ref().map(|deployment| deployment.universal_router)),
         ] {
             if let Some(address) = address {
-                values
-                    .entry((chain, address.to_string()))
-                    .or_insert_with(|| ScanAddress::contract(chain, address, provider.name()));
+                contracts.push(ScanAddress::contract(chain, address, format!("{} Router", provider.name())));
             }
         }
 
@@ -54,33 +59,78 @@ pub fn setup_scan_addresses(database: &Database) -> Result<(), Box<dyn Error + S
             (SwapProvider::Wagmi, wagmi.as_ref().map(|deployment| deployment.permit2)),
         ] {
             if let Some(address) = address {
-                values
-                    .entry((chain, address.to_string()))
-                    .or_insert_with(|| ScanAddress::contract(chain, address, provider.name()));
+                contracts.push(ScanAddress::contract(chain, address, format!("{} Permit2", provider.name())));
             }
         }
 
         if let Some(deployment) = AcrossDeployment::deployment_by_chain(&chain) {
-            values
-                .entry((chain, deployment.spoke_pool.to_string()))
-                .or_insert_with(|| ScanAddress::contract(chain, deployment.spoke_pool, SwapProvider::Across.name()));
+            for address in [deployment.spoke_pool, deployment.multicall_handler()] {
+                contracts.push(ScanAddress::contract(chain, address, SwapProvider::Across.name()));
+            }
         }
     }
 
-    let count = values.len();
-    let addresses = values.keys().map(|(_, address)| address.clone()).collect();
-    let existing = database
-        .scan_addresses()?
-        .get_scan_addresses_by_addresses(addresses)?
-        .into_iter()
-        .map(|row| (row.chain.0, row.address))
-        .collect::<HashSet<_>>();
-    let values = values
-        .into_iter()
-        .filter_map(|(key, value)| (!existing.contains(&key)).then_some(value))
-        .collect::<Vec<_>>();
-    let inserted = if values.is_empty() { 0 } else { database.scan_addresses()?.add_scan_addresses(values)? };
+    for network in [THORChainNetwork::Thorchain, THORChainNetwork::Mayachain] {
+        contracts.extend(
+            network
+                .routers()
+                .iter()
+                .map(|(chain, router)| ScanAddress::contract(*chain, *router, network.provider().name())),
+        );
+    }
+    contracts.extend(chainflip::VAULT_ADDRESSES.map(|(chain, vault)| ScanAddress::contract(chain, vault, SwapProvider::Chainflip.name())));
+    contracts.extend(near_intents::TREASURY_ADDRESSES.map(|(chain, treasury)| ScanAddress::contract(chain, treasury, SwapProvider::NearIntents.name())));
+    contracts.extend(
+        mayan::MAYAN_DEPOSIT_CONTRACTS
+            .into_iter()
+            .chain(mayan::MAYAN_SEND_CONTRACTS)
+            .map(|(chain, contract)| ScanAddress::contract(chain, contract, SwapProvider::Mayan.name())),
+    );
+    let (chain, multicall) = squid::SQUID_COSMOS_MULTICALL;
+    contracts.push(ScanAddress::contract(chain, multicall, SwapProvider::Squid.name()));
 
-    info_with_fields!("setup", step = "scan addresses", count = count, inserted = inserted);
-    Ok(())
+    let mut seen = HashSet::new();
+    contracts.retain(|contract| seen.insert((contract.chain, contract.address.clone())));
+    contracts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_known_contracts_are_named_by_provider_and_role() {
+        let contracts = known_contracts();
+        let names: HashMap<(Chain, &str), &str> = contracts
+            .iter()
+            .map(|contract| ((contract.chain, contract.address.as_str()), contract.name.as_deref().unwrap()))
+            .collect();
+        let uniswap = get_uniswap_router_deployment_by_chain(&Chain::SmartChain).unwrap();
+        let pancakeswap = get_pancakeswap_router_deployment_by_chain(&Chain::SmartChain).unwrap();
+        let across = AcrossDeployment::deployment_by_chain(&Chain::Ethereum).unwrap();
+
+        assert_eq!(names[&(Chain::SmartChain, uniswap.permit2)], "Uniswap Permit2");
+        assert_eq!(names[&(Chain::SmartChain, uniswap.universal_router)], "Uniswap Router");
+        assert_eq!(names[&(Chain::SmartChain, pancakeswap.permit2)], "PancakeSwap Permit2");
+        assert_eq!(names[&(Chain::SmartChain, pancakeswap.universal_router)], "PancakeSwap Router");
+        assert_eq!(names[&(Chain::Ethereum, across.spoke_pool)], "Across");
+        assert_eq!(names[&(Chain::Ethereum, across.multicall_handler())], "Across");
+        for (chain, router) in THORChainNetwork::Thorchain.routers() {
+            assert_eq!(names[&(*chain, *router)], "THORChain");
+        }
+        for (chain, router) in THORChainNetwork::Mayachain.routers() {
+            assert_eq!(names[&(*chain, *router)], "Maya");
+        }
+        for (chain, vault) in chainflip::VAULT_ADDRESSES {
+            assert_eq!(names[&(chain, vault)], "Chainflip");
+        }
+        for (chain, treasury) in near_intents::TREASURY_ADDRESSES {
+            assert_eq!(names[&(chain, treasury)], "NEAR Intents");
+        }
+        for (chain, contract) in mayan::MAYAN_DEPOSIT_CONTRACTS.into_iter().chain(mayan::MAYAN_SEND_CONTRACTS) {
+            assert_eq!(names[&(chain, contract)], "Mayan");
+        }
+        assert_eq!(names[&squid::SQUID_COSMOS_MULTICALL], "Squid");
+    }
 }

--- a/core/crates/storage/src/database/scan_addresses.rs
+++ b/core/crates/storage/src/database/scan_addresses.rs
@@ -1,15 +1,15 @@
+use crate::schema::scan_addresses::dsl::*;
 use crate::{DatabaseClient, models::*};
-
-use diesel::prelude::*;
+use diesel::{prelude::*, upsert::excluded};
 
 pub(crate) trait ScanAddressesStore {
     fn get_scan_addresses_by_addresses(&mut self, addresses: Vec<String>) -> Result<Vec<ScanAddressRow>, diesel::result::Error>;
     fn add_scan_addresses(&mut self, values: Vec<NewScanAddressRow>) -> Result<usize, diesel::result::Error>;
+    fn upsert_scan_addresses(&mut self, values: Vec<NewScanAddressRow>) -> Result<usize, diesel::result::Error>;
 }
 
 impl ScanAddressesStore for DatabaseClient {
     fn get_scan_addresses_by_addresses(&mut self, addresses: Vec<String>) -> Result<Vec<ScanAddressRow>, diesel::result::Error> {
-        use crate::schema::scan_addresses::dsl::*;
         scan_addresses
             .filter(address.eq_any(addresses))
             .order((address.asc(), id.asc()))
@@ -18,7 +18,15 @@ impl ScanAddressesStore for DatabaseClient {
     }
 
     fn add_scan_addresses(&mut self, values: Vec<NewScanAddressRow>) -> Result<usize, diesel::result::Error> {
-        use crate::schema::scan_addresses::dsl::*;
         diesel::insert_into(scan_addresses).values(values).on_conflict_do_nothing().execute(&mut self.connection)
+    }
+
+    fn upsert_scan_addresses(&mut self, values: Vec<NewScanAddressRow>) -> Result<usize, diesel::result::Error> {
+        diesel::insert_into(scan_addresses)
+            .values(values)
+            .on_conflict((chain, address))
+            .do_update()
+            .set(name.eq(excluded(name)))
+            .execute(&mut self.connection)
     }
 }

--- a/core/crates/storage/src/repositories/scan_addresses_repository.rs
+++ b/core/crates/storage/src/repositories/scan_addresses_repository.rs
@@ -10,6 +10,7 @@ pub trait ScanAddressesRepository {
     fn get_scan_addresses(&mut self, queries: &[(Chain, &str)]) -> Result<Vec<ScanAddressRow>, DatabaseError>;
     fn get_scan_addresses_by_addresses(&mut self, addresses: Vec<String>) -> Result<Vec<ScanAddressRow>, DatabaseError>;
     fn add_scan_addresses(&mut self, values: Vec<ScanAddress>) -> Result<usize, DatabaseError>;
+    fn upsert_scan_addresses(&mut self, values: Vec<ScanAddress>) -> Result<usize, DatabaseError>;
 }
 
 impl ScanAddressesRepository for DatabaseClient {
@@ -32,6 +33,11 @@ impl ScanAddressesRepository for DatabaseClient {
     fn add_scan_addresses(&mut self, values: Vec<ScanAddress>) -> Result<usize, DatabaseError> {
         let new_addresses = values.into_iter().map(NewScanAddressRow::from_primitive).collect();
         Ok(ScanAddressesStore::add_scan_addresses(self, new_addresses)?)
+    }
+
+    fn upsert_scan_addresses(&mut self, values: Vec<ScanAddress>) -> Result<usize, DatabaseError> {
+        let new_addresses = values.into_iter().map(NewScanAddressRow::from_primitive).collect();
+        Ok(ScanAddressesStore::upsert_scan_addresses(self, new_addresses)?)
     }
 }
 

--- a/core/crates/swapper/src/chainflip/mod.rs
+++ b/core/crates/swapper/src/chainflip/mod.rs
@@ -9,4 +9,4 @@ pub mod seed;
 pub mod tx_builder;
 
 pub use model::*;
-pub use provider::ChainflipProvider;
+pub use provider::{ChainflipProvider, VAULT_ADDRESSES};

--- a/core/crates/swapper/src/chainflip/provider.rs
+++ b/core/crates/swapper/src/chainflip/provider.rs
@@ -41,10 +41,12 @@ const DEFAULT_SWAP_ERC20_GAS_LIMIT: u64 = 100_000;
 const REFUND_RETRY_BLOCKS: u32 = 150;
 const ASSETS_CACHE_TTL: Duration = MINUTE.saturating_mul(5);
 
-const VAULT_ETH: &str = "0xF5e10380213880111522dd0efD3dbb45b9f62Bcc";
-const VAULT_ARB: &str = "0x79001a5e762f3bEFC8e5871b42F6734e00498920";
-const VAULT_SOL: &str = "J88B7gmadHzTNGiy54c9Ms8BsEXNdB2fntFyhKpk3qoT";
-const VAULT_TRON: &str = "TEcDijvKSXcfWT7S6rd44H5vNgufm7Y4XC";
+pub const VAULT_ADDRESSES: [(Chain, &str); 4] = [
+    (Chain::Ethereum, "0xF5e10380213880111522dd0efD3dbb45b9f62Bcc"),
+    (Chain::Arbitrum, "0x79001a5e762f3bEFC8e5871b42F6734e00498920"),
+    (Chain::Solana, "J88B7gmadHzTNGiy54c9Ms8BsEXNdB2fntFyhKpk3qoT"),
+    (Chain::Tron, "TEcDijvKSXcfWT7S6rd44H5vNgufm7Y4XC"),
+];
 
 #[derive(Debug)]
 pub struct ChainflipProvider<CX, BR>
@@ -85,7 +87,7 @@ where
 }
 
 fn vault_deposit_addresses() -> Vec<String> {
-    vec![VAULT_ETH.to_string(), VAULT_ARB.to_string(), VAULT_SOL.to_string(), VAULT_TRON.to_string()]
+    VAULT_ADDRESSES.iter().map(|(_, address)| address.to_string()).collect()
 }
 
 fn map_asset_id(asset: &QuoteAsset) -> ChainflipAsset {

--- a/core/crates/swapper/src/mayan/constants.rs
+++ b/core/crates/swapper/src/mayan/constants.rs
@@ -1,4 +1,4 @@
-use primitives::contract_constants::MAYAN_SWIFT_CONTRACT;
+use primitives::{Chain, contract_constants::MAYAN_SWIFT_CONTRACT};
 
 pub const MAYAN_FORWARDER: &str = "0x337685fdaB40D39bd02028545a4FfA7D287cC3E2";
 pub const MAYAN_MCTP: &str = "0x875d6d37EC55c8cF220B9E5080717549d8Aa8EcA";
@@ -28,5 +28,10 @@ pub const SDK_VERSION: &str = "14_1_0";
 // https://docs.mayan.finance/integration/quote-api
 pub const MAYAN_MAX_SLIPPAGE_BPS: u32 = 500;
 
-pub const MAYAN_DEPOSIT_CONTRACTS: [&str; 4] = [MAYAN_FORWARDER, MAYAN_MCTP, MAYAN_SWIFT_CONTRACT, SUI_MCTP_PACKAGE_ID];
-pub const MAYAN_SEND_CONTRACTS: [&str; 1] = [MAYAN_FULFILL_HELPER];
+pub const MAYAN_DEPOSIT_CONTRACTS: [(Chain, &str); 4] = [
+    (Chain::Ethereum, MAYAN_FORWARDER),
+    (Chain::Ethereum, MAYAN_MCTP),
+    (Chain::Ethereum, MAYAN_SWIFT_CONTRACT),
+    (Chain::Sui, SUI_MCTP_PACKAGE_ID),
+];
+pub const MAYAN_SEND_CONTRACTS: [(Chain, &str); 1] = [(Chain::Ethereum, MAYAN_FULFILL_HELPER)];

--- a/core/crates/swapper/src/mayan/mod.rs
+++ b/core/crates/swapper/src/mayan/mod.rs
@@ -11,4 +11,5 @@ mod testkit;
 mod tx_builder;
 mod wormhole_chain;
 
+pub use constants::{MAYAN_DEPOSIT_CONTRACTS, MAYAN_SEND_CONTRACTS};
 pub use provider::Mayan;

--- a/core/crates/swapper/src/mayan/provider.rs
+++ b/core/crates/swapper/src/mayan/provider.rs
@@ -185,8 +185,12 @@ where
 
     async fn get_vault_addresses(&self, _from_timestamp: Option<u64>) -> Result<VaultAddresses, SwapperError> {
         let api_addresses = MayanChain::unique_addresses(self.price_client.get_chains().await?);
-        let deposit: BTreeSet<String> = MAYAN_DEPOSIT_CONTRACTS.iter().map(|s| s.to_string()).chain(api_addresses.iter().cloned()).collect();
-        let send: BTreeSet<String> = MAYAN_SEND_CONTRACTS.iter().map(|s| s.to_string()).chain(api_addresses).collect();
+        let deposit: BTreeSet<String> = MAYAN_DEPOSIT_CONTRACTS
+            .iter()
+            .map(|(_, address)| address.to_string())
+            .chain(api_addresses.iter().cloned())
+            .collect();
+        let send: BTreeSet<String> = MAYAN_SEND_CONTRACTS.iter().map(|(_, address)| address.to_string()).chain(api_addresses).collect();
 
         Ok(VaultAddresses {
             deposit: deposit.into_iter().collect(),
@@ -298,14 +302,14 @@ mod tests {
         let api_address = gem_evm::ethereum_address_checksum("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
         let expected_deposit = MAYAN_DEPOSIT_CONTRACTS
             .iter()
-            .map(|address| address.to_string())
+            .map(|(_, address)| address.to_string())
             .chain([api_address.clone()])
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
         let expected_send = MAYAN_SEND_CONTRACTS
             .iter()
-            .map(|address| address.to_string())
+            .map(|(_, address)| address.to_string())
             .chain([api_address])
             .collect::<BTreeSet<_>>()
             .into_iter()

--- a/core/crates/swapper/src/near_intents/mod.rs
+++ b/core/crates/swapper/src/near_intents/mod.rs
@@ -7,7 +7,7 @@ mod target;
 
 pub use client::base_url;
 pub use model::{QuoteResponse, QuoteResponseError, QuoteResponseResult};
-pub use provider::NearIntents;
+pub use provider::{NearIntents, TREASURY_ADDRESSES};
 
 pub(crate) use assets::{get_asset_id_from_near_asset, get_near_asset_id, supported_assets};
 pub(crate) use client::{NearIntentsClient, NearIntentsExplorer};

--- a/core/crates/swapper/src/near_intents/provider.rs
+++ b/core/crates/swapper/src/near_intents/provider.rs
@@ -29,23 +29,23 @@ const DEFAULT_DEADLINE_MINUTES: i64 = 30;
 const BITCOIN_DEADLINE_MINUTES: i64 = 120;
 
 // Supported-chain subset of https://docs.near-intents.org/security-compliance/treasury-addresses
-const TREASURY_ADDRESSES: [&str; 16] = [
-    "0x2CfF890f0378a11913B6129B2E97417a2c302680",                         // EVM chains
-    "0x233c5370CCfb3cD7409d9A3fb98ab94dE94Cb4Cd",                         // Monad, XLayer
-    "1C6XJtNXiuXvk4oUAVMkKF57CRpaTrN5Ra",                                 // Bitcoin
-    "1LxByjYMdnogW9Nc73srT4NCbS8oPVaXvZ",                                 // Bitcoin Cash
-    "DRmCnxzL9U11EJzLmWkm2ikaZikPFbLuQD",                                 // Dogecoin
-    "LQjEMkuiA2pCwFeUPwsu6ktzUubBVLsahX",                                 // Litecoin
-    "t1Ku2KLyndDPsR32jwnrTMd3yvi9tfFP8ML",                                // Zcash
-    "intents.near",                                                       // NEAR
-    "HWjmoUNYckccg9Qrwi43JTzBcGcM1nbdAtATf9GXmz16",                       // Solana
-    "UQAfoBd_f0pIvNpUPAkOguUrFWpGWV9TWBeZs_5TXE95_trZ",                   // TON
-    "GDJ4JZXZELZD737NVFORH4PSSQDWFDZTKW3AIDKHYQG23ZXBPDGGQBJK",           // Stellar
-    "0x00ea18889868519abd2f238966cab9875750bb2859ed3a34debec37781520138", // Sui
-    "0xd1a1c1804e91ba85a569c7f018bb7502d2f13d4742d2611953c9c14681af6446", // Aptos
-    "TX5XiRXdyz7sdFwF5mnhT1QoGCpbkncpke",                                 // TRON
-    "r9R8jciZBYGq32DxxQrBPi5ysZm67iQitH",                                 // XRP
-    "addr1v8wfpcg4qfhmnzprzysj6j9c53u5j56j8rvhyjp08s53s6g07rfjm",         // Cardano
+pub const TREASURY_ADDRESSES: [(Chain, &str); 16] = [
+    (Chain::Ethereum, "0x2CfF890f0378a11913B6129B2E97417a2c302680"), // every EVM chain except Monad and XLayer
+    (Chain::Monad, "0x233c5370CCfb3cD7409d9A3fb98ab94dE94Cb4Cd"),    // Monad and XLayer
+    (Chain::Bitcoin, "1C6XJtNXiuXvk4oUAVMkKF57CRpaTrN5Ra"),
+    (Chain::BitcoinCash, "1LxByjYMdnogW9Nc73srT4NCbS8oPVaXvZ"),
+    (Chain::Doge, "DRmCnxzL9U11EJzLmWkm2ikaZikPFbLuQD"),
+    (Chain::Litecoin, "LQjEMkuiA2pCwFeUPwsu6ktzUubBVLsahX"),
+    (Chain::Zcash, "t1Ku2KLyndDPsR32jwnrTMd3yvi9tfFP8ML"),
+    (Chain::Near, "intents.near"),
+    (Chain::Solana, "HWjmoUNYckccg9Qrwi43JTzBcGcM1nbdAtATf9GXmz16"),
+    (Chain::Ton, "UQAfoBd_f0pIvNpUPAkOguUrFWpGWV9TWBeZs_5TXE95_trZ"),
+    (Chain::Stellar, "GDJ4JZXZELZD737NVFORH4PSSQDWFDZTKW3AIDKHYQG23ZXBPDGGQBJK"),
+    (Chain::Sui, "0x00ea18889868519abd2f238966cab9875750bb2859ed3a34debec37781520138"),
+    (Chain::Aptos, "0xd1a1c1804e91ba85a569c7f018bb7502d2f13d4742d2611953c9c14681af6446"),
+    (Chain::Tron, "TX5XiRXdyz7sdFwF5mnhT1QoGCpbkncpke"),
+    (Chain::Xrp, "r9R8jciZBYGq32DxxQrBPi5ysZm67iQitH"),
+    (Chain::Cardano, "addr1v8wfpcg4qfhmnzprzysj6j9c53u5j56j8rvhyjp08s53s6g07rfjm"),
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -399,7 +399,7 @@ where
     async fn get_vault_addresses(&self, _from_timestamp: Option<u64>) -> Result<VaultAddresses, SwapperError> {
         Ok(VaultAddresses {
             deposit: vec![],
-            send: TREASURY_ADDRESSES.iter().map(|s| s.to_string()).collect(),
+            send: TREASURY_ADDRESSES.iter().map(|(_, address)| address.to_string()).collect(),
         })
     }
 }

--- a/core/crates/swapper/src/squid/mod.rs
+++ b/core/crates/swapper/src/squid/mod.rs
@@ -13,7 +13,7 @@ use primitives::{
 
 pub use provider::Squid;
 
-const SQUID_COSMOS_MULTICALL: &str = "osmo1n6ney9tsf55etz9nrmzyd8wa7e64qd3s06a74fqs30ka8pps6cvqtsycr6";
+pub const SQUID_COSMOS_MULTICALL: (Chain, &str) = (Chain::Osmosis, "osmo1n6ney9tsf55etz9nrmzyd8wa7e64qd3s06a74fqs30ka8pps6cvqtsycr6");
 
 static SUPPORTED_CHAINS: LazyLock<Vec<SwapperChainAsset>> = LazyLock::new(|| {
     vec![

--- a/core/crates/swapper/src/squid/provider.rs
+++ b/core/crates/swapper/src/squid/provider.rs
@@ -173,7 +173,7 @@ where
     }
 
     async fn get_vault_addresses(&self, _from_timestamp: Option<u64>) -> Result<VaultAddresses, SwapperError> {
-        let address = SQUID_COSMOS_MULTICALL.to_string();
+        let address = SQUID_COSMOS_MULTICALL.1.to_string();
         Ok(VaultAddresses {
             deposit: vec![address.clone()],
             send: vec![address],

--- a/core/crates/swapper/src/thorchain/mod.rs
+++ b/core/crates/swapper/src/thorchain/mod.rs
@@ -13,6 +13,7 @@ mod target;
 
 pub use provider::ThorChain;
 
+use primitives::Chain;
 use strum::Display;
 
 use super::SwapperProvider;
@@ -40,17 +41,17 @@ impl THORChainNetwork {
         }
     }
 
-    pub fn router_addresses(&self) -> &'static [&'static str] {
+    pub fn routers(&self) -> &'static [(Chain, &'static str)] {
         match self {
             Self::Thorchain => &[
-                "0xD37BbE5744D730a1d98d8DC97c42F0Ca46aD7146", // Ethereum
-                "0xb30eC53F98ff5947EDe720D32aC2da7e52A5f56b", // SmartChain
-                "0x8F66c4AE756BEbC49Ec8B81966DD8bba9f127549", // AvalancheC
-                "0x68208D99746b805a1Ae41421950A47b711E35681", // Base
+                (Chain::Ethereum, "0xD37BbE5744D730a1d98d8DC97c42F0Ca46aD7146"),
+                (Chain::SmartChain, "0xb30eC53F98ff5947EDe720D32aC2da7e52A5f56b"),
+                (Chain::AvalancheC, "0x8F66c4AE756BEbC49Ec8B81966DD8bba9f127549"),
+                (Chain::Base, "0x68208D99746b805a1Ae41421950A47b711E35681"),
             ],
             Self::Mayachain => &[
-                "0xe3985E6b61b814F7Cdb188766562ba71b446B46d", // Ethereum
-                "0x700E97ef07219440487840Dc472E7120A7FF11F4", // Arbitrum
+                (Chain::Ethereum, "0xe3985E6b61b814F7Cdb188766562ba71b446B46d"),
+                (Chain::Arbitrum, "0x700E97ef07219440487840Dc472E7120A7FF11F4"),
             ],
         }
     }

--- a/core/crates/swapper/src/thorchain/provider.rs
+++ b/core/crates/swapper/src/thorchain/provider.rs
@@ -113,7 +113,7 @@ where
     async fn get_vault_addresses(&self, _from_timestamp: Option<u64>) -> Result<VaultAddresses, SwapperError> {
         let vaults = self.client.get_asgard_vaults().await?;
         let asgard_addresses: HashSet<String> = AsgardVault::all_addresses(self.network, &vaults).into_iter().collect();
-        let router_addresses: HashSet<String> = self.network.router_addresses().iter().map(|address| address.to_string()).collect();
+        let router_addresses: HashSet<String> = self.network.routers().iter().map(|(_, address)| address.to_string()).collect();
 
         let deposit: Vec<String> = asgard_addresses.union(&router_addresses).cloned().collect();
         let send: Vec<String> = asgard_addresses.into_iter().collect();


### PR DESCRIPTION
Part of #1036, new Permit2 approvals look consistent (EIP712 and normal ERC20 Approve), our contract labeling shows both Uniswap (address), one of them is Permit2, another one is Router, this pr adds our known swapper contracts to scan address DB

Changes:
1. Store scan address names as "<provider> Permit2" and "<provider> Router" so the spender row tells Uniswap's Permit2 apart from its Universal Router instead of showing "Uniswap" for both.
2. Upsert the names on the (chain, address) key so a rename reaches rows already in the database on the next setup run; the fraud and verification flags stay untouched.
3. Tag the static THORChain and Maya routers, Chainflip vaults, NEAR Intents treasuries, Mayan contracts and the Squid multicall with their chain at the source, so the provider and the setup step read one table.
4. Add those addresses and the Across multicall handlers under the provider name, so history and confirmation rows show "THORChain" or "Chainflip" instead of a raw address. EVM contracts deployed at one address on every chain sit under Ethereum; the address name lookup already falls back across chains.