### PR TITLE
Fix crash when connecting to a flagged WalletConnect app

### DIFF
--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/ProposalSceneViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/ProposalSceneViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import uniffi.gemstone.GemWalletConnectException
 import uniffi.gemstone.GemWalletConnectServiceInterface
 import uniffi.gemstone.WalletConnectionVerificationStatus
@@ -69,18 +70,20 @@ class ProposalSceneViewModel @Inject constructor(
             Log.d(TAG, "Ignoring duplicate proposal")
             return
         }
-        viewModelScope.launch(Dispatchers.IO) {
-            val prepared = runCatchingCancellable {
-                prepareSessionProposal(
-                    name = proposal.name,
-                    description = proposal.description,
-                    url = proposal.url,
-                    icons = proposal.icons,
-                    requiredChainIds = proposal.requiredNamespaces.values.flatMap { it.chains.orEmpty() },
-                    optionalChainIds = proposal.optionalNamespaces.values.flatMap { it.chains.orEmpty() },
-                    origin = verifyContext.origin,
-                    validation = verifyContext.map(),
-                )
+        viewModelScope.launch {
+            val prepared = withContext(Dispatchers.IO) {
+                runCatchingCancellable {
+                    prepareSessionProposal(
+                        name = proposal.name,
+                        description = proposal.description,
+                        url = proposal.url,
+                        icons = proposal.icons,
+                        requiredChainIds = proposal.requiredNamespaces.values.flatMap { it.chains.orEmpty() },
+                        optionalChainIds = proposal.optionalNamespaces.values.flatMap { it.chains.orEmpty() },
+                        origin = verifyContext.origin,
+                        validation = verifyContext.map(),
+                    )
+                }
             }.getOrElse { error ->
                 Log.e(TAG, "session proposal rejected: ${error.message}")
                 if (error is GemWalletConnectException.InvalidOrigin) onNotify(BridgeRequestError.MaliciousSession)

--- a/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
+++ b/android/features/bridge/viewmodels/src/main/kotlin/com/gemwallet/android/features/bridge/viewmodels/WCRequestViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import uniffi.gemstone.GemSignMessageServiceInterface
 import uniffi.gemstone.GemWalletConnectFailure
 import uniffi.gemstone.GemWalletConnectServiceInterface
@@ -85,18 +86,20 @@ class WCRequestViewModel @Inject constructor(
         pendingRequests.current.value?.takeIf { it.sessionId == sessionRequest.topic }?.reject()
         state.update { RequestViewModelState(sessionRequest = sessionRequest) }
         Log.d(TAG, "Resolving request method=${sessionRequest.request.method} chainId=${sessionRequest.chainId} id=${sessionRequest.request.id}")
-        val job = viewModelScope.launch(Dispatchers.IO) {
-            val outcome = service.processRequest(
-                GemWalletConnectSessionRequest(
-                    topic = sessionRequest.topic,
-                    requestId = sessionRequest.request.id.toString(),
-                    method = sessionRequest.request.method,
-                    params = sessionRequest.request.params,
-                    chainId = sessionRequest.chainId,
-                    origin = verifyContext.origin,
-                    validation = verifyContext.map(),
-                ),
-            )
+        val job = viewModelScope.launch {
+            val outcome = withContext(Dispatchers.IO) {
+                service.processRequest(
+                    GemWalletConnectSessionRequest(
+                        topic = sessionRequest.topic,
+                        requestId = sessionRequest.request.id.toString(),
+                        method = sessionRequest.request.method,
+                        params = sessionRequest.request.params,
+                        chainId = sessionRequest.chainId,
+                        origin = verifyContext.origin,
+                        validation = verifyContext.map(),
+                    ),
+                )
+            }
             when (val failure = outcome.failure) {
                 null -> Unit
                 GemWalletConnectFailure.MaliciousOrigin -> onNotify(BridgeRequestError.MaliciousSession)


### PR DESCRIPTION
When a WalletConnect app was flagged as untrusted, the wallet crashed instead of showing the warning.

Now the warning appears correctly and the app no longer crashes.