### PR TITLE
Seed wallet prices in every currency

### DIFF
--- a/core/crates/gem_api/src/client.rs
+++ b/core/crates/gem_api/src/client.rs
@@ -1,8 +1,6 @@
 use gem_client::{Client, ClientError, ClientExt};
 use primitives::currency::Currency;
-use primitives::{
-    AssetBasic, AssetFull, AssetId, AssetPrice, AssetPrices, AssetPricesRequest, Chain, ChartPeriod, Charts, ConfigResponse, FiatAssets, FiatQuoteType, SearchResponse,
-};
+use primitives::{AssetBasic, AssetFull, AssetId, AssetPrices, AssetPricesRequest, Chain, ChartPeriod, Charts, ConfigResponse, FiatAssets, FiatQuoteType, SearchResponse};
 
 use crate::target::GemApiTarget;
 
@@ -41,9 +39,12 @@ impl<C: Client> GemApiClient<C> {
         self.client.get(GemApiTarget::GetSearch { query, chains, tags }).await
     }
 
-    pub async fn get_prices(&self, currency: Option<Currency>, asset_ids: Vec<AssetId>) -> Result<Vec<AssetPrice>, ClientError> {
-        let request = AssetPricesRequest { currency, asset_ids };
-        Ok(self.client.post::<_, AssetPrices>(GemApiTarget::GetPrices, &request).await?.prices)
+    pub async fn get_prices(&self, asset_ids: Vec<AssetId>) -> Result<AssetPrices, ClientError> {
+        let request = AssetPricesRequest {
+            currency: Some(Currency::USD),
+            asset_ids,
+        };
+        self.client.post(GemApiTarget::GetPrices, &request).await
     }
 
     pub async fn get_fiat_assets(&self, quote_type: FiatQuoteType) -> Result<FiatAssets, ClientError> {

--- a/core/crates/pricer/src/price_client.rs
+++ b/core/crates/pricer/src/price_client.rs
@@ -97,7 +97,11 @@ impl PriceClient {
             .map(|x| x.as_asset_price_primitive_with_rate(rate))
             .collect();
 
-        Ok(AssetPrices { currency, prices })
+        Ok(AssetPrices {
+            currency,
+            prices,
+            rates: self.get_fiat_rates()?,
+        })
     }
 
     pub async fn aggregate_charts(&self, timeframe: ChartTimeframe) -> Result<usize, Box<dyn Error + Send + Sync>> {

--- a/core/crates/primitives/src/asset_price.rs
+++ b/core/crates/primitives/src/asset_price.rs
@@ -5,7 +5,7 @@ use typeshare::typeshare;
 
 use crate::currency::Currency;
 use crate::portfolio::ChartValuePercentage;
-use crate::{AssetId, Price};
+use crate::{AssetId, FiatRate, Price};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[typeshare(swift = "Sendable, Equatable, Hashable")]
@@ -86,6 +86,8 @@ impl AssetMarket {
 pub struct AssetPrices {
     pub currency: Currency,
     pub prices: Vec<AssetPrice>,
+    #[serde(default)]
+    pub rates: Vec<FiatRate>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -162,5 +164,19 @@ impl ChartPeriod {
             ChartPeriod::Year => 525_600,
             ChartPeriod::All => 10_525_600,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_asset_prices_rates_default_to_empty() {
+        let prices: AssetPrices = serde_json::from_str(r#"{"currency":"USD","prices":[]}"#).unwrap();
+        assert!(prices.rates.is_empty());
+
+        let prices: AssetPrices = serde_json::from_str(r#"{"currency":"USD","prices":[],"rates":[{"symbol":"EUR","rate":0.5}]}"#).unwrap();
+        assert_eq!(prices.rates[0].rate, 0.5);
     }
 }

--- a/core/gemstone/src/services/balance/mod.rs
+++ b/core/gemstone/src/services/balance/mod.rs
@@ -134,10 +134,7 @@ impl GemBalanceService {
         if asset_ids.is_empty() {
             return;
         }
-        let currency = self.preferences.get_currency();
-        if let Ok(prices) = self.price.get_prices(currency.clone(), asset_ids.clone()).await {
-            let _ = self.price.update_prices(prices, currency).await;
-        }
+        let _ = self.price.sync_prices(asset_ids.clone(), self.preferences.get_currency()).await;
         let _ = self.stream.add_prices(asset_ids.clone()).await;
         let _ = self.update(wallet_id, asset_ids).await;
     }

--- a/core/gemstone/src/services/price/mod.rs
+++ b/core/gemstone/src/services/price/mod.rs
@@ -34,8 +34,9 @@ impl GemPriceService {
         self.store.get_prices(asset_ids).await
     }
 
-    pub async fn get_prices(&self, currency: Currency, asset_ids: Vec<AssetId>) -> Result<Vec<AssetPrice>, GemApiError> {
-        Ok(self.api.client.get_prices(Some(currency), asset_ids).await?)
+    pub async fn sync_prices(&self, asset_ids: Vec<AssetId>, currency: Currency) -> Result<(), GemServiceError> {
+        let response = self.api.client.get_prices(asset_ids).await.map_err(GemApiError::from)?;
+        sync_prices(self.store.as_ref(), response.rates, response.prices, currency).await
     }
 
     pub async fn update_prices(&self, prices: Vec<AssetPrice>, currency: Currency) -> Result<(), GemServiceError> {
@@ -79,6 +80,11 @@ async fn update_prices(store: &dyn GemPriceStore, prices: Vec<AssetPrice>, curre
         return Ok(());
     };
     store.save_prices(currency, rules::fiat_prices(prices, &rate)).await
+}
+
+async fn sync_prices(store: &dyn GemPriceStore, rates: Vec<FiatRate>, prices: Vec<AssetPrice>, currency: Currency) -> Result<(), GemServiceError> {
+    update_rates(store, rates, currency.clone()).await?;
+    update_prices(store, prices, currency).await
 }
 
 async fn update_rates(store: &dyn GemPriceStore, rates: Vec<FiatRate>, currency: Currency) -> Result<(), GemServiceError> {
@@ -146,6 +152,19 @@ mod tests {
         assert_eq!(saved[0].1[0].asset_id, asset_id);
         assert_eq!(saved[0].1[0].price, 0.0);
         assert_eq!(saved[0].1[0].price_usd, 0.0);
+    }
+
+    #[test]
+    fn test_sync_prices_stores_the_rate_before_converting_a_non_usd_price() {
+        let store = MemoryPriceStore::default();
+        let rates = vec![FiatRate { symbol: Currency::EUR, rate: 0.5 }];
+
+        futures::executor::block_on(sync_prices(&store, rates, vec![price(100.0)], Currency::EUR)).unwrap();
+
+        let saved = store.saved.lock().unwrap();
+        assert_eq!(saved[0].0, Currency::EUR);
+        assert_eq!(saved[0].1[0].price, 50.0);
+        assert_eq!(saved[0].1[0].price_usd, 100.0);
     }
 
     #[test]


### PR DESCRIPTION
A new wallet only got prices when the currency was USD. For any other currency the first price fetch was thrown away because the app had no exchange rate yet, so the wallet screen stayed without prices until the live price stream connected, and never if it did not.

The price endpoint now returns the exchange rates together with USD prices, and the app stores the rate before converting, so prices show up right after the wallet is created in any currency. The API change is backward compatible; deploy it before the app release.