### PR TITLE
Fix push notifications landing on the wallet root after a wallet switch

### DIFF
--- a/ios/Gem/Navigation/NavigationHandler.swift
+++ b/ios/Gem/Navigation/NavigationHandler.swift
@@ -267,8 +267,7 @@ extension NavigationHandler {
             return
         }
 
-        await selectWalletIfNeeded(walletId)
-        navigationState.openAsset(asset)
+        try openWallet(walletId, path: getPath(for: asset))
     }
 
     private func trackNotificationTransaction(walletId: WalletId, transaction: Primitives.Transaction) {
@@ -294,32 +293,28 @@ extension NavigationHandler {
         trackNotificationTransaction(walletId: walletId, transaction: transaction)
         let transaction = try transactionStore.getTransaction(walletId: walletId, transactionId: transaction.id)
 
-        await selectWalletIfNeeded(walletId)
-        switch asset.type {
-        case .perpetual:
-            navigationState.wallet.setPath([Scenes.Perpetuals(), Scenes.Perpetual(asset), Scenes.Transaction(transaction: transaction)])
-        default:
-            navigationState.wallet.setPath([Scenes.Asset(asset: asset), Scenes.Transaction(transaction: transaction)])
-        }
-
-        navigationState.selectedTab = .wallet
+        try openWallet(walletId, path: getPath(for: asset, transaction: transaction))
     }
 
-    private func selectWalletIfNeeded(_ walletId: WalletId) async {
+    private func openWallet(_ walletId: WalletId, path: [any Hashable & Codable]) throws {
         guard walletSessionService.currentWalletId != walletId else {
-            return
+            return navigationState.openWallet(path: path)
         }
+        try walletSessionService.setCurrent(walletId: walletId)
+        navigationState.pendingWalletPath = path
+    }
 
-        do {
-            try walletSessionService.setCurrent(walletId: walletId)
-        } catch {
-            debugLog("set current wallet error: \(error)")
-            return
+    private func getPath(for asset: Asset) -> [any Hashable & Codable] {
+        switch asset.type {
+        case .perpetual: [Scenes.Perpetual(asset)]
+        default: [Scenes.Asset(asset: asset)]
         }
-        await withCheckedContinuation { continuation in
-            RunLoop.main.perform(inModes: [.common]) {
-                continuation.resume()
-            }
+    }
+
+    private func getPath(for asset: Asset, transaction: TransactionExtended) -> [any Hashable & Codable] {
+        switch asset.type {
+        case .perpetual: [Scenes.Perpetuals(), Scenes.Perpetual(asset), Scenes.Transaction(transaction: transaction)]
+        default: [Scenes.Asset(asset: asset), Scenes.Transaction(transaction: transaction)]
         }
     }
 
@@ -348,8 +343,7 @@ extension NavigationHandler {
     }
 
     func resetNavigation() {
-        navigationState.clearAll()
-        navigationState.selectedTab = .wallet
+        navigationState.reset()
     }
 }
 

--- a/ios/Gem/Navigation/NavigationStateManager.swift
+++ b/ios/Gem/Navigation/NavigationStateManager.swift
@@ -22,6 +22,9 @@ final class NavigationStateManager: Sendable {
     @MainActor
     var walletTabReselected = false
 
+    @MainActor
+    var pendingWalletPath: [any Hashable & Codable] = []
+
     init() {}
 }
 
@@ -51,10 +54,13 @@ extension NavigationStateManager {
         }
     }
 
-    func clearAll() {
+    func reset() {
         for tabItem in TabItem.allCases {
             backToRoot(tab: tabItem)
         }
+        selectedTab = .wallet
+        wallet.setPath(pendingWalletPath)
+        pendingWalletPath = []
     }
 
     func openAsset(_ asset: Asset) {
@@ -63,6 +69,12 @@ extension NavigationStateManager {
         } else {
             wallet.append(Scenes.Asset(asset: asset))
         }
+        selectedTab = .wallet
+        previousSelectedTab = .wallet
+    }
+
+    func openWallet(path: [any Hashable & Codable]) {
+        wallet.setPath(path)
         selectedTab = .wallet
         previousSelectedTab = .wallet
     }


### PR DESCRIPTION
A push for another wallet switched the wallet, opened its screen, then waited one run-loop turn hoping the navigation reset that follows a wallet switch had already run. It often hadn't, so the reset wiped the screen and the notification landed on the wallet root.

The reset has to stay tied to the wallet change — core switches the wallet itself when the current one is deleted — so the push now hands its path to that reset instead of racing it: switch, keep the wallet path, and the reset applies it after clearing. A push for the current wallet opens immediately. Stake and fiat pushes now replace the wallet stack like transaction pushes do.

Fixes #904
