### PR TITLE
Keep gallery QR images at full resolution and deliver one camera result

### DIFF
--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/QRCodeDecoder.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/QRCodeDecoder.kt
@@ -8,12 +8,18 @@ import com.google.zxing.MultiFormatReader
 import com.google.zxing.PlanarYUVLuminanceSource
 import com.google.zxing.RGBLuminanceSource
 import com.google.zxing.common.HybridBinarizer
+import kotlin.math.ceil
+import kotlin.math.sqrt
 
 object QRCodeDecoder {
+    private const val MAX_IMAGE_PIXELS = 16_000_000.0
     private val hints = mapOf(
         DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE),
         DecodeHintType.TRY_HARDER to true,
     )
+
+    fun sampleSize(width: Int, height: Int): Int =
+        ceil(sqrt(width.toDouble() * height / MAX_IMAGE_PIXELS)).toInt().coerceAtLeast(1)
 
     fun decode(luma: ByteArray, rowStride: Int, width: Int, height: Int): String? =
         decode(PlanarYUVLuminanceSource(luma, rowStride, height, 0, 0, width, height, false))

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/QRScanner.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/QRScanner.kt
@@ -79,7 +79,6 @@ import java.util.concurrent.Executors
 import kotlin.math.min
 
 private val QR_ANALYSIS_RESOLUTION = Size(1280, 720)
-private const val MAX_IMAGE_SIDE = 1600
 private const val SCAN_FROM_GALLERY_TAG = "scanFromGallery"
 private const val FINDER_SCALE = 0.66f
 private val HINT_SPACING = space24
@@ -168,7 +167,7 @@ fun QRScannerScene(
             try {
                 val bitmap = ImageDecoder.decodeBitmap(ImageDecoder.createSource(context.contentResolver, image)) { decoder, info, _ ->
                     decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
-                    decoder.setTargetSampleSize(maxOf(1, maxOf(info.size.width, info.size.height) / MAX_IMAGE_SIDE))
+                    decoder.setTargetSampleSize(QRCodeDecoder.sampleSize(info.size.width, info.size.height))
                 }
                 val pixels = IntArray(bitmap.width * bitmap.height)
                 bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
@@ -343,11 +342,10 @@ private class QRCodeAnalyzer(
 ) : androidx.camera.core.ImageAnalysis.Analyzer {
 
     override fun analyze(imageProxy: androidx.camera.core.ImageProxy) {
-        val text = imageProxy.use {
+        imageProxy.use {
             val plane = it.planes.first()
-            QRCodeDecoder.decode(plane.buffer.toByteArray(), plane.rowStride, it.width, it.height)
+            QRCodeDecoder.decode(plane.buffer.toByteArray(), plane.rowStride, it.width, it.height)?.let(callback)
         }
-        text?.let(callback)
     }
 }
 

--- a/android/ui/src/test/kotlin/com/gemwallet/android/ui/components/QRCodeDecoderTest.kt
+++ b/android/ui/src/test/kotlin/com/gemwallet/android/ui/components/QRCodeDecoderTest.kt
@@ -40,6 +40,14 @@ class QRCodeDecoderTest {
     }
 
     @Test
+    fun keepsFullResolutionUpToSixteenMegapixels() {
+        assertEquals(1, QRCodeDecoder.sampleSize(1080, 2340))
+        assertEquals(1, QRCodeDecoder.sampleSize(1440, 6400))
+        assertEquals(1, QRCodeDecoder.sampleSize(4000, 3000))
+        assertEquals(2, QRCodeDecoder.sampleSize(8160, 6120))
+    }
+
+    @Test
     fun returnsNullWithoutCode() {
         assertNull(QRCodeDecoder.decode(ByteArray(width * height) { WHITE }, width, width, height))
     }


### PR DESCRIPTION
Picking a tall screenshot from the gallery shrank it several times before decoding, so a small WalletConnect code in it was not read. Images are now downsampled only past 16 megapixels, which still keeps a 50 MP photo from running out of memory.

The camera analyzer released the frame before stopping itself, and CameraX hands over the next frame on release, so the same code could be reported twice. The result is delivered before the frame is released.
