### PR TITLE
Keep one approval value mapping in the confirm rules

### DIFF
--- a/core/gemstone/src/services/confirm/mod.rs
+++ b/core/gemstone/src/services/confirm/mod.rs
@@ -164,7 +164,7 @@ impl GemConfirmService {
             None => self.simulation_formatter.header(simulation.clone()).and_then(|header| {
                 assets.iter().find(|asset| asset.id == header.asset_id).map(|asset| GemSimulationValue {
                     asset: asset.clone(),
-                    value: rules::approval_value_from(&header.value, header.is_unlimited),
+                    value: rules::approval_value_from(header.value.as_ref(), header.is_unlimited),
                 })
             }),
         };

--- a/core/gemstone/src/services/confirm/rules.rs
+++ b/core/gemstone/src/services/confirm/rules.rs
@@ -79,7 +79,7 @@ pub(super) trait ConfirmInput {
 impl ConfirmInput for TransactionInputType {
     fn approval_value(&self) -> Option<(AssetId, GemApprovalValue)> {
         match self {
-            Self::TokenApprove { asset, approval_data } => Some((asset.id.clone(), gem_approval_value(&approval_data.value, approval_data.is_unlimited))),
+            Self::TokenApprove { asset, approval_data } => Some((asset.id.clone(), approval_value_from(Some(&approval_data.value), approval_data.is_unlimited))),
             Self::Transfer { .. }
             | Self::Deposit { .. }
             | Self::Swap { .. }
@@ -119,18 +119,10 @@ impl ConfirmInput for TransactionInputType {
     }
 }
 
-pub fn approval_value_from(value: &Option<GemBigUint>, is_unlimited: bool) -> GemApprovalValue {
+pub fn approval_value_from(value: Option<&GemBigUint>, is_unlimited: bool) -> GemApprovalValue {
     match value {
         Some(value) if !is_unlimited => GemApprovalValue::Exact { value: value.clone() },
         _ => GemApprovalValue::Unlimited,
-    }
-}
-
-fn gem_approval_value(value: &GemBigUint, is_unlimited: bool) -> GemApprovalValue {
-    if is_unlimited {
-        GemApprovalValue::Unlimited
-    } else {
-        GemApprovalValue::Exact { value: value.clone() }
     }
 }
 
@@ -1106,8 +1098,8 @@ mod tests {
 
         assert!(matches!(approval.approval_value(), Some((id, GemApprovalValue::Unlimited)) if id == asset.id));
         assert!((TransactionInputType::Transfer { asset }).approval_value().is_none());
-        assert!(matches!(gem_approval_value(&GemBigUint::from(42u32), false), GemApprovalValue::Exact { value } if value == GemBigUint::from(42u32)));
-        assert!(matches!(gem_approval_value(&GemBigUint::from(42u32), true), GemApprovalValue::Unlimited));
+        assert!(matches!(approval_value_from(Some(&GemBigUint::from(42u32)), false), GemApprovalValue::Exact { value } if value == GemBigUint::from(42u32)));
+        assert!(matches!(approval_value_from(Some(&GemBigUint::from(42u32)), true), GemApprovalValue::Unlimited));
     }
 
     fn balance(asset_id: &AssetId, available: u32) -> GemAssetBalance {


### PR DESCRIPTION
1. Fold gem_approval_value into approval_value_from, which already handled the optional header value the same way, so the token approve input and the simulation header share one function.
2. The function takes the value by optional reference instead of a reference to an Option, which lets both callers pass what they hold without wrapping.