### PR TITLE
Centralize Chainflip chain and asset mapping

### DIFF
--- a/core/crates/swapper/src/chainflip/capitalize.rs
+++ b/core/crates/swapper/src/chainflip/capitalize.rs
@@ -1,7 +1,0 @@
-pub fn capitalize_first_letter(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(first_char) => first_char.to_uppercase().collect::<String>() + chars.as_str(),
-    }
-}

--- a/core/crates/swapper/src/chainflip/chain.rs
+++ b/core/crates/swapper/src/chainflip/chain.rs
@@ -1,0 +1,34 @@
+use primitives::Chain;
+use strum::{AsRefStr, EnumString};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AsRefStr, EnumString)]
+pub enum ChainflipChain {
+    Ethereum,
+    Bitcoin,
+    Solana,
+    Arbitrum,
+    Tron,
+}
+
+impl ChainflipChain {
+    pub fn from_chain(chain: Chain) -> Option<Self> {
+        match chain {
+            Chain::Ethereum => Some(Self::Ethereum),
+            Chain::Bitcoin => Some(Self::Bitcoin),
+            Chain::Solana => Some(Self::Solana),
+            Chain::Arbitrum => Some(Self::Arbitrum),
+            Chain::Tron => Some(Self::Tron),
+            _ => None,
+        }
+    }
+
+    pub fn to_chain(self) -> Chain {
+        match self {
+            Self::Ethereum => Chain::Ethereum,
+            Self::Bitcoin => Chain::Bitcoin,
+            Self::Solana => Chain::Solana,
+            Self::Arbitrum => Chain::Arbitrum,
+            Self::Tron => Chain::Tron,
+        }
+    }
+}

--- a/core/crates/swapper/src/chainflip/client/model.rs
+++ b/core/crates/swapper/src/chainflip/client/model.rs
@@ -9,7 +9,8 @@ use primitives::swap::SwapStatus;
 use primitives::{AssetId, Chain, TransactionSwapMetadata, known_assets::*};
 use serde::{Deserialize, Serialize};
 
-use crate::{SwapResult, SwapperChainAsset, SwapperProvider};
+use crate::chainflip::{broker::ChainflipAsset, chain::ChainflipChain};
+use crate::{SwapResult, SwapperChainAsset, SwapperError, SwapperProvider};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -82,40 +83,40 @@ pub struct SwapDetail {
     pub swapped_output_amount: String,
 }
 
-fn chainflip_chain_to_chain(chain: &str) -> Option<Chain> {
-    match chain {
-        "Ethereum" => Some(Chain::Ethereum),
-        "Bitcoin" => Some(Chain::Bitcoin),
-        "Solana" => Some(Chain::Solana),
-        "Arbitrum" => Some(Chain::Arbitrum),
-        "Tron" => Some(Chain::Tron),
-        _ => None,
-    }
-}
-
-static ASSETS: LazyLock<Vec<(Chain, &'static str, AssetId)>> = LazyLock::new(|| {
+static ASSETS: LazyLock<Vec<(&'static str, AssetId)>> = LazyLock::new(|| {
     vec![
-        (Chain::Bitcoin, "BTC", AssetId::from_chain(Chain::Bitcoin)),
-        (Chain::Ethereum, "ETH", AssetId::from_chain(Chain::Ethereum)),
-        (Chain::Ethereum, "USDC", ETHEREUM_USDC.id.clone()),
-        (Chain::Ethereum, "USDT", ETHEREUM_USDT.id.clone()),
-        (Chain::Ethereum, "WBTC", ETHEREUM_WBTC.id.clone()),
-        (Chain::Ethereum, "FLIP", ETHEREUM_FLIP.id.clone()),
-        (Chain::Solana, "SOL", AssetId::from_chain(Chain::Solana)),
-        (Chain::Solana, "USDC", SOLANA_USDC.id.clone()),
-        (Chain::Solana, "USDT", SOLANA_USDT.id.clone()),
-        (Chain::Tron, "TRX", AssetId::from_chain(Chain::Tron)),
-        (Chain::Tron, "USDT", TRON_USDT.id.clone()),
-        (Chain::Arbitrum, "ETH", AssetId::from_chain(Chain::Arbitrum)),
-        (Chain::Arbitrum, "USDC", ARBITRUM_USDC.id.clone()),
-        (Chain::Arbitrum, "USDT", ARBITRUM_USDT.id.clone()),
+        ("BTC", AssetId::from_chain(Chain::Bitcoin)),
+        ("ETH", AssetId::from_chain(Chain::Ethereum)),
+        ("USDC", ETHEREUM_USDC.id.clone()),
+        ("USDT", ETHEREUM_USDT.id.clone()),
+        ("WBTC", ETHEREUM_WBTC.id.clone()),
+        ("FLIP", ETHEREUM_FLIP.id.clone()),
+        ("SOL", AssetId::from_chain(Chain::Solana)),
+        ("USDC", SOLANA_USDC.id.clone()),
+        ("USDT", SOLANA_USDT.id.clone()),
+        ("TRX", AssetId::from_chain(Chain::Tron)),
+        ("USDT", TRON_USDT.id.clone()),
+        ("ETH", AssetId::from_chain(Chain::Arbitrum)),
+        ("USDC", ARBITRUM_USDC.id.clone()),
+        ("USDT", ARBITRUM_USDT.id.clone()),
     ]
 });
 
+impl ChainflipAsset {
+    pub(crate) fn from_asset_id(asset_id: &AssetId) -> Result<Self, SwapperError> {
+        let (symbol, _) = ASSETS.iter().find(|(_, id)| id == asset_id).ok_or(SwapperError::NotSupportedAsset)?;
+        let chain = ChainflipChain::from_chain(asset_id.chain).ok_or(SwapperError::NotSupportedChain)?;
+        Ok(Self {
+            chain: chain.as_ref().to_string(),
+            asset: symbol.to_string(),
+        })
+    }
+}
+
 pub static SUPPORTED_ASSETS: LazyLock<Vec<SwapperChainAsset>> = LazyLock::new(|| {
     let mut chains: BTreeMap<Chain, Vec<AssetId>> = BTreeMap::new();
-    for (chain, _, asset_id) in ASSETS.iter() {
-        let tokens = chains.entry(*chain).or_default();
+    for (_, asset_id) in ASSETS.iter() {
+        let tokens = chains.entry(asset_id.chain).or_default();
         if asset_id.token_id.is_some() {
             tokens.push(asset_id.clone());
         }
@@ -124,7 +125,7 @@ pub static SUPPORTED_ASSETS: LazyLock<Vec<SwapperChainAsset>> = LazyLock::new(||
 });
 
 fn chainflip_asset_to_asset_id(chain: Chain, asset: &str) -> Option<AssetId> {
-    ASSETS.iter().find(|(c, s, _)| *c == chain && *s == asset).map(|(_, _, id)| id.clone())
+    ASSETS.iter().find(|(symbol, id)| id.chain == chain && *symbol == asset).map(|(_, id)| id.clone())
 }
 
 pub fn map_swap_result(response: &SwapTxResponse) -> SwapResult {
@@ -132,8 +133,8 @@ pub fn map_swap_result(response: &SwapTxResponse) -> SwapResult {
     let eta_in_seconds = response.eta_in_seconds();
 
     let metadata = if status != SwapStatus::Pending {
-        let from_chain = chainflip_chain_to_chain(&response.src_chain);
-        let to_chain = chainflip_chain_to_chain(&response.dest_chain);
+        let from_chain = response.src_chain.parse::<ChainflipChain>().ok().map(ChainflipChain::to_chain);
+        let to_chain = response.dest_chain.parse::<ChainflipChain>().ok().map(ChainflipChain::to_chain);
 
         from_chain.zip(to_chain).and_then(|(fc, tc)| {
             let from_asset = chainflip_asset_to_asset_id(fc, &response.src_asset)?;

--- a/core/crates/swapper/src/chainflip/mod.rs
+++ b/core/crates/swapper/src/chainflip/mod.rs
@@ -1,5 +1,5 @@
 pub mod broker;
-pub mod capitalize;
+pub mod chain;
 pub mod client;
 pub mod default;
 pub mod model;

--- a/core/crates/swapper/src/chainflip/provider.rs
+++ b/core/crates/swapper/src/chainflip/provider.rs
@@ -15,7 +15,6 @@ use super::{
         AssetsResponse, BrokerClient, ChainflipAsset, DcaParameters, QuoteDetails, QuoteRequest as ChainflipQuoteRequest, QuoteResponse, QuoteType, RefundParameters,
         TronVaultSwapResponse, VaultSwapChainExtras, VaultSwapExtras, VaultSwapResponse, VaultSwapSolanaExtras,
     },
-    capitalize::capitalize_first_letter,
     client::{ChainflipClient, SUPPORTED_ASSETS, map_swap_result},
     price::{apply_slippage, price_to_hex_price},
     seed::generate_random_seed,
@@ -31,10 +30,9 @@ use crate::{
     route_cache::Cache,
 };
 use primitives::{
-    Asset, AssetId, ChainType, MINUTE,
+    AssetId, ChainType, MINUTE,
     chain::Chain,
     hex::{decode_hex, encode_with_0x},
-    swap::QuoteAsset,
 };
 
 const DEFAULT_SWAP_ERC20_GAS_LIMIT: u64 = 100_000;
@@ -88,24 +86,13 @@ fn vault_deposit_addresses() -> Vec<String> {
     vec![VAULT_ETH.to_string(), VAULT_ARB.to_string(), VAULT_SOL.to_string(), VAULT_TRON.to_string()]
 }
 
-fn map_asset_id(asset: &QuoteAsset) -> ChainflipAsset {
-    let asset_id = asset.asset_id();
-    let chain_name = capitalize_first_letter(asset_id.chain.as_ref());
-    let symbol = if asset.symbol.is_empty() && asset_id.is_native() {
-        Asset::from_chain(asset_id.chain).symbol
-    } else {
-        asset.symbol.clone()
-    };
-    ChainflipAsset { chain: chain_name, asset: symbol }
-}
-
 fn build_quote_request(request: &QuoteRequest, assets: &AssetsResponse) -> Result<(ChainflipQuoteRequest, BigUint), SwapperError> {
     match request.from_asset.chain().chain_type() {
         ChainType::Ethereum | ChainType::Solana | ChainType::Tron => {}
         _ => return Err(SwapperError::NotSupportedChain),
     }
-    let source_asset = map_asset_id(&request.from_asset);
-    let destination_asset = map_asset_id(&request.to_asset);
+    let source_asset = ChainflipAsset::from_asset_id(&request.from_asset.asset_id())?;
+    let destination_asset = ChainflipAsset::from_asset_id(&request.to_asset.asset_id())?;
     let source_broker_asset = assets.asset(&source_asset).filter(|asset| asset.supports_ingress()).ok_or(SwapperError::NoQuoteAvailable)?;
     let destination_broker_asset = assets
         .asset(&destination_asset)
@@ -286,8 +273,8 @@ where
 
     async fn get_quote_data(&self, quote: &Quote, _data: FetchQuoteData) -> Result<SwapperQuoteData, SwapperError> {
         let from_asset = quote.request.from_asset.asset_id();
-        let source_asset = map_asset_id(&quote.request.from_asset);
-        let destination_asset = map_asset_id(&quote.request.to_asset);
+        let source_asset = ChainflipAsset::from_asset_id(&from_asset)?;
+        let destination_asset = ChainflipAsset::from_asset_id(&quote.request.to_asset.asset_id())?;
 
         let input_amount = quote.from_value.clone();
 


### PR DESCRIPTION
Chainflip requests previously derived protocol identifiers from display symbols and capitalization, while swap results used a separate chain mapping. Centralize chain conversion in `ChainflipChain` and construct `ChainflipAsset` from the shared asset table, so both paths use the same identifiers. Remove the capitalization helper and duplicated chain fields in the table.

Groundwork for #857; this PR adds no new supported assets.

Stack: merge this PR first. #1180 adds BSC/cbBTC support on top of this branch and should be retargeted to `main` afterward.

Validation: `just test swapper` (326 passed, 51 filtered), `cargo clippy -p swapper --all-features --locked -- -D warnings`, formatting, and `git diff --check` passed. No mobile interfaces changed.
