### PR TITLE
Stop refetching a failed NFT image on every frame

### DIFF
--- a/ios/Packages/Components/Sources/CachedAsyncImage.swift
+++ b/ios/Packages/Components/Sources/CachedAsyncImage.swift
@@ -79,8 +79,10 @@ public struct CachedAsyncImage<Content: View>: View {
     private let content: (AsyncImagePhase) -> Content
 
     public var body: some View {
-        content(phase)
-            .task(id: urlRequest) { await load() }
+        ZStack {
+            content(phase)
+        }
+        .task(id: urlRequest) { await load() }
     }
 
     /// Loads and displays an image from the specified URL.


### PR DESCRIPTION
An NFT preview that fails to load was requested again on every frame for as long as the screen stayed open, with no end. This was reproduced with a single failing image: hundreds of requests within seconds on the collection grid and the collectible screen, and thousands of view lifecycle events while the collectible was visible.

The image loader now keeps its load task on a stable container, so a phase change inside the image view no longer restarts the load. A failing image is now requested once per screen and shows its placeholder.