### PR TITLE
Show the pending balance info sheet on Android

### DIFF
--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/AssetDetailsScene.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/AssetDetailsScene.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import com.gemwallet.android.domains.transaction.aggregates.TransactionDataAggregate
 import com.gemwallet.android.ext.asset
 import com.gemwallet.android.ext.type
+import com.gemwallet.android.ui.components.InfoSheetEntity
 import com.gemwallet.android.ui.components.list_item.energyItem
 import com.gemwallet.android.ui.components.list_item.property.itemsPositioned
 import com.gemwallet.android.ui.components.list_item.property.verificationStatusItem
@@ -146,6 +147,12 @@ internal fun AssetDetailsScene(
                         title = item.type.label,
                         balance = item.value,
                         listPosition = position,
+                        info = when (item.type) {
+                            AssetInfoUIModel.BalanceViewType.PendingUnconfirmed -> InfoSheetEntity.PendingUnconfirmedBalanceInfo
+                            AssetInfoUIModel.BalanceViewType.Available,
+                            AssetInfoUIModel.BalanceViewType.Stake,
+                            AssetInfoUIModel.BalanceViewType.Reserved -> null
+                        },
                         onAction = when (item.type) {
                             AssetInfoUIModel.BalanceViewType.Available,
                             AssetInfoUIModel.BalanceViewType.PendingUnconfirmed -> null

--- a/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/components/BalancePropertyItem.kt
+++ b/android/features/asset/presents/src/main/kotlin/com/gemwallet/android/features/asset/presents/details/components/BalancePropertyItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import com.gemwallet.android.ui.components.InfoSheetEntity
 import com.gemwallet.android.ui.components.list_item.property.DataBadgeChevron
 import com.gemwallet.android.ui.components.list_item.property.PropertyDataText
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
@@ -16,13 +17,14 @@ internal fun BalancePropertyItem(
     @StringRes title: Int,
     balance: String,
     listPosition: ListPosition,
-    onAction:(() -> Unit)?,
+    info: InfoSheetEntity? = null,
+    onAction: (() -> Unit)?,
 ) {
     PropertyItem(
         modifier = if (onAction == null) Modifier else Modifier
             .clickable(onClick = onAction)
             .testTag("assetStake"),
-        title = { PropertyTitleText(title) },
+        title = { PropertyTitleText(title, info = info) },
         data = { PropertyDataText(balance, badge = onAction?.let { { DataBadgeChevron() } }) },
         listPosition = listPosition,
     )

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/InfoBottomSheet.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/InfoBottomSheet.kt
@@ -188,6 +188,12 @@ sealed class InfoSheetEntity(
         infoUrl = { AppUrl.docs(DocsUrl.TransactionStatus) },
     )
 
+    object PendingUnconfirmedBalanceInfo : InfoSheetEntity(
+        icon = R.drawable.ic_splash,
+        title = R.string.stake_pending,
+        description = R.string.info_transaction_pending_description,
+    )
+
     class EstimatedConfirmationInfo(chain: Chain) : InfoSheetEntity(
         icon = R.drawable.ic_network_fee,
         title = R.string.transaction_estimated_confirmation,


### PR DESCRIPTION
On the asset screen, the Pending balance row (Bitcoin unconfirmed funds) now has the info button that iOS already shows. Tapping it opens the sheet explaining that the funds are awaiting network confirmation.

<img width="320" alt="android-pending-balance-info-row" src="https://github.com/user-attachments/assets/f23f4e6a-9fa1-4fbd-bd5b-19cdeaa1bc98" />
<img width="320" alt="android-pending-balance-info-sheet" src="https://github.com/user-attachments/assets/06348089-e941-408b-b3ca-6af0576d8dc1" />


