### PR TITLE
Ignore a name lookup result that is no longer current

### DIFF
--- a/ios/Features/Contacts/Tests/ContactsTests/ManageContactAddressViewModelTests.swift
+++ b/ios/Features/Contacts/Tests/ContactsTests/ManageContactAddressViewModelTests.swift
@@ -46,7 +46,7 @@ struct ManageContactAddressViewModelTests {
         let model = ManageContactAddressViewModel.mock(mode: .add)
         model.addressInputModel.text = "john"
 
-        model.addressInputModel.nameRecordViewModel.state = .loading
+        model.addressInputModel.nameRecordViewModel.state = .loading(name: "john")
         #expect(model.buttonState == .disabled)
 
         model.addressInputModel.nameRecordViewModel.state = .error

--- a/ios/Features/Transfer/Tests/RecipientSceneViewModelTests.swift
+++ b/ios/Features/Transfer/Tests/RecipientSceneViewModelTests.swift
@@ -70,7 +70,7 @@ struct RecipientSceneViewModelTests {
 
         #expect(model.actionButtonState == .disabled)
 
-        model.addressInputModel.nameRecordViewModel.state = .loading
+        model.addressInputModel.nameRecordViewModel.state = .loading(name: "test.eth")
         #expect(model.actionButtonState == .disabled)
 
         model.addressInputModel.text = "test.eth"

--- a/ios/Packages/PrimitivesComponents/Sources/Types/NameRecordState.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/Types/NameRecordState.swift
@@ -5,7 +5,7 @@ import Primitives
 
 public enum NameRecordState: Equatable, Hashable, Sendable {
     case none
-    case loading
+    case loading(name: String)
     case error
     case complete(NameRecord)
 }
@@ -14,7 +14,15 @@ public extension NameRecordState {
     var result: NameRecord? {
         switch self {
         case let .complete(result): result
-        default: .none
+        case .none, .loading, .error: .none
+        }
+    }
+
+    var requestedName: String? {
+        switch self {
+        case let .loading(name): name
+        case let .complete(record): record.name
+        case .none, .error: .none
         }
     }
 }

--- a/ios/Packages/PrimitivesComponents/Sources/ViewModels/NameRecordViewModel.swift
+++ b/ios/Packages/PrimitivesComponents/Sources/ViewModels/NameRecordViewModel.swift
@@ -18,7 +18,7 @@ public final class NameRecordViewModel {
     }
 
     public func getNameRecord(name: String, chain: Chain) {
-        guard name != state.result?.name else { return }
+        guard name != state.requestedName else { return }
         nameRecordTask?.cancel()
 
         guard nameService.isNameSupported(name: name) else {
@@ -26,22 +26,21 @@ public final class NameRecordViewModel {
             return
         }
 
-        state = .loading
+        state = .loading(name: name)
         nameRecordTask = Task {
             do {
                 try await Task.sleep(for: .milliseconds(nameService.nameRecordDebounceMilliseconds()))
-                if let record = try await nameService.getNameRecord(name: name, chain: chain),
-                   record.name.isNotEmpty,
-                   record.address.isNotEmpty
-                {
+                let record = try await nameService.getNameRecord(name: name, chain: chain)
+                guard state == .loading(name: name) else { return }
+
+                if let record, record.name.isNotEmpty, record.address.isNotEmpty {
                     state = .complete(record)
                 } else {
                     state = .error
                 }
             } catch {
-                if !error.isCancelled {
-                    state = .error
-                }
+                guard !error.isCancelled, state == .loading(name: name) else { return }
+                state = .error
             }
         }
     }

--- a/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/AddressInputViewModelTests.swift
+++ b/ios/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/AddressInputViewModelTests.swift
@@ -18,7 +18,7 @@ struct AddressInputViewModelTests {
         #expect(model.validate() == false)
 
         model.inputModel.text = "test.eth"
-        model.nameRecordViewModel.state = .loading
+        model.nameRecordViewModel.state = .loading(name: "test.eth")
         #expect(model.validate() == false)
 
         model.nameRecordViewModel.state = .error


### PR DESCRIPTION
When a name is being resolved and the user changes it, a slow answer for the old name could arrive last and replace the newer one.

On the import screen that could create a watch wallet for the wrong address, under the wrong name. On the send and contact screens it could leave the wrong address behind the name shown on screen.

A result is now applied only while it still matches the name being resolved.