### PR TITLE
Stop flashing the default logo when a wallet avatar loads

### DIFF
--- a/ios/Packages/Components/Sources/ImageLoader.swift
+++ b/ios/Packages/Components/Sources/ImageLoader.swift
@@ -38,8 +38,8 @@ final class ImageLoader: @unchecked Sendable {
         if let image = images.object(forKey: request.cacheKey) {
             return image
         }
-        guard let cached = session.configuration.urlCache?.cachedResponse(for: URLRequest(url: request.url)),
-              let image = Self.decode(cached.data, request: request)
+        guard let data = localData(for: request.url),
+              let image = Self.decode(data, request: request)
         else {
             return nil
         }
@@ -64,6 +64,13 @@ final class ImageLoader: @unchecked Sendable {
             cache?.storeCachedResponse(CachedURLResponse(response: response, data: data), for: urlRequest)
         }
         return store(image, for: request)
+    }
+
+    private func localData(for url: URL) -> Data? {
+        if url.isFileURL {
+            return try? Data(contentsOf: url)
+        }
+        return session.configuration.urlCache?.cachedResponse(for: URLRequest(url: url))?.data
     }
 
     private func store(_ image: UIImage, for request: ImageRequest) -> UIImage {

--- a/ios/Packages/Components/Tests/ComponentsTests/ImageLoaderTests.swift
+++ b/ios/Packages/Components/Tests/ComponentsTests/ImageLoaderTests.swift
@@ -57,6 +57,21 @@ struct ImageLoaderTests {
     }
 
     @Test
+    func cachedDecodesALocalFileWithoutLoading() throws {
+        let loader = ImageLoader(cache: URLCache(memoryCapacity: 0, diskCapacity: 0))
+        let file = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).png")
+        let request = ImageRequest(url: file, maxPixelSize: 44, scale: 2)
+        #expect(loader.cached(request) == nil)
+
+        try png(side: 200).write(to: file)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        let image = try #require(loader.cached(request))
+        #expect(image.cgImage?.width == 44)
+        #expect(loader.cached(request) === image)
+    }
+
+    @Test
     func cacheKeyDistinguishesSizeAndScale() {
         let small = ImageRequest(url: url, maxPixelSize: 44, scale: 2)
         let large = ImageRequest(url: url, maxPixelSize: 88, scale: 2)


### PR DESCRIPTION
A wallet avatar is a file on the device, but it was looked up only in the network cache, which never holds files. Every lookup missed, so the avatar loaded asynchronously and the default logo showed until it arrived — on app start and when returning from the avatar picker.

Local files are now read straight from disk, so the avatar is there on the first frame.

Closes #846