### PR TITLE
Stop refetching a failed NFT image on every frame

### DIFF
--- a/ios/Packages/Components/Sources/CachedAsyncImage.swift
+++ b/ios/Packages/Components/Sources/CachedAsyncImage.swift
@@ -32,8 +32,10 @@ public struct CachedAsyncImage<Content: View>: View {
     }
 
     public var body: some View {
-        content(phase)
-            .task(id: request) { await load() }
+        ZStack {
+            content(phase)
+        }
+        .task(id: request) { await load() }
     }
 
     private func load() async {


### PR DESCRIPTION
A collectible whose image fails to load asks for it again on every frame, for as long as the screen stays open — around 120 requests a second.

This was fixed in #1182, but the image loader was rewritten the next day and the fix did not survive it.