### PR TITLE
Move bottom sheets and the keyboard together on Android

### DIFF
--- a/android/app/src/main/kotlin/com/gemwallet/android/features/main/views/ScanReceiveModal.kt
+++ b/android/app/src/main/kotlin/com/gemwallet/android/features/main/views/ScanReceiveModal.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.main.views
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,7 +35,7 @@ fun ScanReceiveModal(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onDismissRequest,
-        skipPartiallyExpanded = true,
+        expansion = SheetExpansion.Full,
         shape = RectangleShape,
         dragHandle = null,
     ) {
@@ -74,7 +75,7 @@ fun ScanReceiveModal(
         ModalBottomSheet(
             isVisible = isReceivePresented,
             onDismissRequest = { isReceivePresented = false },
-            skipPartiallyExpanded = true,
+            expansion = SheetExpansion.Full,
         ) {
             receiveAssetId?.toAssetId()?.let { assetId ->
                 Box(modifier = Modifier.fillMaxHeight(SheetSizing.heightFraction)) {

--- a/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
+++ b/android/features/activities/presents/src/main/kotlin/com/gemwallet/android/features/activities/presents/list/TransactionsScene.kt
@@ -92,18 +92,17 @@ internal fun TransactionsScene(
             }
         }
     }
-    if (showFilters) {
-        TransactionsFilter(
-            availableChains = availableChains,
-            chainsFilter = chainsFilter,
-            typesFilter = typeFilter,
-            onDismissRequest = { showFilters = false },
-            onApplyChainsFilter = { onAction(TransactionsListAction.ApplyChainsFilter(it)) },
-            onApplyTypesFilter = { onAction(TransactionsListAction.ApplyTypesFilter(it)) },
-            onClearChainsFilter = { onAction(TransactionsListAction.ClearChainsFilter) },
-            onClearTypesFilter = { onAction(TransactionsListAction.ClearTypesFilter) },
-        )
-    }
+    TransactionsFilter(
+        isVisible = showFilters,
+        availableChains = availableChains,
+        chainsFilter = chainsFilter,
+        typesFilter = typeFilter,
+        onDismissRequest = { showFilters = false },
+        onApplyChainsFilter = { onAction(TransactionsListAction.ApplyChainsFilter(it)) },
+        onApplyTypesFilter = { onAction(TransactionsListAction.ApplyTypesFilter(it)) },
+        onClearChainsFilter = { onAction(TransactionsListAction.ClearChainsFilter) },
+        onClearTypesFilter = { onAction(TransactionsListAction.ClearTypesFilter) },
+    )
 }
 
 private fun transactionsEmptyContentType(

--- a/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/AssetSelectScene.kt
+++ b/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/AssetSelectScene.kt
@@ -261,18 +261,17 @@ fun AssetSelectScene(
         }
     }
 
-    if (showSelectNetworks) {
-        AssetsFilter(
-            availableChains = availableChains,
-            chainFilter = chainsFilter,
-            balanceFilter = balanceFilter,
-            showBalanceFilter = showBalanceFilter,
-            onDismissRequest = { showSelectNetworks = false },
-            onChainFilter = { onAction(AssetSelectAction.ChainFilter(it)) },
-            onBalanceFilter = { onAction(AssetSelectAction.BalanceFilter(it)) },
-            onClearFilters = { onAction(AssetSelectAction.ClearFilters) }
-        )
-    }
+    AssetsFilter(
+        isVisible = showSelectNetworks,
+        availableChains = availableChains,
+        chainFilter = chainsFilter,
+        balanceFilter = balanceFilter,
+        showBalanceFilter = showBalanceFilter,
+        onDismissRequest = { showSelectNetworks = false },
+        onChainFilter = { onAction(AssetSelectAction.ChainFilter(it)) },
+        onBalanceFilter = { onAction(AssetSelectAction.BalanceFilter(it)) },
+        onClearFilters = { onAction(AssetSelectAction.ClearFilters) }
+    )
 }
 
 private fun LazyListScope.assets(

--- a/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/RecentsBottomSheet.kt
+++ b/android/features/asset_select/presents/src/main/kotlin/com/gemwallet/android/features/asset_select/presents/views/RecentsBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.asset_select.presents.views
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -46,7 +47,7 @@ fun RecentsBottomSheet(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onDismissRequest,
-        skipPartiallyExpanded = true,
+        expansion = SheetExpansion.Full,
     ) {
         Column(
             modifier = Modifier

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/WalletConnectReviewContent.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/WalletConnectReviewContent.kt
@@ -2,6 +2,7 @@
 
 package com.gemwallet.android.features.bridge.views
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,7 +13,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -44,6 +44,7 @@ internal fun LazyListScope.walletConnectTextMessage(message: String) {
 
 @Composable
 internal fun WalletConnectPayloadDetailsSheet(
+    isVisible: Boolean,
     primaryFields: List<PayloadField>,
     secondaryFields: List<PayloadField>,
     addressNames: Map<String, String>,
@@ -51,8 +52,9 @@ internal fun WalletConnectPayloadDetailsSheet(
     onDismissRequest: () -> Unit,
 ) {
     ModalBottomSheet(
+        isVisible = isVisible,
+        expansion = SheetExpansion.Full,
         onDismissRequest = onDismissRequest,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         title = stringResource(R.string.common_details),
     ) {
         LazyColumn {
@@ -74,12 +76,14 @@ internal fun WalletConnectPayloadDetailsSheet(
 
 @Composable
 internal fun WalletConnectFullMessageSheet(
+    isVisible: Boolean,
     message: String,
     onDismissRequest: () -> Unit,
 ) {
     ModalBottomSheet(
+        isVisible = isVisible,
+        expansion = SheetExpansion.Full,
         onDismissRequest = onDismissRequest,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         title = stringResource(R.string.sign_message_view_full_message),
     ) {
         LazyColumn(

--- a/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/WalletConnectReviewScene.kt
+++ b/android/features/bridge/presents/src/main/kotlin/com/gemwallet/android/features/bridge/views/WalletConnectReviewScene.kt
@@ -99,24 +99,19 @@ internal fun WalletConnectReviewScene(
         }
     }
 
-    when (sheetType) {
-        WalletConnectReviewSheetType.Details -> {
-            WalletConnectPayloadDetailsSheet(
-                primaryFields = model.primaryPayloadFields,
-                secondaryFields = model.secondaryPayloadFields,
-                addressNames = model.addressNames,
-                onViewFullMessage = { sheetType = WalletConnectReviewSheetType.FullMessage },
-                onDismissRequest = { sheetType = null },
-            )
-        }
-        WalletConnectReviewSheetType.FullMessage -> {
-            WalletConnectFullMessageSheet(
-                message = model.message,
-                onDismissRequest = { sheetType = null },
-            )
-        }
-        null -> Unit
-    }
+    WalletConnectPayloadDetailsSheet(
+        isVisible = sheetType == WalletConnectReviewSheetType.Details,
+        primaryFields = model.primaryPayloadFields,
+        secondaryFields = model.secondaryPayloadFields,
+        addressNames = model.addressNames,
+        onViewFullMessage = { sheetType = WalletConnectReviewSheetType.FullMessage },
+        onDismissRequest = { sheetType = null },
+    )
+    WalletConnectFullMessageSheet(
+        isVisible = sheetType == WalletConnectReviewSheetType.FullMessage,
+        message = model.message,
+        onDismissRequest = { sheetType = null },
+    )
 }
 
 private enum class WalletConnectReviewSheetType {

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/ConfirmScreen.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.confirm.presents
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.PaddingValues
@@ -313,7 +314,7 @@ fun ConfirmScreen(
         ModalBottomSheet(
             isVisible = showSimulationDetails,
             onDismissRequest = { showSimulationDetails = false },
-            skipPartiallyExpanded = true,
+            expansion = SheetExpansion.Full,
             title = stringResource(R.string.common_details),
         ) {
             LazyColumn {
@@ -377,25 +378,18 @@ private fun ConfirmDetailElementBottomSheet(
     item: ConfirmDetailElement?,
     onDismiss: () -> Unit,
 ) {
-    when (item) {
-        is ConfirmDetailElement.SwapDetails -> SwapDetailsBottomSheet(
-            isVisible = true,
-            isLoading = false,
-            model = item.model,
-            onDismiss = onDismiss,
-            showProviderSectionHeader = true,
-        )
-
-        is ConfirmDetailElement.PerpetualDetails -> PerpetualDetailsBottomSheet(
-            isVisible = true,
-            model = item.model,
-            onDismiss = onDismiss,
-        )
-
-        is ConfirmDetailElement.PerpetualModifyAutoclose -> Unit
-
-        null -> Unit
-    }
+    SwapDetailsBottomSheet(
+        isVisible = item is ConfirmDetailElement.SwapDetails,
+        isLoading = false,
+        model = (item as? ConfirmDetailElement.SwapDetails)?.model,
+        onDismiss = onDismiss,
+        showProviderSectionHeader = true,
+    )
+    PerpetualDetailsBottomSheet(
+        isVisible = item is ConfirmDetailElement.PerpetualDetails,
+        model = (item as? ConfirmDetailElement.PerpetualDetails)?.model,
+        onDismiss = onDismiss,
+    )
 }
 
 @Composable

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/ConfirmErrorInfo.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/ConfirmErrorInfo.kt
@@ -85,17 +85,15 @@ internal fun ConfirmErrorInfo(
         }
     }
 
-    if (isShowGetAssetSheet && requiredAsset != null) {
-        GetAssetBottomSheet(
-            asset = requiredAsset,
-            buyAmount = buyAmount,
-            onDismiss = { isShowGetAssetSheet = false },
-            onAction = {
-                isShowGetAssetSheet = false
-                onAcquireAsset(it, requiredAsset.id)
-            },
-        )
-    }
+    GetAssetBottomSheet(
+        asset = requiredAsset?.takeIf { isShowGetAssetSheet },
+        buyAmount = buyAmount,
+        onDismiss = { isShowGetAssetSheet = false },
+        onAction = { action ->
+            isShowGetAssetSheet = false
+            requiredAsset?.let { onAcquireAsset(action, it.id) }
+        },
+    )
 }
 
 @Composable

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/FeeDetails.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.confirm.presents.components
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import com.gemwallet.android.ext.toGem
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -116,7 +117,7 @@ fun FeeDetails(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onCancel,
-        skipPartiallyExpanded = true,
+        expansion = SheetExpansion.Full,
         title = null,
         dragHandle = {},
     ) {

--- a/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/GetAssetBottomSheet.kt
+++ b/android/features/confirm/presents/src/main/kotlin/com/gemwallet/android/features/confirm/presents/components/GetAssetBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.confirm.presents.components
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -31,17 +32,17 @@ import com.wallet.core.primitives.Asset
 
 @Composable
 internal fun GetAssetBottomSheet(
-    asset: Asset,
+    asset: Asset?,
     buyAmount: Int?,
     onDismiss: () -> Unit,
     onAction: (AcquireAssetAction) -> Unit,
 ) {
     ModalBottomSheet(
-        isVisible = true,
+        item = asset,
         onDismissRequest = onDismiss,
-        skipPartiallyExpanded = true,
-        title = stringResource(R.string.asset_get_asset, asset.symbol),
-    ) {
+        expansion = SheetExpansion.Full,
+        title = { stringResource(R.string.asset_get_asset, it.symbol) },
+    ) { shownAsset ->
         Column(modifier = Modifier.padding(bottom = paddingDefault)) {
             GetAssetItem(
                 title = stringResource(R.string.wallet_buy),

--- a/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/autoclose/AutocloseScene.kt
+++ b/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/autoclose/AutocloseScene.kt
@@ -1,9 +1,7 @@
 package com.gemwallet.android.features.perpetual.views.autoclose
 
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -13,6 +11,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import com.gemwallet.android.features.perpetual.views.components.PerpetualPositionItem
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.isKeyboardVisible
 import com.gemwallet.android.ui.components.PercentSuggestionsBar
 import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.list_item.property.PropertyItem
@@ -27,7 +26,6 @@ import com.gemwallet.android.ui.theme.paddingSmall
 import com.gemwallet.android.ui.theme.sceneContentPadding
 import com.wallet.core.primitives.TpslType
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun AutocloseScene(
     model: AutocloseUIModel,
@@ -48,7 +46,7 @@ internal fun AutocloseScene(
         TpslType.StopLoss -> stopLossText
         null -> ""
     }
-    val isPercentBarVisible = WindowInsets.isImeVisible && activeField != null && activeText.isEmpty()
+    val isPercentBarVisible = WindowInsets.isKeyboardVisible && activeField != null && activeText.isEmpty()
 
     Scene(
         title = stringResource(R.string.perpetual_auto_close),

--- a/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/position/PerpetualPositionNavScreen.kt
+++ b/android/features/perpetual/presents/src/main/kotlin/com/gemwallet/android/features/perpetual/views/position/PerpetualPositionNavScreen.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.perpetual.views.position
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -68,7 +69,7 @@ fun PerpetualPositionNavScreen(
     ModalBottomSheet(
         isVisible = showAutoclose,
         onDismissRequest = { showAutoclose = false },
-        skipPartiallyExpanded = true,
+        expansion = SheetExpansion.Full,
         title = null,
         dragHandle = null,
     ) {

--- a/android/features/receive/presents/src/main/kotlin/com/gemwallet/android/features/receive/presents/ReceiveNetworkSelector.kt
+++ b/android/features/receive/presents/src/main/kotlin/com/gemwallet/android/features/receive/presents/ReceiveNetworkSelector.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.receive.presents
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,7 +28,7 @@ internal fun ReceiveNetworkSelector(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onDismiss,
-        skipPartiallyExpanded = true,
+        expansion = SheetExpansion.Full,
         title = stringResource(R.string.settings_networks_title),
     ) {
         LazyColumn(

--- a/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/RecipientScreen.kt
+++ b/android/features/recipient/presents/src/main/kotlin/com/gemwallet/android/features/recipient/presents/RecipientScreen.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.features.recipient.presents
 
 import uniffi.gemstone.GemRecipient
 import uniffi.gemstone.GemRecipientType
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ButtonDefaults
@@ -37,7 +38,7 @@ import com.gemwallet.android.ui.components.QrCodeScannerModal
 import com.wallet.core.primitives.QRScanType
 import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.models.ButtonState
-import com.gemwallet.android.ui.components.keyboardAsState
+import com.gemwallet.android.ui.components.isKeyboardVisible
 import com.gemwallet.android.ui.components.screen.Scene
 import com.gemwallet.android.ui.models.actions.AmountTransactionAction
 import com.gemwallet.android.ui.models.actions.CancelAction
@@ -124,7 +125,7 @@ internal fun RecipientScreen(
     buttonState: ButtonState,
     onAction: (RecipientAction) -> Unit,
 ) {
-    val isKeyBoardOpen by keyboardAsState()
+    val isKeyBoardOpen = WindowInsets.isKeyboardVisible
     val density = LocalDensity.current
     val isSmallScreen = with(density) {
         LocalWindowInfo.current.containerSize.height.toDp() < 680.dp

--- a/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/ReferralScene.kt
+++ b/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/ReferralScene.kt
@@ -198,17 +198,17 @@ fun ReferralScene(
         }
     }
 
-    if (getStartedDialogShow) {
-        GetStartedDialog(onUsername) {
-            getStartedDialogShow = false
-        }
+    GetStartedDialog(isVisible = getStartedDialogShow, onUsername = onUsername) {
+        getStartedDialogShow = false
     }
 
-    if (codeDialogShow) {
-        ReferralCodeDialog(referralCode = referralCode, onCode = onCode) {
-            codeDialogShow = false
-            onCancelCode()
-        }
+    ReferralCodeDialog(
+        isVisible = codeDialogShow,
+        referralCode = referralCode,
+        onCode = onCode,
+    ) {
+        codeDialogShow = false
+        onCancelCode()
     }
 }
 

--- a/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/dialogs/GetStartedDialog.kt
+++ b/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/dialogs/GetStartedDialog.kt
@@ -31,6 +31,7 @@ import com.gemwallet.android.ui.theme.paddingDefault
 
 @Composable
 internal fun GetStartedDialog(
+    isVisible: Boolean,
     onUsername: (String, (Exception?) -> Unit) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -39,9 +40,6 @@ internal fun GetStartedDialog(
     var showProgress by remember { mutableStateOf(false) }
 
     val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
 
     val dismissDialog: () -> Unit = {
         onDismiss()
@@ -72,10 +70,14 @@ internal fun GetStartedDialog(
     }
 
     FormDialog(
+        isVisible = isVisible,
         title = stringResource(R.string.rewards_create_referral_code_title),
         onDismiss = dismissDialog,
         doneAction = done,
     ) {
+        LaunchedEffect(Unit) {
+            focusRequester.requestFocus()
+        }
         GemTextField(
             modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
             label = stringResource(id = R.string.rewards_username),

--- a/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/dialogs/ReferralCodeDialog.kt
+++ b/android/features/referral/presents/src/main/kotlin/com/gemwallet/android/features/referral/views/dialogs/ReferralCodeDialog.kt
@@ -27,6 +27,7 @@ import com.gemwallet.android.ui.theme.Spacer16
 
 @Composable
 fun ReferralCodeDialog(
+    isVisible: Boolean,
     referralCode: String?,
     onCode: (String, (Exception?) -> Unit) -> Unit,
     onDismiss: () -> Unit,
@@ -36,9 +37,6 @@ fun ReferralCodeDialog(
     var showProgress by remember { mutableStateOf(false) }
 
     val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
 
     val dismissDialog: () -> Unit = {
         onDismiss()
@@ -68,10 +66,14 @@ fun ReferralCodeDialog(
         }
     }
     FormDialog(
+        isVisible = isVisible,
         title = stringResource(R.string.rewards_referral_code),
         onDismiss = dismissDialog,
         doneAction = done,
     ) {
+        LaunchedEffect(Unit) {
+            focusRequester.requestFocus()
+        }
         GemTextField(
             modifier = Modifier
                 .focusRequester(focusRequester)

--- a/android/features/settings/settings/presents/src/main/kotlin/com/gemwallet/android/features/settings/settings/presents/views/SupportMessagesList.kt
+++ b/android/features/settings/settings/presents/src/main/kotlin/com/gemwallet/android/features/settings/settings/presents/views/SupportMessagesList.kt
@@ -1,12 +1,10 @@
 package com.gemwallet.android.features.settings.settings.presents.views
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -21,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import com.gemwallet.android.features.settings.settings.viewmodels.SupportChatDay
 import com.gemwallet.android.features.settings.settings.viewmodels.SupportChatGroup
+import com.gemwallet.android.ui.components.isKeyboardVisible
 import com.gemwallet.android.ui.theme.paddingDefault
 import com.gemwallet.android.ui.theme.paddingSmall
 import com.wallet.core.primitives.SupportMessage
@@ -39,7 +38,6 @@ private sealed interface ChatRow {
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun SupportMessagesList(
     days: List<SupportChatDay>,
@@ -65,7 +63,7 @@ internal fun SupportMessagesList(
         }
     }
 
-    val imeVisible = WindowInsets.isImeVisible
+    val imeVisible = WindowInsets.isKeyboardVisible
     LaunchedEffect(imeVisible) {
         if (imeVisible && rows.isNotEmpty()) {
             listState.animateScrollToItem(0)

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScene.kt
@@ -2,11 +2,9 @@ package com.gemwallet.android.features.swap.views
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.input.TextFieldState
@@ -23,6 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.R
+import com.gemwallet.android.ui.components.isKeyboardVisible
 import com.gemwallet.android.ui.components.PercentSuggestionsBar
 import com.gemwallet.android.ui.components.buttons.IndicatorButton
 import com.gemwallet.android.ui.components.list_item.sectionHeaderItem
@@ -43,7 +42,6 @@ import com.gemwallet.android.ui.theme.paddingSmall
 import com.gemwallet.android.ui.theme.sceneContentPadding
 import com.gemwallet.android.ui.theme.space0
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun SwapScene(
     swapState: SwapUiState,
@@ -61,7 +59,7 @@ internal fun SwapScene(
     fun clearAmountFocus() {
         focusManager.clearFocus(force = true)
     }
-    val isKeyboardVisible = WindowInsets.isImeVisible
+    val isKeyboardVisible = WindowInsets.isKeyboardVisible
     val isPercentBarVisible = isKeyboardVisible && pay != null && swapState.isInputEmpty
 
     Scene(

--- a/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScreen.kt
+++ b/android/features/swap/presents/src/main/kotlin/com/gemwallet/android/features/swap/views/SwapScreen.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.swap.views
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -104,7 +105,7 @@ fun SwapScreen(
         isLoading = swapState.isQuoteLoading && swapDetails == null,
         model = swapDetails,
         onDismiss = { isShowDetails = false },
-        skipPartiallyExpanded = true,
+        expansion = SheetExpansion.Full,
         onProviderSelect = if (swapState.isQuoteInteractionEnabled) viewModel::setProvider else null,
     )
 

--- a/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/AmountScene.kt
+++ b/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/AmountScene.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.features.transfer_amount.presents
 
 import com.gemwallet.android.ui.components.image.iconModel
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -34,7 +35,7 @@ import com.gemwallet.android.ui.components.InfoBottomSheet
 import com.gemwallet.android.ui.components.InfoSheetEntity
 import com.gemwallet.android.ui.components.buttons.MainActionButton
 import com.gemwallet.android.ui.components.fields.AmountField
-import com.gemwallet.android.ui.components.keyboardAsState
+import com.gemwallet.android.ui.components.isKeyboardVisible
 import com.gemwallet.android.ui.components.list_item.listItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyAssetInfoItem
 import com.gemwallet.android.ui.components.screen.Scene
@@ -67,7 +68,7 @@ internal fun AmountScene(
     additionParams: (@Composable () -> Unit)? = null,
 ) {
     val focusRequester = remember { FocusRequester() }
-    val isKeyBoardOpen by keyboardAsState()
+    val isKeyBoardOpen = WindowInsets.isKeyboardVisible
     val density = LocalDensity.current
     val isSmallScreen = with(density) {
         LocalWindowInfo.current.containerSize.height.toDp() < 680.dp

--- a/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/dialogs/AmountAutocloseSheet.kt
+++ b/android/features/transfer_amount/presents/src/main/kotlin/com/gemwallet/android/features/transfer_amount/presents/dialogs/AmountAutocloseSheet.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.features.transfer_amount.presents.dialogs
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -100,7 +101,7 @@ internal fun AmountAutocloseSheet(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onDismiss,
-        skipPartiallyExpanded = true,
+        expansion = SheetExpansion.Full,
         title = stringResource(R.string.perpetual_auto_close),
     ) {
         Column(

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/InfoBottomSheet.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/InfoBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.ui.components
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.annotation.StringRes
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -323,16 +324,12 @@ fun InfoBottomSheet(
 ) {
     val uriHandler = LocalUriHandler.current
     val context = LocalContext.current
-    var displayItem by remember { mutableStateOf(item) }
-    if (item != null) displayItem = item
-    val shownItem = displayItem ?: return
-
     ModalBottomSheet(
-        isVisible = item != null,
-        skipPartiallyExpanded = true,
+        item = item,
+        expansion = SheetExpansion.Full,
         containerColor = MaterialTheme.colorScheme.background,
         onDismissRequest = onClose,
-    ) {
+    ) { shownItem ->
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/QrCodeScannerModal.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/QrCodeScannerModal.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.ui.components
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -18,7 +19,7 @@ fun QrCodeScannerModal(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onDismissRequest,
-        skipPartiallyExpanded = true,
+        expansion = SheetExpansion.Full,
         shape = RectangleShape,
         dragHandle = null,
     ) {

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/States.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/States.kt
@@ -1,14 +1,28 @@
 package com.gemwallet.android.ui.components
 
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalDensity
 
-@Composable
-fun keyboardAsState(): State<Boolean> {
-    val isImeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
-    return rememberUpdatedState(isImeVisible)
-}
+@OptIn(ExperimentalLayoutApi::class)
+val WindowInsets.Companion.keyboard: WindowInsets
+    @Composable get() {
+        val density = LocalDensity.current
+        val height = ime.getBottom(density)
+        val isAnimating = height != imeAnimationTarget.getBottom(density)
+        var wasOurs by remember { mutableStateOf(height > 0) }
+        val isOurs = isAnimating || (wasOurs && height > 0)
+        SideEffect { wasOurs = isOurs }
+        return if (isOurs) ime else WindowInsets()
+    }
+
+val WindowInsets.Companion.isKeyboardVisible: Boolean
+    @Composable get() = keyboard.getBottom(LocalDensity.current) > 0

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/filters/ActivitiesFilter.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/filters/ActivitiesFilter.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.ui.components.filters
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import com.gemwallet.android.ui.LocalChainService
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -36,6 +37,7 @@ import com.wallet.core.primitives.Chain
 
 @Composable
 fun TransactionsFilter(
+    isVisible: Boolean,
     availableChains: List<Chain>,
     chainsFilter: List<Chain>,
     typesFilter: List<TransactionTypeFilter>,
@@ -48,6 +50,7 @@ fun TransactionsFilter(
     var showedSubFilter by remember { mutableStateOf<FilterType?>(null) }
 
     FormDialog(
+        isVisible = isVisible,
         title = stringResource(R.string.filter_title),
         onDismiss = onDismissRequest,
         onClear = {
@@ -117,50 +120,50 @@ fun TransactionsFilter(
         }
     }
 
-    when (showedSubFilter) {
-        FilterType.ByChains -> SubFilterDialog(
-            initialSelection = chainsFilter,
-            onDone = {
-                onApplyChainsFilter(it)
-                showedSubFilter = null
-            },
-            onConfirm = {
-                onApplyChainsFilter(it)
-                showedSubFilter = null
-                onDismissRequest()
-            },
-            onDismiss = { showedSubFilter = null },
-        ) { selectedItems, onToggle ->
-            val query = rememberTextFieldState()
-            val chainService = LocalChainService.current
-            SearchBar(query)
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                selectFilterChain(availableChains, selectedItems, query.text.toString(), chainService, onToggle)
-            }
+    SubFilterDialog(
+        isVisible = showedSubFilter == FilterType.ByChains,
+        initialSelection = chainsFilter,
+        onDone = {
+            onApplyChainsFilter(it)
+            showedSubFilter = null
+        },
+        onConfirm = {
+            onApplyChainsFilter(it)
+            showedSubFilter = null
+            onDismissRequest()
+        },
+        onDismiss = { showedSubFilter = null },
+    ) { selectedItems, onToggle ->
+        val query = rememberTextFieldState()
+        val chainService = LocalChainService.current
+        SearchBar(query)
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            selectFilterChain(availableChains, selectedItems, query.text.toString(), chainService, onToggle)
         }
-        FilterType.ByTypes -> SubFilterDialog(
-            initialSelection = typesFilter,
-            onDone = {
-                onApplyTypesFilter(it)
-                showedSubFilter = null
-            },
-            onConfirm = {
-                onApplyTypesFilter(it)
-                showedSubFilter = null
-                onDismissRequest()
-            },
-            onDismiss = { showedSubFilter = null },
-        ) { selectedItems, onToggle ->
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                selectFilterTransactionType(selectedItems, onToggle)
-            }
+    }
+    SubFilterDialog(
+        isVisible = showedSubFilter == FilterType.ByTypes,
+        initialSelection = typesFilter,
+        onDone = {
+            onApplyTypesFilter(it)
+            showedSubFilter = null
+        },
+        onConfirm = {
+            onApplyTypesFilter(it)
+            showedSubFilter = null
+            onDismissRequest()
+        },
+        onDismiss = { showedSubFilter = null },
+    ) { selectedItems, onToggle ->
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            selectFilterTransactionType(selectedItems, onToggle)
         }
-        null -> {}
     }
 }
 
 @Composable
 private fun <T> SubFilterDialog(
+    isVisible: Boolean,
     initialSelection: List<T>,
     onDone: (List<T>) -> Unit,
     onConfirm: (List<T>) -> Unit,
@@ -169,8 +172,9 @@ private fun <T> SubFilterDialog(
 ) {
     var selectedItems by remember { mutableStateOf(initialSelection) }
     FormDialog(
+        isVisible = isVisible,
         title = stringResource(R.string.filter_title),
-        fullScreen = true,
+        expansion = SheetExpansion.Full,
         onDismiss = onDismiss,
         onClear = { selectedItems = emptyList() }.takeIf { selectedItems.isNotEmpty() },
         doneAction = {

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/filters/AssetsFilterDialog.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/filters/AssetsFilterDialog.kt
@@ -15,6 +15,7 @@ import com.wallet.core.primitives.Chain
 
 @Composable
 fun AssetsFilter(
+    isVisible: Boolean,
     availableChains: List<Chain>,
     chainFilter: List<Chain>,
     balanceFilter: Boolean,
@@ -28,6 +29,7 @@ fun AssetsFilter(
     val chainService = LocalChainService.current
 
     FormDialog(
+        isVisible = isVisible,
         title = stringResource(R.string.filter_title),
         onDismiss = onDismissRequest,
         onClear = onClearFilters,

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/filters/FormDialog.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/filters/FormDialog.kt
@@ -8,12 +8,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,23 +20,23 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import com.gemwallet.android.ui.theme.normalPadding
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FormDialog(
+    isVisible: Boolean,
     title: String,
-    fullScreen: Boolean = false,
+    expansion: SheetExpansion = SheetExpansion.Partial,
     onDismiss: () -> Unit,
     onClear: (() -> Unit)? = null,
     doneAction: @Composable (() -> Unit)? = null,
     bottomAction: @Composable (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = fullScreen)
-
     ModalBottomSheet(
-        sheetState = sheetState,
+        isVisible = isVisible,
+        expansion = expansion,
         onDismissRequest = onDismiss,
         dragHandle = {
             Row (

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/perpetual/PerpetualConfirmDetailsComponents.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/perpetual/PerpetualConfirmDetailsComponents.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.ui.components.perpetual
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.MaterialTheme
@@ -47,13 +48,12 @@ fun PerpetualDetailsBottomSheet(
     model: PerpetualConfirmDetailsUIModel?,
     onDismiss: () -> Unit,
 ) {
-    if (model == null) return
     ModalBottomSheet(
-        isVisible = isVisible,
+        item = model.takeIf { isVisible },
         onDismissRequest = onDismiss,
-        skipPartiallyExpanded = true,
-        title = stringResource(R.string.common_details),
-    ) {
+        expansion = SheetExpansion.Full,
+        title = { stringResource(R.string.common_details) },
+    ) { model ->
         Column {
             PropertyItem(
                 title = stringResource(R.string.perpetual_position),

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/ModalBottomSheet.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/ModalBottomSheet.kt
@@ -2,60 +2,83 @@ package com.gemwallet.android.ui.components.screen
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.imeAnimationSource
+import androidx.compose.foundation.layout.imeAnimationTarget
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import com.gemwallet.android.ui.components.dialog.DialogBar
 import com.gemwallet.android.ui.components.dialog.DialogBarDismissType
 import com.gemwallet.android.ui.theme.Spacer16
 import com.gemwallet.android.ui.theme.alpha20
 import com.gemwallet.android.ui.theme.SheetSizing
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun ModalBottomSheet(
-    onDismissRequest: () -> Unit,
-    modifier: Modifier = Modifier,
-    sheetState: SheetState = rememberModalBottomSheetState(),
-    containerColor: Color = MaterialTheme.colorScheme.surface,
-    shape: Shape = RoundedCornerShape(topStart = SheetSizing.cornerSize, topEnd = SheetSizing.cornerSize),
-    title: String? = null,
-    dismissType: DialogBarDismissType = DialogBarDismissType.Close,
-    dragHandle: (@Composable () -> Unit)? = { Box { Spacer16() } },
-    content: @Composable ColumnScope.() -> Unit,
-) {
-    androidx.compose.material3.ModalBottomSheet(
-        onDismissRequest = onDismissRequest,
-        modifier = modifier,
-        sheetState = sheetState,
-        scrimColor = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha20),
-        shape = shape,
-        containerColor = containerColor,
-        dragHandle = if (title != null) null else dragHandle,
-        content = { SheetContent(onDismissRequest, title, dismissType, content) },
-    )
+enum class SheetExpansion {
+    Partial,
+    Full,
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun <T : Any> ModalBottomSheet(
+    item: T?,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    expansion: SheetExpansion = SheetExpansion.Partial,
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+    shape: Shape = RoundedCornerShape(topStart = SheetSizing.cornerSize, topEnd = SheetSizing.cornerSize),
+    title: (@Composable (T) -> String)? = null,
+    dismissType: DialogBarDismissType = DialogBarDismissType.Close,
+    dragHandle: (@Composable () -> Unit)? = { Box { Spacer16() } },
+    content: @Composable ColumnScope.(T) -> Unit,
+) {
+    var closingItem by remember { mutableStateOf(item) }
+    if (item != null) closingItem = item
+    val presentedItem = closingItem ?: return
+
+    ModalBottomSheet(
+        isVisible = item != null,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        expansion = expansion,
+        containerColor = containerColor,
+        shape = shape,
+        title = title?.invoke(presentedItem),
+        dismissType = dismissType,
+        dragHandle = dragHandle,
+    ) {
+        content(presentedItem)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun ModalBottomSheet(
     isVisible: Boolean,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
-    skipPartiallyExpanded: Boolean = false,
+    expansion: SheetExpansion = SheetExpansion.Partial,
     containerColor: Color = MaterialTheme.colorScheme.surface,
     shape: Shape = RoundedCornerShape(topStart = SheetSizing.cornerSize, topEnd = SheetSizing.cornerSize),
     title: String? = null,
@@ -63,55 +86,70 @@ fun ModalBottomSheet(
     dragHandle: (@Composable () -> Unit)? = { Box { Spacer16() } },
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    var showSheet by remember { mutableStateOf(false) }
-    var presentationId by remember { mutableIntStateOf(0) }
+    var isPresented by remember { mutableStateOf(isVisible) }
 
     LaunchedEffect(isVisible) {
         if (isVisible) {
-            presentationId += 1
-            showSheet = true
+            isPresented = true
         }
     }
 
-    if (!showSheet) return
+    if (!isPresented) return
 
-    key(presentationId) {
-        val sheetState = rememberModalBottomSheetState(
-            skipPartiallyExpanded = skipPartiallyExpanded,
-        )
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = expansion == SheetExpansion.Full)
+    var ownsKeyboard by remember { mutableStateOf(false) }
+    LaunchedEffect(isVisible) {
+        if (isVisible) {
+            sheetState.show()
+        } else {
+            sheetState.hide()
+            isPresented = false
+        }
+    }
 
-        LaunchedEffect(isVisible) {
-            if (!isVisible) {
-                if (sheetState.isVisible) {
-                    sheetState.hide()
-                }
-                showSheet = false
+    androidx.compose.material3.ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.onFocusChanged { ownsKeyboard = it.hasFocus },
+        sheetState = sheetState,
+        scrimColor = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha20),
+        shape = shape,
+        containerColor = containerColor,
+        dragHandle = if (title != null) null else dragHandle,
+        contentWindowInsets = {
+            when {
+                sheetState.targetValue == sheetState.currentValue -> BottomSheetDefaults.windowInsets
+                sheetState.targetValue == SheetValue.Hidden -> sheetWindowInsets(WindowInsets.imeAnimationSource)
+                ownsKeyboard -> sheetWindowInsets(WindowInsets.imeAnimationTarget)
+                else -> sheetWindowInsets(WindowInsets())
             }
-        }
-
-        androidx.compose.material3.ModalBottomSheet(
-            onDismissRequest = {
-                showSheet = false
-                onDismissRequest()
-            },
-            modifier = modifier,
-            sheetState = sheetState,
-            scrimColor = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha20),
-            shape = shape,
-            containerColor = containerColor,
-            dragHandle = if (title != null) null else dragHandle,
-            content = { SheetContent(onDismissRequest, title, dismissType, content) },
-        )
-    }
+        },
+        content = { SheetContent(sheetState, onDismissRequest, title, dismissType, content) },
+    )
 }
 
 @Composable
+private fun sheetWindowInsets(keyboard: WindowInsets): WindowInsets =
+    WindowInsets.systemBars
+        .union(WindowInsets.displayCutout)
+        .union(keyboard)
+        .only(WindowInsetsSides.Vertical)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
 private fun ColumnScope.SheetContent(
+    sheetState: SheetState,
     onDismissRequest: () -> Unit,
     title: String?,
     dismissType: DialogBarDismissType,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    val keyboard = LocalSoftwareKeyboardController.current
+    val isLeaving = sheetState.currentValue != SheetValue.Hidden && sheetState.targetValue == SheetValue.Hidden
+    LaunchedEffect(isLeaving) {
+        if (isLeaving) {
+            keyboard?.hide()
+        }
+    }
     if (title != null) {
         DialogBar(onDismissRequest = onDismissRequest, title = title, dismissType = dismissType)
     }

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/Scene.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/screen/Scene.kt
@@ -9,10 +9,12 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -32,6 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.gemwallet.android.ui.components.ConnectionStatusBannerHost
+import com.gemwallet.android.ui.components.keyboard
 import com.gemwallet.android.ui.icons.AppIcons
 import com.gemwallet.android.ui.theme.SceneSizing
 import com.gemwallet.android.ui.theme.Spacer16
@@ -143,7 +146,10 @@ fun Scene(
         bottomBar = {
             Column(
                 modifier = Modifier.windowInsetsPadding(
-                    WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)
+                    WindowInsets.systemBars
+                        .union(WindowInsets.displayCutout)
+                        .union(WindowInsets.keyboard)
+                        .only(WindowInsetsSides.Bottom)
                 ),
             ) {
                 ConnectionStatusBannerHost()

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapDetailsComponents.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapDetailsComponents.kt
@@ -34,6 +34,7 @@ import com.gemwallet.android.ui.components.list_item.property.PropertyItem
 import com.gemwallet.android.ui.components.list_item.property.PropertyTitleText
 import com.gemwallet.android.ui.components.progress.CircularProgressIndicator20
 import com.gemwallet.android.ui.components.screen.ModalBottomSheet
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import com.gemwallet.android.ui.models.ListPosition
 import com.gemwallet.android.ui.models.swap.SwapDetailsUIModel
 import com.gemwallet.android.ui.models.swap.SwapPriceImpactUIModel
@@ -87,20 +88,18 @@ fun SwapDetailsBottomSheet(
     model: SwapDetailsUIModel?,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
-    skipPartiallyExpanded: Boolean = false,
+    expansion: SheetExpansion = SheetExpansion.Partial,
     showProviderSectionHeader: Boolean = false,
     onProviderSelect: ((SwapProvider) -> Unit)? = null,
 ) {
-    if (model == null) return
-
     ModalBottomSheet(
-        isVisible = isVisible,
+        item = model.takeIf { isVisible },
         onDismissRequest = onDismiss,
         modifier = modifier,
-        skipPartiallyExpanded = skipPartiallyExpanded,
-        title = stringResource(R.string.common_details),
+        expansion = expansion,
+        title = { stringResource(R.string.common_details) },
         dismissType = DialogBarDismissType.Confirm,
-    ) {
+    ) { model ->
         if (isLoading) {
             Box(modifier = Modifier.fillMaxWidth()) {
                 CircularProgressIndicator20(modifier = Modifier.align(Alignment.Center))

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapSlippageBottomSheet.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/swap/SwapSlippageBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.gemwallet.android.ui.components.swap
 
+import com.gemwallet.android.ui.components.screen.SheetExpansion
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -54,7 +55,7 @@ fun SwapSlippageBottomSheet(
     ModalBottomSheet(
         isVisible = isVisible,
         onDismissRequest = onDismiss,
-        skipPartiallyExpanded = true,
+        expansion = SheetExpansion.Full,
         title = stringResource(R.string.swap_slippage),
     ) {
         var isAuto by remember(currentBps) { mutableStateOf(currentBps == null) }


### PR DESCRIPTION
Bottom sheets behaved badly whenever a keyboard was involved. The swap pickers stalled and jumped when opening, the provider list on buy arrived too high and dropped, the username sheet in rewards appeared after the keyboard, and the button at the bottom of a screen jumped when a sheet raised its own keyboard.

Sheets now arrive and leave together with the keyboard, a screen reacts only to its own keyboard, and every sheet keeps its closing animation.

Closes #1125