### PR TITLE
Keep the stake screen alive when the delegations sync fails

### DIFF
--- a/android/features/earn/stake/viewmodels/build.gradle.kts
+++ b/android/features/earn/stake/viewmodels/build.gradle.kts
@@ -26,6 +26,11 @@ android {
             )
         }
     }
+    testOptions {
+        unitTests {
+            isReturnDefaultValues = true
+        }
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
@@ -55,4 +60,9 @@ dependencies {
 
     implementation(libs.lifecycle.viewmodel)
     implementation(libs.lifecycle.viewmodel.savedstate)
+
+    testImplementation(testFixtures(project(":gemcore")))
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk.android)
 }

--- a/android/features/earn/stake/viewmodels/src/main/kotlin/com/gemwallet/android/features/stake/viewmodels/StakeViewModel.kt
+++ b/android/features/earn/stake/viewmodels/src/main/kotlin/com/gemwallet/android/features/stake/viewmodels/StakeViewModel.kt
@@ -3,6 +3,7 @@ package com.gemwallet.android.features.stake.viewmodels
 import uniffi.gemstone.GemClaimRewardsDestination
 import uniffi.gemstone.GemDelegationDestination
 import uniffi.gemstone.GemStakeServiceInterface
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -15,6 +16,7 @@ import com.gemwallet.android.application.stake.cases.SyncStakeDelegations
 import com.gemwallet.android.domains.asset.chain
 import com.gemwallet.android.domains.asset.stakeChain
 import com.gemwallet.android.AppUrl
+import com.gemwallet.android.ext.runCatchingCancellable
 import com.gemwallet.android.ext.toGem
 import com.gemwallet.android.serializer.toJson
 import com.gemwallet.android.ext.toIdentifier
@@ -134,7 +136,8 @@ class StakeViewModel @Inject constructor(
                 }
                 val assetInfo = assetInfo.filterNotNull().first()
                 emit(true)
-                syncStakeDelegations.sync(assetInfo.asset.id.chain)
+                runCatchingCancellable { syncStakeDelegations.sync(assetInfo.asset.id.chain) }
+                    .onFailure { Log.e(TAG, "stake delegations sync failed", it) }
                 emit(false)
                 sync.update { false }
             }
@@ -165,5 +168,9 @@ class StakeViewModel @Inject constructor(
             is GemClaimRewardsDestination.Transfer -> onConfirm(destination.transfer)
             is GemClaimRewardsDestination.Amount -> onAmount(AmountParams.Stake.Rewards(assetInfo.asset.id))
         }
+    }
+
+    private companion object {
+        const val TAG = "Stake"
     }
 }

--- a/android/features/earn/stake/viewmodels/src/test/kotlin/com/gemwallet/android/features/stake/viewmodels/StakeViewModelTest.kt
+++ b/android/features/earn/stake/viewmodels/src/test/kotlin/com/gemwallet/android/features/stake/viewmodels/StakeViewModelTest.kt
@@ -1,0 +1,104 @@
+package com.gemwallet.android.features.stake.viewmodels
+
+import android.net.Uri
+import uniffi.gemstone.GemStakeServiceInterface
+import androidx.lifecycle.SavedStateHandle
+import com.gemwallet.android.application.assets.cases.GetAssetInfo
+import com.gemwallet.android.application.assets.cases.GetWalletAssets
+import com.gemwallet.android.application.session.cases.GetSession
+import com.gemwallet.android.application.stake.cases.GetDelegations
+import com.gemwallet.android.application.stake.cases.GetValidators
+import com.gemwallet.android.application.stake.cases.SyncStakeDelegations
+import com.gemwallet.android.ext.toIdentifier
+import com.gemwallet.android.testkit.mockAssetCosmos
+import com.gemwallet.android.testkit.mockAssetInfo
+import com.gemwallet.android.testkit.mockClaimRewards
+import com.gemwallet.android.testkit.mockDelegation
+import com.gemwallet.android.testkit.mockSession
+import com.gemwallet.android.ui.models.navigation.RouteArgument
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.math.BigInteger
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StakeViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val asset = mockAssetCosmos()
+    private val delegation = mockDelegation(assetId = asset.id, balance = BigInteger("77"))
+
+    private val getAssetInfo = mockk<GetAssetInfo> {
+        every { this@mockk(asset.id) } returns flowOf(mockAssetInfo(asset = asset))
+    }
+    private val getWalletAssets = mockk<GetWalletAssets> {
+        every { this@mockk() } returns MutableStateFlow(emptyList())
+    }
+    private val getDelegations = mockk<GetDelegations> {
+        every { this@mockk(any(), asset.id) } returns flowOf(listOf(delegation))
+    }
+    private val getValidators = mockk<GetValidators> {
+        every { this@mockk(asset.id) } returns flowOf(emptyList())
+    }
+    private val getSession = mockk<GetSession> {
+        every { this@mockk() } returns MutableStateFlow(mockSession())
+    }
+    private val syncStakeDelegations = mockk<SyncStakeDelegations>()
+    private val stakeService = mockk<GemStakeServiceInterface>(relaxed = true) {
+        every { minStakeAmount(asset.id.chain.string) } returns BigInteger.ZERO
+        every { claimRewards(asset.id.chain.string, any()) } returns mockClaimRewards()
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic(Uri::class)
+        every { Uri.parse(any()) } returns mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkStatic(Uri::class)
+    }
+
+    @Test
+    fun `a failed delegations sync stops the spinner instead of taking the screen down`() = runTest(testDispatcher, timeout = 10.seconds) {
+        coEvery { syncStakeDelegations.sync(asset.id.chain) } throws IllegalStateException("Network offline")
+
+        val viewModel = StakeViewModel(
+            getAssetInfo = getAssetInfo,
+            getWalletAssets = getWalletAssets,
+            getDelegations = getDelegations,
+            getValidators = getValidators,
+            syncStakeDelegations = syncStakeDelegations,
+            stakeService = stakeService,
+            getSession = getSession,
+            stateHandle = SavedStateHandle(mapOf(RouteArgument.AssetId.key to asset.id.toIdentifier())),
+        )
+
+        assertEquals(listOf(true, false), viewModel.isSync.take(2).toList())
+
+        runCurrent()
+        assertEquals(listOf(delegation), viewModel.delegations.value)
+    }
+
+}

--- a/android/gemcore/src/testFixtures/kotlin/com/gemwallet/android/testkit/DelegationMock.kt
+++ b/android/gemcore/src/testFixtures/kotlin/com/gemwallet/android/testkit/DelegationMock.kt
@@ -7,6 +7,8 @@ import com.wallet.core.primitives.DelegationBase
 import com.wallet.core.primitives.DelegationState
 import com.wallet.core.primitives.DelegationValidator
 import com.wallet.core.primitives.StakeProviderType
+import uniffi.gemstone.GemClaimRewards
+import uniffi.gemstone.GemClaimRewardsDestination
 import java.math.BigInteger
 
 fun mockDelegationValidator(
@@ -50,4 +52,11 @@ fun mockDelegation(
         validatorId = validatorId,
     ),
     validator = validator,
+)
+
+fun mockClaimRewards(
+    value: BigInteger = BigInteger.ZERO,
+) = GemClaimRewards(
+    value = value,
+    destination = GemClaimRewardsDestination.Amount(emptyList()),
 )


### PR DESCRIPTION
Opening the stake screen while the delegations sync failed crashed the app: the failure was thrown out of the flow that drives the refresh state and nothing caught it. Reproduced on an emulator with the network off, on BNB Chain.

The failure is now handled the way every other sync in the app handles it, and the delegations already stored stay on screen.