### PR TITLE
Count the Solana unstake wait from the epoch's progress

### DIFF
--- a/android/features/earn/delegation/presents/src/main/kotlin/com/gemwallet/android/features/earn/delegation/presents/DelegationScene.kt
+++ b/android/features/earn/delegation/presents/src/main/kotlin/com/gemwallet/android/features/earn/delegation/presents/DelegationScene.kt
@@ -61,6 +61,7 @@ fun DelegationScene(
                         amount = info.cryptoFormatted,
                         equivalent = info.fiatFormatted,
                         icon = info.iconUrl,
+                        iconPlaceholder = info.iconPlaceholder,
                     )
                 }
             }

--- a/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/models/DelegationInfo.kt
+++ b/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/models/DelegationInfo.kt
@@ -2,6 +2,7 @@ package com.gemwallet.android.features.earn.delegation.models
 
 import androidx.compose.runtime.Stable
 import com.gemwallet.android.domains.asset.getIconUrl
+import com.gemwallet.android.domains.stake.displayName
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.model.Crypto
 import com.gemwallet.android.model.ValueFormatter
@@ -20,6 +21,9 @@ class HeadDelegationInfo(
 
     val iconUrl: String
         get() = delegation.validator.getIconUrl()
+
+    val iconPlaceholder: String
+        get() = delegation.validator.displayName().take(1)
 
     override val cryptoAmount: Double by lazy {
         Crypto(delegation.base.balance).value(asset.decimals).toDouble()

--- a/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/viewmodels/DelegationViewModel.kt
+++ b/android/features/earn/delegation/viewmodels/src/main/kotlin/com/gemwallet/android/features/earn/delegation/viewmodels/DelegationViewModel.kt
@@ -12,6 +12,7 @@ import com.gemwallet.android.application.assets.cases.GetAssetInfo
 import com.gemwallet.android.application.session.cases.GetSession
 import com.gemwallet.android.application.stake.cases.GetDelegation
 import com.gemwallet.android.domains.asset.chain
+import com.gemwallet.android.domains.stake.displayName
 import com.gemwallet.android.model.AmountParams
 import com.wallet.core.primitives.StakeType
 import com.gemwallet.android.model.Crypto
@@ -71,7 +72,7 @@ class DelegationViewModel @Inject constructor(
         val validatorUrl = stakeService.validatorUrl(delegation.validator.toGem())?.link
         val status = delegationStatus(delegation.toGem())
         listOfNotNull(
-            DelegationProperty.Name(delegation.validator.name, validatorUrl),
+            DelegationProperty.Name(delegation.validator.displayName(), validatorUrl),
             delegation.validator.takeIf { it.apr != 0.0 }?.let { DelegationProperty.Apr(it) },
             DelegationProperty.TransactionStatus(status),
             status.completion

--- a/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/stake/ValidatorNameExt.kt
+++ b/android/gemcore/src/main/kotlin/com/gemwallet/android/domains/stake/ValidatorNameExt.kt
@@ -1,0 +1,7 @@
+package com.gemwallet.android.domains.stake
+
+import com.gemwallet.android.ext.toGem
+import com.wallet.core.primitives.DelegationValidator
+import uniffi.gemstone.validatorDisplayName
+
+fun DelegationValidator.displayName(): String = validatorDisplayName(toGem())

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_head/AmountListHead.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_head/AmountListHead.kt
@@ -92,6 +92,7 @@ fun AmountListHead(
     hideToggle: HideToggle? = null,
     equivalent: String? = null,
     icon: Any? = null,
+    iconPlaceholder: String? = null,
     changedValue: String? = null,
     changedPercentages: String? = null,
     changeState: ValueDirection = ValueDirection.None,
@@ -116,6 +117,7 @@ fun AmountListHead(
                 HeaderIcon(it)
             } ?: IconWithBadge(
                 icon = icon,
+                placeholder = iconPlaceholder,
                 size = headerIconSize,
                 badgeBackgroundColor = MaterialTheme.colorScheme.surface,
             )

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/DelegationItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/DelegationItem.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.gemwallet.android.domains.asset.getIconUrl
+import com.gemwallet.android.domains.stake.displayName
 import com.gemwallet.android.ext.toGem
 import com.gemwallet.android.model.AssetInfo
 import com.gemwallet.android.ui.components.image.IconWithBadge
@@ -30,11 +31,11 @@ fun DelegationItem(
         leading = {
             IconWithBadge(
                 icon = delegation.validator.getIconUrl(),
-                placeholder = delegation.validator.name.firstOrNull()?.toString() ?: delegation.validator.id.firstOrNull()?.toString() ?: "",
+                placeholder = delegation.validator.displayName().firstOrNull()?.toString() ?: "",
             )
         },
         title = {
-            ListItemTitleText(text = delegation.validator.name)
+            ListItemTitleText(text = delegation.validator.displayName())
         },
         subtitle = {
             ListItemSupportText(

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/ValidatorItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/ValidatorItem.kt
@@ -13,6 +13,7 @@ import com.gemwallet.android.domains.asset.getIconUrl
 import com.gemwallet.android.domains.duration.formatAvailableIn
 import com.gemwallet.android.domains.percentage.PercentageFormatterStyle
 import com.gemwallet.android.domains.percentage.formatAsPercentage
+import com.gemwallet.android.domains.stake.displayName
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.image.IconWithBadge
 import com.gemwallet.android.ui.models.ListPosition
@@ -36,7 +37,7 @@ fun ValidatorItem(
         },
         title = {
             Text(
-                text = data.name,
+                text = data.displayName(),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.titleMedium,
@@ -76,7 +77,7 @@ fun DelegationValidator.formatApr(): String {
 }
 
 private val DelegationValidator.placeholder: String
-    get() = name.firstOrNull()?.toString() ?: id.firstOrNull()?.toString() ?: "V"
+    get() = displayName().firstOrNull()?.toString() ?: "V"
 
 fun availableIn(delegation: Delegation?): String {
     val remaining = availableInDurationMillis(delegation) ?: return ""

--- a/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/PropertyValidatorItem.kt
+++ b/android/ui/src/main/kotlin/com/gemwallet/android/ui/components/list_item/property/PropertyValidatorItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import com.gemwallet.android.ui.R
 import com.gemwallet.android.ui.components.image.IconWithBadge
 import com.gemwallet.android.domains.asset.getIconUrl
+import com.gemwallet.android.domains.stake.displayName
 import com.gemwallet.android.ui.components.list_item.ListItemSupportText
 import com.gemwallet.android.ui.components.list_item.formatApr
 import com.gemwallet.android.ui.models.ListPosition
@@ -35,11 +36,11 @@ fun PropertyValidatorItem(
             ) {
                 IconWithBadge(
                     icon = validator.getIconUrl(),
-                    placeholder = validator.name.firstOrNull()?.toString() ?: validator.id.firstOrNull()?.toString() ?: "V",
+                    placeholder = validator.displayName().firstOrNull()?.toString() ?: "V",
                 )
                 Text(
                     modifier = Modifier.weight(1f),
-                    text = validator.name,
+                    text = validator.displayName(),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.bodyLarge,

--- a/core/crates/gem_solana/src/provider/staking.rs
+++ b/core/crates/gem_solana/src/provider/staking.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use chain_traits::ChainStaking;
+use chrono::Utc;
 use std::error::Error;
 
 use gem_client::Client;
@@ -33,7 +34,7 @@ impl<C: Client + Clone> ChainStaking for SolanaProvider<C> {
 
     async fn get_staking_delegations(&self, address: String) -> Result<Vec<DelegationBase>, Box<dyn Error + Sync + Send>> {
         let (epoch, accounts) = futures::try_join!(self.get_epoch_info(), self.get_staking_balance(&address))?;
-        Ok(map_staking_delegations(accounts, epoch, self.get_chain().as_asset_id()))
+        Ok(map_staking_delegations(accounts, epoch, self.get_chain().as_asset_id(), Utc::now()))
     }
 }
 

--- a/core/crates/gem_solana/src/provider/staking_mapper.rs
+++ b/core/crates/gem_solana/src/provider/staking_mapper.rs
@@ -1,5 +1,5 @@
 use crate::models::{EpochInfo, TokenAccountInfo, VoteAccount};
-use chrono::Utc;
+use chrono::{DateTime, Duration, Utc};
 use num_bigint::BigUint;
 use primitives::{AssetId, Chain, DelegationBase, DelegationState, DelegationValidator};
 
@@ -24,7 +24,7 @@ pub fn map_staking_validators(vote_accounts: Vec<VoteAccount>, chain: Chain, net
         .collect()
 }
 
-pub fn map_staking_delegations(stake_accounts: Vec<TokenAccountInfo>, epoch: EpochInfo, asset_id: AssetId) -> Vec<DelegationBase> {
+pub fn map_staking_delegations(stake_accounts: Vec<TokenAccountInfo>, epoch: EpochInfo, asset_id: AssetId, now: DateTime<Utc>) -> Vec<DelegationBase> {
     stake_accounts
         .into_iter()
         .filter_map(|account| {
@@ -55,10 +55,9 @@ pub fn map_staking_delegations(stake_accounts: Vec<TokenAccountInfo>, epoch: Epo
 
                 let completion_date = match state {
                     DelegationState::Activating | DelegationState::Deactivating => {
-                        let remaining_slots = epoch.slots_in_epoch - (epoch.epoch % epoch.slots_in_epoch);
+                        let remaining_slots = epoch.slots_in_epoch.saturating_sub(epoch.slot_index);
                         let completion_seconds = remaining_slots as f64 * 0.420;
-                        let completion_time = Utc::now() + chrono::Duration::milliseconds(completion_seconds as i64 * 1000);
-                        Some(completion_time)
+                        Some(now + Duration::seconds(completion_seconds as i64))
                     }
                     _ => None,
                 };
@@ -111,9 +110,8 @@ mod tests {
         assert_eq!(apy, 50.0);
     }
 
-    #[test]
-    fn test_map_staking_delegations() {
-        let stake_accounts = vec![TokenAccountInfo {
+    fn stake_account(activation_epoch: u64, deactivation_epoch: u64) -> TokenAccountInfo {
+        TokenAccountInfo {
             pubkey: "stake1".to_string(),
             account: TokenAccountData {
                 data: crate::models::Parsed {
@@ -123,8 +121,8 @@ mod tests {
                             token_amount: None,
                             stake: Some(crate::models::StakeInfo {
                                 delegation: crate::models::StakeDelegation {
-                                    activation_epoch: 100,
-                                    deactivation_epoch: 18446744073709551615,
+                                    activation_epoch,
+                                    deactivation_epoch,
                                     stake: "1000000".to_string(),
                                     voter: "validator1".to_string(),
                                 },
@@ -135,19 +133,40 @@ mod tests {
                 owner: "owner1".to_string(),
                 lamports: 1000000,
             },
-        }];
+        }
+    }
 
-        let epoch = EpochInfo {
+    fn epoch_info(slot_index: u64) -> EpochInfo {
+        EpochInfo {
             epoch: 200,
-            slot_index: 0,
+            slot_index,
             slots_in_epoch: 432000,
-        };
+        }
+    }
 
-        let result = map_staking_delegations(stake_accounts, epoch, AssetId::from_chain(Chain::Solana));
+    #[test]
+    fn test_map_staking_delegations() {
+        let now = DateTime::from_timestamp(1_757_000_000, 0).unwrap();
+
+        let result = map_staking_delegations(vec![stake_account(100, u64::MAX)], epoch_info(0), AssetId::from_chain(Chain::Solana), now);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].validator_id, "validator1");
         assert_eq!(result[0].balance.to_string(), "1000000");
-        assert!(matches!(result[0].state, DelegationState::Active));
+        assert_eq!(result[0].state, DelegationState::Active);
+        assert_eq!(result[0].completion_date, None);
+    }
+
+    #[test]
+    fn test_map_staking_delegations_completion_date() {
+        let now = DateTime::from_timestamp(1_757_000_000, 0).unwrap();
+        let deactivating = |slot_index: u64| map_staking_delegations(vec![stake_account(100, 200)], epoch_info(slot_index), AssetId::from_chain(Chain::Solana), now)[0].clone();
+
+        assert_eq!(deactivating(0).state, DelegationState::Deactivating);
+
+        assert_eq!(deactivating(0).completion_date, Some(now + Duration::seconds(181_440)));
+        assert_eq!(deactivating(216_000).completion_date, Some(now + Duration::seconds(90_720)));
+        assert_eq!(deactivating(431_000).completion_date, Some(now + Duration::seconds(420)));
+        assert_eq!(deactivating(432_000).completion_date, Some(now));
     }
 }

--- a/core/crates/gem_solana/src/provider/staking_mapper.rs
+++ b/core/crates/gem_solana/src/provider/staking_mapper.rs
@@ -83,7 +83,7 @@ pub fn map_staking_delegations(stake_accounts: Vec<TokenAccountInfo>, epoch: Epo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{EpochInfo, TokenAccountData, TokenAccountInfo, VoteAccount};
+    use crate::models::{EpochInfo, Info, Parsed, StakeDelegation, StakeInfo, TokenAccountData, TokenAccountInfo, TokenAccountInfoData, VoteAccount};
     use primitives::{AssetId, Chain, DelegationState};
 
     #[test]
@@ -114,13 +114,13 @@ mod tests {
         TokenAccountInfo {
             pubkey: "stake1".to_string(),
             account: TokenAccountData {
-                data: crate::models::Parsed {
-                    parsed: crate::models::Info {
-                        info: crate::models::TokenAccountInfoData {
+                data: Parsed {
+                    parsed: Info {
+                        info: TokenAccountInfoData {
                             mint: None,
                             token_amount: None,
-                            stake: Some(crate::models::StakeInfo {
-                                delegation: crate::models::StakeDelegation {
+                            stake: Some(StakeInfo {
+                                delegation: StakeDelegation {
                                     activation_epoch,
                                     deactivation_epoch,
                                     stake: "1000000".to_string(),
@@ -136,19 +136,11 @@ mod tests {
         }
     }
 
-    fn epoch_info(slot_index: u64) -> EpochInfo {
-        EpochInfo {
-            epoch: 200,
-            slot_index,
-            slots_in_epoch: 432000,
-        }
-    }
-
     #[test]
     fn test_map_staking_delegations() {
         let now = DateTime::from_timestamp(1_757_000_000, 0).unwrap();
 
-        let result = map_staking_delegations(vec![stake_account(100, u64::MAX)], epoch_info(0), AssetId::from_chain(Chain::Solana), now);
+        let result = map_staking_delegations(vec![stake_account(100, u64::MAX)], EpochInfo::mock(0), AssetId::from_chain(Chain::Solana), now);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].validator_id, "validator1");
@@ -160,7 +152,8 @@ mod tests {
     #[test]
     fn test_map_staking_delegations_completion_date() {
         let now = DateTime::from_timestamp(1_757_000_000, 0).unwrap();
-        let deactivating = |slot_index: u64| map_staking_delegations(vec![stake_account(100, 200)], epoch_info(slot_index), AssetId::from_chain(Chain::Solana), now)[0].clone();
+        let deactivating =
+            |slot_index: u64| map_staking_delegations(vec![stake_account(100, 200)], EpochInfo::mock(slot_index), AssetId::from_chain(Chain::Solana), now)[0].clone();
 
         assert_eq!(deactivating(0).state, DelegationState::Deactivating);
 

--- a/core/crates/gem_solana/src/testkit.rs
+++ b/core/crates/gem_solana/src/testkit.rs
@@ -1,6 +1,7 @@
 use primitives::testkit::signer_mock::TEST_PRIVATE_KEY_SOLANA_ADDRESS;
 use solana_primitives::{CompiledInstruction, LegacyMessage, MessageHeader, Pubkey, VersionedTransaction};
 
+use crate::models::EpochInfo;
 use crate::siws::SiwsMessage;
 
 pub(crate) fn mock_transaction(programs: &[(&str, Vec<u8>)]) -> VersionedTransaction {
@@ -43,4 +44,14 @@ impl SiwsMessage {
 
 pub(crate) fn mock_siws_message(body: &str) -> String {
     format!("example.com wants you to sign in with your Solana account:\n{TEST_PRIVATE_KEY_SOLANA_ADDRESS}{body}")
+}
+
+impl EpochInfo {
+    pub fn mock(slot_index: u64) -> Self {
+        EpochInfo {
+            epoch: 200,
+            slot_index,
+            slots_in_epoch: 432000,
+        }
+    }
 }

--- a/core/gemstone/src/services/stake/mod.rs
+++ b/core/gemstone/src/services/stake/mod.rs
@@ -28,6 +28,11 @@ use crate::services::transfer::rules as transfer_rules;
 use crate::services::wallet_session::GemWalletSessionService;
 use primitives::BlockExplorerLink;
 
+#[uniffi::export]
+pub fn validator_display_name(validator: DelegationValidator) -> String {
+    rules::validator_display_name(&validator)
+}
+
 #[derive(uniffi::Object)]
 pub struct GemStakeService {
     gateway: Arc<GemGateway>,

--- a/core/gemstone/src/services/stake/rules.rs
+++ b/core/gemstone/src/services/stake/rules.rs
@@ -68,7 +68,7 @@ pub fn can_claim_rewards(wallet_type: WalletType, delegation: &Delegation) -> bo
 }
 
 pub fn validator_display_name(validator: &DelegationValidator) -> String {
-    if validator.name.trim().is_empty() {
+    if validator.name.is_empty() {
         return AddressFormatter::format(&validator.id, Some(validator.chain), AddressFormatStyle::Short);
     }
     validator.name.clone()
@@ -436,7 +436,7 @@ pub fn stale_validator_ids(existing: Vec<DelegationValidator>, incoming: &[Deleg
 pub fn validator_address_names(validators: &[DelegationValidator]) -> Vec<AddressName> {
     validators
         .iter()
-        .filter(|validator| !validator.name.trim().is_empty())
+        .filter(|validator| !validator.name.is_empty())
         .map(|validator| AddressName {
             chain: validator.chain,
             address: validator.id.clone(),
@@ -458,27 +458,33 @@ mod tests {
     use primitives::{AssetId, Resource};
 
     fn solana_validator(name: &str) -> DelegationValidator {
-        DelegationValidator::stake(Chain::Solana, "8GbwASqdpw4dVcwbWUxbHXMrjyQx2aKkoBR5H1GJF8iD".to_string(), name.to_string(), true, 0.0, 5.0)
+        DelegationValidator {
+            chain: Chain::Solana,
+            id: "8GbwASqdpw4dVcwbWUxbHXMrjyQx2aKkoBR5H1GJF8iD".to_string(),
+            name: name.to_string(),
+            ..DelegationValidator::mock()
+        }
     }
 
     #[test]
     fn test_validator_display_name() {
-        assert_eq!(validator_display_name(&solana_validator("Everstake")), "Everstake");
+        assert_eq!(validator_display_name(&DelegationValidator::mock()), "Test Validator");
         assert_eq!(validator_display_name(&solana_validator("")), "8GbwA...JF8iD");
-        assert_eq!(validator_display_name(&solana_validator("   ")), "8GbwA...JF8iD");
 
-        let mut earn = solana_validator("");
-        earn.provider_type = StakeProviderType::Earn;
-        earn.id = "yo".to_string();
+        let earn = DelegationValidator {
+            id: "yo".to_string(),
+            name: String::new(),
+            provider_type: StakeProviderType::Earn,
+            ..DelegationValidator::mock()
+        };
         assert_eq!(validator_display_name(&earn), "yo");
     }
 
     #[test]
     fn test_validator_address_names() {
         let named = solana_validator("Everstake");
-        let unnamed = solana_validator("");
 
-        let names = validator_address_names(&[named.clone(), unnamed]);
+        let names = validator_address_names(&[named.clone(), solana_validator("")]);
 
         assert_eq!(names.len(), 1);
         assert_eq!(names[0].name, "Everstake");

--- a/core/gemstone/src/services/stake/rules.rs
+++ b/core/gemstone/src/services/stake/rules.rs
@@ -5,8 +5,8 @@ use crate::services::collections::{stale, unique};
 use num_bigint::{BigInt, BigUint};
 use primitives::AddressName;
 use primitives::{
-    AddressType, Asset, Chain, Delegation, DelegationBase, DelegationState, DelegationValidator, RedelegateData, Resource, StakeChain, StakeProviderType, StakeType,
-    VerificationStatus, WalletType,
+    AddressFormatStyle, AddressFormatter, AddressType, Asset, Chain, Delegation, DelegationBase, DelegationState, DelegationValidator, RedelegateData, Resource, StakeChain,
+    StakeProviderType, StakeType, VerificationStatus, WalletType,
 };
 use rand::seq::IndexedRandom;
 
@@ -65,6 +65,13 @@ pub fn can_claim_rewards(wallet_type: WalletType, delegation: &Delegation) -> bo
         return false;
     };
     wallet_type != WalletType::View && config.can_claim_rewards && shows_rewards(&delegation.base)
+}
+
+pub fn validator_display_name(validator: &DelegationValidator) -> String {
+    if validator.name.trim().is_empty() {
+        return AddressFormatter::format(&validator.id, Some(validator.chain), AddressFormatStyle::Short);
+    }
+    validator.name.clone()
 }
 
 pub fn validator_explorer_address(validator: &DelegationValidator) -> Option<String> {
@@ -429,6 +436,7 @@ pub fn stale_validator_ids(existing: Vec<DelegationValidator>, incoming: &[Deleg
 pub fn validator_address_names(validators: &[DelegationValidator]) -> Vec<AddressName> {
     validators
         .iter()
+        .filter(|validator| !validator.name.trim().is_empty())
         .map(|validator| AddressName {
             chain: validator.chain,
             address: validator.id.clone(),
@@ -448,6 +456,34 @@ pub fn earn_validators(providers: Vec<DelegationValidator>, apr: f64) -> Vec<Del
 mod tests {
     use super::*;
     use primitives::{AssetId, Resource};
+
+    fn solana_validator(name: &str) -> DelegationValidator {
+        DelegationValidator::stake(Chain::Solana, "8GbwASqdpw4dVcwbWUxbHXMrjyQx2aKkoBR5H1GJF8iD".to_string(), name.to_string(), true, 0.0, 5.0)
+    }
+
+    #[test]
+    fn test_validator_display_name() {
+        assert_eq!(validator_display_name(&solana_validator("Everstake")), "Everstake");
+        assert_eq!(validator_display_name(&solana_validator("")), "8GbwA...JF8iD");
+        assert_eq!(validator_display_name(&solana_validator("   ")), "8GbwA...JF8iD");
+
+        let mut earn = solana_validator("");
+        earn.provider_type = StakeProviderType::Earn;
+        earn.id = "yo".to_string();
+        assert_eq!(validator_display_name(&earn), "yo");
+    }
+
+    #[test]
+    fn test_validator_address_names() {
+        let named = solana_validator("Everstake");
+        let unnamed = solana_validator("");
+
+        let names = validator_address_names(&[named.clone(), unnamed]);
+
+        assert_eq!(names.len(), 1);
+        assert_eq!(names[0].name, "Everstake");
+        assert_eq!(names[0].address, named.id);
+    }
 
     #[test]
     fn test_a_chain_without_staking_answers_instead_of_failing() {

--- a/ios/Features/Stake/Sources/ViewModels/ValidatorViewModel.swift
+++ b/ios/Features/Stake/Sources/ViewModels/ValidatorViewModel.swift
@@ -2,7 +2,7 @@
 
 import Components
 import Foundation
-import class Gemstone.GemAddressService
+import func Gemstone.validatorDisplayName
 import GemstonePrimitives
 import Localization
 import Primitives
@@ -18,15 +18,7 @@ public struct ValidatorViewModel {
     }
 
     public var name: String {
-        switch validator.providerType {
-        case .stake:
-            if validator.name.isEmpty {
-                return GemAddressService.shared.format(address: validator.id, chain: validator.chain)
-            }
-            return validator.name
-        case .earn:
-            return validator.name
-        }
+        validatorDisplayName(validator: validator.map())
     }
 
     public var aprModel: AprViewModel {

--- a/ios/Features/Stake/Tests/ViewModels/ValidatorViewModelTests.swift
+++ b/ios/Features/Stake/Tests/ViewModels/ValidatorViewModelTests.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
+import Primitives
 import PrimitivesTestKit
 import Stake
 import Testing
@@ -10,5 +11,12 @@ struct ValidatorViewModelTests {
         let model = ValidatorViewModel(validator: .mock(apr: 2.15))
 
         #expect(model.aprModel.text == "APR 2.15%")
+    }
+
+    @Test func nameFallsBackToTheAddressWhenUnnamed() {
+        let validator = DelegationValidator.mock(.solana, id: "8GbwASqdpw4dVcwbWUxbHXMrjyQx2aKkoBR5H1GJF8iD", name: "")
+
+        #expect(ValidatorViewModel(validator: validator).name == "8GbwA...JF8iD")
+        #expect(ValidatorViewModel(validator: .mock(name: "Everstake")).name == "Everstake")
     }
 }


### PR DESCRIPTION
A Solana stake that is activating or deactivating becomes available when the current epoch ends. The wait was measured against the epoch number instead of how far the epoch had actually run, so it read about two days for the whole epoch, no matter how close the end was.

Checked on a watch wallet with a real deactivating stake: before it said 2 days 2 hours, after it said 19 hours 59 minutes, which is what the chain reported at that moment.

Before

<img width="280" alt="01-before-list" src="https://github.com/user-attachments/assets/6d33e495-bf49-4c3c-b666-7c3f22e62d7f" />
<img width="280" alt="03-before-detail" src="https://github.com/user-attachments/assets/fda26311-2d70-44c6-8aad-f50f49b90f1a" />

After

<img width="280" alt="02-after-list" src="https://github.com/user-attachments/assets/8b7bfe51-38b9-436b-b404-0d13d8b3db92" />
<img width="280" alt="04-after-detail" src="https://github.com/user-attachments/assets/4255e000-0d4f-40ad-b86a-3269e2a762d3" />
