### PR TITLE
Drop the validator name test that Core already covers

### DIFF
--- a/ios/Features/Stake/Tests/ViewModels/ValidatorViewModelTests.swift
+++ b/ios/Features/Stake/Tests/ViewModels/ValidatorViewModelTests.swift
@@ -10,23 +10,16 @@ import Testing
 
 struct ValidatorViewModelTests {
     @Test func aprText() {
-        #expect(model(.mock(apr: 2.15)).aprModel.text == "APR 2.15%")
+        #expect(mock(.mock(apr: 2.15)).aprModel.text == "APR 2.15%")
     }
 
-    @Test func nameAndPlaceholderComeFromTheRow() {
-        let model = model(.mock(name: "Everstake"), name: "Everstake", placeholder: "E")
-
-        #expect(model.name == "Everstake")
-        #expect(model.validatorImage.type == .text("E"))
-    }
-
-    private func model(_ validator: DelegationValidator, name: String = "", placeholder: String = "") -> ValidatorViewModel {
+    private func mock(_ validator: DelegationValidator) -> ValidatorViewModel {
         ValidatorViewModel(
             row: GemValidatorRow(
                 validator: validator.map(),
-                name: name,
+                name: "",
                 imageUrl: "https://assets.gemwallet.com/validator.png",
-                placeholder: placeholder,
+                placeholder: "",
                 provider: .none,
             ),
         )


### PR DESCRIPTION
The stake validator's name and letter placeholder come from Core now, so the iOS test only checked that the view model handed back the value it had just been given. The naming itself is already covered on the gemstone side.

Follows up on the review comment on #1225.